### PR TITLE
fix(apple): pass seek completion closure in demo after wrapper API change

### DIFF
--- a/apple/Examples/KitharaDemo/KitharaPlayground.playground/Contents.swift
+++ b/apple/Examples/KitharaDemo/KitharaPlayground.playground/Contents.swift
@@ -3,18 +3,6 @@ import Kithara
 import PlaygroundSupport
 import SwiftUI
 
-final class SeekHandler: SeekCallback, @unchecked Sendable {
-    private let onDone: @Sendable (Bool) -> Void
-
-    init(onDone: @escaping @Sendable (Bool) -> Void) {
-        self.onDone = onDone
-    }
-
-    func onComplete(finished: Bool) {
-        onDone(finished)
-    }
-}
-
 @MainActor
 final class PlaygroundModel: ObservableObject {
     @Published var url = "https://audio-ssl.itunes.apple.com/itunes-assets/AudioPreview116/" +
@@ -87,11 +75,11 @@ final class PlaygroundModel: ObservableObject {
 
     func seek() {
         let target = currentTime
-        player.seek(to: target, tolerance: nil, completionHandler: SeekHandler { [weak self] done in
+        player.seek(to: target, tolerance: nil) { [weak self] done in
             Task { @MainActor in
                 self?.log = done ? "Seek done: \(Int(target))s" : "Seek failed"
             }
-        })
+        }
     }
 
     func commitVolume() {

--- a/apple/Examples/KitharaDemo/Sources/PlayerViewModelBase.swift
+++ b/apple/Examples/KitharaDemo/Sources/PlayerViewModelBase.swift
@@ -372,18 +372,14 @@ class PlayerViewModelBase: ObservableObject {
 
     func onSeekEnded(_ value: TimeInterval) {
         currentTime = value
-        player.seek(
-            to: value,
-            tolerance: nil,
-            completionHandler: SeekHandler { [weak self] finished in
-                DispatchQueue.main.async {
-                    self?.isSeeking = false
-                    if !finished {
-                        self?.errorMessage = "Seek failed"
-                    }
+        player.seek(to: value, tolerance: nil) { [weak self] finished in
+            DispatchQueue.main.async {
+                self?.isSeeking = false
+                if !finished {
+                    self?.errorMessage = "Seek failed"
                 }
             }
-        )
+        }
     }
 
     // MARK: - Helpers used by both subclasses
@@ -422,20 +418,6 @@ class PlayerViewModelBase: ObservableObject {
     func trackLabel(_ entryId: TrackId) -> String {
         let name = playlist.first(where: { $0.id == entryId })?.name ?? "unknown"
         return "[\(name)]"
-    }
-}
-
-// MARK: - SeekCallback implementation
-
-final class SeekHandler: SeekCallback, @unchecked Sendable {
-    private let handler: (Bool) -> Void
-
-    init(handler: @escaping (Bool) -> Void) {
-        self.handler = handler
-    }
-
-    func onComplete(finished: Bool) {
-        handler(finished)
     }
 }
 


### PR DESCRIPTION
## Summary
`KitharaPlayer.seek(to:tolerance:completionHandler:)` now takes a `SeekCompletionHandler` closure (`(Bool) -> Void`) and wraps it in the internal `ClosureSeekCallback` itself, but the demo app still constructed a `SeekCallback`-conforming `SeekHandler` object and passed it as `completionHandler`. This drift breaks the demo build on `main` ("cannot convert value of type 'SeekHandler' to expected argument type 'SeekCompletionHandler'"). The fix replaces the object with a trailing closure at both call sites and deletes the now-unused `SeekHandler` class from `PlayerViewModelBase.swift` and the playground copy in `KitharaPlayground.playground`.

## Behavior / scope
- contract or behavior: none — demo-only compile fix; runtime seek behavior is unchanged
- affected area: `apple/Examples/KitharaDemo` (shared `PlayerViewModelBase.swift` used by iOS/macOS/Rx targets, plus the playground example)

## Validation
- `xcodegen generate` in `apple/Examples/KitharaDemo` (twice: the first build's pre-build script bakes `Sources/Generated/Secrets.swift`, the second generate picks it up)
- `xcodebuild -scheme KitharaDemo_iOS -destination 'generic/platform=iOS Simulator' ARCHS=arm64 ONLY_ACTIVE_ARCH=YES build` — BUILD SUCCEEDED (arm64-only because the locally prebuilt Rust static lib has no x86_64 slice; unrelated to this change)
- `xcodebuild -scheme KitharaDemoUITests_macOS -destination 'platform=macOS' build` — BUILD SUCCEEDED (builds the `KitharaDemo_macOS` host; it has no standalone scheme)
- `xcodebuild -scheme KitharaDemoRx_iOS -destination 'generic/platform=iOS Simulator' ARCHS=arm64 ONLY_ACTIVE_ARCH=YES build` — BUILD SUCCEEDED

## Surface impact
- Public API: none
- Platform/runtime: apple (demo/example targets only)
- Perf-sensitive paths: none

## Risks / follow-ups
- none