### PR TITLE
feat(waveform): waveform view zoom/pan controls; beat grid visualization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -347,11 +347,18 @@ opt-level = 2
 # Time-stretch DSP (FFT/phase-vocoder + C++) is ~10× slower in debug.
 [profile.dev.package.signalsmith-stretch]
 opt-level = 3
-# rten float inference is orders of magnitude slower unoptimised; parity
-# tests run whole-track NN inference.
+# rten float inference is orders of magnitude slower unoptimised.
 [profile.dev.package.rten]
 opt-level = 3
 [profile.dev.package.rten-tensor]
+opt-level = 3
+[profile.dev.package.rten-gemm]
+opt-level = 3
+[profile.dev.package.rten-simd]
+opt-level = 3
+[profile.dev.package.rten-vecmath]
+opt-level = 3
+[profile.dev.package.rten-base]
 opt-level = 3
 [profile.dev.package.bungee-sys]
 opt-level = 3

--- a/crates/kithara-app/Cargo.toml
+++ b/crates/kithara-app/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 workspace = true
 
 [features]
-default = ["tui", "gui"]
+default = ["tui", "gui", "beat-nn"]
 tui = ["dep:ratatui", "dep:crossterm"]
 gui = ["dep:iced"]
 # NN beat/downbeat detection.

--- a/crates/kithara-app/README.md
+++ b/crates/kithara-app/README.md
@@ -78,7 +78,7 @@ non-exhaustive seam) is in-memory-only by capability, not a fallback.
 
 Invalidation is by `ANALYSIS_BYTES_VERSION` (kithara-app): bump it whenever
 the blob encoding, BPM analysis parameters, waveform encoding, or
-`WAVEFORM_BUCKETS` change. The
+`WAVEFORM_MAX_BUCKETS` change. The
 filename is a sha256 of the key — a `std` hasher is not stable across toolchain
 versions and would orphan every blob. Because the key is the source location
 and not the bytes, a file overwritten in place keeps its key until the version

--- a/crates/kithara-app/src/analysis.rs
+++ b/crates/kithara-app/src/analysis.rs
@@ -18,9 +18,9 @@ use crate::{
     waveform::{TrackAnalysis, TrackAnalysisRunner},
 };
 
-/// Analysis resolution for the colored waveform. Changing it invalidates
-/// cached track-analysis blobs.
-const WAVEFORM_BUCKETS: usize = 1500;
+/// Upper bound on waveform buckets (native = one per FFT window); only caps very
+/// long tracks to bound the cached blob.
+const WAVEFORM_MAX_BUCKETS: usize = 96_000;
 
 /// Analysis-aware state listener: mirrors queue events into [`UiState`] and
 /// drives the background [`AnalysisController`]. Starts analysing the already
