### PR TITLE
feat: add mobile playlist controls and playback end events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
+name = "android_log-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85965b6739a430150bdd138e2374a98af0c3ee0d030b3bb7fc3bddff58d0102e"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3777,6 +3783,8 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-android",
+ "tracing-subscriber",
  "uniffi",
  "url",
  "uuid",
@@ -7541,6 +7549,17 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-android"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12612be8f868a09c0ceae7113ff26afe79d81a24473a393cb9120ece162e86c0"
+dependencies = [
+ "android_log-sys",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,6 +210,7 @@ thiserror = "2.0.18"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter", "fmt"] }
 tracing-wasm = "0.2"
+tracing-android = "0.2.0"
 tracing-log = "0.2"
 web-time = "1.1"
 gloo-timers = { version = "0.3", features = ["futures"] }

--- a/android/example/src/main/kotlin/com/kithara/example/FileUtils.kt
+++ b/android/example/src/main/kotlin/com/kithara/example/FileUtils.kt
@@ -1,0 +1,52 @@
+package com.kithara.example
+
+import android.content.Context
+import android.net.Uri
+import android.provider.OpenableColumns
+import java.io.File
+import java.io.IOException
+import java.util.UUID
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+internal data class ImportedFile(
+    val displayName: String,
+    val path: String,
+)
+
+internal suspend fun copyDocumentToCache(context: Context, uri: Uri): ImportedFile =
+    withContext(Dispatchers.IO) {
+        val displayName = queryDisplayName(context, uri)
+            ?.takeIf(String::isNotBlank)
+            ?: uri.lastPathSegment?.substringAfterLast('/')
+            ?: "selected-audio"
+        val importDir = File(context.cacheDir, "imports")
+        if (!importDir.exists() && !importDir.mkdirs()) {
+            throw IOException("Unable to create import directory")
+        }
+
+        val outputFile = buildImportedFile(importDir, displayName)
+
+        context.contentResolver.openInputStream(uri)?.use { input ->
+            outputFile.outputStream().use { output -> input.copyTo(output) }
+        } ?: throw IOException("Unable to open selected file")
+
+        ImportedFile(
+            displayName = displayName,
+            path = outputFile.absolutePath,
+        )
+    }
+
+internal fun buildImportedFile(
+    importDir: File,
+    fileName: String,
+    id: UUID = UUID.randomUUID(),
+): File = File(importDir, "$id-$fileName")
+
+private fun queryDisplayName(context: Context, uri: Uri): String? =
+    context.contentResolver.query(
+        uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null,
+    )?.use { cursor ->
+        val col = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+        if (col < 0 || !cursor.moveToFirst()) null else cursor.getString(col)
+    }

--- a/android/example/src/main/kotlin/com/kithara/example/PlayerUiState.kt
+++ b/android/example/src/main/kotlin/com/kithara/example/PlayerUiState.kt
@@ -1,15 +1,35 @@
 package com.kithara.example
 
 import com.kithara.PlayerStatus
+import java.util.UUID
+
+internal data class PlaylistEntry(
+    val name: String,
+    val url: String,
+    val id: UUID = UUID.randomUUID(),
+)
 
 internal data class PlayerUiState(
     val currentTimeSeconds: Float = 0f,
+    val currentTrackId: UUID? = null,
     val durationSeconds: Float? = null,
     val errorMessage: String? = null,
     val isPlaying: Boolean = false,
     val isSeeking: Boolean = false,
-    val selectedRate: Float = PlayerViewModel.DefaultRate,
+    val playlist: List<PlaylistEntry> = emptyList(),
+    val selectedRate: Float = DefaultRate,
+    val availableRates: List<Float> = AvailableRates,
     val status: PlayerStatus = PlayerStatus.Unknown,
-    val trackTitle: String = "",
     val url: String = "",
-)
+) {
+
+    val currentTrackIndex: Int = playlist.indexOfFirst { it.id == currentTrackId }
+
+    val trackTitle: String
+        get() = playlist.getOrNull(currentTrackIndex)?.name ?: "No Track"
+
+    companion object {
+        private const val DefaultRate = 1.0f
+        private val AvailableRates: List<Float> = listOf(0.5f, 0.75f, 1.0f, 1.2f, 1.5f, 2.0f)
+    }
+}

--- a/android/example/src/main/kotlin/com/kithara/example/PlayerViewModel.kt
+++ b/android/example/src/main/kotlin/com/kithara/example/PlayerViewModel.kt
@@ -1,132 +1,143 @@
 package com.kithara.example
 
 import android.app.Application
-import android.content.Context
 import android.net.Uri
-import android.provider.OpenableColumns
 import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.kithara.Kithara
 import com.kithara.KitharaError
 import com.kithara.KitharaPlayer
+import com.kithara.KitharaPlayerEvent
 import com.kithara.KitharaPlayerItem
+import com.kithara.LogLevel
 import com.kithara.PlayerStatus
 import java.io.File
 import java.io.IOException
-import java.util.UUID
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import androidx.core.net.toUri
+import java.util.UUID
 
 private const val TAG = "KitharaExample"
