### PR TITLE
docs: add PR description skill and summary rules

### DIFF
--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: pr
+description: Draft project-aligned PR descriptions from the current branch. Use when the user asks to prepare a PR description, PR notes, a branch summary for review, or to fill the repository pull request template. Follow `.docs/workflow/pr-description.md` for the output shape and expectations.
+---
+
+# PR Description
+
+## When to use
+
+- Use this skill for requests such as "prepare a PR description", "write PR notes", "summarize this branch for review", or "fill the PR template".
+
+## Workflow
+
+1. Determine the base branch for the current branch comparison.
+2. Review the branch history from the merge-base to `HEAD`.
+3. Review the current diff for the same range.
+4. If there are no committed changes in that range, inspect the current staged and unstaged changes instead and draft the PR from that evidence.
+5. Otherwise, include staged and unstaged changes only when the user explicitly asks for them or clearly wants them included in the draft.
+6. If you see staged or unstaged changes while preparing the draft, explicitly offer the user to commit them before finalizing the PR description.
+7. Derive every statement from actual commits, diffs, and validation evidence.
+
+## Output rules
+
+- Keep the description concise and reviewer-oriented.
+- Use the repository source structure and section names.
+- In `Summary`, explain the motivation and meaning of the change in plain reviewer-friendly language as prose, not as a checklist of bullets.
+- Do not invent motivation, risks, validation steps, or follow-ups; derive them from commits, diffs, and validation evidence.
+- If a required impact field has no evidence, write `none`.
+- If validation was not run, say so explicitly.
+
+## Repo note
+
+- In this repository, use `.docs/workflow/pr-description.md` as the source of truth for the PR description shape.
+- Do not invent a parallel template when the workflow document already defines the structure.

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.docs/workflow/pr-description.md
+++ b/.docs/workflow/pr-description.md
@@ -7,7 +7,7 @@ reopening the issue, agent handoff, or chat history.
 
 Include:
 
-- `Summary`: what changed and why;
+- `Summary`: a prose summary in plain language that explains what changed, why it changed, and what it means for the reviewer;
 - `Behavior / scope`: the main contract change and affected area;
 - `Validation`: exact commands run locally, or an explicit note that validation was not run;
 - `Surface impact`: whether public API, platform/runtime surfaces, or perf-sensitive paths changed;
@@ -19,8 +19,7 @@ Use this shape:
 
 ```md
 ## Summary
-- what changed
-- why it changed
+Plain-language prose covering what changed, why it changed, and what it means.
 
 ## Behavior / scope
 - contract or behavior: ...

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ Use `.docs/workflow/rust-ai.md` for the recommended execution flow.
 - If a new dependency is unavoidable, justify it in the task, plan, or PR description and add it to `[workspace.dependencies]` first.
 
 ## Code Style
+- Prefer clean, maintainable code over clever shortcuts or speculative abstractions.
 
 ### Imports and qualified paths
 


### PR DESCRIPTION
## Summary
This change adds a dedicated skill for drafting PR descriptions and updates the repository PR-description contract to require a readable prose summary instead of fragmented bullets. The workflow is now more practical because it can draft from uncommitted changes when a branch has no committed diff yet, and it also tells the user to commit visible working tree changes before finalizing the PR text.

## Behavior / scope
- contract or behavior: PR drafting now falls back to staged and unstaged changes when the merge-base to `HEAD` range is empty, prompts the user to commit visible working tree changes, and requires `Summary` to be written as plain-language prose that explains the change, its motivation, and its meaning
- affected area: agent workflow and PR description contract under `.agents/skills/` and `.docs/workflow/`

## Validation
- not run: no code validation commands were executed

## Surface impact
- Public API: none
- Platform/runtime: changed: tooling surface
- Perf-sensitive paths: none

## Risks / follow-ups
- none