@@ -41,9 +41,7 @@ pub(crate) async fn listen(
         tokio::select! {
             biased;
             () = cancel.cancelled() => break,
-            () = driver.wait_result() => {
-                driver.on_result(&queue, &state, &config);
-            }
+            () = driver.drive(&queue, &state, &config) => {}
             event = rx.recv() => match event {
                 Ok(event) => {
                     let track_changed =
@@ -87,13 +85,20 @@ struct Run {
     rx: watch::Receiver<Option<TrackAnalysis>>,
 }
 
+/// A run that closed with a usable analysis result.
+struct CompletedRun {
+    track_id: TrackId,
+    key: Option<AnalysisKey>,
+    analysis: TrackAnalysis,
+}
+
 impl AnalysisController {
     /// `cancel` must be a child of the app master so analysis stops on app
     /// shutdown; `store` is the shared file store whose per-track asset
     /// scopes hold the durable analysis blobs.
     pub(crate) fn new(cancel: &CancellationToken, store: Option<Arc<AssetStore>>) -> Self {
         Self {
-            runner: TrackAnalysisRunner::new(cancel, WAVEFORM_BUCKETS),
+            runner: TrackAnalysisRunner::new(cancel, WAVEFORM_MAX_BUCKETS),
             cache: TrackAnalysisCache::new(store, analysis_fingerprint()),
             current: None,
             displayed: None,
@@ -101,28 +106,25 @@ impl AnalysisController {
         }
     }
 
-    /// Await the in-flight run's result, or pend forever when no run is
-    /// active so the caller's `select!` branch stays inert.
-    pub(crate) async fn wait_result(&mut self) {
-        match &mut self.current {
-            Some(run) => {
-                // `changed` errs when the sender dropped without a result
-                // (failed/cancelled run); `on_result` then just clears it.
-                let _ = run.rx.changed().await;
-            }
-            None => std::future::pending::<()>().await,
-        }
-    }
-
-    /// Commit the finished (or failed) run, then start the next pending one.
-    pub(crate) fn on_result(
+    /// Await the run's next event and handle it: publish the staged
+    /// intermediate, or commit and pump on close. Parks when no run is active.
+    pub(crate) async fn drive(
         &mut self,
         queue: &Arc<Queue>,
         state: &Mutex<UiState>,
         config: &AppConfig,
     ) {
-        self.commit(state);
-        self.pump(queue, state, config);
+        let closed = match &mut self.current {
+            Some(run) => run.rx.changed().await.is_err(),
+            None => std::future::pending::<bool>().await,
+        };
+
+        if closed {
+            self.commit(state);
+            self.pump(queue, state, config);
+        } else {
+            self.publish_intermediate(state);
+        }
     }
 
     /// The current track changed: put it at the front of the queue and
@@ -195,7 +197,7 @@ impl AnalysisController {
                 Plan::Skip => {}
                 Plan::Serve(analysis) => {
                     if is_current {
-                        state.lock_sync().analysis = Some(analysis);
+                        state.lock_sync().set_analysis(Some(analysis));
                         self.displayed = key;
                     }
                 }
@@ -211,7 +213,7 @@ impl AnalysisController {
                     };
 
                     if is_current {
-                        state.lock_sync().analysis = None;
+                        state.lock_sync().set_analysis(None);
                         self.displayed = None;
                     }
 
@@ -223,11 +225,10 @@ impl AnalysisController {
         }
     }
 
-    /// Commit a finished analysis: cache it under its content key (valid for
-    /// that content regardless of the current track), then publish it if its
-    /// track is still current. Clears the run either way.
-    fn commit(&mut self, state: &Mutex<UiState>) {
-        let Some(run) = self.current.take() else {
+    /// Publish the first part emit to the UI (no caching) when its
+    /// track is still current; the beat overlay arrives on the closing commit.
+    fn publish_intermediate(&self, state: &Mutex<UiState>) {
+        let Some(run) = &self.current else {
             return;
         };
 
@@ -235,22 +236,37 @@ impl AnalysisController {
             return;
         };
 
-        if let Some(key) = run.key.clone() {
-            self.cache.put(key, analysis.clone());
-        }
+        publish_if_current(state, run.track_id, analysis);
+    }
 
-        let mut st = state.lock_sync();
-        let still_current = st
-            .current_track_index
-            .and_then(|i| st.tracks.get(i))
-            .map(|entry| entry.id);
-        let is_current = still_current == Some(run.track_id);
-        if is_current {
-            st.analysis = Some(analysis);
+    /// Cache the finished analysis under its content key, publish it if its
+    /// track is still current, and clear the run.
+    fn commit(&mut self, state: &Mutex<UiState>) {
+        let Some(completed) = self.take_completed_run() else {
+            return;
+        };
+
+        self.cache_completed(&completed);
+
+        if publish_if_current(state, completed.track_id, completed.analysis) {
+            self.displayed = completed.key;
         }
-        drop(st);
-        if is_current {
-            self.displayed = run.key;
+    }
+
+    fn take_completed_run(&mut self) -> Option<CompletedRun> {
+        let run = self.current.take()?;
+        let analysis = run.rx.borrow().clone()?;
+
+        Some(CompletedRun {
+            track_id: run.track_id,
+            key: run.key,
+            analysis,
+        })
+    }
+
+    fn cache_completed(&mut self, completed: &CompletedRun) {
+        if let Some(key) = &completed.key {
+            self.cache.put(key.clone(), completed.analysis.clone());
         }
     }
 }
@@ -259,7 +275,7 @@ impl AnalysisController {
 /// A mismatch is a cache miss, so config changes re-analyse.
 fn analysis_fingerprint() -> String {
     let beat = beat_cache_tag().unwrap_or_else(|| "off".to_string());
-    format!("buckets={WAVEFORM_BUCKETS};beat={beat}")
+    format!("wave=native:max{WAVEFORM_MAX_BUCKETS};beat={beat}")
 }
 
 /// What [`AnalysisController::pump`] should do for a track.
@@ -310,9 +326,22 @@ fn pending_order(ids: &[TrackId], current: Option<usize>) -> VecDeque<TrackId> {
 
 fn current_track_id(state: &Mutex<UiState>) -> Option<TrackId> {
     let st = state.lock_sync();
+    current_track_id_in(&st)
+}
+
+fn current_track_id_in(st: &UiState) -> Option<TrackId> {
     st.current_track_index
         .and_then(|i| st.tracks.get(i))
         .map(|entry| entry.id)
+}
+
+fn publish_if_current(state: &Mutex<UiState>, track_id: TrackId, analysis: TrackAnalysis) -> bool {
+    let mut st = state.lock_sync();
+    if current_track_id_in(&st) != Some(track_id) {
+        return false;
+    }
+    st.set_analysis(Some(analysis));
+    true
 }
 
 /// Build an analysis resource from a track's source, reusing the shared
@@ -327,10 +356,14 @@ fn resource_config_from_source(source: TrackSource, config: &AppConfig) -> Optio
 
 #[cfg(test)]
 mod tests {
-    use kithara::audio::Waveform;
+    use kithara::{audio::Waveform, events::TrackId};
+    use kithara_platform::{CancellationToken, sync::Mutex};
+    use kithara_queue::{Queue, QueueConfig};
+    use tokio::sync::watch;
 
-    use super::{Plan, pending_order, plan_analysis};
+    use super::{AnalysisController, Plan, Run, pending_order, plan_analysis};
     use crate::{
+        state::UiState,
         wave_cache::{AnalysisKey, TrackAnalysisCache},
         waveform::TrackAnalysis,
     };
@@ -349,6 +382,33 @@ mod tests {
 
     fn cache() -> TrackAnalysisCache {
         TrackAnalysisCache::new(None, "test".to_string())
+    }
+
+    fn state_with_current(ids: &[TrackId], current: usize) -> Mutex<UiState> {
+        let queue = Queue::new(QueueConfig::new());
+        for id in ids {
+            queue.append_with_id(*id, format!("file:///tmp/track-{id}.mp3"));
+        }
+        let mut state = UiState::empty();
+        state.tracks = queue.tracks();
+        state.current_track_index = Some(current);
+        Mutex::new(state)
+    }
+
+    fn controller_with_run(
+        track_id: TrackId,
+        key: AnalysisKey,
+        value: Option<TrackAnalysis>,
+    ) -> (AnalysisController, watch::Sender<Option<TrackAnalysis>>) {
+        let cancel = CancellationToken::default();
+        let mut controller = AnalysisController::new(&cancel, None);
+        let (tx, rx) = watch::channel(value);
+        controller.current = Some(Run {
+            track_id,
+            key: Some(key),
+            rx,
+        });
+        (controller, tx)
     }
 
     #[test]
@@ -391,8 +451,6 @@ mod tests {
 
     #[test]
     fn pending_puts_current_track_first_then_list_order() {
-        use kithara::events::TrackId;
-
         let ids: Vec<TrackId> = [10u64, 11, 12].into_iter().map(TrackId::from).collect();
 
         let order: Vec<u64> = pending_order(&ids, Some(1))
@@ -406,5 +464,86 @@ mod tests {
             .map(u64::from)
             .collect();
         assert_eq!(order, vec![10, 11, 12], "no current: plain list order");
+    }
+
+    /// Drive `commit` with a run whose result channel already holds `value`,
+    /// returning whether the run's key landed in the cache.
+    fn commit_caches(value: Option<TrackAnalysis>) -> bool {
+        let key = AnalysisKey::new("root");
+        let (mut controller, tx) = controller_with_run(TrackId::allocate(), key.clone(), value);
+        let state = Mutex::new(UiState::empty());
+        controller.commit(&state);
+        drop(tx);
+        controller.cache.get(&key).is_some()
+    }
+
+    #[test]
+    fn commit_caches_the_complete_result() {
+        assert!(
+            commit_caches(Some(analysis())),
+            "a close carrying a value caches the complete analysis"
+        );
+    }
+
+    #[test]
+    fn commit_caches_nothing_when_the_run_failed() {
+        assert!(
+            !commit_caches(None),
+            "a run that closes with no value (failure/cancel) caches nothing"
+        );
+    }
+
+    #[tokio::test]
+    async fn commit_publishes_current_track_and_marks_displayed() {
+        let key = AnalysisKey::new("root_current");
+        let analysis = analysis();
+        let ids = [
+            TrackId::allocate(),
+            TrackId::allocate(),
+            TrackId::allocate(),
+        ];
+        let (mut controller, tx) = controller_with_run(ids[1], key.clone(), Some(analysis));
+        let state = state_with_current(&ids, 1);
+
+        controller.commit(&state);
+
+        let state = state.lock_sync();
+        assert!(state.analysis.is_some(), "current run publishes to the UI");
+        assert_eq!(
+            controller.displayed.as_ref(),
+            Some(&key),
+            "displayed tracks the content key currently shown in the UI"
+        );
+        drop(tx);
+    }
+
+    #[tokio::test]
+    async fn commit_caches_stale_track_without_publishing_or_marking_displayed() {
+        let key = AnalysisKey::new("root_stale");
+        let analysis = analysis();
+        let ids = [
+            TrackId::allocate(),
+            TrackId::allocate(),
+            TrackId::allocate(),
+        ];
+        let (mut controller, tx) = controller_with_run(ids[0], key.clone(), Some(analysis));
+        let state = state_with_current(&ids, 1);
+
+        controller.commit(&state);
+
+        let state = state.lock_sync();
+        assert!(
+            state.analysis.is_none(),
+            "stale run must not replace the current track's analysis"
+        );
+        assert!(
+            controller.cache.get(&key).is_some(),
+            "stale run is still reusable by content key"
+        );
+        assert!(
+            controller.displayed.is_none(),
+            "stale cached analysis is not the analysis displayed by the UI"
+        );
+        drop(tx);
     }
 }

--- a/crates/kithara-app/src/gui/dj.rs
+++ b/crates/kithara-app/src/gui/dj.rs
@@ -2,13 +2,15 @@ use iced::{Task, window};
 #[cfg(any(feature = "stretch-signalsmith", feature = "stretch-bungee"))]
 use kithara::prelude::StretchBackendKind;
 
-use super::{app::Kithara, frontend::window_settings, message::Message};
+use super::{app::Kithara, frontend::window_settings, message::Message, widgets::Viewport};
+use crate::gui::widgets::WaveMsg;
 
 /// View-local DJ Studio state.
 #[derive(Debug, Default, Clone, Copy)]
 pub(crate) struct DjView {
     pub(crate) open: bool,
     pub(crate) timestretch: TimestretchState,
+    pub(crate) wave: Viewport,
 }
 
 /// View-local timestretch deck state.
@@ -61,6 +63,8 @@ impl TimestretchState {
 pub(crate) enum DjMsg {
     /// Toggle between the compact player and the DJ Studio shell.
     Toggle,
+    /// Deck waveform zoom/pan request (wheel, drag, or the `−`/`+` control).
+    Wave(WaveMsg),
     /// Set the tempo offset (± percent) from the slider.
     SetTempo(f32),
     /// Select a tempo range bound (± percent).
@@ -80,6 +84,10 @@ pub(crate) enum DjMsg {
 pub(crate) fn handle(state: &mut Kithara, msg: &DjMsg) -> Task<Message> {
     match msg {
         DjMsg::Toggle => return handle_toggle(state),
+        DjMsg::Wave(m) => {
+            state.dj.wave = state.dj.wave.apply(*m);
+            return Task::none();
+        }
         DjMsg::SetTempo(t) => state.dj.timestretch.set_tempo(*t),
         DjMsg::SetRange(r) => state.dj.timestretch.set_range(*r),
         DjMsg::Nudge(d) => state.dj.timestretch.nudge(*d),

--- a/crates/kithara-app/src/gui/message.rs
+++ b/crates/kithara-app/src/gui/message.rs
@@ -11,6 +11,8 @@ pub(crate) enum Message {
     SeekChanged(f64),
     /// Seek slider released — commit the seek.
     SeekReleased,
+    /// One-shot seek to an absolute position (seconds) — a waveform click.
+    SeekTo(f64),
     /// Volume slider changed (0.0 – 1.0).
     VolumeChanged(f32),
     /// EQ band gain changed (band index, dB value).

--- a/crates/kithara-app/src/gui/studio/deck.rs
+++ b/crates/kithara-app/src/gui/studio/deck.rs
@@ -1,12 +1,13 @@
 use iced::{
-    Alignment, Background, Border, Element, Length, Theme,
+    Alignment, Background, Border, Element, Length, Padding, Theme,
+    alignment::{Horizontal, Vertical},
     font::Weight,
     widget::{
         Row, Space, button,
         button::{Status as ButtonStatus, Style as ButtonStyle},
         column, container,
         container::Style as ContainerStyle,
-        row, text,
+        row, stack, text,
     },
 };
 use num_traits::cast::AsPrimitive;
@@ -18,12 +19,14 @@ use super::{
 use crate::{
     gui::{
         app::Kithara,
+        dj::DjMsg,
         fonts,
         icons::Icon,
         message::Message,
         tokens::gap,
         view::{eq_band_label, format_time, track_subtitle, with_alpha},
         widgets,
+        widgets::WaveMsg,
     },
     theme::gui::GuiPalette,
 };
@@ -157,30 +160,49 @@ fn waveform_cluster(state: &Kithara, p: GuiPalette) -> Element<'_, Message> {
     let total = format_time(duration);
     let progress = playhead_progress(head_position, duration);
 
-    let canvas: Element<'_, Message> = match state
+    let wave = state
         .ui_state
         .analysis
         .as_ref()
         .and_then(|analysis| analysis.waveform.as_ref())
-    {
-        Some(wave) if !wave.is_empty() => widgets::waveform(
-            wave.clone(),
-            progress,
-            duration,
-            studio_size::WAVEFORM_HEIGHT,
-            p,
-        ),
-        _ => Space::new()
-            .width(Length::Fill)
-            .height(Length::Fixed(studio_size::WAVEFORM_HEIGHT))
-            .into(),
+        .filter(|wave| !wave.is_empty());
+
+    let canvas: Element<'_, Message> = wave.map_or_else(
+        || {
+            Space::new()
+                .width(Length::Fill)
+                .height(Length::Fixed(studio_size::WAVEFORM_HEIGHT))
+                .into()
+        },
+        |wave| {
+            widgets::waveform(
+                wave.clone(),
+                widgets::BeatMarks {
+                    beats: state.ui_state.beat_marks.clone(),
+                    downbeats: state.ui_state.downbeat_marks.clone(),
+                },
+                progress,
+                duration,
+                state.dj.wave,
+                studio_size::WAVEFORM_HEIGHT,
+                p,
+            )
+        },
+    );
+
+    let wave_box = container(canvas)
+        .width(Length::Fill)
+        .height(Length::Fixed(studio_size::WAVEFORM_HEIGHT))
+        .style(waveform_style(p));
+    
+    let wave_layer: Element<'_, Message> = if wave.is_some() {
+        stack![wave_box, zoom_control(state.dj.wave.zoom(), p)].into()
+    } else {
+        wave_box.into()
     };
 
     column![
-        container(canvas)
-            .width(Length::Fill)
-            .height(Length::Fixed(studio_size::WAVEFORM_HEIGHT))
-            .style(waveform_style(p)),
+        wave_layer,
         row![
             text(current)
                 .size(studio_type::MONO_SM)
@@ -205,6 +227,73 @@ fn playhead_progress(position: f64, duration: f64) -> f32 {
     }
     let progress: f32 = (position / duration).clamp(0.0, 1.0).as_();
     progress
+}
+
+fn zoom_control(zoom: f32, p: GuiPalette) -> Element<'static, Message> {
+    let control = row![
+        zoom_button("\u{2212}", WaveMsg::Zoom(1.0 / widgets::ZOOM_STEP), p),
+        text(format!("{zoom:.1}\u{00d7}"))
+            .size(studio_type::MONO_SM)
+            .font(fonts::MONO)
+            .color(p.text_dim),
+        zoom_button("+", WaveMsg::Zoom(widgets::ZOOM_STEP), p),
+    ]
+    .spacing(gap::INLINE_TIGHT)
+    .align_y(Alignment::Center);
+
+    container(container(control).padding([2.0, 6.0]).style(zoom_pill_style(p)))
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .align_x(Horizontal::Right)
+        .align_y(Vertical::Top)
+        .padding(Padding::from(8.0))
+        .into()
+}
+
+fn zoom_button(label: &'static str, msg: WaveMsg, p: GuiPalette) -> Element<'static, Message> {
+    const SIZE: f32 = 20.0;
+
+    button(
+        container(text(label).size(studio_type::BODY_MD).color(p.text))
+            .center_x(Length::Fill)
+            .center_y(Length::Fill),
+    )
+    .width(Length::Fixed(SIZE))
+    .height(Length::Fixed(SIZE))
+    .padding(0)
+    .style(move |_theme: &Theme, status| zoom_button_style(p, status))
+    .on_press(Message::Dj(DjMsg::Wave(msg)))
+    .into()
+}
+
+fn zoom_pill_style(p: GuiPalette) -> impl Fn(&Theme) -> ContainerStyle {
+    move |_theme| {
+        ContainerStyle::default()
+            .background(Background::Color(with_alpha(p.bg_deep, 0.7)))
+            .border(
+                Border::default()
+                    .rounded(studio_radius::SM)
+                    .width(1.0)
+                    .color(p.line),
+            )
+    }
+}
+
+fn zoom_button_style(p: GuiPalette, status: ButtonStatus) -> ButtonStyle {
+    let background = match status {
+        ButtonStatus::Hovered => Some(Background::Color(with_alpha(p.bg_panel_2, 0.7))),
+        ButtonStatus::Pressed => Some(Background::Color(with_alpha(p.bg_panel_2, 0.5))),
+        ButtonStatus::Active | ButtonStatus::Disabled => {
+            Some(Background::Color(iced::Color::TRANSPARENT))
+        }
+    };
+
+    ButtonStyle {
+        background,
+        text_color: p.text,
+        border: Border::default().rounded(studio_radius::SM),
+        ..ButtonStyle::default()
+    }
 }
 
 /// Transport (prev / play / next) on the left, a divider, then the EQ fader

--- a/crates/kithara-app/src/gui/update.rs
+++ b/crates/kithara-app/src/gui/update.rs
@@ -38,6 +38,7 @@ fn handle_player(state: &mut Kithara, message: &Message) {
         Message::Prev => handle_prev(state),
         Message::SeekChanged(pos) => handle_seek_changed(state, pos),
         Message::SeekReleased => handle_seek_released(state),
+        Message::SeekTo(pos) => handle_seek_to(state, pos),
         Message::VolumeChanged(vol) => handle_volume_changed(state, vol),
         Message::EqBandChanged(band, db) => handle_eq_band_changed(state, band, db),
         Message::PlayRateChanged(rate) => handle_play_rate_changed(state, rate),
@@ -98,6 +99,17 @@ fn handle_seek_released(state: &Kithara) {
         st.seek_position
     });
     if let Err(e) = state.controller.queue().seek(target) {
+        error!("seek failed: {e:?}");
+    }
+}
+
+fn handle_seek_to(state: &Kithara, pos: f64) {
+    state.controller.mutate(|st| {
+        st.is_seeking = false;
+        st.seek_position = pos;
+    });
+    
+    if let Err(e) = state.controller.queue().seek(pos) {
         error!("seek failed: {e:?}");
     }
 }

--- a/crates/kithara-app/src/gui/widgets/mod.rs
+++ b/crates/kithara-app/src/gui/widgets/mod.rs
@@ -3,9 +3,11 @@ mod speed_slider;
 mod ts_slider;
 mod vfader;
 mod waveform;
+mod waveform_viewport;
 
 pub(crate) use play_button::play_button;
 pub(crate) use speed_slider::speed_slider;
 pub(crate) use ts_slider::ts_slider;
 pub(crate) use vfader::vfader;
-pub(crate) use waveform::waveform;
+pub(crate) use waveform::{BeatMarks, waveform};
+pub(crate) use waveform_viewport::{Viewport, WaveMsg, ZOOM_STEP};

--- a/crates/kithara-app/src/gui/widgets/waveform.rs
+++ b/crates/kithara-app/src/gui/widgets/waveform.rs
@@ -1,24 +1,44 @@
+use std::sync::Arc;
+
 use iced::{
     Color, Element, Event, Length, Point, Rectangle, Renderer, Size, Theme,
-    mouse::{self, Button, Cursor},
+    mouse::{self, Button, Cursor, ScrollDelta},
     widget::canvas::{self, Action, Canvas, Frame, Geometry, Path, Stroke},
 };
 use kithara::audio::Waveform;
 use num_traits::cast::AsPrimitive;
 
+use super::waveform_viewport::{Viewport, WaveMsg};
 use crate::{
-    gui::message::Message,
+    gui::{dj::DjMsg, message::Message},
     theme::gui::{GuiPalette, WAVE_HIGH, WAVE_LOW, WAVE_MID},
 };
 
-/// Deck waveform: per bucket, three concentric mirrored bars (low/mid/high band
-/// heights) painted low->mid->high so bass forms the outer hull and highs sit
-/// in the center, over a faint 1/8 column grid, a 16-tick beat grid and a
-/// playhead. Click or drag the pointer to seek when `duration` is known.
+/// Movement past this (in px) turns a press into a pan; a release within it
+/// reads as a click and seeks.
+const DRAG_THRESHOLD_PX: f32 = 3.0;
+
+/// Zoom multiplier per wheel line notch.
+const WHEEL_BASE: f32 = 1.2;
+
+/// Trackpad pixel deltas are normalized to line-equivalents.
+const WHEEL_PIXELS_PER_LINE: f32 = 50.0;
+
+/// Beat-grid overlay data for the deck waveform: positions as track fractions
+/// in `[0, 1]`, derived from the track's analysed beat grid.
+pub(crate) struct BeatMarks {
+    pub(crate) beats: Arc<[f32]>,
+    pub(crate) downbeats: Arc<[f32]>,
+}
+
+/// Deck waveform: three concentric mirrored band bars over a grid + playhead.
 struct WaveformCanvas {
     wave: Waveform,
+    beats: Arc<[f32]>,
+    downbeats: Arc<[f32]>,
     progress: f32,
     duration: f64,
+    view: Viewport,
     p: GuiPalette,
 }
 
@@ -32,79 +52,181 @@ fn dim(c: Color) -> Color {
     }
 }
 
-/// Maps an absolute cursor x to a seek target in seconds, clamped to the
-/// widget width and `[0, duration]`.
-fn seek_target(cursor_x: f32, bounds: Rectangle, duration: f64) -> f64 {
-    let frac = ((cursor_x - bounds.x) / bounds.width).clamp(0.0, 1.0);
-    f64::from(frac) * duration
+fn wheel_factor(delta: ScrollDelta) -> f32 {
+    let lines = match delta {
+        ScrollDelta::Lines { y, .. } => y,
+        ScrollDelta::Pixels { y, .. } => y / WHEEL_PIXELS_PER_LINE,
+    };
+    WHEEL_BASE.powf(lines)
 }
 
-/// Tracks an in-progress pointer drag so cursor moves between press and
-/// release keep emitting seek updates even past the widget edges.
+#[derive(Clone, Copy)]
+struct Press {
+    start_x: f32,
+    last_x: f32,
+    moved: bool,
+}
+
 #[derive(Default)]
-struct DragState {
-    dragging: bool,
+struct PointerState {
+    press: Option<Press>,
+}
+
+/// Minimum on-screen gap (px) between drawn downbeat lines; closer ones are culled.
+const DOWNBEAT_MIN_GAP_PX: f32 = 6.0;
+
+/// Minimum on-screen gap (px) between drawn beat ticks; closer ones are culled.
+const BEAT_MIN_GAP_PX: f32 = 5.0;
+
+impl WaveformCanvas {
+    fn draw_beatgrid(&self, frame: &mut Frame, w: f32, h: f32) {
+        self.draw_beats(frame, w, h);
+        self.draw_downbeats(frame, w, h);
+    }
+
+    fn draw_beats(&self, frame: &mut Frame, w: f32, h: f32) {
+        if self.beats.is_empty() {
+            return;
+        }
+        let beat_color = Color {
+            a: 0.18,
+            ..self.p.accent
+        };
+        let mut last_x = f32::NEG_INFINITY;
+        for &frac in self.beats.iter() {
+            let x = self.view.screen_frac(frac) * w;
+            if !(0.0..=w).contains(&x) || (x - last_x).abs() < BEAT_MIN_GAP_PX {
+                continue;
+            }
+            last_x = x;
+            frame.stroke(
+                &Path::line(Point::new(x, 0.0), Point::new(x, h)),
+                Stroke::default().with_color(beat_color).with_width(1.0),
+            );
+        }
+    }
+
+    fn draw_downbeats(&self, frame: &mut Frame, w: f32, h: f32) {
+        let downbeats = &self.downbeats;
+        let len = downbeats.len();
+        if len == 0 {
+            return;
+        }
+
+        let accent = self.p.accent;
+        let accent_strong = self.p.accent_strong;
+        let active = downbeats
+            .iter()
+            .rposition(|&d| d <= self.progress + 1e-4);
+
+        let mut last_x = f32::NEG_INFINITY;
+        for i in 0..len {
+            let frac = downbeats[i];
+            let x = self.view.screen_frac(frac) * w;
+            let is_active = active == Some(i);
+
+            if is_active {
+                let end = if i + 1 < len { downbeats[i + 1] } else { 1.0 };
+                let x_end = self.view.screen_frac(end) * w;
+                let cx0 = x.clamp(0.0, w);
+                let cx1 = x_end.clamp(0.0, w);
+                let seg_w = (cx1 - cx0).max(0.0);
+                frame.fill_rectangle(
+                    Point::new(cx0, 0.0),
+                    Size::new(seg_w, h),
+                    Color { a: 0.12, ..accent },
+                );
+            }
+
+            if !(0.0..=w).contains(&x) {
+                continue;
+            }
+
+            if !is_active && (x - last_x).abs() < DOWNBEAT_MIN_GAP_PX {
+                continue;
+            }
+            last_x = x;
+
+            let (marker_color, marker_w) = if is_active {
+                (accent_strong, 2.0)
+            } else {
+                (Color { a: 0.6, ..accent }, 1.0)
+            };
+            frame.stroke(
+                &Path::line(Point::new(x, 0.0), Point::new(x, h)),
+                Stroke::default().with_color(marker_color).with_width(marker_w),
+            );
+            let tab = Path::new(|b| {
+                b.move_to(Point::new(x - 4.0, 0.0));
+                b.line_to(Point::new(x + 4.0, 0.0));
+                b.line_to(Point::new(x, 6.0));
+                b.close();
+            });
+            frame.fill(&tab, accent_strong);
+        }
+    }
 }
 
 impl canvas::Program<Message> for WaveformCanvas {
-    type State = DragState;
+    type State = PointerState;
 
     fn update(
         &self,
-        state: &mut DragState,
+        state: &mut PointerState,
         event: &Event,
         bounds: Rectangle,
         cursor: Cursor,
     ) -> Option<Action<Message>> {
-        if self.duration <= 0.0 {
-            return None;
-        }
         match event {
+            Event::Mouse(mouse::Event::WheelScrolled { delta }) if cursor.is_over(bounds) => {
+                let factor = wheel_factor(*delta);
+                let cursor_x = cursor.position().map_or(bounds.x, |p| p.x);
+                let anchor = ((cursor_x - bounds.x) / bounds.width).clamp(0.0, 1.0);
+                ((factor - 1.0).abs() >= f32::EPSILON)
+                    .then(|| zoom_action(WaveMsg::ZoomBy { factor, anchor }))
+            }
             Event::Mouse(mouse::Event::ButtonPressed(Button::Left)) => {
                 cursor.position_over(bounds).map(|pos| {
-                    state.dragging = true;
-                    Action::publish(Message::SeekChanged(seek_target(
-                        pos.x,
-                        bounds,
-                        self.duration,
-                    )))
-                    .and_capture()
+                    state.press = Some(Press {
+                        start_x: pos.x,
+                        last_x: pos.x,
+                        moved: false,
+                    });
+                    Action::capture()
                 })
             }
-            Event::Mouse(mouse::Event::CursorMoved { .. }) if state.dragging => {
-                cursor.position().map(|pos| {
-                    Action::publish(Message::SeekChanged(seek_target(
-                        pos.x,
-                        bounds,
-                        self.duration,
-                    )))
-                    .and_capture()
-                })
+            Event::Mouse(mouse::Event::CursorMoved { .. }) => {
+                let press = state.press.as_mut()?;
+                let pos = cursor.position()?;
+                let dx = pos.x - press.last_x;
+                press.last_x = pos.x;
+                if (pos.x - press.start_x).abs() > DRAG_THRESHOLD_PX {
+                    press.moved = true;
+                }
+                if press.moved {
+                    Some(zoom_action(WaveMsg::Pan(dx / bounds.width)))
+                } else {
+                    Some(Action::capture())
+                }
             }
-            Event::Mouse(mouse::Event::ButtonReleased(Button::Left)) if state.dragging => {
-                state.dragging = false;
-                Some(Action::publish(Message::SeekReleased).and_capture())
+            Event::Mouse(mouse::Event::ButtonReleased(Button::Left)) => {
+                let press = state.press.take()?;
+                if press.moved || self.duration <= 0.0 {
+                    return Some(Action::capture());
+                }
+                let x = cursor.position().map_or(press.last_x, |p| p.x);
+                let frac = ((x - bounds.x) / bounds.width).clamp(0.0, 1.0);
+                let secs =
+                    (f64::from(self.view.track_frac(frac)) * self.duration).clamp(0.0, self.duration);
+                Some(Action::publish(Message::SeekTo(secs)).and_capture())
             }
             _ => None,
         }
     }
 
-    fn mouse_interaction(
-        &self,
-        state: &DragState,
-        bounds: Rectangle,
-        cursor: Cursor,
-    ) -> mouse::Interaction {
-        if self.duration > 0.0 && (state.dragging || cursor.is_over(bounds)) {
-            mouse::Interaction::Pointer
-        } else {
-            mouse::Interaction::default()
-        }
-    }
-
     fn draw(
         &self,
-        _state: &DragState,
+        _state: &PointerState,
         renderer: &Renderer,
         _theme: &Theme,
         bounds: Rectangle,
@@ -121,42 +243,47 @@ impl canvas::Program<Message> for WaveformCanvas {
             a: 0.08,
             ..self.p.accent
         };
+
         for i in 1u16..=8 {
-            let x = (f32::from(i) / 8.0) * w;
-            frame.stroke(
-                &Path::line(Point::new(x, 0.0), Point::new(x, h)),
-                Stroke::default().with_color(grid_color).with_width(1.0),
-            );
+            let x = self.view.screen_frac(f32::from(i) / 8.0) * w;
+            if (0.0..=w).contains(&x) {
+                frame.stroke(
+                    &Path::line(Point::new(x, 0.0), Point::new(x, h)),
+                    Stroke::default().with_color(grid_color).with_width(1.0),
+                );
+            }
         }
+
+        let head_x = self.view.screen_frac(self.progress.clamp(0.0, 1.0)) * w;
 
         let buckets = self.wave.buckets();
         let n = buckets.len();
         if n >= 1 {
             let mid = h / 2.0;
             let amp = (mid - 4.0).max(0.0);
-            let count: f32 = n.as_();
-            let col_w = w / count;
-            let bar_w = col_w.max(1.0);
-            let head_x = self.progress.clamp(0.0, 1.0) * w;
             let bands = [WAVE_LOW, WAVE_MID, WAVE_HIGH];
 
-            for (i, bucket) in buckets.iter().enumerate() {
-                let idx: f32 = i.as_();
-                let x = idx * col_w;
-                let played = (x + bar_w * 0.5) <= head_x;
-                let heights = [bucket.low, bucket.mid, bucket.high];
-
-                for (value, base) in heights.iter().zip(bands.iter()) {
+            let cols: usize = w.ceil().as_();
+            for col in 0..cols {
+                let x: f32 = col.as_();
+                let (lo, hi) = self.view.pixel_buckets(x, w, n);
+                let mut peak = [0.0_f32; 3];
+                for b in &buckets[lo..hi] {
+                    peak[0] = peak[0].max(b.low);
+                    peak[1] = peak[1].max(b.mid);
+                    peak[2] = peak[2].max(b.high);
+                }
+                let played = (x + 0.5) <= head_x;
+                for (value, base) in peak.iter().zip(bands.iter()) {
                     let v = value.clamp(0.0, 1.0);
                     if v <= 0.0 {
                         continue;
                     }
                     let half = v * amp;
-                    // The played past is dimmed so the upcoming part stays vivid.
                     let color = if played { dim(*base) } else { *base };
                     frame.fill_rectangle(
                         Point::new(x, mid - half),
-                        Size::new(bar_w, half * 2.0),
+                        Size::new(1.0, half * 2.0),
                         color,
                     );
                 }
@@ -168,38 +295,64 @@ impl canvas::Program<Message> for WaveformCanvas {
             ..self.p.accent
         };
         for i in 0u16..16 {
-            let x = (f32::from(i) / 16.0) * w;
+            let x = self.view.screen_frac(f32::from(i) / 16.0) * w;
+            if (0.0..=w).contains(&x) {
+                frame.stroke(
+                    &Path::line(Point::new(x, h - 6.0), Point::new(x, h)),
+                    Stroke::default().with_color(tick_color).with_width(1.0),
+                );
+            }
+        }
+
+        self.draw_beatgrid(&mut frame, w, h);
+
+        if (0.0..=w).contains(&head_x) {
             frame.stroke(
-                &Path::line(Point::new(x, h - 6.0), Point::new(x, h)),
-                Stroke::default().with_color(tick_color).with_width(1.0),
+                &Path::line(Point::new(head_x, 0.0), Point::new(head_x, h)),
+                Stroke::default().with_color(self.p.accent).with_width(2.0),
             );
         }
 
-        let px = self.progress.clamp(0.0, 1.0) * w;
-        let head = Path::line(Point::new(px, 0.0), Point::new(px, h));
-        frame.stroke(
-            &head,
-            Stroke::default().with_color(self.p.accent).with_width(2.0),
-        );
-
         vec![frame.into_geometry()]
+    }
+
+    fn mouse_interaction(
+        &self,
+        state: &PointerState,
+        bounds: Rectangle,
+        cursor: Cursor,
+    ) -> mouse::Interaction {
+        if state.press.is_some() {
+            mouse::Interaction::Grabbing
+        } else if cursor.is_over(bounds) {
+            mouse::Interaction::Grab
+        } else {
+            mouse::Interaction::default()
+        }
     }
 }
 
-/// Build the deck waveform element from a precomputed colored waveform.
-/// `duration` (track length in seconds) enables click/drag seeking; pass
-/// `0.0` when it is unknown to keep the widget display-only.
+fn zoom_action(msg: WaveMsg) -> Action<Message> {
+    Action::publish(Message::Dj(DjMsg::Wave(msg))).and_capture()
+}
+
+/// Deck waveform element. `view` is the zoom/pan window.
 pub(crate) fn waveform<'a>(
     wave: Waveform,
+    marks: BeatMarks,
     progress: f32,
     duration: f64,
+    view: Viewport,
     height: f32,
     p: GuiPalette,
 ) -> Element<'a, Message> {
     Canvas::new(WaveformCanvas {
         wave,
+        beats: marks.beats,
+        downbeats: marks.downbeats,
         progress,
         duration,
+        view,
         p,
     })
     .width(Length::Fill)

--- a/crates/kithara-app/src/gui/widgets/waveform_viewport.rs
+++ b/crates/kithara-app/src/gui/widgets/waveform_viewport.rs
@@ -1,0 +1,137 @@
+use num_traits::cast::AsPrimitive;
+
+/// Whole track fits the widget; the smallest meaningful zoom.
+pub(crate) const MIN_ZOOM: f32 = 1.0;
+
+/// Deepest zoom; the data is native-resolution so this is just a practical cap.
+pub(crate) const MAX_ZOOM: f32 = 40.0;
+
+/// Multiplier applied by the on-screen `−` / `+` buttons per click.
+pub(crate) const ZOOM_STEP: f32 = 1.5;
+
+/// A zoom/pan request from the canvas or the `−`/`+` control.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum WaveMsg {
+    /// Wheel zoom anchored at a screen fraction in `[0, 1]` (toward cursor).
+    ZoomBy { factor: f32, anchor: f32 },
+    /// Button zoom: multiply zoom, re-centered on the viewport middle.
+    Zoom(f32),
+    /// Drag pan by a screen-fraction delta.
+    Pan(f32),
+}
+
+/// Normalized zoom/pan window over the track `[0, 1]`, pixel- and iced-free.
+/// Every accessor normalizes first, so any `(zoom, offset)` maps to a valid
+/// window without panicking. Bucket `i` of `n` spans `[i/n, (i+1)/n]`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct Viewport {
+    zoom: f32,
+    offset: f32,
+}
+
+impl Default for Viewport {
+    fn default() -> Self {
+        Self {
+            zoom: MIN_ZOOM,
+            offset: 0.0,
+        }
+    }
+}
+
+impl Viewport {
+    /// Clamp zoom into range, then offset into `[0, 1 - 1/zoom]`. Order matters:
+    /// deriving the offset bound from the clamped zoom keeps it non-negative.
+    fn normalized(self) -> Self {
+        let zoom = if self.zoom.is_finite() {
+            self.zoom.clamp(MIN_ZOOM, MAX_ZOOM)
+        } else {
+            MIN_ZOOM
+        };
+        let max_offset = (1.0 - 1.0 / zoom).max(0.0);
+        let offset = if self.offset.is_finite() {
+            self.offset.clamp(0.0, max_offset)
+        } else {
+            0.0
+        };
+        Self { zoom, offset }
+    }
+
+    /// Clamped zoom level, for the on-screen `N×` readout.
+    pub(crate) fn zoom(self) -> f32 {
+        self.normalized().zoom
+    }
+
+    /// Multiply zoom by `factor`, keeping the track point under `anchor` (screen
+    /// fraction) pinned — zoom toward the cursor. Pin slips only at track edges.
+    pub(crate) fn zoom_by(self, factor: f32, anchor: f32) -> Self {
+        let cur = self.normalized();
+        let anchor = if anchor.is_finite() {
+            anchor.clamp(0.0, 1.0)
+        } else {
+            0.5
+        };
+        let factor = if factor.is_finite() && factor > 0.0 {
+            factor
+        } else {
+            1.0
+        };
+        let pinned = cur.offset + anchor / cur.zoom;
+        let new_zoom = (cur.zoom * factor).clamp(MIN_ZOOM, MAX_ZOOM);
+        Self {
+            zoom: new_zoom,
+            offset: pinned - anchor / new_zoom,
+        }
+        .normalized()
+    }
+
+    /// Shift the window by a screen-fraction drag delta. Dragging right
+    /// (positive delta) reveals earlier content, so offset decreases.
+    pub(crate) fn pan(self, delta_screen_frac: f32) -> Self {
+        let cur = self.normalized();
+        let delta = if delta_screen_frac.is_finite() {
+            delta_screen_frac
+        } else {
+            0.0
+        };
+        Self {
+            zoom: cur.zoom,
+            offset: cur.offset - delta / cur.zoom,
+        }
+        .normalized()
+    }
+
+    /// Map a screen fraction in `[0, 1]` to a track fraction.
+    pub(crate) fn track_frac(self, screen_frac: f32) -> f32 {
+        let cur = self.normalized();
+        cur.offset + screen_frac / cur.zoom
+    }
+
+    /// Map a track fraction to a screen fraction. May fall outside `[0, 1]`
+    /// when the point is off-screen (e.g. a playhead past the visible window).
+    pub(crate) fn screen_frac(self, track_frac: f32) -> f32 {
+        let cur = self.normalized();
+        (track_frac - cur.offset) * cur.zoom
+    }
+
+    /// Apply a [`WaveMsg`] transition, yielding the next viewport.
+    pub(crate) fn apply(self, msg: WaveMsg) -> Self {
+        match msg {
+            WaveMsg::ZoomBy { factor, anchor } => self.zoom_by(factor, anchor),
+            WaveMsg::Zoom(factor) => self.zoom_by(factor, 0.5),
+            WaveMsg::Pan(delta) => self.pan(delta),
+        }
+    }
+
+    /// Bucket range `[lo, hi)` covering pixel column `[x, x+1]` of a `w`-wide
+    /// canvas.
+    pub(crate) fn pixel_buckets(self, x: f32, w: f32, n: usize) -> (usize, usize) {
+        if n == 0 || w <= 0.0 {
+            return (0, 0);
+        }
+        let nf: f32 = n.as_();
+        let lo: usize = (self.track_frac(x / w) * nf).floor().max(0.0).as_();
+        let hi: usize = (self.track_frac((x + 1.0) / w) * nf).ceil().max(0.0).as_();
+        let lo = lo.min(n - 1);
+        (lo, hi.clamp(lo + 1, n))
+    }
+}

--- a/crates/kithara-app/src/state.rs
+++ b/crates/kithara-app/src/state.rs
@@ -9,6 +9,7 @@ use kithara::{
 };
 use kithara_platform::{CancellationToken, sync::Mutex};
 use kithara_queue::{Queue, QueueEvent, RepeatMode, TrackEntry};
+use num_traits::cast::AsPrimitive;
 
 use crate::{config::AppConfig, waveform::TrackAnalysis};
 
@@ -29,6 +30,10 @@ pub struct UiState {
     pub tracks: Vec<TrackEntry>,
     /// Source analysis of the current track; `None` until analysed.
     pub analysis: Option<TrackAnalysis>,
+    /// Beat positions as track fractions in `[0, 1]`, derived from `analysis.beat`.
+    pub beat_marks: Arc<[f32]>,
+    /// Downbeat positions as track fractions in `[0, 1]`, derived from `analysis.beat`.
+    pub downbeat_marks: Arc<[f32]>,
     pub repeat_mode: RepeatMode,
     pub abr_mode_is_auto: bool,
     pub shuffle_enabled: bool,
@@ -67,6 +72,8 @@ impl UiState {
             crossfade_progress: None,
             eq_bands: vec![0.0; queue.eq_band_count()],
             analysis: None,
+            beat_marks: Arc::from(Vec::new()),
+            downbeat_marks: Arc::from(Vec::new()),
             status_note: None,
             is_seeking: false,
             seek_position: 0.0,
@@ -74,6 +81,74 @@ impl UiState {
             engine_load: EngineLoadSnapshot::default(),
         }
     }
+
+    /// Bare default state for unit tests.
+    #[cfg(test)]
+    pub(crate) fn empty() -> Self {
+        Self {
+            crossfade_progress: None,
+            current_track_index: None,
+            selected_variant: None,
+            status_note: None,
+            track_name: String::new(),
+            variant_label: String::new(),
+            abr_variants: Vec::new(),
+            eq_bands: Vec::new(),
+            tracks: Vec::new(),
+            analysis: None,
+            beat_marks: Arc::from(Vec::new()),
+            downbeat_marks: Arc::from(Vec::new()),
+            repeat_mode: RepeatMode::default(),
+            abr_mode_is_auto: true,
+            shuffle_enabled: false,
+            is_seeking: false,
+            playing: false,
+            crossfade: 0.0,
+            selected_rate: 1.0,
+            volume: 1.0,
+            duration: 0.0,
+            position: 0.0,
+            seek_position: 0.0,
+            engine_load: EngineLoadSnapshot::default(),
+        }
+    }
+
+    /// Set the analysis and re-derive `beat_marks`/`downbeat_marks` from its
+    /// beat grid, keeping them in sync with their single source.
+    pub(crate) fn set_analysis(&mut self, analysis: Option<TrackAnalysis>) {
+        let (beats, downbeats) = analysis
+            .as_ref()
+            .and_then(|a| {
+                a.beat.as_ref().filter(|_| a.source_frames > 0).map(|grid| {
+                    (
+                        frames_to_fractions(&grid.beats, a.source_frames),
+                        frames_to_fractions(&grid.downbeats, a.source_frames),
+                    )
+                })
+            })
+            .unwrap_or_else(|| (Arc::from(Vec::new()), Arc::from(Vec::new())));
+        self.beat_marks = beats;
+        self.downbeat_marks = downbeats;
+        self.analysis = analysis;
+    }
+}
+
+/// Map source-frame positions to track fractions in `[0, 1]`, clamping
+/// out-of-range frames to `1.0`. Empty input or `total == 0` yields empty.
+fn frames_to_fractions(frames: &[u64], total: u64) -> Arc<[f32]> {
+    if frames.is_empty() || total == 0 {
+        return Arc::from(Vec::new());
+    }
+    let total_f: f64 = total.as_();
+    let out: Vec<f32> = frames
+        .iter()
+        .map(|&frame| {
+            let frame_f: f64 = frame.as_();
+            let frac: f32 = (frame_f / total_f).clamp(0.0, 1.0).as_();
+            frac
+        })
+        .collect();
+    Arc::from(out)
 }
 
 /// Owns the canonical [`UiState`] and bridges queue events to it.
@@ -310,7 +385,28 @@ fn variant_short_label(v: &VariantInfo) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::codec_label;
+    use super::{codec_label, frames_to_fractions};
+
+    #[test]
+    fn frames_to_fractions_maps_and_clamps() {
+        assert!(frames_to_fractions(&[], 100).is_empty(), "empty input");
+        assert!(
+            frames_to_fractions(&[0, 50, 100], 0).is_empty(),
+            "zero total yields empty"
+        );
+
+        let got = frames_to_fractions(&[0, 5_000, 10_000], 10_000);
+        assert_eq!(got.len(), 3);
+        assert!((got[0] - 0.0).abs() < 1e-6, "start at 0.0: {got:?}");
+        assert!((got[1] - 0.5).abs() < 1e-6, "midpoint 0.5: {got:?}");
+        assert!((got[2] - 1.0).abs() < 1e-6, "end at 1.0: {got:?}");
+
+        // An out-of-range frame clamps to 1.0 and order is preserved.
+        let clamped = frames_to_fractions(&[2_000, 50_000], 10_000);
+        assert!((clamped[0] - 0.2).abs() < 1e-6, "{clamped:?}");
+        assert!((clamped[1] - 1.0).abs() < 1e-6, "over-range clamps: {clamped:?}");
+        assert!(clamped[0] < clamped[1], "ascending preserved");
+    }
 
     #[test]
     fn codec_label_maps_known_hls_codecs() {

--- a/crates/kithara-app/src/wave_cache.rs
+++ b/crates/kithara-app/src/wave_cache.rs
@@ -20,7 +20,7 @@ use crate::waveform::TrackAnalysis;
 
 /// Cap on the in-memory tier; past it the oldest entries fall back to disk.
 const MAX_MEM_ENTRIES: usize = 64;
-const ANALYSIS_BYTES_VERSION: u32 = 0x4b41_0002;
+const ANALYSIS_BYTES_VERSION: u32 = 0x4b41_0004;
 
 /// Analysis artifact resource under the track's asset scope. One blob per
 /// track: the active config fingerprint is checked inside it.
@@ -224,7 +224,7 @@ fn analysis_to_bytes(
         .map(BeatGrid::to_bytes)
         .unwrap_or_default();
     let mut out =
-        Vec::with_capacity(4 + 4 + fingerprint.len() + 8 + waveform.len() + 8 + beat.len());
+        Vec::with_capacity(4 + 4 + fingerprint.len() + 8 + waveform.len() + 8 + beat.len() + 8);
     out.extend_from_slice(&ANALYSIS_BYTES_VERSION.to_le_bytes());
     let fingerprint_len =
         u32::try_from(fingerprint.len()).map_err(|_| AnalysisBytesError::TooLarge)?;
@@ -232,6 +232,7 @@ fn analysis_to_bytes(
     out.extend_from_slice(fingerprint.as_bytes());
     write_section(&mut out, &waveform)?;
     write_section(&mut out, &beat)?;
+    out.extend_from_slice(&analysis.source_frames.to_le_bytes());
     Ok(out)
 }
 
@@ -255,6 +256,7 @@ fn analysis_from_bytes(
     }
     let waveform_bytes = read_section(bytes, &mut cursor)?;
     let beat_bytes = read_section(bytes, &mut cursor)?;
+    let source_frames = read_u64(bytes, &mut cursor)?;
     if cursor != bytes.len() {
         return Err(AnalysisBytesError::Corrupt);
     }
@@ -268,6 +270,7 @@ fn analysis_from_bytes(
         analysis.beat =
             Some(BeatGrid::from_bytes(beat_bytes).map_err(|_| AnalysisBytesError::Corrupt)?);
     }
+    analysis.source_frames = source_frames;
     Ok(analysis)
 }
 
@@ -356,6 +359,7 @@ mod tests {
         let mut analysis = TrackAnalysis::default();
         analysis.waveform = Some(wave());
         analysis.beat = Some(grid());
+        analysis.source_frames = 1_234_567;
         analysis
     }
 
@@ -383,6 +387,10 @@ mod tests {
             wave().buckets()
         );
         assert_eq!(back.beat.expect("beat grid survives"), grid());
+        assert_eq!(
+            back.source_frames, 1_234_567,
+            "source_frames must survive the round-trip"
+        );
     }
 
     #[kithara::test]

--- a/crates/kithara-app/src/waveform.rs
+++ b/crates/kithara-app/src/waveform.rs
@@ -17,7 +17,6 @@ use tracing::warn;
 /// and keeps at most one run in flight. Dropping it cancels the run and
 /// stops the worker.
 pub struct TrackAnalysisRunner {
-    cancel: CancellationToken,
     worker: Arc<AnalysisWorker>,
     current: Option<RunHandle>,
     /// Whether any analyzer is compiled in; without one a decode pass would
@@ -35,18 +34,16 @@ struct RunHandle {
 
 impl TrackAnalysisRunner {
     /// `master` must be a child of the app master cancel; the worker thread
-    /// and every run scope live under it. `buckets` is the waveform
-    /// resolution registered with the worker.
+    /// and every run scope live under it. `buckets` caps the waveform output;
+    /// the native window count is the real resolution.
     #[must_use]
     pub fn new(master: &CancellationToken, buckets: usize) -> Self {
-        let cancel = master.child_token();
         let builder = AnalyzerBuilder::default()
             .with_waveform(buckets)
             .with_beat();
         let active = !builder.is_empty();
-        let worker = Arc::new(AnalysisWorker::new(&cancel, builder));
+        let worker = Arc::new(AnalysisWorker::new(master, builder));
         Self {
-            cancel,
             worker,
             current: None,
             active,
@@ -60,16 +57,13 @@ impl TrackAnalysisRunner {
         self.active
     }
 
-    /// Cancel any prior run and queue `config` for analysis. The latest
-    /// result (or none on failure/cancel) arrives on the returned receiver.
-    ///
-    /// Two watch channels bridge here on purpose: this receiver must exist
-    /// before the async `Resource` open completes, while the worker hands
-    /// out its own channel only once the opened reader is queued.
+    /// Cancel any prior run and queue `config` for analysis.
+    /// Staged results arrive on the returned receiver,
+    /// which closes when the run ends; nothing arrives on failure/cancel.
     pub fn analyze(&mut self, config: ResourceConfig) -> watch::Receiver<Option<TrackAnalysis>> {
         self.clear();
 
-        let run = self.cancel.child_token();
+        let run = self.worker.child_token();
         let (tx, rx) = watch::channel(None);
         let task = tokio::spawn(run_analysis(
             Arc::clone(&self.worker),
@@ -81,8 +75,7 @@ impl TrackAnalysisRunner {
         rx
     }
 
-    /// Cancel the in-flight run, if any, without starting a new one. The
-    /// worker skips or aborts the job at its next cancel check.
+    /// Cancel the in-flight run.
     pub fn clear(&mut self) {
         if let Some(prev) = self.current.take() {
             prev.cancel.cancel();
@@ -94,12 +87,11 @@ impl TrackAnalysisRunner {
 impl Drop for TrackAnalysisRunner {
     fn drop(&mut self) {
         self.clear();
-        self.cancel.cancel();
     }
 }
 
-/// Open `config` and run it through the shared worker, forwarding the
-/// result to `tx`. Nothing is sent on failure or cancel.
+/// Open `config` and run it through the shared worker, forwarding every
+/// staged update to `tx`.
 async fn run_analysis(
     worker: Arc<AnalysisWorker>,
     config: ResourceConfig,
@@ -110,13 +102,13 @@ async fn run_analysis(
         return;
     };
     let mut rx = worker.analyze(reader, cancel);
-    if rx.changed().await.is_err() {
-        return;
-    }
-    let analysis = rx.borrow().clone();
-    if let Some(analysis) = analysis {
-        // The receiver may be gone (deck swapped); a failed send is fine.
-        let _ = tx.send(Some(analysis));
+
+    while rx.changed().await.is_ok() {
+        let analysis = rx.borrow().clone();
+        if let Some(analysis) = analysis {
+            // The receiver may be gone (deck swapped).
+            let _ = tx.send(Some(analysis));
+        }
     }
 }
 

--- a/crates/kithara-audio/README.md
+++ b/crates/kithara-audio/README.md
@@ -138,8 +138,8 @@ the band -> color mapping and orchestration live in the consumer crates.
   track position `[0, 1]`, never wall-clock seconds. `bucketize` is the single
   home of that `[0, 1]` mapping: bucket `b` folds the raw range
   `[b*R/N, (b+1)*R/N)`. A bucket whose range is empty (tracks shorter than the
-  bucket count) is filled with the supplied `empty` value, so the output length
-  always equals the requested bucket count.
+  bucket count) is filled with the supplied `empty` value, so `bucketize`'s
+  output length always equals its requested count.
 - **Source-only invariant**: analysis runs on the decoded SOURCE signal, never
   the post-EQ / post-timestretch / post-resample output. The waveform is the
   track's identity; playback-rate and mixer transforms remap only the time axis

--- a/crates/kithara-audio/src/analysis/analyzer/set.rs
+++ b/crates/kithara-audio/src/analysis/analyzer/set.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use kithara_decode::{PcmChunk, PcmSpec};
+use num_traits::cast::AsPrimitive;
 
 use super::{
     track_analysis::{Analyzer, TrackAnalysis},
@@ -20,10 +21,14 @@ pub fn beat_cache_tag() -> Option<String> {
 pub(crate) struct TrackAnalyzers {
     waveform: Option<WaveformPass>,
     beat: Option<BeatPass>,
+    source_frames: u64,
 }
 
 impl TrackAnalyzers {
     pub(crate) fn push(&mut self, chunk: &PcmChunk) {
+        let frames: u64 = chunk.frames().as_();
+        self.source_frames = self.source_frames.saturating_add(frames);
+
         if let Some(a) = &mut self.waveform {
             a.push(chunk);
         }
@@ -33,17 +38,37 @@ impl TrackAnalyzers {
         }
     }
 
-    pub(crate) fn finish(self) -> TrackAnalysis {
-        TrackAnalysis {
-            waveform: self.waveform.map(Analyzer::finish),
-            beat: self.beat.and_then(Analyzer::finish),
+    /// Emit the fast waveform first, then waveform+beat.
+    pub(crate) fn finish_staged<F: FnMut(TrackAnalysis)>(mut self, mut emit: F) {
+        let source_frames = self.source_frames;
+        let waveform = self.waveform.take().map(Analyzer::finish);
+
+        if self.beat.is_none() {
+            emit(TrackAnalysis {
+                waveform,
+                beat: None,
+                source_frames,
+            });
+            return;
         }
+
+        emit(TrackAnalysis {
+            waveform: waveform.clone(),
+            beat: None,
+            source_frames,
+        });
+
+        let beat = self.beat.and_then(Analyzer::finish);
+        emit(TrackAnalysis {
+            waveform,
+            beat,
+            source_frames,
+        });
     }
 }
 
 /// Configures which analyzers run, then mints a fresh [`TrackAnalyzers`]
-/// per track at the source spec. Cfg-free for callers: a beat backend
-/// absent at compile time is silently ignored.
+/// per track at the source spec.
 #[derive(Default)]
 pub struct AnalyzerBuilder {
     waveform_buckets: Option<usize>,
@@ -51,7 +76,8 @@ pub struct AnalyzerBuilder {
 }
 
 impl AnalyzerBuilder {
-    /// Run a waveform analyzer at `buckets` resolution.
+    /// Run a waveform analyzer; `buckets` caps output (the native window count
+    /// is the real resolution).
     #[must_use]
     pub fn with_waveform(self, buckets: usize) -> Self {
         Self {
@@ -92,6 +118,7 @@ impl AnalyzerBuilder {
             beat: self.beat.as_ref().map(|(detector, params)| {
                 BeatPass::new(spec.sample_rate, params.clone(), Arc::clone(detector))
             }),
+            source_frames: 0,
         }
     }
 
@@ -104,5 +131,99 @@ impl AnalyzerBuilder {
     ) -> Self {
         self.beat = Some((detector, params));
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use kithara_bufpool::PcmPool;
+    use kithara_decode::{PcmChunk, PcmMeta, PcmSpec};
+    use kithara_platform::sync::Mutex;
+    use unimock::{MockFn, Unimock, matching};
+
+    use super::super::track_analysis::TrackAnalysis;
+    use super::{AnalyzerBuilder, GridParams, TrackAnalyzers};
+    use crate::{
+        analysis::beat::{BeatDetector, BeatDetectorMock, RawBeats, SharedBeatDetector},
+        waveform::Waveform,
+    };
+
+    fn chunk(frames: usize, channels: u16) -> PcmChunk {
+        let samples = vec![0.0_f32; frames * usize::from(channels)];
+        PcmChunk::new(
+            PcmMeta {
+                spec: PcmSpec {
+                    channels,
+                    sample_rate: 44_100,
+                },
+                frames: u32::try_from(frames).unwrap_or(0),
+                ..Default::default()
+            },
+            PcmPool::default().attach(samples),
+        )
+    }
+
+    fn collect(analyzers: TrackAnalyzers) -> Vec<TrackAnalysis> {
+        let mut out = Vec::new();
+        analyzers.finish_staged(|a| out.push(a));
+        out
+    }
+
+    fn beat_detector() -> SharedBeatDetector {
+        let raw = RawBeats {
+            beats: Vec::new(),
+            downbeats: (0..9u8).map(|n| f32::from(n) * 2.0).collect(),
+        };
+        let mock = Unimock::new(
+            BeatDetectorMock
+                .next_call(matching!(_))
+                .answers_arc(Arc::new(move |_, _| Ok(raw.clone()))),
+        );
+        Arc::new(Mutex::new(Box::new(mock) as Box<dyn BeatDetector>))
+    }
+
+    #[test]
+    fn finish_staged_emits_once_without_a_beat_pass() {
+        let spec = PcmSpec {
+            channels: 2,
+            sample_rate: 44_100,
+        };
+        let mut analyzers = AnalyzerBuilder::default().with_waveform(8).build(spec);
+        analyzers.push(&chunk(64, 2));
+
+        let stages = collect(analyzers);
+        assert_eq!(stages.len(), 1, "waveform-only emits exactly once");
+        assert!(stages[0].waveform.is_some());
+        assert!(stages[0].beat.is_none());
+    }
+
+    #[test]
+    fn finish_staged_emits_waveform_then_waveform_plus_beat() {
+        let spec = PcmSpec {
+            channels: 2,
+            sample_rate: 44_100,
+        };
+        let mut analyzers = AnalyzerBuilder::default()
+            .with_waveform(8)
+            .with_beat_detector(beat_detector(), GridParams::default())
+            .build(spec);
+        analyzers.push(&chunk(8192, 2));
+
+        let stages = collect(analyzers);
+        assert_eq!(stages.len(), 2, "beat pass emits a fast stage then a complete one");
+
+        let first = &stages[0];
+        assert!(first.waveform.is_some(), "stage 1 carries the waveform");
+        assert!(first.beat.is_none(), "stage 1 has no beat yet");
+
+        let second = &stages[1];
+        assert!(second.beat.is_some(), "stage 2 carries the beat grid");
+        assert_eq!(
+            first.waveform.as_ref().map(Waveform::to_bytes),
+            second.waveform.as_ref().map(Waveform::to_bytes),
+            "both stages share the same waveform"
+        );
     }
 }

--- a/crates/kithara-audio/src/analysis/analyzer/track_analysis.rs
+++ b/crates/kithara-audio/src/analysis/analyzer/track_analysis.rs
@@ -22,4 +22,6 @@ pub struct TrackAnalysis {
     pub waveform: Option<Waveform>,
     /// Cleaned beat grid (source frames).
     pub beat: Option<BeatGrid>,
+    /// Total decoded source frames: the denominator for `BeatGrid` frame → fraction.
+    pub source_frames: u64,
 }

--- a/crates/kithara-audio/src/analysis/run.rs
+++ b/crates/kithara-audio/src/analysis/run.rs
@@ -9,19 +9,20 @@ use crate::traits::{ChunkOutcome, PcmReader};
 /// Backoff while the reader is buffering and has no chunk ready.
 const PENDING_BACKOFF: Duration = Duration::from_millis(5);
 
-/// Decode `reader` to EOF and feed the analyzer set: one decode, many
-/// analyzers. The set is built on the first chunk so it can take the source
-/// spec. `None` on cancel, decode error, or empty input.
-pub fn analyze_reader(
+/// Decode `reader` to EOF feeding the analyzer set, then finalize in stages
+/// to `emit` (waveform first, then waveform+beat). Nothing is emitted on
+/// cancel, decode error, or empty input.
+pub fn analyze_reader<F: FnMut(TrackAnalysis)>(
     reader: &mut dyn PcmReader,
     builder: &AnalyzerBuilder,
     cancel: &CancellationToken,
-) -> Option<TrackAnalysis> {
+    emit: F,
+) {
     let mut analyzers: Option<TrackAnalyzers> = None;
     loop {
         if cancel.is_cancelled() {
             debug!("analysis cancelled");
-            return None;
+            return;
         }
         match reader.next_chunk() {
             Ok(ChunkOutcome::Chunk(chunk)) => {
@@ -31,18 +32,21 @@ pub fn analyze_reader(
             }
             Ok(ChunkOutcome::Pending { .. }) => sleep(PENDING_BACKOFF),
             Ok(ChunkOutcome::Eof { .. }) => {
-                let analyzers = analyzers?;
+                let Some(analyzers) = analyzers else {
+                    return;
+                };
                 // Finalize can be expensive: honor a cancel that raced the last chunk before
                 // paying for it.
                 if cancel.is_cancelled() {
                     debug!("analysis cancelled before finalize");
-                    return None;
+                    return;
                 }
-                return Some(analyzers.finish());
+                analyzers.finish_staged(emit);
+                return;
             }
             Err(e) => {
                 warn!(?e, "analysis: decode error");
-                return None;
+                return;
             }
         }
     }

--- a/crates/kithara-audio/src/analysis/tests.rs
+++ b/crates/kithara-audio/src/analysis/tests.rs
@@ -165,18 +165,31 @@ mod run {
 
     use super::{
         super::{
-            analyzer::AnalyzerBuilder,
+            analyzer::{AnalyzerBuilder, TrackAnalysis},
             beat::{BeatDetector, BeatDetectorMock, GridParams, RawBeats, SharedBeatDetector},
             run::analyze_reader,
         },
         FakeReader, SR, sine,
     };
-    use crate::waveform::{AnalysisParams, WaveformAnalyzer};
+    use crate::{
+        traits::PcmReader,
+        waveform::{AnalysisParams, WaveformAnalyzer},
+    };
 
     const BUCKETS: usize = 64;
 
     fn waveform_only() -> AnalyzerBuilder {
         AnalyzerBuilder::default().with_waveform(BUCKETS)
+    }
+
+    fn stages(
+        reader: &mut dyn PcmReader,
+        builder: &AnalyzerBuilder,
+        cancel: &CancellationToken,
+    ) -> Vec<TrackAnalysis> {
+        let mut out = Vec::new();
+        analyze_reader(reader, builder, cancel, |a| out.push(a));
+        out
     }
 
     #[kithara::test]
@@ -187,9 +200,12 @@ mod run {
         let want = direct.finalize(BUCKETS);
 
         let mut reader = FakeReader::chunked(&samples, 4);
-        let out = analyze_reader(&mut reader, &waveform_only(), &CancellationToken::default())
-            .expect("stream with data analyses");
-        let got = out.waveform.expect("waveform analyzer fills its slot");
+        let out = stages(&mut reader, &waveform_only(), &CancellationToken::default());
+        assert_eq!(out.len(), 1, "waveform-only emits once");
+        let got = out[0]
+            .waveform
+            .clone()
+            .expect("waveform analyzer fills its slot");
         assert_eq!(
             got.to_bytes(),
             want.to_bytes(),
@@ -202,21 +218,21 @@ mod run {
         let cancel = CancellationToken::default();
         cancel.cancel();
         let mut reader = FakeReader::chunked(&sine(4096), 2);
-        assert!(analyze_reader(&mut reader, &waveform_only(), &cancel).is_none());
+        assert!(stages(&mut reader, &waveform_only(), &cancel).is_empty());
     }
 
     #[kithara::test]
     fn decode_error_yields_none() {
         let mut reader = FakeReader::failing();
-        let out = analyze_reader(&mut reader, &waveform_only(), &CancellationToken::default());
-        assert!(out.is_none());
+        let out = stages(&mut reader, &waveform_only(), &CancellationToken::default());
+        assert!(out.is_empty());
     }
 
     #[kithara::test]
     fn empty_stream_yields_none() {
         let mut reader = FakeReader::empty();
-        let out = analyze_reader(&mut reader, &waveform_only(), &CancellationToken::default());
-        assert!(out.is_none(), "EOF with no chunks is not an analysis");
+        let out = stages(&mut reader, &waveform_only(), &CancellationToken::default());
+        assert!(out.is_empty(), "EOF with no chunks is not an analysis");
     }
 
     #[kithara::test]
@@ -236,9 +252,16 @@ mod run {
             AnalyzerBuilder::default().with_beat_detector(detector, GridParams::default());
 
         let mut reader = FakeReader::chunked(&sine(8192), 3);
-        let out = analyze_reader(&mut reader, &builder, &CancellationToken::default())
-            .expect("stream with data analyses");
-        let grid = out.beat.expect("beat slot fills its slot");
+        let out = stages(&mut reader, &builder, &CancellationToken::default());
+        assert_eq!(
+            out.len(),
+            2,
+            "beat pass emits a fast stage then a complete one"
+        );
+        let grid = out[1]
+            .beat
+            .clone()
+            .expect("beat slot fills its slot in the complete stage");
         assert!(
             (grid.bpm - 120.0).abs() < 1e-6,
             "2 s bars are 120 bpm, got {}",
@@ -251,8 +274,8 @@ mod run {
     fn pending_is_tolerated_mid_stream() {
         let samples = sine(8192);
         let mut reader = FakeReader::chunked_with_pending(&samples, 2);
-        let out = analyze_reader(&mut reader, &waveform_only(), &CancellationToken::default());
-        assert!(out.is_some_and(|a| a.waveform.is_some()));
+        let out = stages(&mut reader, &waveform_only(), &CancellationToken::default());
+        assert!(out.len() == 1 && out[0].waveform.is_some());
     }
 }
 
@@ -276,7 +299,7 @@ mod worker {
         let worker = AnalysisWorker::new(&master, waveform_only());
         let mut rx = worker.analyze(
             Box::new(FakeReader::chunked(&sine(8192), 3)),
-            master.child_token(),
+            worker.child_token(),
         );
         rx.changed().await.expect("worker sends a result");
         assert!(rx.borrow().as_ref().is_some_and(|a| a.waveform.is_some()));
@@ -287,13 +310,13 @@ mod worker {
         let master = CancellationToken::default();
         let worker = AnalysisWorker::new(&master, waveform_only());
 
-        let stale = master.child_token();
+        let stale = worker.child_token();
         stale.cancel();
         let mut stale_rx = worker.analyze(Box::new(FakeReader::chunked(&sine(8192), 3)), stale);
 
         let mut live_rx = worker.analyze(
             Box::new(FakeReader::chunked(&sine(8192), 3)),
-            master.child_token(),
+            worker.child_token(),
         );
         live_rx.changed().await.expect("live job completes");
         assert!(live_rx.borrow().is_some());
@@ -302,5 +325,19 @@ mod worker {
             "preempted job must drop its sender without a result"
         );
         assert!(stale_rx.borrow().is_none());
+    }
+
+    #[kithara::test(tokio)]
+    async fn job_token_belongs_to_worker_scope() {
+        let master = CancellationToken::default();
+        let worker = AnalysisWorker::new(&master, waveform_only());
+        let job = worker.child_token();
+
+        drop(worker);
+
+        assert!(
+            job.is_cancelled(),
+            "dropping the worker must cancel tokens it creates for jobs"
+        );
     }
 }

--- a/crates/kithara-audio/src/analysis/worker.rs
+++ b/crates/kithara-audio/src/analysis/worker.rs
@@ -41,6 +41,12 @@ impl AnalysisWorker {
         Self { jobs, cancel }
     }
 
+    /// Create a job-scoped token owned by this worker.
+    #[must_use]
+    pub fn child_token(&self) -> CancellationToken {
+        self.cancel.child_token()
+    }
+
     /// Queue one opened track. On success the result arrives on the
     /// returned receiver; on failure or cancel the sender drops without a
     /// value (`changed()` errs). Cancel `cancel` to preempt the job.
@@ -71,8 +77,8 @@ fn run_jobs(jobs: &mpsc::Receiver<Job>, builder: &AnalyzerBuilder, cancel: &Canc
         if job.cancel.is_cancelled() {
             continue;
         }
-        if let Some(out) = analyze_reader(job.reader.as_mut(), builder, &job.cancel) {
-            let _ = job.tx.send(Some(out));
-        }
+        analyze_reader(job.reader.as_mut(), builder, &job.cancel, |a| {
+            let _ = job.tx.send(Some(a));
+        });
     }
 }

--- a/crates/kithara-audio/src/waveform/analyzer.rs
+++ b/crates/kithara-audio/src/waveform/analyzer.rs
@@ -196,9 +196,8 @@ impl WaveformAnalyzer {
         ]
     }
 
-    /// Bucketize the band-energy series (combine = component-wise max, so each
-    /// bucket keeps its loudest window) and turn it into per-bucket band heights
-    /// via [`normalize_bands`]. Empty when no frames were analysed.
+    /// Reduce the band-energy series to per-bucket heights. `buckets` is an
+    /// upper bound: output is capped at the window count.
     #[must_use]
     pub fn finalize(mut self, buckets: usize) -> Waveform {
         if self.raw_bands.is_empty() {
@@ -208,6 +207,7 @@ impl WaveformAnalyzer {
             return Waveform::from_buckets(Vec::new());
         }
 
+        let buckets = buckets.min(self.raw_bands.len());
         let max = |a: [f32; 3], b: [f32; 3]| [a[0].max(b[0]), a[1].max(b[1]), a[2].max(b[2])];
         let energy = bucketize(&self.raw_bands, buckets, [0.0; 3], max);
         let bands = normalize_bands(energy, self.params.band_gain);
@@ -363,7 +363,7 @@ mod tests {
         let mut a = analyzer(AnalysisParams::default());
         a.push_interleaved(&[0.5, -0.5, 0.25], 1);
         let wave = a.finalize(5);
-        assert_eq!(wave.len(), 5);
+        assert!(!wave.is_empty() && wave.len() <= 5, "len {}", wave.len());
         for b in wave.buckets() {
             for v in [b.low, b.mid, b.high] {
                 assert!(
@@ -372,6 +372,22 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[kithara::test]
+    fn output_is_native_window_resolution_capped() {
+        // Ten full FFT windows (4096 + 9 hops of 1024).
+        let samples = 4096 + 1024 * 9;
+        let make = || {
+            let mut a = analyzer(flat());
+            a.push_interleaved(&sine(440.0, samples), 1);
+            a
+        };
+        
+        // Above the window count: native resolution, never fabricated.
+        assert_eq!(make().finalize(100_000).len(), 10, "large = native count");
+        // Below it: still decimates (long-track cap).
+        assert_eq!(make().finalize(4).len(), 4, "small request decimates");
     }
 
     #[kithara::test]

--- a/tests/tests/kithara_app/waveform_analyzer.rs
+++ b/tests/tests/kithara_app/waveform_analyzer.rs
@@ -30,10 +30,13 @@ async fn run_analysis(
 ) -> Option<TrackAnalysis> {
     let mut runner = TrackAnalysisRunner::new(master, buckets);
     let mut rx = runner.analyze(config);
-    if rx.changed().await.is_err() {
-        return None;
+    
+    // Staged analysis can emit twice (waveform, then waveform+beat).
+    let mut last = None;
+    while rx.changed().await.is_ok() {
+        last = rx.borrow().clone();
     }
-    rx.borrow().clone()
+    last
 }
 
 #[kithara::test(


### PR DESCRIPTION
## Summary
This branch turns the DJ deck waveform into a zoomable, beat-aware view and fixes the analysis plumbing and build profile behind it.

First, the deck waveform becomes zoom/pan-capable. A new `Viewport` maps a zoom/pan window onto the track; the canvas coalesces **native-resolution** analysis buckets per on-screen pixel, so zooming reveals real detail instead of magnifying a fixed downsample. Scroll-to-zoom, drag-to-pan, and click-to-seek all operate in the zoomed coordinate space. To make honest zoom possible, the waveform analyzer now finalizes at native resolution (one bucket per FFT window, capped only for very long tracks) instead of a fixed bucket count.

Second, the deck overlays the **real** beat grid from the existing BeatThis NN analyzer (`TrackAnalysis.beat`) — faint beat ticks, accented downbeat markers, and an active-bar highlight, all mapped through the same viewport. Because the NN is slow, analysis now publishes in **stages**: the fast waveform is emitted and shown first, then the waveform+beat result follows when the NN finishes — so enabling `beat-nn` no longer gates the waveform behind NN latency. The analysis cache learns `source_frames` (the denominator that maps source-frame beat positions to `[0,1]` track fractions), bumps its blob version, and folds the active config into its fingerprint so a config change is a cache miss. `beat-nn` is added to the desktop default features so the analyzer actually runs.

Finally, the dev build profile is corrected. The rten inference override previously optimized only `rten` and `rten-tensor`, leaving the compute kernels (`rten-gemm`, `rten-simd`, `rten-vecmath`, `rten-base`) at `opt-level = 0`, so whole-track NN inference took minutes in debug. Extending the override to those crates cuts debug inference on a 5:48 track from ~314 s to ~11.5 s with an identical result.

## Behavior / scope
- contract/behavior: deck waveform gains zoom/pan/click-seek and a real beat-grid overlay; source analysis publishes staged (waveform-first, then +beat); the analysis blob gains `source_frames`, a new version, and a config fingerprint; the waveform analyzer emits native resolution.
- affected area: `kithara-app` GUI deck + analysis driver + wave cache; `kithara-audio` analysis (analyzer set, waveform analyzer, worker, run); workspace dev build profile; desktop default feature set.

## Validation
- Runtime probe (this session): drove the real analysis pipeline (waveform + NN beat) on a local 5:48 file; produced a non-empty grid (690 beats / 173 downbeats / 120 bpm). Confirmed the dev-profile fix: debug NN inference ~314 s → ~11.5 s, identical grid. GUI pixels not observed (headless); render path verified by code only.
- not run (this session): `cargo test -p kithara-audio -p kithara-app`, `cargo clippy`, `cargo xtask lint arch`.

## Surface impact
- Public API: changed — `kithara-audio` analysis surface (`AnalyzerBuilder::with_beat`, `beat_cache_tag`, staged `analyze_reader` emit callback, `TrackAnalysis.source_frames`). App-internal widget signatures (`waveform()` now takes `BeatMarks` + `Viewport`) are `pub(crate)`.
- Platform/runtime: changed — native desktop GUI deck; tooling surface (dev build profile). Desktop default features now include `beat-nn`.
- Perf-sensitive paths: changed — per-pixel native-bucket coalescing in the waveform render; staged analysis publishing; dev-profile NN inference speed.

## Risks / follow-ups
- Latent poisoned-cache trap: `beat_cache_tag()` returns `Some` purely from the compile-time `beat-nn` feature, but a completed analysis can legitimately be `beat = None` (NN init/inference fails), and the cache stores that waveform-only result under a `beat=NnBeatThis…` fingerprint — so one NN failure caches a permanently beatless result. Not triggered on this branch; worth a separate fix (don't cache `beat = None` when a detector is configured, or fold runtime detector availability into the fingerprint).
- Even after the profile fix, debug NN inference is ~11.5 s on a long track, so the beat grid appears ~12 s after the waveform in debug; `--release` is far faster.
- `beat-nn` in default features pulls the embedded ~10.5 MB ONNX model into the desktop build.
