### PR TITLE
fix: set host_sample_rate on track load to prevent 2x playback on Apple

### DIFF
--- a/android/example/src/main/kotlin/com/kithara/example/PlayerViewModel.kt
+++ b/android/example/src/main/kotlin/com/kithara/example/PlayerViewModel.kt
@@ -35,6 +35,7 @@ internal class PlayerViewModel(application: Application) : AndroidViewModel(appl
     private var localError: String? = null
     private var player: KitharaPlayer
     private var playerJob: Job? = null
+    private var itemJob: Job? = null
     private var sourceUrl: String? = null
 
     init {
@@ -132,9 +133,21 @@ internal class PlayerViewModel(application: Application) : AndroidViewModel(appl
 
     override fun onCleared() {
         super.onCleared()
+        itemJob?.cancel()
         playerJob?.cancel()
         player.pause()
         player.removeAllItems()
+    }
+
+    private fun observeItem(item: KitharaPlayerItem) {
+        itemJob?.cancel()
+        itemJob = viewModelScope.launch {
+            item.state.collectLatest { state ->
+                val error = state.error ?: return@collectLatest
+                Log.e(TAG, "Item error for source: $sourceUrl — ${error.message}")
+                setPlaybackError(error)
+            }
+        }
     }
 
     private fun observePlayer() {
@@ -180,6 +193,7 @@ internal class PlayerViewModel(application: Application) : AndroidViewModel(appl
         }
 
         val item = KitharaPlayerItem(source)
+        observeItem(item)
         item.load()
         player.removeAllItems()
         player.insert(item)
@@ -187,6 +201,7 @@ internal class PlayerViewModel(application: Application) : AndroidViewModel(appl
     }
 
     private fun resetPlayer() {
+        itemJob?.cancel()
         player.pause()
         player.removeAllItems()
     }

--- a/apple/Sources/KitharaFFI/KitharaFFI.swift
+++ b/apple/Sources/KitharaFFI/KitharaFFI.swift
@@ -887,7 +887,7 @@ public protocol AudioPlayerItemProtocol: AnyObject, Sendable {
     
     func setPreferredPeakBitrateForExpensiveNetworks(bitrate: Double) 
     
-    func setStoreOptions(store: FfiStoreOptions) 
+    func setStoreOptions(store: StoreOptions) 
     
     func url()  -> String
     
@@ -1025,10 +1025,10 @@ open func setPreferredPeakBitrateForExpensiveNetworks(bitrate: Double)  {try! ru
 }
 }
     
-open func setStoreOptions(store: FfiStoreOptions)  {try! rustCall() {
+open func setStoreOptions(store: StoreOptions)  {try! rustCall() {
     uniffi_kithara_ffi_fn_method_audioplayeritem_set_store_options(
             self.uniffiCloneHandle(),
-        FfiConverterTypeFfiStoreOptions_lower(store),$0
+        FfiConverterTypeStoreOptions_lower(store),$0
     )
 }
 }
@@ -1752,59 +1752,6 @@ public func FfiConverterTypeFfiPlayerSnapshot_lower(_ value: FfiPlayerSnapshot) 
 
 
 /**
- * Store configuration forwarded from platform layer to resource creation.
- */
-public struct FfiStoreOptions: Equatable, Hashable {
-    public let cacheDir: String?
-
-    // Default memberwise initializers are never public by default, so we
-    // declare one manually.
-    public init(cacheDir: String?) {
-        self.cacheDir = cacheDir
-    }
-
-    
-
-    
-}
-
-#if compiler(>=6)
-extension FfiStoreOptions: Sendable {}
-#endif
-
-#if swift(>=5.8)
-@_documentation(visibility: private)
-#endif
-public struct FfiConverterTypeFfiStoreOptions: FfiConverterRustBuffer {
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> FfiStoreOptions {
-        return
-            try FfiStoreOptions(
-                cacheDir: FfiConverterOptionString.read(from: &buf)
-        )
-    }
-
-    public static func write(_ value: FfiStoreOptions, into buf: inout [UInt8]) {
-        FfiConverterOptionString.write(value.cacheDir, into: &buf)
-    }
-}
-
-
-#if swift(>=5.8)
-@_documentation(visibility: private)
-#endif
-public func FfiConverterTypeFfiStoreOptions_lift(_ buf: RustBuffer) throws -> FfiStoreOptions {
-    return try FfiConverterTypeFfiStoreOptions.lift(buf)
-}
-
-#if swift(>=5.8)
-@_documentation(visibility: private)
-#endif
-public func FfiConverterTypeFfiStoreOptions_lower(_ value: FfiStoreOptions) -> RustBuffer {
-    return FfiConverterTypeFfiStoreOptions.lower(value)
-}
-
-
-/**
  * FFI-friendly time range (seconds-based).
  */
 public struct FfiTimeRange: Equatable, Hashable {
@@ -1858,6 +1805,59 @@ public func FfiConverterTypeFfiTimeRange_lift(_ buf: RustBuffer) throws -> FfiTi
 #endif
 public func FfiConverterTypeFfiTimeRange_lower(_ value: FfiTimeRange) -> RustBuffer {
     return FfiConverterTypeFfiTimeRange.lower(value)
+}
+
+
+/**
+ * Store configuration forwarded from platform layer to resource creation.
+ */
+public struct StoreOptions: Equatable, Hashable {
+    public let cacheDir: String?
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(cacheDir: String?) {
+        self.cacheDir = cacheDir
+    }
+
+    
+
+    
+}
+
+#if compiler(>=6)
+extension StoreOptions: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeStoreOptions: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> StoreOptions {
+        return
+            try StoreOptions(
+                cacheDir: FfiConverterOptionString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: StoreOptions, into buf: inout [UInt8]) {
+        FfiConverterOptionString.write(value.cacheDir, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeStoreOptions_lift(_ buf: RustBuffer) throws -> StoreOptions {
+    return try FfiConverterTypeStoreOptions.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeStoreOptions_lower(_ value: StoreOptions) -> RustBuffer {
+    return FfiConverterTypeStoreOptions.lower(value)
 }
 
 
@@ -2652,7 +2652,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_kithara_ffi_checksum_method_audioplayeritem_set_preferred_peak_bitrate_for_expensive_networks() != 44522) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_kithara_ffi_checksum_method_audioplayeritem_set_store_options() != 53474) {
+    if (uniffi_kithara_ffi_checksum_method_audioplayeritem_set_store_options() != 11848) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_kithara_ffi_checksum_method_audioplayeritem_url() != 17628) {

--- a/crates/kithara-net/src/error.rs
+++ b/crates/kithara-net/src/error.rs
@@ -65,9 +65,13 @@ impl From<ReqwestError> for NetError {
         if e.is_timeout() {
             return Self::Timeout;
         }
-        // Use alternate formatting {:#} to include the full error chain
-        // (e.g. "error sending request … : connection refused")
-        Self::Http(format!("{e:#}"))
+        let mut msg = e.to_string();
+        let mut current: &dyn std::error::Error = &e;
+        while let Some(source) = current.source() {
+            msg += &format!(": {source}");
+            current = source;
+        }
+        Self::Http(msg)
     }
 }
 

--- a/crates/kithara-play/src/impls/player_processor.rs
+++ b/crates/kithara-play/src/impls/player_processor.rs
@@ -162,6 +162,10 @@ impl PlayerNodeProcessor {
 
         self.evict_tracks_if_needed();
 
+        if let Ok(res) = resource.try_lock() {
+            res.set_host_sample_rate(self.sample_rate);
+        }
+
         let track = PlayerTrack::new(
             resource,
             Arc::clone(&src),

--- a/crates/kithara-play/src/impls/player_processor.rs
+++ b/crates/kithara-play/src/impls/player_processor.rs
@@ -491,7 +491,10 @@ impl AudioNodeProcessor for PlayerNodeProcessor {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc as TestArc, Mutex};
+    use std::sync::{
+        Arc as TestArc, Mutex,
+        atomic::{AtomicU32, Ordering as AtomicOrdering},
+    };
 
     use kithara_audio::{DecodeResult, PcmReader};
     use kithara_decode::{PcmSpec, TrackMetadata};
@@ -524,6 +527,104 @@ mod tests {
         let processor =
             PlayerNodeProcessor::new(rx, shared_state, sample_rate, kithara_bufpool::pcm_pool());
         (processor, tx)
+    }
+
+    /// Reader that records the last `host_sample_rate` set via `set_host_sample_rate`.
+    struct SampleRateTrackingReader {
+        spec: PcmSpec,
+        meta: TrackMetadata,
+        events_tx: broadcast::Sender<AudioEvent>,
+        recorded_host_rate: TestArc<AtomicU32>,
+    }
+
+    impl SampleRateTrackingReader {
+        fn new(spec: PcmSpec) -> (Self, TestArc<AtomicU32>) {
+            let (events_tx, _) = broadcast::channel(1);
+            let recorded = TestArc::new(AtomicU32::new(0));
+            let reader = Self {
+                spec,
+                meta: TrackMetadata::default(),
+                events_tx,
+                recorded_host_rate: TestArc::clone(&recorded),
+            };
+            (reader, recorded)
+        }
+    }
+
+    impl PcmReader for SampleRateTrackingReader {
+        fn read(&mut self, _buf: &mut [f32]) -> usize {
+            0
+        }
+
+        fn read_planar<'a>(&mut self, _output: &'a mut [&'a mut [f32]]) -> usize {
+            0
+        }
+
+        fn seek(&mut self, _position: Duration) -> DecodeResult<()> {
+            Ok(())
+        }
+
+        fn spec(&self) -> PcmSpec {
+            self.spec
+        }
+
+        fn is_eof(&self) -> bool {
+            false
+        }
+
+        fn position(&self) -> Duration {
+            Duration::ZERO
+        }
+
+        fn duration(&self) -> Option<Duration> {
+            Some(Duration::from_secs(60))
+        }
+
+        fn metadata(&self) -> &TrackMetadata {
+            &self.meta
+        }
+
+        fn decode_events(&self) -> broadcast::Receiver<AudioEvent> {
+            self.events_tx.subscribe()
+        }
+
+        fn set_host_sample_rate(&self, sample_rate: NonZeroU32) {
+            self.recorded_host_rate
+                .store(sample_rate.get(), AtomicOrdering::Relaxed);
+        }
+    }
+
+    #[kithara::test(tokio)]
+    async fn load_track_propagates_host_sample_rate() {
+        let host_rate = 88_200u32;
+
+        let (reader, recorded) = SampleRateTrackingReader::new(PcmSpec {
+            channels: 2,
+            sample_rate: 44_100,
+        });
+
+        let resource = Resource::from_reader(reader);
+        let player_resource = Arc::new(PlatformMutex::new(PlayerResource::new(
+            resource,
+            Arc::from("track.mp3"),
+            kithara_bufpool::pcm_pool(),
+        )));
+
+        let shared_state = make_shared_state();
+        let (tx, rx) = HeapRb::<PlayerCmd>::new(8).split();
+        let sample_rate = NonZeroU32::new(host_rate).expect("non-zero");
+        let mut processor =
+            PlayerNodeProcessor::new(rx, shared_state, sample_rate, kithara_bufpool::pcm_pool());
+
+        let mut tx = tx;
+        tx.try_push(PlayerCmd::LoadTrack {
+            resource: player_resource,
+            src: Arc::from("track.mp3"),
+        })
+        .ok();
+        processor.drain_commands();
+
+        assert_eq!(recorded.load(AtomicOrdering::Relaxed), host_rate);
     }
 
     #[kithara::test]

--- a/xtask/src/xcframework.rs
+++ b/xtask/src/xcframework.rs
@@ -63,6 +63,8 @@ pub(crate) fn run(profile: crate::BuildProfile) -> Result<()> {
         "-y",
     ]);
     cmd.current_dir(&crate_dir);
+    // Match the deployment target declared in project.yml / Package.swift.
+    cmd.env("IPHONEOS_DEPLOYMENT_TARGET", "16.0");
 
     let status = cmd.status().context("failed to run cargo swift package")?;
     if !status.success() {


### PR DESCRIPTION
PlayerNodeProcessor.load_track() did not propagate the host sample rate to the newly created PlayerResource, leaving the resampler in passthrough mode. When the hardware runs at 88.2 kHz and the source is 44.1 kHz the audio played at double speed.

Also sets IPHONEOS_DEPLOYMENT_TARGET=16.0 in xtask xcframework build and regenerates Swift bindings to match current Rust API.

## Description

Brief description of the changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Other (describe):

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] Tests added/updated
- [x] No `unwrap()`/`expect()` in production code
- [ ] Documentation updated (if applicable)
