### PR TITLE
fix(kithara-app): desktop deps for non-wasm, not macOS-only

### DIFF
--- a/crates/kithara-app/Cargo.toml
+++ b/crates/kithara-app/Cargo.toml
@@ -18,27 +18,23 @@ kithara = { workspace = true, features = ["file", "hls"] }
 kithara-drm = { workspace = true }
 thunderdome = { workspace = true }
 
-[target.'cfg(target_os = "macos")'.dependencies]
-kithara = { workspace = true, features = ["apple"] }
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 bytes = { workspace = true }
 clap = { workspace = true }
 crabtime = { workspace = true }
+crossterm = { workspace = true, optional = true }
+iced = { workspace = true, optional = true }
+kithara-workspace-hack = { version = "0.1", path = "../kithara-workspace-hack" }
 obfstr = { workspace = true }
 rand = { workspace = true }
+ratatui = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }
 
-# TUI-only
-ratatui = { workspace = true, optional = true }
-crossterm = { workspace = true, optional = true }
-
-# GUI-only
-iced = { workspace = true, optional = true }
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-kithara-workspace-hack = { version = "0.1", path = "../kithara-workspace-hack" }
+[target.'cfg(target_os = "macos")'.dependencies]
+kithara = { workspace = true, features = ["apple"] }
 
 [[bin]]
 name = "kithara"


### PR DESCRIPTION
# Summary
kithara-app had most desktop deps under cfg(target_os = "macos"), so Linux builds did not pull them in. Those deps are now gated by cfg(not(target_arch = "wasm32")) for all native desktops; kithara with the apple feature stays macOS-only.

# Behavior / scope
contract or behavior: Dependency resolution only: shared desktop deps for non-wasm; apple on macOS.
affected area: crates/kithara-app/Cargo.toml, native Linux/desktop builds.

# Validation
cargo check -p kithara-app (pass; unrelated warnings in kithara-decode).

# Surface impact

# Public API: none

# Platform/runtime: changed: native app (non-wasm desktops; wasm unchanged)

# Perf-sensitive paths: none

# Risks / follow-ups
none