-private const val DefaultTrackTitle = "No Track"
 
 internal class PlayerViewModel(application: Application) : AndroidViewModel(application) {
-    private val _uiState = MutableStateFlow(PlayerUiState(trackTitle = DefaultTrackTitle))
+    private val _uiState = MutableStateFlow(PlayerUiState())
     val uiState = _uiState.asStateFlow()
 
-    private var localError: String? = null
-    private var player: KitharaPlayer
-    private var playerJob: Job? = null
+    private val player = KitharaPlayer().apply { defaultRate = _uiState.value.selectedRate }
     private var itemJob: Job? = null
-    private var sourceUrl: String? = null
+    private var shouldReloadCurrentTrack = false
 
     init {
-        Kithara.initialize(application)
-        player = KitharaPlayer().apply { defaultRate = _uiState.value.selectedRate }
+        Kithara.initialize(application, logLevel = LogLevel.Debug)
         observePlayer()
+        observeEvents()
     }
 
     fun onUrlChanged(value: String) {
-        localError = null
-        _uiState.update { state -> state.copy(errorMessage = null, url = value) }
+        _uiState.update { it.copy(url = value, errorMessage = null) }
     }
 
-    fun loadAndPlay() {
-        val trimmed = _uiState.value.url.trim()
-        if (trimmed.isEmpty()) {
+    fun addTrack() {
+        val url = _uiState.value.url.trim()
+        if (url.isEmpty()) {
             setLocalError("Enter an audio URL or pick a file")
             return
         }
 
-        viewModelScope.launch(Dispatchers.Default) {
-            try {
-                prepareAndPlay(trimmed)
-            } catch (error: KitharaError) {
-                Log.e(TAG, "Load/play failed for source: $trimmed", error)
-                setPlaybackError(error)
-            }
-        }
+        _uiState.update { it.copy(url = "", errorMessage = null) }
+        enqueue(url)
     }
 
     fun onFilePicked(uri: Uri) {
-        localError = null
         viewModelScope.launch {
-            val localPath = try {
+            val file = try {
                 copyDocumentToCache(getApplication(), uri)
-            } catch (error: IOException) {
-                Log.e(TAG, "Failed to copy file: $uri", error)
-                setLocalError(error.message ?: error::class.simpleName.orEmpty())
+            } catch (e: IOException) {
+                Log.e(TAG, "Failed to copy file: $uri", e)
+                setLocalError(e.message ?: e::class.simpleName.orEmpty())
                 return@launch
             }
-            _uiState.update { state -> state.copy(url = localPath) }
-            withContext(Dispatchers.Default) {
-                try {
-                    prepareAndPlay(localPath)
-                } catch (error: KitharaError) {
-                    Log.e(TAG, "Load/play failed for selected file: $uri", error)
-                    setPlaybackError(error)
-                }
-            }
+
+            enqueue(file.path, file.displayName)
         }
     }
 
-
     fun playPause() {
-        if (_uiState.value.isPlaying) {
+        val state = _uiState.value
+        if (state.isPlaying) {
             player.pause()
             return
         }
 
-        if (player.items.isEmpty() && _uiState.value.url.isNotBlank()) {
-            loadAndPlay()
+        trackToReplay(state, shouldReloadCurrentTrack)?.let { track ->
+            loadTrack(track, force = true)
             return
         }
 
         player.play()
     }
 
-    fun setRate(rate: Float) {
-        _uiState.update { state -> state.copy(selectedRate = rate) }
-        player.defaultRate = rate
-        if (_uiState.value.isPlaying) {
-            player.play()
+    fun playNext() {
+        val state = _uiState.value
+        val current = state.currentTrackIndex
+        if (current < 0) return
+        if (current >= state.playlist.lastIndex) {
+            player.pause()
+            return
         }
+        loadTrack(state.playlist[current + 1])
+    }
+
+    fun playPrev() {
+        val state = _uiState.value
+        val current = state.currentTrackIndex
+        if (current < 0) return
+        val prev = current.dec().coerceAtLeast(0)
+        loadTrack(state.playlist[prev])
+    }
+
+
+    fun selectTrack(trackId: UUID) {
+        val state = _uiState.value
+        val track = state.playlist.single { it.id == trackId }
+        loadTrack(
+            track = track,
+            force = shouldReloadSelectedTrack(state, trackId, shouldReloadCurrentTrack),
+        )
+    }
+
+    fun setRate(rate: Float) {
+        _uiState.update { it.copy(selectedRate = rate) }
+        player.defaultRate = rate
+        if (_uiState.value.isPlaying) player.play()
     }
 
     fun onSeekStarted() {
-        _uiState.update { state -> state.copy(isSeeking = true) }
+        _uiState.update { it.copy(isSeeking = true) }
     }
 
     fun onSeekChanged(value: Float) {
-        _uiState.update { state -> state.copy(currentTimeSeconds = value) }
+        _uiState.update { it.copy(currentTimeSeconds = value) }
     }
 
     fun onSeekFinished() {
         val target = _uiState.value.currentTimeSeconds.toDouble()
-        player.seek(target) { finished ->
-            if (finished) {
-                _uiState.update { state -> state.copy(isSeeking = false) }
+        player.seek(target) { ok ->
+            if (ok) {
+                _uiState.update { it.copy(isSeeking = false) }
             } else {
-                Log.e(TAG, "Seek failed for source: $sourceUrl")
-                setLocalError("Seek failed")
+                Log.e(TAG, "Seek failed")
+                _uiState.update {
+                    it.copy(
+                        errorMessage = "Seek failed",
+                        isSeeking = false,
+                    )
+                }
             }
         }
     }
@@ -134,9 +145,48 @@ internal class PlayerViewModel(application: Application) : AndroidViewModel(appl
     override fun onCleared() {
         super.onCleared()
         itemJob?.cancel()
-        playerJob?.cancel()
         player.pause()
         player.removeAllItems()
+    }
+
+    private fun enqueue(url: String, name: String = resolveTrackTitle(url)) {
+        val wasEmpty = _uiState.value.playlist.isEmpty()
+        val entry = PlaylistEntry(url = url, name = name)
+
+        _uiState.update { it.copy(playlist = it.playlist + entry) }
+
+        if (wasEmpty) {
+            loadTrack(entry)
+        }
+    }
+
+    private fun loadTrack(track: PlaylistEntry, force: Boolean = false) {
+        if (!force && _uiState.value.currentTrackId == track.id) return
+
+        val item = KitharaPlayerItem(track.url).also { it.load() }
+        observeItem(item)
+
+        player.removeAllItems()
+        try {
+            player.insert(item)
+        } catch (e: KitharaError) {
+            Log.e(TAG, "Failed to insert: ${track.url}", e)
+            setLocalError(e.message ?: e::class.simpleName.orEmpty())
+            return
+        }
+        player.play()
+        shouldReloadCurrentTrack = false
+
+        _uiState.update {
+            it.copy(
+                currentTimeSeconds = 0f,
+                currentTrackId = track.id,
+                durationSeconds = null,
+                errorMessage = null,
+                isSeeking = false,
+                status = PlayerStatus.Unknown,
+            )
+        }
     }
 
     private fun observeItem(item: KitharaPlayerItem) {
@@ -144,122 +194,72 @@ internal class PlayerViewModel(application: Application) : AndroidViewModel(appl
         itemJob = viewModelScope.launch {
             item.state.collectLatest { state ->
                 val error = state.error ?: return@collectLatest
-                Log.e(TAG, "Item error for source: $sourceUrl — ${error.message}")
-                setPlaybackError(error)
+                Log.e(TAG, "Item error for source: ${item.url}", error)
+                setLocalError(error.message ?: error::class.simpleName.orEmpty())
             }
         }
     }
 
     private fun observePlayer() {
-        playerJob?.cancel()
-        playerJob = viewModelScope.launch {
+        viewModelScope.launch {
             player.state.collectLatest { state ->
                 _uiState.update { current ->
-                    val playerTime = if (current.isSeeking) {
-                        current.currentTimeSeconds
-                    } else {
-                        state.currentTime.toFloat()
-                    }
+                    val time = if (current.isSeeking) current.currentTimeSeconds
+                    else state.currentTime.toFloat()
                     val duration = state.duration?.toFloat()
                     current.copy(
-                        currentTimeSeconds = duration?.let { playerTime.coerceIn(0f, it) }
-                            ?: playerTime,
+                        currentTimeSeconds = duration?.let { time.coerceIn(0f, it) } ?: time,
                         durationSeconds = duration,
-                        errorMessage = localError ?: state.error?.message,
                         isPlaying = state.rate > 0f,
                         status = state.status,
-                        trackTitle = sourceUrl?.let(::resolveTrackTitle) ?: DefaultTrackTitle,
                     )
                 }
             }
         }
     }
 
-    private fun prepareAndPlay(source: String) {
-        resetPlayer()
-        localError = null
-        sourceUrl = source
-        _uiState.update { state ->
-            state.copy(
-                currentTimeSeconds = 0f,
-                durationSeconds = null,
-                errorMessage = null,
-                isPlaying = false,
-                isSeeking = false,
-                status = PlayerStatus.Unknown,
-                trackTitle = resolveTrackTitle(source),
-                url = source,
-            )
+    private fun observeEvents() {
+        viewModelScope.launch {
+            player.events.collect { event ->
+                when (event) {
+                    is KitharaPlayerEvent.CurrentItemChanged -> Unit
+                    is KitharaPlayerEvent.PlayedToEnd -> {
+                        shouldReloadCurrentTrack = true
+                        playNext()
+                    }
+                }
+            }
         }
-
-        val item = KitharaPlayerItem(source)
-        observeItem(item)
-        item.load()
-        player.removeAllItems()
-        player.insert(item)
-        player.play()
-    }
-
-    private fun resetPlayer() {
-        itemJob?.cancel()
-        player.pause()
-        player.removeAllItems()
     }
 
     private fun setLocalError(message: String) {
-        localError = message
-        _uiState.update { state ->
-            state.copy(
+        _uiState.update {
+            it.copy(
                 errorMessage = message,
                 isSeeking = false,
-                status = PlayerStatus.Failed,
+                status = PlayerStatus.Failed
             )
         }
     }
 
-    private fun setPlaybackError(error: KitharaError) {
-        setLocalError(error.message ?: error::class.simpleName.orEmpty())
-    }
-
     private fun resolveTrackTitle(source: String): String {
-        val parsed = source.toUri().lastPathSegment?.substringAfterLast('/')
-        val fallback = source.substringAfterLast('/').substringAfterLast(File.separatorChar)
-        return (parsed ?: fallback).ifBlank { source }
-    }
-
-    // "content://" URIs can only be read via ContentResolver; Kithara needs a file path.
-    private suspend fun copyDocumentToCache(context: Context, uri: Uri): String =
-        withContext(Dispatchers.IO) {
-            val fileName = queryDisplayName(context, uri)
-                ?.takeIf(String::isNotBlank)
-                ?: uri.lastPathSegment?.substringAfterLast('/')
-                ?: "selected-audio"
-            val importDir = File(context.cacheDir, "imports")
-            if (!importDir.exists() && !importDir.mkdirs()) {
-                throw IOException("Unable to create import directory")
-            }
-            val outputFile = File(importDir, "${UUID.randomUUID()}-$fileName")
-            context.contentResolver.openInputStream(uri)?.use { input ->
-                outputFile.outputStream().use { output -> input.copyTo(output) }
-            } ?: throw IOException("Unable to open selected file")
-            outputFile.absolutePath
-        }
-
-    private fun queryDisplayName(context: Context, uri: Uri): String? =
-        context.contentResolver.query(
-            uri,
-            arrayOf(OpenableColumns.DISPLAY_NAME),
-            null,
-            null,
-            null,
-        )?.use { cursor ->
-            val nameColumn = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
-            if (nameColumn < 0 || !cursor.moveToFirst()) return@use null
-            cursor.getString(nameColumn)
-        }
-
-    internal companion object {
-        const val DefaultRate = 1.0f
-        val AvailableRates: List<Float> = listOf(0.5f, 0.75f, 1.0f, 1.2f, 1.5f, 2.0f)
+        return source.substringAfterLast(File.separatorChar).ifBlank { source }
     }
 }
+
+internal fun trackToReplay(
+    state: PlayerUiState,
+    shouldReloadCurrentTrack: Boolean,
+): PlaylistEntry? {
+    if (state.isPlaying || !shouldReloadCurrentTrack) {
+        return null
+    }
+
+    return state.playlist.getOrNull(state.currentTrackIndex)
+}
+
+internal fun shouldReloadSelectedTrack(
+    state: PlayerUiState,
+    trackId: UUID,
+    shouldReloadCurrentTrack: Boolean,
+): Boolean = shouldReloadCurrentTrack && state.currentTrackId == trackId

--- a/android/example/src/main/kotlin/com/kithara/example/ui/PlayerRoute.kt
+++ b/android/example/src/main/kotlin/com/kithara/example/ui/PlayerRoute.kt
@@ -13,20 +13,25 @@ internal fun PlayerRoute(viewModel: PlayerViewModel) {
     val openFileLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenDocument(),
     ) { uri ->
-        if (uri != null) {
-            viewModel.onFilePicked(uri)
-        }
+        if (uri != null) viewModel.onFilePicked(uri)
     }
 
     PlayerScreen(
         uiState = uiState,
-        onLoadClick = viewModel::loadAndPlay,
-        onPickFileClick = { openFileLauncher.launch(arrayOf("audio/*")) },
-        onPlayPauseClick = viewModel::playPause,
-        onRateClick = viewModel::setRate,
-        onSeekChanged = viewModel::onSeekChanged,
-        onSeekFinished = viewModel::onSeekFinished,
-        onSeekStarted = viewModel::onSeekStarted,
-        onUrlChanged = viewModel::onUrlChanged,
+        onEvent = { event ->
+            when (event) {
+                is PlayerScreenEvent.UrlChanged -> viewModel.onUrlChanged(event.url)
+                PlayerScreenEvent.AddClick -> viewModel.addTrack()
+                PlayerScreenEvent.PickFileClick -> openFileLauncher.launch(arrayOf("audio/*"))
+                PlayerScreenEvent.PlayPauseClick -> viewModel.playPause()
+                PlayerScreenEvent.PrevClick -> viewModel.playPrev()
+                PlayerScreenEvent.NextClick -> viewModel.playNext()
+                is PlayerScreenEvent.TrackClick -> viewModel.selectTrack(event.uuid)
+                is PlayerScreenEvent.RateClick -> viewModel.setRate(event.rate)
+                PlayerScreenEvent.SeekStarted -> viewModel.onSeekStarted()
+                is PlayerScreenEvent.SeekChanged -> viewModel.onSeekChanged(event.value)
+                PlayerScreenEvent.SeekFinished -> viewModel.onSeekFinished()
+            }
+        },
     )
 }

--- a/android/example/src/main/kotlin/com/kithara/example/ui/PlayerScreen.kt
+++ b/android/example/src/main/kotlin/com/kithara/example/ui/PlayerScreen.kt
@@ -2,6 +2,7 @@ package com.kithara.example.ui
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,6 +15,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
@@ -22,12 +25,15 @@ import androidx.compose.material.icons.rounded.FolderOpen
 import androidx.compose.material.icons.rounded.MusicNote
 import androidx.compose.material.icons.rounded.Pause
 import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material.icons.rounded.SkipNext
+import androidx.compose.material.icons.rounded.SkipPrevious
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
@@ -44,34 +50,43 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kithara.PlayerStatus
+import com.kithara.example.PlaylistEntry
 import com.kithara.example.PlayerUiState
-import com.kithara.example.PlayerViewModel
 import com.kithara.example.R
 import com.kithara.example.ui.theme.AccentGold
 import com.kithara.example.ui.theme.KitharaBackground
 import com.kithara.example.ui.theme.KitharaDanger
 import com.kithara.example.ui.theme.KitharaMuted
 import com.kithara.example.ui.theme.KitharaSuccess
+import com.kithara.example.ui.theme.KitharaTheme
 import com.kithara.example.ui.theme.PanelBackground
 import com.kithara.example.ui.theme.PanelBorder
 import com.kithara.example.ui.theme.PrimaryText
 import com.kithara.example.ui.theme.SecondaryText
-import com.kithara.example.ui.theme.KitharaTheme
+import java.util.UUID
+
+internal sealed interface PlayerScreenEvent {
+    data class UrlChanged(val url: String) : PlayerScreenEvent
+    data object AddClick : PlayerScreenEvent
+    data object PickFileClick : PlayerScreenEvent
+    data object PlayPauseClick : PlayerScreenEvent
+    data object PrevClick : PlayerScreenEvent
+    data object NextClick : PlayerScreenEvent
+    data class TrackClick(val uuid: UUID) : PlayerScreenEvent
+    data class RateClick(val rate: Float) : PlayerScreenEvent
+    data object SeekStarted : PlayerScreenEvent
+    data class SeekChanged(val value: Float) : PlayerScreenEvent
+    data object SeekFinished : PlayerScreenEvent
+}
 
 @Composable
 internal fun PlayerScreen(
     uiState: PlayerUiState,
-    onUrlChanged: (String) -> Unit,
-    onLoadClick: () -> Unit,
-    onPickFileClick: () -> Unit,
-    onPlayPauseClick: () -> Unit,
-    onRateClick: (Float) -> Unit,
-    onSeekStarted: () -> Unit,
-    onSeekChanged: (Float) -> Unit,
-    onSeekFinished: () -> Unit,
+    onEvent: (PlayerScreenEvent) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val duration = uiState.durationSeconds ?: 0f
@@ -93,47 +108,43 @@ internal fun PlayerScreen(
                 start = 20.dp,
                 end = 20.dp,
             ),
-        verticalArrangement = Arrangement.spacedBy(18.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        HeaderSection(
-            isPlaying = uiState.isPlaying,
-            status = uiState.status,
-        )
+        HeaderSection(isPlaying = uiState.isPlaying, status = uiState.status)
         UrlSection(
             url = uiState.url,
-            onUrlChanged = onUrlChanged,
-            onLoadClick = onLoadClick,
+            onEvent = onEvent,
         )
-        LocalFileAction(onPickFileClick = onPickFileClick)
+        LocalFileAction(onEvent = onEvent)
         NowPlayingSection(trackTitle = uiState.trackTitle)
         SeekSection(
             currentTimeSeconds = sliderValue,
             durationSeconds = uiState.durationSeconds,
             enabled = sliderEnabled,
             isSeeking = uiState.isSeeking,
-            onSeekStarted = onSeekStarted,
-            onSeekChanged = onSeekChanged,
-            onSeekFinished = onSeekFinished,
+            onEvent = onEvent,
         )
         TransportSection(
             isPlaying = uiState.isPlaying,
-            onPlayPauseClick = onPlayPauseClick,
+            onEvent = onEvent,
         )
         RateSection(
             selectedRate = uiState.selectedRate,
-            onRateClick = onRateClick,
+            availableRates = uiState.availableRates,
+            onEvent = onEvent,
         )
-        uiState.errorMessage?.let { message ->
-            ErrorSection(message = message)
-        }
+        PlaylistSection(
+            playlist = uiState.playlist,
+            currentTrackId = uiState.currentTrackId,
+            onEvent = onEvent,
+            modifier = Modifier.weight(1f),
+        )
+        uiState.errorMessage?.let { ErrorSection(message = it) }
     }
 }
 
 @Composable
-private fun HeaderSection(
-    isPlaying: Boolean,
-    status: PlayerStatus,
-) {
+private fun HeaderSection(isPlaying: Boolean, status: PlayerStatus) {
     Row(
         modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
@@ -191,11 +202,7 @@ private fun StatusBadge(status: PlayerStatus) {
 }
 
 @Composable
-private fun UrlSection(
-    url: String,
-    onUrlChanged: (String) -> Unit,
-    onLoadClick: () -> Unit,
-) {
+private fun UrlSection(url: String, onEvent: (PlayerScreenEvent) -> Unit) {
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(12.dp),
@@ -203,13 +210,10 @@ private fun UrlSection(
     ) {
         OutlinedTextField(
             value = url,
-            onValueChange = onUrlChanged,
+            onValueChange = { onEvent(PlayerScreenEvent.UrlChanged(it)) },
             modifier = Modifier.weight(1f),
             placeholder = {
-                Text(
-                    text = stringResource(R.string.audio_url_hint),
-                    color = KitharaMuted,
-                )
+                Text(text = stringResource(R.string.audio_url_hint), color = KitharaMuted)
             },
             singleLine = true,
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
@@ -226,7 +230,7 @@ private fun UrlSection(
             shape = RoundedCornerShape(16.dp),
         )
         Button(
-            onClick = onLoadClick,
+            onClick = { onEvent(PlayerScreenEvent.AddClick) },
             enabled = url.isNotBlank(),
             shape = RoundedCornerShape(16.dp),
             colors = ButtonDefaults.buttonColors(
@@ -236,22 +240,19 @@ private fun UrlSection(
                 disabledContentColor = KitharaBackground.copy(alpha = 0.7f),
             ),
         ) {
-            Text(text = stringResource(R.string.load_action))
+            Text(text = stringResource(R.string.add_action))
         }
     }
 }
 
 @Composable
-private fun LocalFileAction(onPickFileClick: () -> Unit) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.End,
-    ) {
-        TextButton(onClick = onPickFileClick) {
+private fun LocalFileAction(onEvent: (PlayerScreenEvent) -> Unit) {
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+        TextButton(onClick = { onEvent(PlayerScreenEvent.PickFileClick) }) {
             Icon(
                 imageVector = Icons.Rounded.FolderOpen,
                 contentDescription = null,
-                tint = AccentGold,
+                tint = AccentGold
             )
             Text(
                 text = stringResource(R.string.open_local_file),
@@ -272,20 +273,21 @@ private fun NowPlayingSection(trackTitle: String) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 18.dp),
+                .padding(horizontal = 16.dp, vertical = 14.dp),
             horizontalArrangement = Arrangement.spacedBy(12.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Icon(
                 imageVector = Icons.Rounded.MusicNote,
                 contentDescription = null,
-                tint = AccentGold,
+                tint = AccentGold
             )
             Text(
                 text = trackTitle.ifBlank { stringResource(R.string.no_track) },
                 color = PrimaryText,
-                style = MaterialTheme.typography.titleLarge,
+                style = MaterialTheme.typography.titleMedium,
                 maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
             )
         }
     }
@@ -297,26 +299,19 @@ private fun SeekSection(
     durationSeconds: Float?,
     enabled: Boolean,
     isSeeking: Boolean,
-    onSeekStarted: () -> Unit,
-    onSeekChanged: (Float) -> Unit,
-    onSeekFinished: () -> Unit,
+    onEvent: (PlayerScreenEvent) -> Unit,
 ) {
-    Column(
-        modifier = Modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
+    Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(4.dp)) {
         Slider(
             value = currentTimeSeconds,
             onValueChange = { value ->
-                if (!isSeeking) {
-                    onSeekStarted()
-                }
-                onSeekChanged(value)
+                if (!isSeeking) onEvent(PlayerScreenEvent.SeekStarted)
+                onEvent(PlayerScreenEvent.SeekChanged(value))
             },
             modifier = Modifier.fillMaxWidth(),
             valueRange = 0f..(durationSeconds ?: 1f),
             enabled = enabled,
-            onValueChangeFinished = onSeekFinished,
+            onValueChangeFinished = { onEvent(PlayerScreenEvent.SeekFinished) },
             colors = SliderDefaults.colors(
                 thumbColor = PrimaryText,
                 activeTrackColor = AccentGold,
@@ -326,10 +321,7 @@ private fun SeekSection(
                 disabledThumbColor = PanelBorder,
             ),
         )
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
+        Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
             Text(
                 text = formatTime(currentTimeSeconds),
                 color = SecondaryText,
@@ -346,17 +338,25 @@ private fun SeekSection(
 }
 
 @Composable
-private fun TransportSection(
-    isPlaying: Boolean,
-    onPlayPauseClick: () -> Unit,
-) {
+private fun TransportSection(isPlaying: Boolean, onEvent: (PlayerScreenEvent) -> Unit) {
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
     ) {
+        IconButton(onClick = { onEvent(PlayerScreenEvent.PrevClick) }) {
+            Icon(
+                imageVector = Icons.Rounded.SkipPrevious,
+                contentDescription = null,
+                tint = PrimaryText,
+                modifier = Modifier.size(32.dp),
+            )
+        }
         FilledTonalButton(
-            onClick = onPlayPauseClick,
-            modifier = Modifier.size(96.dp),
+            onClick = { onEvent(PlayerScreenEvent.PlayPauseClick) },
+            modifier = Modifier
+                .padding(horizontal = 24.dp)
+                .size(64.dp),
             shape = CircleShape,
             colors = ButtonDefaults.filledTonalButtonColors(
                 containerColor = AccentGold,
@@ -365,12 +365,16 @@ private fun TransportSection(
         ) {
             Icon(
                 imageVector = if (isPlaying) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
-                contentDescription = if (isPlaying) {
-                    stringResource(R.string.pause_action)
-                } else {
-                    stringResource(R.string.play_action)
-                },
-                modifier = Modifier.size(40.dp),
+                contentDescription = null,
+                modifier = Modifier.size(28.dp),
+            )
+        }
+        IconButton(onClick = { onEvent(PlayerScreenEvent.NextClick) }) {
+            Icon(
+                imageVector = Icons.Rounded.SkipNext,
+                contentDescription = null,
+                tint = PrimaryText,
+                modifier = Modifier.size(32.dp),
             )
         }
     }
@@ -379,16 +383,14 @@ private fun TransportSection(
 @Composable
 private fun RateSection(
     selectedRate: Float,
-    onRateClick: (Float) -> Unit,
+    availableRates: List<Float>,
+    onEvent: (PlayerScreenEvent) -> Unit
 ) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(6.dp),
-    ) {
-        PlayerViewModel.AvailableRates.forEach { rate ->
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+        availableRates.forEach { rate ->
             val selected = selectedRate == rate
             OutlinedButton(
-                onClick = { onRateClick(rate) },
+                onClick = { onEvent(PlayerScreenEvent.RateClick(rate)) },
                 modifier = Modifier.weight(1f),
                 shape = RoundedCornerShape(10.dp),
                 border = BorderStroke(
@@ -410,6 +412,77 @@ private fun RateSection(
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun PlaylistSection(
+    playlist: List<PlaylistEntry>,
+    currentTrackId: UUID?,
+    onEvent: (PlayerScreenEvent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (playlist.isEmpty()) {
+        Box(modifier = modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+            Text(
+                text = stringResource(R.string.playlist_empty),
+                color = KitharaMuted,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+        return
+    }
+
+    LazyColumn(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        itemsIndexed(playlist, key = { _, entry -> entry.id }) { index, entry ->
+            PlaylistItem(
+                index = index,
+                entry = entry,
+                isCurrent = entry.id == currentTrackId,
+                onClick = { onEvent(PlayerScreenEvent.TrackClick(entry.id)) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun PlaylistItem(
+    index: Int,
+    entry: PlaylistEntry,
+    isCurrent: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val background = if (isCurrent) AccentGold.copy(alpha = 0.18f) else KitharaBackground
+    val indexColor = if (isCurrent) AccentGold else KitharaMuted
+    val nameColor = if (isCurrent) PrimaryText else SecondaryText
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(background)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 10.dp, vertical = 16.dp),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = "%02d".format(index + 1),
+            color = indexColor,
+            style = MaterialTheme.typography.labelMedium,
+        )
+        Text(
+            text = entry.name,
+            color = nameColor,
+            style = MaterialTheme.typography.bodyMedium,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f),
+        )
     }
 }
 
@@ -436,35 +509,34 @@ private fun formatTime(seconds: Float?): String {
     return "%d:%02d".format(totalSeconds / 60, totalSeconds % 60)
 }
 
-private fun rateLabel(rate: Float): String {
-    return if (rate == rate.toInt().toFloat()) {
-        "${rate.toInt()}x"
-    } else {
-        "${rate}x"
-    }
-}
+private fun rateLabel(rate: Float): String =
+    if (rate == rate.toInt().toFloat()) "${rate.toInt()}x" else "${rate}x"
 
-@Preview(showBackground = true, backgroundColor = 0xFF050507)
+@Preview(
+    showBackground = true,
+    backgroundColor = 0xFF050507,
+    heightDp = 900,
+)
 @Composable
 private fun PlayerScreenPreview() {
+    val playlist = listOf(
+        PlaylistEntry(url = "", name = "song.mp3"),
+        PlaylistEntry(url = "", name = "another-long-track-name-that-gets-truncated.mp3"),
+        PlaylistEntry(url = "", name = "third-track.mp3"),
+    )
+
     KitharaTheme {
         PlayerScreen(
             uiState = PlayerUiState(
                 currentTimeSeconds = 42f,
                 durationSeconds = 180f,
                 selectedRate = 1f,
-                status = PlayerStatus.Unknown,
-                trackTitle = "No Track",
-                url = "https://example.com/song.mp3",
+                status = PlayerStatus.ReadyToPlay,
+                url = "",
+                playlist = playlist,
+                currentTrackId = playlist.first().id,
             ),
-            onUrlChanged = {},
-            onLoadClick = {},
-            onPickFileClick = {},
-            onPlayPauseClick = {},
-            onRateClick = {},
-            onSeekStarted = {},
-            onSeekChanged = {},
-            onSeekFinished = {},
+            onEvent = {},
         )
     }
 }

--- a/android/example/src/main/res/values/strings.xml
+++ b/android/example/src/main/res/values/strings.xml
@@ -4,12 +4,11 @@
     <string name="app_title">Kithara</string>
     <string name="audio_url_hint">Audio URL</string>
     <string name="demo_label">Demo</string>
-    <string name="load_action">Load</string>
     <string name="no_track">No Track</string>
     <string name="open_local_file">Open local file</string>
-    <string name="pause_action">Pause</string>
-    <string name="play_action">Play</string>
     <string name="status_failed">Failed</string>
     <string name="status_not_ready">Not Ready</string>
     <string name="status_ready">Ready</string>
+    <string name="add_action">Add</string>
+    <string name="playlist_empty">No tracks in playlist</string>
 </resources>

--- a/android/lib/src/main/kotlin/com/kithara/Kithara.kt
+++ b/android/lib/src/main/kotlin/com/kithara/Kithara.kt
@@ -3,6 +3,20 @@ package com.kithara
 import android.content.Context
 
 /**
+ * Minimum log level forwarded from the Rust layer to logcat.
+ *
+ * Maps to `tracing` levels: [Trace] is the most verbose, [Off] disables all logging.
+ */
+enum class LogLevel {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+    Off,
+}
+
+/**
  * Entry point for the Kithara audio engine.
  *
  * Call [initialize] once before using any Kithara API — typically in
@@ -10,7 +24,7 @@ import android.content.Context
  *
  * ```kotlin
  * // In Application.onCreate:
- * Kithara.initialize(applicationContext)
+ * Kithara.initialize(applicationContext, logLevel = LogLevel.Debug)
  *
  * // Anywhere in the app:
  * val player = KitharaPlayer()
@@ -41,13 +55,14 @@ object Kithara {
      * Safe to call multiple times — subsequent calls are no-ops.
      *
      * @param context Any [Context]; the application context is used internally.
+     * @param logLevel Minimum log level forwarded from Rust to logcat. Defaults to [LogLevel.Warn].
      */
-    fun initialize(context: Context) {
+    fun initialize(context: Context, logLevel: LogLevel = LogLevel.Warn) {
         if (ready) return
         synchronized(this) {
             if (ready) return
             System.loadLibrary("kithara_ffi")
-            nativeInitRustlsPlatformVerifier(context.applicationContext)
+            nativeInit(context.applicationContext, logLevel.ordinal)
             cacheDir = context.applicationContext.cacheDir
                 .resolve("kithara")
                 .absolutePath
@@ -56,5 +71,5 @@ object Kithara {
     }
 
     @JvmStatic
-    private external fun nativeInitRustlsPlatformVerifier(context: Context)
+    private external fun nativeInit(context: Context, logLevel: Int)
 }

--- a/android/lib/src/main/kotlin/com/kithara/KitharaPlayer.kt
+++ b/android/lib/src/main/kotlin/com/kithara/KitharaPlayer.kt
@@ -31,7 +31,7 @@ import kotlinx.coroutines.flow.update
 class KitharaPlayer() {
     private val inner: FfiAudioPlayer = FfiAudioPlayer()
     private val observer = PlayerObserverBridge(this)
-    private val currentItemChangesFlow = MutableSharedFlow<String?>(extraBufferCapacity = 1)
+    private val eventsFlow = MutableSharedFlow<KitharaPlayerEvent>(extraBufferCapacity = 16)
     private val stateFlow = MutableStateFlow(PlayerState())
 
     init {
@@ -44,9 +44,12 @@ class KitharaPlayer() {
     val state: StateFlow<PlayerState> = stateFlow.asStateFlow()
 
     /**
-     * Emits the new current item ID (or null) whenever the current item changes.
+     * One-shot player events: item changes, playback completion, and failures.
+     *
+     * Subscribe with [kotlinx.coroutines.flow.collect] to react to lifecycle transitions
+     * without polling [state].
      */
-    val currentItemChanges: SharedFlow<String?> = currentItemChangesFlow.asSharedFlow()
+    val events: SharedFlow<KitharaPlayerEvent> = eventsFlow.asSharedFlow()
 
     /**
      * Current playback time in seconds.
@@ -195,7 +198,10 @@ class KitharaPlayer() {
                 updateState { it.copy(error = KitharaError.Internal(event.error)) }
 
             is FfiPlayerEvent.CurrentItemChanged ->
-                currentItemChangesFlow.tryEmit(event.itemId)
+                eventsFlow.tryEmit(KitharaPlayerEvent.CurrentItemChanged(event.itemId))
+
+            is FfiPlayerEvent.ItemDidPlayToEnd ->
+                eventsFlow.tryEmit(KitharaPlayerEvent.PlayedToEnd)
 
             is FfiPlayerEvent.TimeControlStatusChanged,
             is FfiPlayerEvent.VolumeChanged,

--- a/android/lib/src/main/kotlin/com/kithara/PlayerState.kt
+++ b/android/lib/src/main/kotlin/com/kithara/PlayerState.kt
@@ -63,3 +63,16 @@ data class ItemState(
     val error: KitharaError? = null,
     val status: ItemStatus = ItemStatus.Unknown,
 )
+
+/**
+ * One-shot player events delivered via [KitharaPlayer.events].
+ *
+ * Distinct from [PlayerState], which carries continuously-updated snapshot data.
+ */
+sealed interface KitharaPlayerEvent {
+    /** The current item changed; [itemId] is null when the queue becomes empty. */
+    data class CurrentItemChanged(val itemId: String?) : KitharaPlayerEvent
+
+    /** The current item played to its end successfully. */
+    data object PlayedToEnd : KitharaPlayerEvent
+}

--- a/apple/Examples/KitharaDemo/Sources/KitharaDemoApp.swift
+++ b/apple/Examples/KitharaDemo/Sources/KitharaDemoApp.swift
@@ -24,7 +24,7 @@ struct KitharaDemoApp: App {
             TextEditingCommands()
         }
         // Quit the process when the last window is closed.
-        .defaultSize(width: 500, height: 600)
+        .defaultSize(width: 520, height: 760)
         #endif
     }
 }

--- a/apple/Examples/KitharaDemo/Sources/PlayerView.swift
+++ b/apple/Examples/KitharaDemo/Sources/PlayerView.swift
@@ -27,19 +27,21 @@ struct PlayerView: View {
     var body: some View {
         VStack(spacing: 0) {
             headerSection
-            Spacer().frame(height: 24)
+            Spacer().frame(height: 20)
             urlSection
-            Spacer().frame(height: 20)
+            Spacer().frame(height: 16)
             nowPlayingSection
-            Spacer().frame(height: 16)
+            Spacer().frame(height: 12)
             seekSection
-            Spacer().frame(height: 20)
-            transportSection
             Spacer().frame(height: 16)
+            transportSection
+            Spacer().frame(height: 12)
             rateSection
-            Spacer().frame(height: 20)
+            Spacer().frame(height: 16)
             volumeSection
-            Spacer()
+            Spacer().frame(height: 16)
+            playlistSection
+            Spacer().frame(height: 16)
             errorSection
         }
         .padding(18)
@@ -96,9 +98,9 @@ struct PlayerView: View {
                 #endif
 
             Button {
-                viewModel.loadAndPlay()
+                viewModel.addTrack()
             } label: {
-                Text("Load")
+                Text("Add")
                     .font(.system(size: 13, weight: .semibold))
                     .foregroundStyle(Color.kitharaBg)
                     .padding(.horizontal, 16)
@@ -114,26 +116,15 @@ struct PlayerView: View {
     // MARK: - Now Playing
 
     private var nowPlayingSection: some View {
-        VStack(spacing: 6) {
-            HStack(spacing: 8) {
-                Image(systemName: "music.note")
-                    .font(.system(size: 16))
-                    .foregroundStyle(Color.kitharaGold)
-                Text(viewModel.trackName)
-                    .font(.system(size: 18, weight: .medium))
-                    .foregroundStyle(Color.kitharaLight)
-                    .lineLimit(1)
-                Spacer()
-            }
-
-            if let itemId = viewModel.currentItemId {
-                HStack {
-                    Text("ID: \(itemId.prefix(8))…")
-                        .font(.system(size: 11, design: .monospaced))
-                        .foregroundStyle(Color.kitharaMuted)
-                    Spacer()
-                }
-            }
+        HStack(spacing: 8) {
+            Image(systemName: "music.note")
+                .font(.system(size: 16))
+                .foregroundStyle(Color.kitharaGold)
+            Text(viewModel.trackName)
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(Color.kitharaLight)
+                .lineLimit(1)
+            Spacer()
         }
         .padding(12)
         .background(Color.kitharaPanel)
@@ -178,7 +169,15 @@ struct PlayerView: View {
 
     private var transportSection: some View {
         HStack(spacing: 32) {
-            Spacer()
+            Button {
+                viewModel.playPrev()
+            } label: {
+                Image(systemName: "backward.fill")
+                    .font(.system(size: 22))
+                    .foregroundStyle(Color.kitharaLight)
+            }
+            .buttonStyle(.plain)
+
             Button {
                 viewModel.togglePlayPause()
             } label: {
@@ -190,8 +189,17 @@ struct PlayerView: View {
                     .clipShape(Circle())
             }
             .buttonStyle(.plain)
-            Spacer()
+
+            Button {
+                viewModel.playNext()
+            } label: {
+                Image(systemName: "forward.fill")
+                    .font(.system(size: 22))
+                    .foregroundStyle(Color.kitharaLight)
+            }
+            .buttonStyle(.plain)
         }
+        .frame(maxWidth: .infinity)
     }
 
     // MARK: - Rate
@@ -246,6 +254,32 @@ struct PlayerView: View {
         .clipShape(RoundedRectangle(cornerRadius: 10))
     }
 
+    // MARK: - Playlist
+
+    @ViewBuilder
+    private var playlistSection: some View {
+        if viewModel.playlist.isEmpty {
+            Text("No tracks in playlist")
+                .font(.system(size: 13))
+                .foregroundStyle(Color.kitharaMuted)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(Color.kitharaPanel)
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+        } else {
+            ScrollView {
+                LazyVStack(spacing: 6) {
+                    ForEach(Array(viewModel.playlist.enumerated()), id: \.element.id) { index, entry in
+                        playlistRow(entry: entry, index: index)
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            .padding(10)
+            .background(Color.kitharaPanel)
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+        }
+    }
+
     // MARK: - Error
 
     @ViewBuilder
@@ -274,6 +308,33 @@ struct PlayerView: View {
 
     private func rateLabel(_ rate: Float) -> String {
         rate == Float(Int(rate)) ? "\(Int(rate))x" : String(format: "%.2gx", rate)
+    }
+
+    private func playlistRow(entry: PlaylistEntry, index: Int) -> some View {
+        let isCurrent = entry.id == viewModel.currentTrackId
+
+        return Button {
+            viewModel.selectTrack(entry.id)
+        } label: {
+            HStack(spacing: 10) {
+                Text(String(format: "%02d", index + 1))
+                    .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                    .foregroundStyle(isCurrent ? Color.kitharaGold : .kitharaMuted)
+
+                Text(entry.name)
+                    .font(.system(size: 13))
+                    .foregroundStyle(isCurrent ? Color.kitharaLight : .kitharaMuted)
+                    .lineLimit(1)
+
+                Spacer()
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 12)
+            .frame(maxWidth: .infinity)
+            .background(isCurrent ? Color.kitharaGold.opacity(0.16) : Color.kitharaBg)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+        }
+        .buttonStyle(.plain)
     }
 
     private var statusText: String {

--- a/apple/Examples/KitharaDemo/Sources/PlayerViewModel.swift
+++ b/apple/Examples/KitharaDemo/Sources/PlayerViewModel.swift
@@ -2,6 +2,18 @@ import Combine
 import Foundation
 import Kithara
 
+struct PlaylistEntry: Identifiable, Equatable {
+    let id: UUID
+    let name: String
+    let url: String
+
+    init(url: String, name: String? = nil, id: UUID = UUID()) {
+        self.id = id
+        self.url = url
+        self.name = name ?? trackName(for: url)
+    }
+}
+
 @MainActor
 final class PlayerViewModel: ObservableObject {
     @Published var status: PlayerStatus = .unknown
@@ -11,17 +23,21 @@ final class PlayerViewModel: ObservableObject {
     @Published var errorMessage: String?
     @Published var urlText = ""
     @Published var isSeeking = false
-    @Published var currentItemId: String?
+    @Published private(set) var playlist: [PlaylistEntry] = []
+    @Published private(set) var currentTrackId: UUID?
     @Published var volume: Float = 1.0
     @Published var isMuted = false
     @Published var selectedRate: Float = 1.0
 
     private let player = KitharaPlayer()
     private var cancellables = Set<AnyCancellable>()
+    private var itemCancellable: AnyCancellable?
+    private var shouldReloadCurrentTrack = false
 
     init() {
         volume = player.volume
         isMuted = player.isMuted
+        player.defaultRate = selectedRate
 
         player.eventPublisher
             .receive(on: DispatchQueue.main)
@@ -41,12 +57,14 @@ final class PlayerViewModel: ObservableObject {
                 case let .error(message):
                     self.errorMessage = message
                     self.status = .failed
-                case let .currentItemChanged(itemId):
-                    self.currentItemId = itemId
+                case .currentItemChanged:
+                    break
                 case let .volumeChanged(vol):
                     self.volume = vol
                 case let .muteChanged(muted):
                     self.isMuted = muted
+                case .itemDidPlayToEnd:
+                    self.playNext(afterPlaybackEnded: true)
                 case .timeControlStatusChanged, .bufferedDurationChanged:
                     break
                 }
@@ -57,25 +75,11 @@ final class PlayerViewModel: ObservableObject {
     // MARK: - Track info
 
     var trackName: String {
-        guard let itemId = currentItemId else {
-            if !urlText.isEmpty {
-                return "Press Play to reload"
-            }
-            return "No Track"
-        }
-        if let item = player.items.first(where: { $0.id == itemId }) {
-            if let url = URL(string: item.url) {
-                let name = url.lastPathComponent
-                return name.isEmpty ? item.url : name
-            }
-            return item.url
-        }
-        // Track was consumed (played to end).
-        if let url = URL(string: urlText), !urlText.isEmpty {
-            let name = url.lastPathComponent
-            return name.isEmpty ? "Press Play to reload" : "\(name) (ended)"
-        }
-        return "Press Play to reload"
+        playlist[safe: currentTrackIndex]?.name ?? "No Track"
+    }
+
+    var currentTrackIndex: Int {
+        playlist.firstIndex { $0.id == currentTrackId } ?? -1
     }
 
     // MARK: - Time formatting
@@ -112,41 +116,22 @@ final class PlayerViewModel: ObservableObject {
 
     // MARK: - Load & Play
 
-    func loadAndPlay() {
+    func addTrack() {
         let url = urlText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !url.isEmpty else {
             errorMessage = "Enter a URL"
             return
         }
 
-        // Reset stale state from previous session.
+        let entry = PlaylistEntry(url: url)
+        let shouldStartPlayback = playlist.isEmpty
+
+        playlist.append(entry)
+        urlText = ""
         errorMessage = nil
-        currentTime = 0
-        duration = nil
-        currentItemId = nil
 
-        let item = KitharaPlayerItem(url: url)
-
-        // Subscribe to item errors (network failures, invalid format, etc.).
-        item.eventPublisher
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] event in
-                if case let .error(message) = event {
-                    self?.errorMessage = message
-                    self?.status = .failed
-                }
-            }
-            .store(in: &cancellables)
-
-        item.load()
-
-        do {
-            player.removeAllItems()
-            try player.insert(item)
-            player.play()
-        } catch {
-            self.errorMessage = "\(error)"
-            self.status = .failed
+        if shouldStartPlayback {
+            loadTrack(entry, force: true)
         }
     }
 
@@ -168,13 +153,38 @@ final class PlayerViewModel: ObservableObject {
         if isPlaying {
             player.pause()
         } else {
-            // If the queue is empty (track played to end or never loaded), re-load.
-            if player.items.isEmpty && !urlText.isEmpty {
-                loadAndPlay()
-            } else {
-                player.play()
+            if let track = currentTrack, shouldReloadCurrentTrack {
+                loadTrack(track, force: true)
+                return
             }
+
+            if currentTrack == nil, let firstTrack = playlist.first {
+                loadTrack(firstTrack, force: true)
+                return
+            }
+
+            player.play()
         }
+    }
+
+    func playNext() {
+        playNext(afterPlaybackEnded: false)
+    }
+
+    func playPrev() {
+        guard let track = playlist[safe: max(currentTrackIndex - 1, 0)] else {
+            return
+        }
+        loadTrack(track)
+    }
+
+    func selectTrack(_ trackId: UUID) {
+        guard let track = playlist.first(where: { $0.id == trackId }) else {
+            return
+        }
+
+        let forceReload = shouldReloadCurrentTrack && currentTrackId == trackId
+        loadTrack(track, force: forceReload)
     }
 
     // MARK: - Seek
@@ -193,6 +203,62 @@ final class PlayerViewModel: ObservableObject {
                 }
             }
         })
+    }
+
+    private var currentTrack: PlaylistEntry? {
+        playlist[safe: currentTrackIndex]
+    }
+
+    private func playNext(afterPlaybackEnded: Bool) {
+        guard currentTrackIndex >= 0 else {
+            return
+        }
+
+        let nextIndex = currentTrackIndex + 1
+        if let track = playlist[safe: nextIndex] {
+            loadTrack(track, force: true)
+            return
+        }
+
+        if afterPlaybackEnded {
+            shouldReloadCurrentTrack = true
+            player.pause()
+        }
+    }
+
+    private func loadTrack(_ track: PlaylistEntry, force: Bool = false) {
+        if !force && currentTrackId == track.id {
+            return
+        }
+
+        currentTime = 0
+        duration = nil
+        errorMessage = nil
+        isSeeking = false
+        status = .unknown
+        shouldReloadCurrentTrack = false
+
+        let item = KitharaPlayerItem(url: track.url)
+        itemCancellable = item.eventPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] event in
+                if case let .error(message) = event {
+                    self?.errorMessage = message
+                    self?.status = .failed
+                }
+            }
+
+        item.load()
+
+        do {
+            player.removeAllItems()
+            try player.insert(item)
+            currentTrackId = track.id
+            player.play()
+        } catch {
+            errorMessage = "\(error)"
+            status = .failed
+        }
     }
 }
 
@@ -216,4 +282,25 @@ private func formatTime(_ seconds: TimeInterval) -> String {
     let mins = Int(seconds) / 60
     let secs = Int(seconds) % 60
     return String(format: "%d:%02d", mins, secs)
+}
+
+private func trackName(for source: String) -> String {
+    if let url = URL(string: source) {
+        let name = url.lastPathComponent
+        if !name.isEmpty {
+            return name
+        }
+    }
+
+    let name = source.split(separator: "/").last.map(String.init) ?? source
+    return name.isEmpty ? source : name
+}
+
+private extension Array {
+    subscript(safe index: Int) -> Element? {
+        guard indices.contains(index) else {
+            return nil
+        }
+        return self[index]
+    }
 }

--- a/apple/Sources/KitharaFFI/KitharaFFI.swift
+++ b/apple/Sources/KitharaFFI/KitharaFFI.swift
@@ -2187,6 +2187,7 @@ public enum FfiPlayerEvent: Equatable, Hashable {
     )
     case muteChanged(muted: Bool
     )
+    case itemDidPlayToEnd
 
 
 
@@ -2237,6 +2238,8 @@ public struct FfiConverterTypeFfiPlayerEvent: FfiConverterRustBuffer {
         
         case 10: return .muteChanged(muted: try FfiConverterBool.read(from: &buf)
         )
+        
+        case 11: return .itemDidPlayToEnd
         
         default: throw UniffiInternalError.unexpectedEnumCase
         }
@@ -2295,6 +2298,10 @@ public struct FfiConverterTypeFfiPlayerEvent: FfiConverterRustBuffer {
             writeInt(&buf, Int32(10))
             FfiConverterBool.write(muted, into: &buf)
             
+        
+        case .itemDidPlayToEnd:
+            writeInt(&buf, Int32(11))
+        
         }
     }
 }

--- a/crates/kithara-ffi/Cargo.toml
+++ b/crates/kithara-ffi/Cargo.toml
@@ -47,3 +47,5 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 jni = { workspace = true }
 ndk-context = { workspace = true }
 rustls-platform-verifier = { workspace = true }
+tracing-android = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/crates/kithara-ffi/src/android.rs
+++ b/crates/kithara-ffi/src/android.rs
@@ -6,20 +6,29 @@ use std::sync::{
 use jni::{
     JNIEnv,
     objects::{GlobalRef, JClass, JObject},
+    sys::jint,
 };
 use tracing::error;
+use tracing_subscriber::{filter::LevelFilter, prelude::*};
 
 static ANDROID_CONTEXT_READY: AtomicBool = AtomicBool::new(false);
 static ANDROID_CONTEXT_GLOBAL: OnceLock<GlobalRef> = OnceLock::new();
 
 #[expect(unreachable_pub, reason = "JNI entrypoint must remain exported")]
 #[unsafe(no_mangle)]
-pub extern "system" fn Java_com_kithara_Kithara_nativeInitRustlsPlatformVerifier(
+pub extern "system" fn Java_com_kithara_Kithara_nativeInit(
     mut env: JNIEnv<'_>,
     _class: JClass<'_>,
     context: JObject<'_>,
+    log_level: jint,
 ) {
     if !ANDROID_CONTEXT_READY.load(Ordering::Acquire) {
+        let filter = level_filter(log_level);
+        if let Ok(layer) = tracing_android::layer("kithara") {
+            let _ = tracing_subscriber::registry()
+                .with(layer.with_filter(filter))
+                .try_init();
+        }
         match init_android_context(&mut env, &context) {
             Ok(()) => {
                 ANDROID_CONTEXT_READY.store(true, Ordering::Release);
@@ -36,6 +45,17 @@ pub extern "system" fn Java_com_kithara_Kithara_nativeInitRustlsPlatformVerifier
         let message = format!("failed to initialize rustls platform verifier: {err}");
         error!(message = %message);
         let _ = env.throw_new("java/lang/IllegalStateException", &message);
+    }
+}
+
+fn level_filter(ordinal: jint) -> LevelFilter {
+    match ordinal {
+        0 => LevelFilter::TRACE,
+        1 => LevelFilter::DEBUG,
+        2 => LevelFilter::INFO,
+        3 => LevelFilter::WARN,
+        4 => LevelFilter::ERROR,
+        _ => LevelFilter::OFF,
     }
 }
 

--- a/crates/kithara-ffi/src/event_bridge.rs
+++ b/crates/kithara-ffi/src/event_bridge.rs
@@ -88,6 +88,7 @@ impl EventBridge {
                 let inner = player.lock_sync();
                 // Pump Firewheel graph updates (volume, etc.) on native.
                 let _ = inner.tick();
+                inner.process_notifications();
                 let time = inner.position_seconds();
                 let duration = inner.duration_seconds();
                 drop(inner);
@@ -147,6 +148,7 @@ impl EventBridge {
                 FfiPlayerEvent::VolumeChanged { volume: *volume }
             }
             PlayerEvent::MuteChanged { muted } => FfiPlayerEvent::MuteChanged { muted: *muted },
+            PlayerEvent::ItemDidPlayToEnd => FfiPlayerEvent::ItemDidPlayToEnd,
             _ => return,
         };
         observer.on_event(ffi_event);

--- a/crates/kithara-ffi/src/types.rs
+++ b/crates/kithara-ffi/src/types.rs
@@ -194,6 +194,7 @@ impl From<TimeRange> for FfiTimeRange {
 /// thread-safe delivery internally.
 #[derive(Debug)]
 #[cfg_attr(feature = "backend-uniffi", derive(uniffi::Enum))]
+#[rustfmt::skip]
 pub enum FfiPlayerEvent {
     TimeChanged { seconds: f64 },
     RateChanged { rate: f32 },
@@ -205,6 +206,7 @@ pub enum FfiPlayerEvent {
     BufferedDurationChanged { seconds: f64 },
     VolumeChanged { volume: f32 },
     MuteChanged { muted: bool },
+    ItemDidPlayToEnd,
 }
 
 /// Typed item event dispatched through [`ItemObserver::on_event`].

--- a/crates/kithara-play/src/events.rs
+++ b/crates/kithara-play/src/events.rs
@@ -29,6 +29,7 @@ pub enum PlayerEvent {
     PrerollCompleted {
         success: bool,
     },
+    ItemDidPlayToEnd,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/kithara-play/src/impls/engine.rs
+++ b/crates/kithara-play/src/impls/engine.rs
@@ -381,6 +381,22 @@ impl Engine for EngineImpl {
     }
 }
 
+impl EngineImpl {
+    /// Inject a test slot handle without starting the audio session.
+    #[cfg(test)]
+    pub(crate) fn inject_test_slot(&self, slot_id: SlotId, shared_state: Arc<SharedPlayerState>) {
+        use ringbuf::{HeapRb, traits::Split};
+
+        let (cmd_tx, _cmd_rx) = HeapRb::<PlayerCmd>::new(32).split();
+        self.slot_handles.lock_sync().push(SlotHandle {
+            slot_id,
+            cmd_tx,
+            eq: SharedEq::new(0),
+            shared_state,
+        });
+    }
+}
+
 #[cfg(test)]
 pub(crate) fn ducking_test_lock() -> &'static Mutex<()> {
     use std::sync::OnceLock;

--- a/crates/kithara-play/src/impls/player.rs
+++ b/crates/kithara-play/src/impls/player.rs
@@ -15,10 +15,11 @@ use kithara_bufpool::{PcmPool, pcm_pool};
 use kithara_platform::{Mutex, tokio::sync::broadcast};
 use portable_atomic::AtomicF32;
 use ringbuf::traits::Consumer;
-use tracing::{debug, warn};
+use tracing::{debug, trace, warn};
 
 use super::{
     engine::{EngineConfig, EngineImpl},
+    player_notification::{PlayerNotification, TrackStopReason},
     player_processor::PlayerCmd,
     player_resource::PlayerResource,
     player_track::TrackTransition,
@@ -408,20 +409,29 @@ impl PlayerImpl {
         self.engine.tick()
     }
 
-    /// Drain audio-thread notifications for the active slot.
-    pub fn drain_notifications(&self) -> Vec<String> {
+    /// Drain audio-thread notifications for the active slot and broadcast
+    /// corresponding [`PlayerEvent`]s.
+    pub fn process_notifications(&self) {
         let Some(slot_id) = *self.current_slot.lock_sync() else {
-            return Vec::new();
+            return;
         };
         let Some(state) = self.engine.slot_shared_state(slot_id) else {
-            return Vec::new();
+            return;
         };
 
-        let mut out = Vec::new();
         while let Some(notification) = state.notification_rx.lock_sync().try_pop() {
-            out.push(format!("{notification:?}"));
+            match notification {
+                PlayerNotification::TrackPlaybackStopped {
+                    reason: TrackStopReason::Eof,
+                    ..
+                } => {
+                    let _ = self.events_tx.send(PlayerEvent::ItemDidPlayToEnd);
+                }
+                other => {
+                    trace!(?other, "unhandled player notification");
+                }
+            }
         }
-        out
     }
 
     /// Number of EQ bands available for this player.
@@ -923,5 +933,83 @@ mod tests {
 
         player.set_rate(-1.0);
         assert!(player.rate() >= 0.01);
+    }
+
+    #[kithara::test]
+    fn process_notifications_empty_player_no_panic() {
+        let player = PlayerImpl::new(PlayerConfig::default());
+        // No slot allocated → should be a no-op.
+        player.process_notifications();
+    }
+
+    #[kithara::test]
+    fn process_notifications_emits_did_play_to_end() {
+        use ringbuf::traits::Producer;
+
+        use crate::impls::{
+            player_notification::{PlayerNotification, TrackStopReason},
+            shared_player_state::SharedPlayerState,
+        };
+
+        let player = PlayerImpl::new(PlayerConfig::default());
+        let shared = Arc::new(SharedPlayerState::new());
+        let slot_id = SlotId(0);
+
+        player
+            .engine()
+            .inject_test_slot(slot_id, Arc::clone(&shared));
+        *player.current_slot.lock_sync() = Some(slot_id);
+
+        shared
+            .notification_tx
+            .lock_sync()
+            .try_push(PlayerNotification::TrackPlaybackStopped {
+                src: Arc::from("test.mp3"),
+                reason: TrackStopReason::Eof,
+            })
+            .unwrap();
+
+        let mut rx = player.subscribe();
+        player.process_notifications();
+
+        let event = rx.try_recv().unwrap();
+        assert!(matches!(event, PlayerEvent::ItemDidPlayToEnd));
+    }
+
+    #[kithara::test]
+    #[case(TrackStopReason::FadeOut)]
+    #[case(TrackStopReason::Stop)]
+    fn process_notifications_ignores_non_eof_stop_reasons(#[case] reason: TrackStopReason) {
+        use ringbuf::traits::Producer;
+
+        use crate::impls::{
+            player_notification::PlayerNotification, shared_player_state::SharedPlayerState,
+        };
+
+        let player = PlayerImpl::new(PlayerConfig::default());
+        let shared = Arc::new(SharedPlayerState::new());
+        let slot_id = SlotId(0);
+
+        player
+            .engine()
+            .inject_test_slot(slot_id, Arc::clone(&shared));
+        *player.current_slot.lock_sync() = Some(slot_id);
+
+        shared
+            .notification_tx
+            .lock_sync()
+            .try_push(PlayerNotification::TrackPlaybackStopped {
+                src: Arc::from("test.mp3"),
+                reason,
+            })
+            .unwrap();
+
+        let mut rx = player.subscribe();
+        player.process_notifications();
+
+        assert!(matches!(
+            rx.try_recv(),
+            Err(broadcast::error::TryRecvError::Empty)
+        ));
     }
 }

--- a/crates/kithara-play/src/impls/player_notification.rs
+++ b/crates/kithara-play/src/impls/player_notification.rs
@@ -7,6 +7,17 @@ use std::sync::Arc;
 
 use crate::error::PlayError;
 
+/// Reason why a track transitioned into a stopped state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TrackStopReason {
+    /// The track naturally reached end-of-file.
+    Eof,
+    /// The track finished a fade-out transition.
+    FadeOut,
+    /// The track was explicitly stopped.
+    Stop,
+}
+
 /// Notifications emitted by the player processor on the audio thread.
 ///
 /// All variants carry an `Arc<str>` identifier for the track they refer to.
@@ -27,8 +38,11 @@ pub(crate) enum PlayerNotification {
     TrackAboutToEnd(Arc<str>),
     /// A track started audible playback (fade-in completed or `play()`).
     TrackPlaybackStarted(Arc<str>),
-    /// A track stopped playback (EOF or `stop()`).
-    TrackPlaybackStopped(Arc<str>),
+    /// A track stopped playback for the given reason.
+    TrackPlaybackStopped {
+        src: Arc<str>,
+        reason: TrackStopReason,
+    },
     /// A track was paused (fade-out completed).
     TrackPlaybackPaused(Arc<str>),
     /// The next track should be queued (position reached fade duration before end).
@@ -59,6 +73,14 @@ mod tests {
         PlayerNotification::TrackRequested(Arc::from("queued.mp3")),
         "TrackRequested",
         "queued.mp3"
+    )]
+    #[case(
+        PlayerNotification::TrackPlaybackStopped {
+            src: Arc::from("ended.mp3"),
+            reason: TrackStopReason::Eof,
+        },
+        "TrackPlaybackStopped",
+        "ended.mp3"
     )]
     fn notification_debug_format(
         #[case] n: PlayerNotification,

--- a/crates/kithara-play/src/impls/player_track.rs
+++ b/crates/kithara-play/src/impls/player_track.rs
@@ -16,7 +16,10 @@ use firewheel::{
 use kithara_platform::Mutex;
 use ringbuf::{HeapProd, traits::Producer};
 
-use super::{player_notification::PlayerNotification, player_resource::PlayerResource};
+use super::{
+    player_notification::{PlayerNotification, TrackStopReason},
+    player_resource::PlayerResource,
+};
 
 /// Default fade duration in seconds.
 pub(crate) const DEFAULT_FADE_DURATION: f32 = 1.0;
@@ -31,7 +34,10 @@ pub(crate) enum TrackState {
     #[default]
     Preloading,
     /// Track is paused (explicit pause by user).
-    #[expect(dead_code, reason = "retained for future explicit-pause support")]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "retained for future explicit-pause support")
+    )]
     Paused,
     /// Track is actively playing at full volume.
     Playing,
@@ -84,6 +90,7 @@ pub(crate) struct PlayerTrack {
     ///
     /// This is a fallback value only. Source of truth is `PlayerResource`.
     observed_duration: f64,
+    stop_reason: Option<TrackStopReason>,
     src: Arc<str>,
 }
 
@@ -113,6 +120,7 @@ impl PlayerTrack {
             fade_curve,
             observed_position: 0.0,
             observed_duration: 0.0,
+            stop_reason: None,
             src,
         }
     }
@@ -168,6 +176,9 @@ impl PlayerTrack {
             self.check_notifications(notification_tx);
         } else {
             self.handle_eof(notification_tx);
+            if self.state_dirty {
+                self.notify_state_change(notification_tx);
+            }
             return;
         }
 
@@ -182,17 +193,11 @@ impl PlayerTrack {
     }
 
     /// Handle EOF or read error.
-    fn handle_eof(&mut self, notification_tx: &Mutex<HeapProd<PlayerNotification>>) {
+    fn handle_eof(&mut self, _notification_tx: &Mutex<HeapProd<PlayerNotification>>) {
         if self.state == TrackState::Finished {
             return;
         }
-        self.set_state(TrackState::Finished);
-        notification_tx
-            .lock_sync()
-            .try_push(PlayerNotification::TrackPlaybackStopped(Arc::clone(
-                &self.src,
-            )))
-            .ok();
+        self.finish(TrackStopReason::Eof);
     }
 
     /// Check position-based notifications.
@@ -251,12 +256,11 @@ impl PlayerTrack {
     /// removes the track from the arena. Previously `Paused` left the track
     /// in the arena indefinitely, leaking resources on every crossfade.
     fn update_state_after_fade(&mut self) {
-        let new_state = match self.state {
-            TrackState::FadingIn => TrackState::Playing,
-            TrackState::FadingOut => TrackState::Finished,
-            current => current,
-        };
-        self.set_state(new_state);
+        match self.state {
+            TrackState::FadingIn => self.set_state(TrackState::Playing),
+            TrackState::FadingOut => self.finish(TrackStopReason::FadeOut),
+            current => self.set_state(current),
+        }
     }
 
     /// Emit notification when state changes.
@@ -270,7 +274,10 @@ impl PlayerTrack {
             TrackState::FadingOut => PlayerNotification::TrackFadingOut(Arc::clone(&self.src)),
             TrackState::Playing => PlayerNotification::TrackPlaybackStarted(Arc::clone(&self.src)),
             TrackState::Paused => PlayerNotification::TrackPlaybackPaused(Arc::clone(&self.src)),
-            TrackState::Finished => PlayerNotification::TrackPlaybackStopped(Arc::clone(&self.src)),
+            TrackState::Finished => PlayerNotification::TrackPlaybackStopped {
+                src: Arc::clone(&self.src),
+                reason: self.stop_reason.unwrap_or(TrackStopReason::Stop),
+            },
         };
 
         if notification_tx.lock_sync().try_push(notification).is_ok() {
@@ -286,8 +293,14 @@ impl PlayerTrack {
         }
     }
 
+    fn finish(&mut self, reason: TrackStopReason) {
+        self.stop_reason = Some(reason);
+        self.set_state(TrackState::Finished);
+    }
+
     /// Start a fade-in: transitions to `FadingIn`, targets `FULLY_DRY` (audible).
     pub(crate) fn fade_in(&mut self) {
+        self.stop_reason = None;
         self.set_state(TrackState::FadingIn);
         self.mix.set_mix(Mix::FULLY_DRY, self.fade_curve);
         self.notified_about_to_end = false;
@@ -302,6 +315,7 @@ impl PlayerTrack {
 
     /// Instantly start playing at full volume.
     pub(crate) fn play(&mut self) {
+        self.stop_reason = None;
         self.set_state(TrackState::Playing);
         self.mix.set_mix(Mix::FULLY_DRY, self.fade_curve);
         self.mix.reset_to_target();
@@ -311,7 +325,7 @@ impl PlayerTrack {
 
     /// Instantly stop (silent, finished state).
     pub(crate) fn stop(&mut self) {
-        self.set_state(TrackState::Finished);
+        self.finish(TrackStopReason::Stop);
         self.mix.set_mix(Mix::FULLY_WET, self.fade_curve);
         self.mix.reset_to_target();
     }
@@ -386,6 +400,10 @@ mod tests {
     use kithara_audio::mock::TestPcmReader;
     use kithara_decode::PcmSpec;
     use kithara_test_utils::kithara;
+    use ringbuf::{
+        HeapProd, HeapRb,
+        traits::{Consumer, Split},
+    };
 
     use super::*;
     use crate::impls::resource::Resource;
@@ -417,6 +435,14 @@ mod tests {
         let arc_resource = Arc::new(Mutex::new(player_resource));
         let sample_rate = NonZeroU32::new(44100).expect("non-zero sample rate");
         PlayerTrack::new(arc_resource, src, 1.0, sample_rate, FadeCurve::SquareRoot)
+    }
+
+    fn make_notification_pair() -> (
+        Mutex<HeapProd<PlayerNotification>>,
+        ringbuf::HeapCons<PlayerNotification>,
+    ) {
+        let (tx, rx) = HeapRb::<PlayerNotification>::new(8).split();
+        (Mutex::new(tx), rx)
     }
 
     #[kithara::test(tokio)]
@@ -477,5 +503,45 @@ mod tests {
         let track = make_track();
         assert_eq!(track.position(), 0.0);
         assert!((track.duration() - 60.0).abs() < f64::EPSILON);
+    }
+
+    #[kithara::test(tokio)]
+    async fn track_handle_eof_emits_eof_stop_reason() {
+        let mut track = make_track();
+        let (tx, mut rx) = make_notification_pair();
+
+        track.handle_eof(&tx);
+        track.notify_state_change(&tx);
+
+        let notification = rx.try_pop().unwrap();
+        assert!(matches!(
+            notification,
+            PlayerNotification::TrackPlaybackStopped {
+                src,
+                reason: TrackStopReason::Eof,
+            } if &*src == "test.mp3"
+        ));
+    }
+
+    #[kithara::test(tokio)]
+    async fn track_stop_emits_stop_reason() {
+        let mut track = make_track();
+        let (tx, mut rx) = make_notification_pair();
+
+        track.play();
+        track.notify_state_change(&tx);
+        let _ = rx.try_pop();
+
+        track.stop();
+        track.notify_state_change(&tx);
+
+        let notification = rx.try_pop().unwrap();
+        assert!(matches!(
+            notification,
+            PlayerNotification::TrackPlaybackStopped {
+                src,
+                reason: TrackStopReason::Stop,
+            } if &*src == "test.mp3"
+        ));
     }
 }


### PR DESCRIPTION
## Description

- добавлен playlist-driven сценарий воспроизведения в Android- и Apple-демо
- в `kithara-play` добавлено событие `ItemDidPlayToEnd`, которое теперь прокидывается через FFI-биндинги
- в Android-инициализацию добавлен вывод Rust-логов в logcat с настраиваемым `LogLevel`
- удалено неиспользуемое событие `FailedToPlayToEnd`, после чего биндинги были перегенерированы

## Зачем

Мобильные демо были завязаны на сценарий с одним треком, из-за чего было неудобно проверять реальное поведение очереди и переходы после окончания воспроизведения. 

На стороне движка `TrackPlaybackStopped` теперь различает причины остановки. Благодаря этому наружу как `ItemDidPlayToEnd` уходит только реальное завершение трека, а не stop или fade-out.

Обновление Android-инициализации добавляет вывод Rust-side `tracing` в android logcat.

Отдельно удалён `FailedToPlayToEnd`, потому что production-код его не эмитил. 


## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Other (describe):

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] Tests added/updated
- [x] No `unwrap()`/`expect()` in production code
- [x] Documentation updated (if applicable)
