### PR TITLE
Add code-hygiene skill and rust-architecture-guardian agent

### DIFF
--- a/.agents/skills/code-hygiene/SKILL.md
+++ b/.agents/skills/code-hygiene/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: code-hygiene
+description: "Validate code hygiene against kithara conventions: strict comment cleanup, ASCII/English-only sources, visibility, surface/protocol crate boundaries. Runs on the diff - aggressively flags AI-ish/redundant comments, block-label comments, status/handoff/commit markers, bloated doc comments. Triggers: clean up comments, check code hygiene, code hygiene, scrub AI code, validate comments, tidy before commit, review hygiene, check doc comments."
+allowed-tools: Read Edit Bash Grep
+---
+
+# code-hygiene: kithara code hygiene validator
+
+This skill reproduces the manual cleanup the repo owner does: it **aggressively**
+strips noise comments and AI artifacts, keeps sources ASCII/English-only, and
+narrows over-broad visibility. It works **on the diff** (changed lines), not on
+whole files.
+
+**Removal is the default for inline comments (`//` in the code body).** Such a
+comment must *earn* its place: only one that carries a non-obvious **why** a
+competent reader cannot infer from the code survives. When in doubt, flag for
+removal.
+
+**Public-API doc comments (`///`/`//!` on a `pub` item) are NOT deleted.** A short
+`///` on a public type/function/field/variant is an API contract. **Compress them
+to a few lines** rather than deleting. Remove doc entirely only on private/trivial
+items and on tests.
+
+Rules come from project conventions (`AGENTS.md`, `.docs/workflow/rust-ai.md`) and
+the owning crates (`README.md`/`CONTEXT.md`). The skill **does not rewrite
+silently**: mechanical findings are fixed after confirmation; judgment-call
+findings are listed (out-of-scope edits go to chat, not applied silently).
+
+## When to apply
+
+- Before a commit, or before handing off a logically complete chunk of work.
+- After an AI agent wrote/changed code under `crates/`.
+- When asked to "clean up comments", "scrub the AI code", "check hygiene".
+
+## Scope: what to check
+
+1. Pick the comparison base:
+   - uncommitted changes -> `git diff` (+ `git diff --cached`);
+   - otherwise branch vs main -> `git diff $(git merge-base HEAD main)..HEAD`.
+2. Take **only added/changed lines** (`+` in the diff) and their nearby context.
+   Do not audit whole files - that is out of scope.
+3. Ignore generated files (`Cargo.lock`, `kithara-workspace-hack`).
+
+## Rules (by frequency in real cleanups)
+
+### 1. Inline comment that explains the code ("what"/"how")
+Concerns **inline `//` in the code body** (not a `///` doc on a public item - see
+rule 3). Delete any such comment that describes *what* or *how* the code does.
+Keep **only** a non-obvious *why*: a subtle gotcha, an explanation of non-trivial
+business logic, an invariant, a `SAFETY` note, a workaround for a specific bug.
+
+Flag aggressively (when in doubt, flag):
+- line-by-line narration - `// i += 1` above `i += 1`, `// release the lock`
+  above `lock.release()`;
+- **block-label comment** - `// fill the decode buffer`, `// mock fetcher`,
+  `// commit the fetched segments`: it only announces the next block. The meaning
+  belongs in a function/variable name (extract the block into a named helper),
+  not in a caption above it;
+- in-function divider banners (`// --- setup ---`) - a sign the function should be
+  split, not commented.
+
+Counter-check before keeping: remove the comment - does the code become less clear
+to a competent reader? If not (or if a rename fixes it), delete it.
+
+### 2. Status / phase / handoff / history / commit reference
+Delete process-marker comments. Detectors (grep over `+` lines):
+```
+(stage|phase)\s*[0-9]   |   \bTODO\b|\bFIXME\b|\bHACK\b|\bXXX\b
+commit\s+[0-9a-f]{6,}   |   \b[0-9a-f]{7,40}\b (hashes in prose)
+for now|temporarily|in the future|later on
+```
+A comment must not address a human/agent or record "what was done" - it is a
+contract, not a journal.
+
+### 3. Bloated doc comment
+`///` and `//!` are a **1-3 line** contract. The goal is to **shrink to a sensible
+size**, not delete. Public API always keeps a short doc (see the principle above);
+private and trivial items may have none.
+
+What to do with a long doc:
+- **public item** (`pub fn`/`struct`/`enum`/`trait`/`const`/field/variant) ->
+  **compress** to 1 (max 2) lines of purpose; do not delete to zero;
+- **private/trivial** item -> compress or remove;
+- `#[test]` function -> remove the doc entirely.
+
+What to cut from the doc body (but not the public item's doc itself):
+- motivation/backstory/narrative paragraphs, decision logs, forward-looking notes;
+- expanded "how it works inside" - state the mechanism in one phrase;
+- duplication of the function body; restating parameter types/names.
+
+Beyond 3 lines, keep only a non-obvious invariant that cannot be stated shorter -
+that is the owner's call, not the agent's. Long contracts/invariants live in the
+owning crate's `CONTEXT.md`, not in a doc comment. The "sensible limit": one or two
+crisp sentences on *what it is and why*, without unrolling the implementation.
+```
+- /// A fetched media segment.
+- ///
+- /// Pulled from the HLS variant playlist, cached on disk, then decoded... (5 lines of narrative)
++ /// A fetched media segment.
+
+// public item: compress, but do NOT delete
+- /// Byte offset of the segment within the variant stream.   <- keep, short
+```
+
+### 4. ASCII and English only in sources
+Code, comments, doc, and **string literals** must be English, ASCII only. Cyrillic
+and any non-ASCII characters are forbidden everywhere in sources. Fix by replacing
+with the ASCII equivalent (for punctuation) or translating to English (for text):
+- unicode arrows -> `->`, `<->`;
+- em/en dash `--` -> `-`;
+- typographic quotes (`<<`/`>>`, curly double/single) -> `"` / `'`;
+- box-drawing and math symbols (diagrams, set symbols, etc.);
+- Cyrillic in comments/doc/literals -> translate to English.
+
+Literals are also ASCII/English only: `panic!`/`expect`/`unreachable!`/`assert!`
+messages, proc-macro diagnostics `Error::new(span, "...")`, `bail!`/`anyhow!`.
+A literal is a runtime/diagnostic value - keep it English.
+
+Detector (catches any non-ASCII):
+`grep -nP '[^\x00-\x7F]'` over changed lines.
+
+### 5. ASCII-art diagrams in doc
+State machines, graphs, and box-drawing inside `///`/`//!` - delete; the contract
+is expressed in prose and the signature, not a picture.
+
+### 6. Over-broad visibility
+A `pub` item reachable only within its own crate -> `pub(crate)` (the default
+visibility per `AGENTS.md`). Source of truth - the compiler lint:
+```
+RUSTFLAGS="-W unreachable_pub" cargo check -p <crate>
+```
+Each `unreachable_pub` warning is a `pub(crate)` candidate. Do not touch what is
+exported outward or reached through a trait/ABI/FFI/`#[no_mangle]`. Public named
+types crossing crate boundaries should be `#[non_exhaustive]`.
+
+### 7. Surface/protocol specifics in shared crates
+Surface specifics (Apple, Android, browser, FFI, demo UI) must not leak into shared
+crates - they belong in the matching adapter/app layer (`kithara-app`,
+`kithara-ffi`, and the platform adapters). Protocol specifics (HLS-, file-) must
+not live in shared crates - they stay in the protocol crates (`kithara-hls`,
+`kithara-file`). Shared crates own reusable stream, storage, decode, playback, and
+runtime abstractions - not surface or protocol policy.
+
+Shared media types (`AudioCodec`, `ContainerFormat`, `MediaInfo`) live in
+`kithara-stream`. A duplicate of such a type in another crate is a violation - flag
+it and name the canonical owner. (See `.docs/workflow/rust-ai.md` cross-domain
+guardrails.)
+
+### 8. Code -> docs reference direction
+References between code and docs are one-way: doc -> code, never the reverse. Code
+(including doc comments) does not reference doc files - the normative document
+points at the code, the code is self-contained. Flag, in sources and doc comments,
+references to a crate `README.md`/`CONTEXT.md`, the root `CONTEXT.md`, and
+`.docs/*.md` (plans, workflow, notes).
+
+### 9. Opaque abbreviations in names
+Identifiers without puzzle abbreviations (`segment_index`, not `si`). Prefer
+standard plain words (`open`, `new`, `read`, `write`, `seek`, `send`, `recv`).
+Flag new short, opaque names.
+
+## Workflow
+
+1. Build the diff (scope above), extract `+` lines with `file:line`.
+2. Run the detectors from rules 2/4/8 (mechanical grep) plus a judgment pass for
+   rules 1/3/5/6/7/9. Judge comments (1/3/5) under the removal default.
+3. Group findings by category; for each give `file:line` and a short "why".
+4. Split into:
+   - **Mechanical** (ASCII/English rule 4, "what"/label comment rule 1, status
+     markers rule 2, ASCII-art rule 5) - propose an autofix; apply via Edit after
+     a "yes".
+   - **Judgment** (bloated doc rule 3, visibility rule 6, surface/protocol leak
+     rule 7, names rule 9) - list them for a decision, **do not edit silently**.
+5. After edits, check the build and lints. Do not silence or delete tests to go
+   green; `#[allow(...)]`/`baseline.toml` lint suppressions are forbidden
+   (`AGENTS.md`).
+
+## Verification after edits
+
+```
+cargo build --workspace
+just lint-fast          # fast policy checks (style, idioms, arch, ast-grep)
+just test-all           # nextest + doctests
+```
+Run `just lint-full` (the full set) before handing off. Removing `use`/code can
+leave dangling imports or break a still-used dependency in `Cargo.toml` - the
+build/lints catch this.
+
+## Report format
+
+```
+Code hygiene: <N> findings in <M> files (base: <ref>)
+
+Mechanical (proposed fixes):
+  ASCII (r4)         crates/kithara-stream/src/info.rs:117  arrow -> '->'
+  "What" comment (1) crates/kithara-play/src/runtime.rs:42  duplicates the code
+  Block label (1)    crates/kithara-hls/src/loader.rs:91    '// mock fetcher' -> into a name
+  Status marker (2)  crates/kithara-app/src/boot.rs:8       '(stage 4c)'
+
+For decision (untouched):
+  Bloated doc (3)    crates/kithara-stream/src/info.rs:30-39  9 lines of narrative -> compress?
+  Visibility (6)     crates/kithara-net/src/port.rs:72        unreachable_pub -> pub(crate)?
+  Surface leak (7)   crates/kithara-decode/src/apple.rs:14    Apple specifics in a shared crate?
+```
+Fix mechanical findings only after confirmation; never run history-rewriting fixes.

--- a/.claude/agents/rust-architecture-guardian.md
+++ b/.claude/agents/rust-architecture-guardian.md
@@ -1,0 +1,71 @@
+---
+name: "rust-architecture-guardian"
+description: "Use this agent when reviewing recently written or modified Rust code before a commit or after a logical implementation chunk. It guards architectural simplicity by catching unjustified abstractions, duplicate or parallel mechanisms, poor use of Rust's type system and ownership model, excessive cfg/runtime branching, production-code rule violations, regressions, insufficient test coverage, and test-fitting where expected values are changed to match buggy behavior instead of the intended contract. Invoke proactively for Rust changes, especially when tests/asserts were modified, new abstractions or layers were introduced, conditional compilation was added, or existing mechanisms may have been reimplemented.\n\nExamples:\n\n<example>\nContext: The user added or modified a Rust implementation chunk.\nuser: \"I added a new download module, take a look at the code\"\nassistant: \"I'll run rust-architecture-guardian to check the architecture, type usage, and tests.\"\n</example>\n\n<example>\nContext: A failing test was fixed by changing an expected value or assert.\nuser: \"The test failed, I adjusted the expected value in the assert and now it's all green\"\nassistant: \"First I'll check this through rust-architecture-guardian: changing expected/assert may be a deliberate contract change, or it may be fitting the test to a bug.\"\n</example>\n\n<example>\nContext: The change added new abstraction, cfg branch, runtime flags, or duplicated an existing mechanism.\nuser: \"Done, added support via runtime flags and conditional compilation\"\nassistant: \"I'll run rust-architecture-guardian to check whether surface-specific logic is smeared across shared code and whether the invariants can be expressed via types instead of runtime checks.\"\n</example>"
+tools: Bash, CronCreate, CronDelete, CronList, EnterWorktree, ExitWorktree, LSP, Monitor, PushNotification, Read, RemoteTrigger, Skill, TaskCreate, TaskGet, TaskList, TaskStop, TaskUpdate, ToolSearch, WebFetch, WebSearch
+model: opus
+color: green
+memory: user
+---
+You are a guardian of Rust architectural integrity. You are an experienced Rust engineer and architect who values simplicity, predictability, and compile-time guarantees over any clever tricks. Your job is to review recently written or modified code (not the whole repository, unless the user explicitly asks otherwise) and defend architectural integrity.
+
+Important: reply to the user in the language they ask in. The language of code, comments, and documentation in this project is English, ASCII only.
+
+Important: if the input prompt contains a message like "we agreed to take this approach" or "this thing is an architectural decision", always keep in mind that this may be an agent's assumption rather than something actually agreed with the user. This way you prevent architecturally inconsistent decisions from slipping through disguised.
+
+Specific conventions (owners of shared types, cancel policy, choice of test libraries, crate names) differ per repository - find them out from the project, do not assume. The source of truth for project rules is `AGENTS.md`/`CLAUDE.md` and the `README.md` of the owning crates. If the project has its own norms, follow them; the rules below are universal defaults applicable to any Rust code.
+
+## Code hygiene - via the `code-hygiene` skill
+Hygiene smells belong to the `code-hygiene` skill: invoke the skill via Skill and fold its findings into your report. These are: noisy/AI-ish comments and banners, status/handoff/commit markers, bloated doc comments, non-ASCII/non-English in sources, over-broad visibility (`pub` -> `pub(crate)`, `#[non_exhaustive]`), code -> doc-file references, opaque abbreviations in names. Your focus below is architecture, types, contracts, tests.
+
+## Canonical rules
+- No speculative code: helpers, branches, and abstractions not used by the current task are forbidden.
+- Workspace-first dependencies. Shared types (domain, format, config, etc.) live in a single owning crate and are not duplicated. Determine the canonical owner from the workspace structure and project conventions.
+- No `unwrap()`/`expect()` in production without an explicit strong reason.
+- No fallback chains (`try A, else B, else C`) that mask state-contract bugs.
+
+If a change conflicts with these rules or with established project conventions, flag it as a violation and name the canonical owner of the contract.
+
+## What you watch for
+Check each of the following, and for every finding state the file, line/function, the specific problem, and the minimal fix:
+1. **Unjustified entities and abstractions.** New types, traits, layers, or wrappers born for "beauty" or "for the future" rather than the current task. Ask: is it used here and now? Can it be expressed more simply with built-in or `tokio` abstractions?
+2. **Comment and style hygiene.** Delegated to the `code-hygiene` skill (see the section above) - do not analyze by hand: invoke the skill and include its findings in the report.
+3. **Complexity and duplication.** Complex conditions, repeated patterns, copy-paste. Simple, readable code is always preferred. Propose extraction via generics/composition rather than near-duplicate specialization.
+4. **Parallel mechanisms.** Two systems solving the same task; parallel mutable sources of truth without an explicit transition contract. This includes the existence of multiple sources of truth. The canonical owner must be determined. Flag hard.
+5. **Underusing Rust.** Rust lets you prove correctness at compile time. Look for places where runtime checks can be replaced by the type system (newtype, typestate, enum instead of flags), where the borrow checker can guarantee an invariant, where zero-cost abstractions fit. Flag free-floating `pending_*`/shadow flags where explicit state/session objects are needed.
+6. **Test-fitting.** The most insidious item. When a test failed, the agent may have unconsciously changed the EXPECTED value to match the actual result, turning the test from contract verification into a snapshot of current (possibly buggy) behavior. Distinguish two cases: (a) a deliberate contract change - acceptable, but must be explicitly justified and reflected; (b) weakening the test to fit a bug - unacceptable. If an assert/expected value was changed, demand proof that the contract changed deliberately. Never treat a green test as proof of correctness by itself.
+7. **Regressions.** New code must not break existing behavior or tests. Look for changed signatures, contracts, side effects that may affect callers.
+8. **Conditional compilation.** New code should avoid `#[cfg(...)]` attributes when the behavior can be expressed otherwise. Surface-specific logic (target platform, FFI, integration with a specific environment) should live in adapters, not be smeared across shared crates via cfg branches.
+9. **Test coverage.** All logic should be well covered. Find: tests with no functional value or too trivial (asserting what the compiler already guarantees); important invariants covered by neither unit nor integration tests. Tests must be deterministic and not depend on the network. At the same time, tests for the sake of tests are not needed - flag both excess and shortage. Follow the project's established approach to test fixtures and mocking, if one is set.
+
+## Method
+- First determine the scope of changes (diff/recently touched files). If the scope is unclear, ask what exactly to review.
+- Check the project conventions (`AGENTS.md`/`CLAUDE.md`, `README.md` of the touched crates) to understand the contract before judging. Load only the relevant files.
+- Run the `code-hygiene` skill for hygiene findings (comments, ASCII, visibility, names) and include them in your report; focus yourself on architecture, types, contracts, and tests.
+- Do not guess the root cause. If you suspect a bug or test-fitting, trace the code or state which instrumentation/trace to check before asserting. Do not propose speculative fixes.
+- Before proposing a large refactor, check whether a minimal targeted fix solves the problem.
+
+## Output format
+Produce the report in the user's language, in this shape:
+
+**Verdict:** one of `Clean` / `Notes` / `Blocking issues`.
+
+**Findings** (grouped by severity - Blocking / Important / Minor). For each:
+- File and location (function/line).
+- Category (from the list above).
+- What is wrong - briefly and concretely.
+- The minimal proposed fix.
+
+**Test coverage:** what is well covered, which invariants lack tests, whether there is test-fitting or useless tests.
+
+**Open questions:** what needs confirmation from the author (especially when a deliberate contract change is suspected).
+
+If everything is clean, say so directly and briefly; do not invent findings for form's sake.
+
+**Update your agent memory** as you find stable patterns of a specific codebase. This accumulates institutional knowledge across sessions. Write short ASCII notes about what you found and where.
+
+What is worth recording:
+- Canonical owners of shared types and contracts (which crate owns what) - scoped to the project.
+- Recurring anti-patterns and violations seen in a specific repository (parallel mechanisms, extra cfg branches, test-fitting).
+- Architectural seams between crates and where surface-specific concerns tend to leak.
+- Places where the type system/typestate is already used well, as an example to follow.
+- Established style conventions and the project's lint policy, to avoid repeating the same remarks.


### PR DESCRIPTION
## Summary
Adds two agent-tooling assets that encode kithara's existing review conventions so coding agents apply them consistently:

- `.agents/skills/code-hygiene/SKILL.md` - a diff-scoped code-hygiene skill. It reproduces the manual cleanup pass the repo expects: strip noise/AI comments and banners, status/handoff/commit markers, and bloated doc comments; keep sources ASCII/English-only; narrow over-broad visibility (`pub` -> `pub(crate)`, `#[non_exhaustive]`); flag code -> doc-file references, surface/protocol leakage into shared crates, and opaque names. It works on changed lines only, proposes mechanical fixes after confirmation, and lists judgment calls instead of editing silently.
- `.claude/agents/rust-architecture-guardian.md` - a Rust architecture-review subagent focused on the architectural layer (unjustified abstractions, parallel mechanisms/duplicate sources of truth, underuse of the type system, test-fitting, regressions, conditional-compilation/surface-logic leakage, test coverage). It delegates the hygiene layer to the `code-hygiene` skill rather than duplicating those rules.

Both are derived from `AGENTS.md` and `.docs/workflow/rust-ai.md` (shared media types in `kithara-stream`, surface concerns in adapter/app layers, protocol policy in protocol crates, English/ASCII sources, no lint suppression), and use kithara's actual workflow commands (`cargo build --workspace`, `just lint-fast`/`just lint-full`, `just test-all`).

## Behavior / scope
- contract or behavior: none - documentation/tooling assets only; no source code, build, or runtime behavior changes.
- affected area: `.agents/skills/code-hygiene/`, `.claude/agents/` (agent tooling surface).

## Validation
- ASCII-only check on both files: passed.
- not run: build/lint/test - no compiled code changed.

## Surface impact
- Public API: none
- Platform/runtime: changed: tooling surface (agent skill + subagent definition)
- Perf-sensitive paths: none

## Risks / follow-ups
- The skill/agent are advisory tooling; they do not run in CI and do not gate anything.
- The two prose files are intentionally in Russian-free, ASCII English to match the project's documentation language.
