### PR TITLE
chore(deps): upgrade workspace dependencies

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -28,7 +28,6 @@
     ]
   },
   "enabledPlugins": {
-    "ralph-loop@claude-plugins-official": true,
-    "claude-octopus@nyldn-plugins": true
+    "ralph-loop@claude-plugins-official": true
   }
 }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,8 @@ version: 2
 updates:
   - package-ecosystem: cargo
     directory: /
+    exclude-paths:
+      - crates/kithara-workspace-hack/Cargo.toml
     schedule:
       interval: weekly
     open-pull-requests-limit: 5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,11 +297,11 @@ dependencies = [
 
 [[package]]
 name = "askama"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f75363874b771be265f4ffe307ca705ef6f3baa19011c149da8674a87f1b75c4"
+checksum = "f1bf825125edd887a019d0a3a837dcc5499a68b0d034cc3eb594070c3e18addc"
 dependencies = [
- "askama_derive",
+ "askama_macros",
  "itoa",
  "percent-encoding",
  "serde",
@@ -310,12 +310,13 @@ dependencies = [
 
 [[package]]
 name = "askama_derive"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "129397200fe83088e8a68407a8e2b1f826cf0086b21ccdb866a722c8bcd3a94f"
+checksum = "e1c7065972a130eafa84215f21352ae15b4a7393da48c1f5e103904490736738"
 dependencies = [
  "askama_parser",
  "basic-toml",
+ "glob",
  "memchr",
  "proc-macro2",
  "quote",
@@ -326,15 +327,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "askama_parser"
-version = "0.14.0"
+name = "askama_macros"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ab5630b3d5eaf232620167977f95eb51f3432fc76852328774afbd242d4358"
+checksum = "0e23b1d2c4bd39a41971f6124cef4cc6fd0540913ecb90919b69ab3bbe44ae1a"
 dependencies = [
- "memchr",
+ "askama_derive",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7db09fde9143e7ac4513358fb32ee32847125b63b18ea715afd487956da715da"
+dependencies = [
+ "rustc-hash 2.1.2",
  "serde",
  "serde_derive",
- "winnow 0.7.15",
+ "unicode-ident",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -754,7 +765,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-time",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1219,15 +1230,6 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo-platform"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
@@ -1238,26 +1240,12 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
-dependencies = [
- "camino",
- "cargo-platform 0.1.9",
- "semver",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "cargo_metadata"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
 dependencies = [
  "camino",
- "cargo-platform 0.3.3",
+ "cargo-platform",
  "semver",
  "serde",
  "serde_json",
@@ -2390,7 +2378,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2582,7 +2570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3074,9 +3062,9 @@ dependencies = [
 
 [[package]]
 name = "fs-err"
-version = "2.11.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
 dependencies = [
  "autocfg",
 ]
@@ -3586,9 +3574,9 @@ dependencies = [
 
 [[package]]
 name = "hotpath"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2c28b1fa962e433f800ed1ea0bf53dc028d3745cf2acec6cfd28b65ac96afa"
+checksum = "467479f30ae7262ad93eff1f6653a58ecfca4b44dd9ff82ef4b469ba1ad00017"
 dependencies = [
  "arc-swap",
  "cfg-if",
@@ -3610,9 +3598,9 @@ dependencies = [
 
 [[package]]
 name = "hotpath-macros"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a585238d8daf746e27df0f24d1bbdcd2410e9febff63f9a0173f90d7e71c50f6"
+checksum = "7edb8da2a00454786fbb75ab24c4f72380afeb9b5136776caa7737df9895bfa7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3621,15 +3609,15 @@ dependencies = [
 
 [[package]]
 name = "hotpath-macros-meta"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "309f63c2f755dead454dd4b3ea8ab5c947f14f8ea435fbcd37fa820e17290e80"
+checksum = "e804ccbbd13922ff16b752ab72043d15ea38411a03a82917b8ea5b36b6b45655"
 
 [[package]]
 name = "hotpath-meta"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68faa91a9e1114dff668cd90560f332da6bbde40dae37ec28ea1c43ca5ce3be3"
+checksum = "7f76b1b9a176e5677878243b0c9052d2e0a62405359bd6990bbd85b59cafa2aa"
 dependencies = [
  "hotpath-macros-meta",
 ]
@@ -3781,7 +3769,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -4185,7 +4173,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4410,7 +4398,7 @@ dependencies = [
  "kithara-workspace-hack",
  "num-traits",
  "obfstr",
- "rand 0.10.1",
+ "rand 0.10.2",
  "ratatui",
  "serde",
  "serde_yml",
@@ -4640,7 +4628,7 @@ dependencies = [
  "kithara-test-utils",
  "ndk-context",
  "num-traits",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rustls-platform-verifier",
  "send_wrapper",
  "tempfile",
@@ -4775,7 +4763,7 @@ dependencies = [
  "mmap-io",
  "moka",
  "num-traits",
- "rand 0.10.1",
+ "rand 0.10.2",
  "reqwest",
  "ringbuf 0.5.0",
  "rkyv",
@@ -5082,6 +5070,7 @@ dependencies = [
  "thiserror 2.0.18",
  "thunderdome",
  "time",
+ "tokio",
  "tokio-util",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
@@ -5736,7 +5725,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5849,9 +5838,9 @@ dependencies = [
 
 [[package]]
 name = "obfstr"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d354e9a302760d07e025701d40534f17dd1fe4c4db955b4e3bd2907c63bdee"
+checksum = "fac6bb46461d099d52dbd345e021b92d21d1be9be967ef2bb4430b23af439a4f"
 
 [[package]]
 name = "objc"
@@ -6922,7 +6911,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6960,7 +6949,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -7016,9 +7005,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -7468,9 +7457,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
+checksum = "815cc8a37159a463064825246cadb07961e25cd9885908606f6d08a98d8f8874"
 dependencies = [
  "bytecheck",
  "bytes",
@@ -7487,9 +7476,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
+checksum = "c0ed1a78a1b19d184b0daa629dd9a024573173ec7d485b287cb369fb3607cc1c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7677,9 +7666,9 @@ dependencies = [
 
 [[package]]
 name = "rustdoc-types"
-version = "0.57.4"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7be7e9f2ca82c1fcefb69332b82c289051edcd4a3245b1715f7756103918255"
+checksum = "d5b3f47eac1cf443b5556c2351d68ea609197f7a40735c9725ce7515d6fd5e91"
 dependencies = [
  "serde",
  "serde_derive",
@@ -7722,7 +7711,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7779,7 +7768,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.8",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8875,7 +8864,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9777,13 +9766,13 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "uniffi"
-version = "0.31.2"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46eefd5468602930da46b1f49d3448c6dfc2e81295f93120f23f8174fd70267f"
+checksum = "a782a48d72cfd7a2d65cfc7c691dbf5375c43104b3c195f7eccc716dcc3540c8"
 dependencies = [
  "anyhow",
  "camino",
- "cargo_metadata 0.19.2",
+ "cargo_metadata",
  "clap",
  "uniffi_bindgen",
  "uniffi_core",
@@ -9793,14 +9782,14 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.31.2"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a0c9b375d32e1365cdb2bdd7cb495eecf6fac851ddbad077412b4ee1888514"
+checksum = "533b0312c73e3b54eb78a4b257ceae390962dd4767995778309a74644643f9ac"
 dependencies = [
  "anyhow",
  "askama",
  "camino",
- "cargo_metadata 0.19.2",
+ "cargo_metadata",
  "fs-err",
  "glob",
  "goblin 0.8.2",
@@ -9810,7 +9799,7 @@ dependencies = [
  "serde",
  "tempfile",
  "textwrap",
- "toml 0.8.23",
+ "toml 1.1.2+spec-1.1.0",
  "uniffi_internal_macros",
  "uniffi_meta",
  "uniffi_pipeline",
@@ -9819,9 +9808,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.31.2"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eec017b112701681f6fbbe5d92014b5c468eb0b177a94389de03ceec40665095"
+checksum = "8e32e261c5b0dfaba6488f536e71957dddd6b1a498ac7eb791bee56b60a086be"
 dependencies = [
  "anyhow",
  "bytes",
@@ -9831,9 +9820,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_internal_macros"
-version = "0.31.2"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4641669b48fefbc5e80ff08c5004d9c7617fb91232131a6734ab6712779cb04c"
+checksum = "84ae78069a5e6772ef694fd5bdb628532c88d2c2f0e7142bf6a384636eadb1af"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -9844,9 +9833,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.31.2"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb8617ee814de22caf7417bf514715ba0b3f46bd9d5a5d794413fd8282cb737"
+checksum = "330be6770532e86320df31f54c70bb0be67588594e8e77fa56e9083a3fed5d0d"
 dependencies = [
  "camino",
  "fs-err",
@@ -9855,15 +9844,15 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.118",
- "toml 0.8.23",
+ "toml 1.1.2+spec-1.1.0",
  "uniffi_meta",
 ]
 
 [[package]]
 name = "uniffi_meta"
-version = "0.31.2"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58d5b94fc92803d21b2928bd15c6f06e57609b95caf98ea561c99cda1b6d2a25"
+checksum = "78de021f5547e56ab16c665a49d67d4fd3d31e77422f7739a2e9359d328cd9e7"
 dependencies = [
  "anyhow",
  "siphasher",
@@ -9873,9 +9862,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_pipeline"
-version = "0.31.2"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "032739b3ec725576914c15899dedaf080163ced86b6934566c20ec2b20ce90ca"
+checksum = "3f8201bb1907ed8a42d80e11cbc25c8a033e7a31c3cff1d911f56eedb81d4948"
 dependencies = [
  "anyhow",
  "heck",
@@ -9886,9 +9875,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.31.2"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0a1d0a0252ce1af9e8ce78ba67ac0d8937fb2bedaf10cbddd43d3614d06ec6"
+checksum = "a6e57996bc58009cc29bf04845d627ae313c2547b87171c1c349d6c51a1656c0"
 dependencies = [
  "anyhow",
  "textwrap",
@@ -10755,7 +10744,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11466,7 +11455,7 @@ name = "xtask"
 version = "0.0.1-alpha4"
 dependencies = [
  "anyhow",
- "cargo_metadata 0.23.1",
+ "cargo_metadata",
  "clap",
  "glob",
  "kithara-workspace-hack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -269,7 +269,7 @@ gloo-timers = { version = "0.4", features = ["futures"] }
 # hex encoding
 hex = "0.4"
 hls_m3u8 = "0.7.0"
-hotpath = "0.18.0"
+hotpath = "0.19.1"
 # Optional: unify lint settings later via workspace.metadata or deny.toml.
 
 # UI frameworks
@@ -286,7 +286,7 @@ mmap-io = { version = "1.0", default-features = false }
 moka = { version = "0.12", features = ["sync"] }
 ndk-context = "0.1.1"
 num-traits = { version = "0.2", default-features = false }
-obfstr = "0.4.4"
+obfstr = "0.4.5"
 objc2 = "0.6.4"
 objc2-foundation = { version = "0.3.2", default-features = false }
 parking_lot = "0.12"
@@ -298,7 +298,7 @@ portable-atomic = { version = "1.13.1", default-features = false, features = ["f
 proc-macro2 = "1"
 proptest = "1"
 quote = "1"
-rand = "0.10.1"
+rand = "0.10.2"
 rangemap = { version = "1.7.1", features = ["serde1"] }
 ratatui = "0.30.2"
 re_mp4 = "0.5.0"
@@ -306,13 +306,13 @@ realfft = "3.5"
 regex = "1"
 reqwest = { version = "0.13.4", default-features = false }
 ringbuf = "0.5.0"
-rkyv = "0.8.16"
+rkyv = "0.8.17"
 rstest = { version = "0.26.1", features = ["async-timeout", "crate-name"] }
 # Beat detection NN inference (kithara-beat).
 rten = { version = "0.24", features = ["fft"] }
 rten-tensor = "0.24"
 rubato = "3.0"
-rustdoc-types = "0.57.4"
+rustdoc-types = "0.60.0"
 rustls-platform-verifier = "0.7.0"
 send_wrapper = "0.6"
 serde = { version = "1.0", features = ["derive"] }
@@ -346,7 +346,7 @@ tracing-android = "0.2.0"
 tracing-log = "0.2"
 tracing-subscriber = { version = "0.3.23", default-features = false, features = ["fmt", "registry"] }
 tracing-wasm = "0.2"
-uniffi = { version = "0.31.2", default-features = false }
+uniffi = { version = "0.32.0", default-features = false }
 unimock = { version = "0.6", features = ["std"] }
 url = "2.5.8"
 usdt = { version = "0.6", default-features = false, features = ["asm"] }

--- a/crates/kithara-file/src/session/source.rs
+++ b/crates/kithara-file/src/session/source.rs
@@ -3,11 +3,11 @@ use std::{num::NonZeroUsize, ops::Range, sync::Arc};
 use kithara_assets::{AssetReader, AssetStore, ReadSide, ResourceKey};
 use kithara_events::EventBus;
 use kithara_platform::{CancelToken, sync::Mutex, time::Duration};
-use kithara_storage::WaitOutcome;
+use kithara_storage::{ResourceStatus, StorageError, WaitOutcome};
 use kithara_stream::{
-    Activity, AudioCodec, MediaInfo, PlayheadRead, PlayheadWrite, ReadOutcome, SeekControl,
-    SeekObserve, SegmentDescriptor, SourceError as StreamSourceError, SourcePhase, StreamError,
-    WorkerWake, dl::PeerHandle,
+    Activity, AudioCodec, MediaInfo, NotReadyCause, PendingReason, PlayheadRead, PlayheadWrite,
+    ReadOutcome, SeekControl, SeekObserve, SegmentDescriptor, SourceError as StreamSourceError,
+    SourcePhase, StreamError, WorkerWake, dl::PeerHandle,
 };
 use tracing::trace;
 use url::Url;
@@ -115,6 +115,26 @@ impl FileSource {
         }
     }
 
+    fn zero_read_outcome(&self, offset: u64) -> kithara_stream::StreamResult<ReadOutcome> {
+        match self.inner.asset.reader.status() {
+            ResourceStatus::Active => Ok(ReadOutcome::Pending(PendingReason::NotReady(
+                NotReadyCause::SourcePending,
+            ))),
+            ResourceStatus::Committed {
+                final_len: Some(len),
+            } if offset < len => Ok(ReadOutcome::Pending(PendingReason::NotReady(
+                NotReadyCause::SourcePending,
+            ))),
+            ResourceStatus::Committed { .. } => Ok(ReadOutcome::Eof),
+            ResourceStatus::Failed(reason) => Err(StreamError::Source(
+                FileSourceError::Storage(StorageError::Failed(reason)).into(),
+            )),
+            ResourceStatus::Cancelled => Err(StreamError::Source(
+                FileSourceError::Storage(StorageError::Cancelled).into(),
+            )),
+        }
+    }
+
     /// Build a `FileSource` over a pre-constructed [`FileInner`]. The
     /// inner is created up in `stream.rs::Stream<File>::open` and shared
     /// with [`FilePeer`](super::FilePeer); the Downloader owns the fetch
@@ -159,7 +179,12 @@ impl kithara_stream::Source for FileSource {
 
     fn phase_at(&self, range: Range<u64>) -> SourcePhase {
         let Some(readable) = self.readable_part(range.clone()) else {
-            return SourcePhase::Eof;
+            return match self.inner.asset.reader.status() {
+                ResourceStatus::Committed { .. } => SourcePhase::Eof,
+                ResourceStatus::Active | ResourceStatus::Failed(_) | ResourceStatus::Cancelled => {
+                    SourcePhase::Waiting
+                }
+            };
         };
         let contains = readable.is_empty() || self.inner.asset.reader.contains_range(readable);
         if contains {
@@ -198,7 +223,7 @@ impl kithara_stream::Source for FileSource {
             .map_err(|e| StreamError::Source(FileSourceError::Storage(e).into()))?;
 
         let Some(count) = NonZeroUsize::new(n) else {
-            return Ok(ReadOutcome::Eof);
+            return self.zero_read_outcome(offset);
         };
 
         trace!(offset, bytes = n, "FileSource read complete");

--- a/crates/kithara-file/src/session/tests.rs
+++ b/crates/kithara-file/src/session/tests.rs
@@ -7,8 +7,8 @@ use kithara_events::EventBus;
 use kithara_platform::{CancelToken, time::Duration};
 use kithara_storage::WaitOutcome;
 use kithara_stream::{
-    PlayheadState, ReadOutcome, SeekState, Source, SourceError as StreamSourceError, SourcePhase,
-    StreamError,
+    NotReadyCause, PendingReason, PlayheadState, ReadOutcome, SeekState, Source,
+    SourceError as StreamSourceError, SourcePhase, StreamError,
 };
 use kithara_test_utils::kithara;
 
@@ -131,6 +131,22 @@ fn test_file_source_read_at() {
 }
 
 #[kithara::test]
+fn file_source_read_at_active_gap_reports_pending() {
+    let (res, _writer) = create_active_resource(b"hello");
+    let coord = make_coord();
+    let bus = EventBus::new(16);
+    let mut source = make_source(res, coord, bus);
+
+    let mut buf = [0u8; 5];
+    let outcome = Source::read_at(&mut source, 5, &mut buf).unwrap();
+
+    assert_eq!(
+        outcome,
+        ReadOutcome::Pending(PendingReason::NotReady(NotReadyCause::SourcePending))
+    );
+}
+
+#[kithara::test]
 fn test_file_source_len() {
     let res = create_committed_resource(b"abc");
 
@@ -159,6 +175,19 @@ fn file_source_phase_at_range(
     let source = make_source(res, coord, bus);
 
     assert_eq!(source.phase_at(range), expected);
+}
+
+#[kithara::test]
+fn file_source_phase_at_known_end_waits_until_active_commit() {
+    let data = b"hello";
+    let (res, _writer) = create_active_resource(data);
+    let coord = make_coord();
+    let bus = EventBus::new(16);
+    let total = u64::try_from(data.len()).expect("test data length fits u64");
+    coord.set_total_bytes(Some(total));
+    let source = make_source(res, coord, bus);
+
+    assert_eq!(source.phase_at(total..total + 1), SourcePhase::Waiting);
 }
 
 #[kithara::test]

--- a/crates/kithara-workspace-hack/Cargo.toml
+++ b/crates/kithara-workspace-hack/Cargo.toml
@@ -25,7 +25,7 @@ futures-channel = { version = "0.3", default-features = false, features = ["sink
 futures-sink = { version = "0.3", default-features = false, features = ["std"] }
 futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
 hashbrown-9067fe90e8c1f593 = { package = "hashbrown", version = "0.17" }
-hotpath = { version = "0.18", features = ["hotpath", "hotpath-alloc"] }
+hotpath = { version = "0.19", features = ["hotpath", "hotpath-alloc"] }
 indexmap = { version = "2", features = ["serde"] }
 memchr = { version = "2" }
 num-integer = { version = "0.1", features = ["i128"] }
@@ -47,25 +47,58 @@ thiserror = { version = "2" }
 thunderdome = { version = "0.6", default-features = false, features = ["std"] }
 toml_parser = { version = "1" }
 
-[target.aarch64-apple-darwin.dependencies]
+[build-dependencies]
+arrayvec = { version = "0.7" }
+cpal = { version = "0.17", default-features = false, features = ["wasm-bindgen"] }
+crossbeam-utils = { version = "0.8" }
+firewheel = { version = "0.10", default-features = false, features = ["cpal", "tracing", "wasm-bindgen"] }
+firewheel-cpal = { version = "0.10", default-features = false, features = ["tracing", "wasm-bindgen"] }
+foldhash = { version = "0.2", default-features = false, features = ["std"] }
+futures-channel = { version = "0.3", default-features = false, features = ["sink", "std"] }
+futures-sink = { version = "0.3", default-features = false, features = ["std"] }
+futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
+hashbrown-9067fe90e8c1f593 = { package = "hashbrown", version = "0.17" }
+hotpath = { version = "0.19", features = ["hotpath", "hotpath-alloc"] }
+indexmap = { version = "2", features = ["serde"] }
+memchr = { version = "2" }
+num-integer = { version = "0.1", features = ["i128"] }
+num-traits = { version = "0.2", features = ["i128", "libm"] }
+once_cell = { version = "1" }
+portable-atomic = { version = "1", default-features = false, features = ["fallback", "float", "require-cas", "std"] }
+proc-macro2 = { version = "1", features = ["span-locations"] }
+quote = { version = "1" }
+reqwest = { version = "0.13", default-features = false, features = ["brotli", "cookies", "deflate", "gzip", "native-tls", "rustls", "stream", "zstd"] }
+ringbuf = { version = "0.4", features = ["portable-atomic"] }
+rustfft = { version = "6" }
+semver = { version = "1", features = ["serde"] }
+serde = { version = "1", features = ["alloc", "derive"] }
+serde_core = { version = "1", features = ["alloc"] }
+serde_json = { version = "1", features = ["alloc", "unbounded_depth"] }
+smallvec = { version = "1", default-features = false, features = ["const_new", "union"] }
+syn = { version = "2", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
+thiserror = { version = "2" }
+thunderdome = { version = "0.6", default-features = false, features = ["std"] }
+toml_parser = { version = "1" }
+
+[target.x86_64-unknown-linux-gnu.dependencies]
 aho-corasick = { version = "1" }
 bit-set = { version = "0.8" }
 bit-vec = { version = "0.8" }
 bitflags = { version = "2", default-features = false, features = ["std"] }
-block2 = { version = "0.6" }
 bytemuck = { version = "1", default-features = false, features = ["aarch64_simd", "derive", "extern_crate_alloc", "min_const_generics"] }
 clap = { version = "4", features = ["derive", "env"] }
 clap_builder = { version = "4", default-features = false, features = ["color", "env", "help", "std", "suggestions", "usage"] }
 dasp_sample = { version = "0.11" }
 derive_more = { version = "2", features = ["from", "is_variant"] }
 either = { version = "1", default-features = false, features = ["use_std"] }
-errno = { version = "0.3" }
 form_urlencoded = { version = "1" }
 futures = { version = "0.3", features = ["thread-pool"] }
 futures-channel = { version = "0.3" }
 futures-core = { version = "0.3" }
 futures-executor = { version = "0.3", default-features = false, features = ["thread-pool"] }
+futures-io = { version = "0.3" }
 futures-sink = { version = "0.3" }
+getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 half = { version = "2", features = ["num-traits"] }
 hashbrown-986da7b5efc2b80e = { package = "hashbrown", version = "0.16" }
@@ -74,61 +107,86 @@ hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "ht
 idna = { version = "1" }
 itertools = { version = "0.13" }
 libc = { version = "0.2" }
+linux-raw-sys = { version = "0.12", default-features = false, features = ["auxvec", "elf", "errno", "general", "if_ether", "ioctl", "net", "netlink", "no_std", "prctl", "system", "xdp"] }
 log = { version = "0.4", default-features = false, features = ["std"] }
 miniz_oxide = { version = "0.8", features = ["simd"] }
 mio = { version = "1", features = ["net", "os-ext"] }
-objc2-foundation = { version = "0.3" }
 percent-encoding = { version = "2" }
 regex = { version = "1" }
 regex-automata = { version = "0.4", default-features = false, features = ["dfa-build", "dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
 regex-syntax = { version = "0.8" }
 rustc-hash = { version = "1" }
-rustix = { version = "1", features = ["fs", "stdio", "termios"] }
-rustls-pki-types = { version = "1", features = ["std"] }
+rustix = { version = "1", features = ["event", "mm", "net", "pipe", "process", "shm", "stdio", "system", "termios", "time"] }
 serde_json = { version = "1", default-features = false, features = ["raw_value"] }
 simd-adler32 = { version = "0.3" }
 slab = { version = "0.4" }
-symphonia-core = { version = "0.6", features = ["opt-simd-avx", "opt-simd-neon", "opt-simd-sse"] }
 sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
 time = { version = "0.3", features = ["formatting", "local-offset", "macros", "parsing"] }
+tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-util = { version = "0.7", features = ["codec", "io"] }
+toml_datetime = { version = "1", features = ["serde"] }
 tower = { version = "0.5", default-features = false, features = ["log", "make", "retry", "timeout"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
+winnow = { version = "1" }
 zstd = { version = "0.13" }
 zstd-safe = { version = "7", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
 zstd-sys = { version = "2", default-features = false, features = ["legacy", "std", "zdict_builder"] }
 
-[target.aarch64-apple-ios.dependencies]
+[target.x86_64-unknown-linux-gnu.build-dependencies]
 aho-corasick = { version = "1" }
+bit-set = { version = "0.8" }
+bit-vec = { version = "0.8" }
 bitflags = { version = "2", default-features = false, features = ["std"] }
-block2 = { version = "0.6" }
+bytemuck = { version = "1", default-features = false, features = ["aarch64_simd", "derive", "extern_crate_alloc", "min_const_generics"] }
+cc = { version = "1", default-features = false, features = ["parallel"] }
+clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "runtime"] }
 clap = { version = "4", features = ["derive", "env"] }
 clap_builder = { version = "4", default-features = false, features = ["color", "env", "help", "std", "suggestions", "usage"] }
 dasp_sample = { version = "0.11" }
+derive_more = { version = "2", features = ["from", "is_variant"] }
+derive_more-impl = { version = "2", features = ["from", "is_variant"] }
 either = { version = "1", default-features = false, features = ["use_std"] }
-errno = { version = "0.3" }
 form_urlencoded = { version = "1" }
+futures = { version = "0.3", features = ["thread-pool"] }
 futures-channel = { version = "0.3" }
 futures-core = { version = "0.3" }
+futures-executor = { version = "0.3", default-features = false, features = ["thread-pool"] }
+futures-io = { version = "0.3" }
 futures-sink = { version = "0.3" }
+getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
+getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
+half = { version = "2", features = ["num-traits"] }
+hashbrown-986da7b5efc2b80e = { package = "hashbrown", version = "0.16" }
+hotpath-macros = { version = "0.19", features = ["hotpath"] }
 hyper = { version = "1", features = ["client", "http1", "server"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "http1", "server", "service"] }
 idna = { version = "1" }
 itertools = { version = "0.13" }
 libc = { version = "0.2" }
-objc2-foundation = { version = "0.3" }
+linux-raw-sys = { version = "0.12", default-features = false, features = ["auxvec", "elf", "errno", "general", "if_ether", "ioctl", "net", "netlink", "no_std", "prctl", "system", "xdp"] }
+log = { version = "0.4", default-features = false, features = ["std"] }
+miniz_oxide = { version = "0.8", features = ["simd"] }
+mio = { version = "1", features = ["net", "os-ext"] }
 percent-encoding = { version = "2" }
+prettyplease = { version = "0.2", default-features = false, features = ["verbatim"] }
 regex = { version = "1" }
-regex-automata = { version = "0.4", default-features = false, features = ["dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
+regex-automata = { version = "0.4", default-features = false, features = ["dfa-build", "dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
 regex-syntax = { version = "0.8" }
+rustc-hash = { version = "1" }
+rustix = { version = "1", features = ["event", "mm", "net", "pipe", "process", "shm", "stdio", "system", "termios", "time"] }
 serde_json = { version = "1", default-features = false, features = ["raw_value"] }
+simd-adler32 = { version = "0.3" }
 slab = { version = "0.4" }
 sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
-time = { version = "0.3", features = ["formatting", "macros", "parsing"] }
+time = { version = "0.3", features = ["formatting", "local-offset", "macros", "parsing"] }
+tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-util = { version = "0.7", features = ["codec", "io"] }
+toml_datetime = { version = "1", features = ["serde"] }
 tower = { version = "0.5", default-features = false, features = ["log", "make", "retry", "timeout"] }
 tracing = { version = "0.1", features = ["log"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
+winnow = { version = "1" }
 zstd = { version = "0.13" }
 zstd-safe = { version = "7", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
 zstd-sys = { version = "2", default-features = false, features = ["legacy", "std", "zdict_builder"] }
@@ -177,190 +235,11 @@ slab = { version = "0.4" }
 symphonia-core = { version = "0.6", features = ["opt-simd-avx", "opt-simd-neon", "opt-simd-sse"] }
 sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
 time = { version = "0.3", features = ["formatting", "local-offset", "macros", "parsing"] }
+tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-util = { version = "0.7", features = ["codec", "io"] }
 tower = { version = "0.5", default-features = false, features = ["log", "make", "retry", "timeout"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
-zstd = { version = "0.13" }
-zstd-safe = { version = "7", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
-zstd-sys = { version = "2", default-features = false, features = ["legacy", "std", "zdict_builder"] }
-
-[target.x86_64-unknown-linux-gnu.dependencies]
-aho-corasick = { version = "1" }
-bit-set = { version = "0.8" }
-bit-vec = { version = "0.8" }
-bitflags = { version = "2", default-features = false, features = ["std"] }
-bytemuck = { version = "1", default-features = false, features = ["aarch64_simd", "derive", "extern_crate_alloc", "min_const_generics"] }
-clap = { version = "4", features = ["derive", "env"] }
-clap_builder = { version = "4", default-features = false, features = ["color", "env", "help", "std", "suggestions", "usage"] }
-dasp_sample = { version = "0.11" }
-derive_more = { version = "2", features = ["from", "is_variant"] }
-either = { version = "1", default-features = false, features = ["use_std"] }
-form_urlencoded = { version = "1" }
-futures = { version = "0.3", features = ["thread-pool"] }
-futures-channel = { version = "0.3" }
-futures-core = { version = "0.3" }
-futures-executor = { version = "0.3", default-features = false, features = ["thread-pool"] }
-futures-io = { version = "0.3" }
-futures-sink = { version = "0.3" }
-getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
-getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
-half = { version = "2", features = ["num-traits"] }
-hashbrown-986da7b5efc2b80e = { package = "hashbrown", version = "0.16" }
-hyper = { version = "1", features = ["client", "http1", "server"] }
-hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "http1", "server", "service"] }
-idna = { version = "1" }
-itertools = { version = "0.13" }
-libc = { version = "0.2" }
-linux-raw-sys = { version = "0.12", default-features = false, features = ["auxvec", "elf", "errno", "general", "if_ether", "ioctl", "net", "netlink", "no_std", "prctl", "system", "xdp"] }
-log = { version = "0.4", default-features = false, features = ["std"] }
-miniz_oxide = { version = "0.8", features = ["simd"] }
-mio = { version = "1", features = ["net", "os-ext"] }
-percent-encoding = { version = "2" }
-regex = { version = "1" }
-regex-automata = { version = "0.4", default-features = false, features = ["dfa-build", "dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
-regex-syntax = { version = "0.8" }
-rustc-hash = { version = "1" }
-rustix = { version = "1", features = ["event", "mm", "net", "pipe", "process", "shm", "stdio", "system", "termios", "time"] }
-serde_json = { version = "1", default-features = false, features = ["raw_value"] }
-simd-adler32 = { version = "0.3" }
-slab = { version = "0.4" }
-sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
-time = { version = "0.3", features = ["formatting", "local-offset", "macros", "parsing"] }
-tokio-util = { version = "0.7", features = ["codec", "io"] }
-toml_datetime = { version = "1", features = ["serde"] }
-tower = { version = "0.5", default-features = false, features = ["log", "make", "retry", "timeout"] }
-tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
-winnow = { version = "1" }
-zstd = { version = "0.13" }
-zstd-safe = { version = "7", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
-zstd-sys = { version = "2", default-features = false, features = ["legacy", "std", "zdict_builder"] }
-
-[build-dependencies]
-arrayvec = { version = "0.7" }
-cpal = { version = "0.17", default-features = false, features = ["wasm-bindgen"] }
-crossbeam-utils = { version = "0.8" }
-firewheel = { version = "0.10", default-features = false, features = ["cpal", "tracing", "wasm-bindgen"] }
-firewheel-cpal = { version = "0.10", default-features = false, features = ["tracing", "wasm-bindgen"] }
-foldhash = { version = "0.2", default-features = false, features = ["std"] }
-futures-channel = { version = "0.3", default-features = false, features = ["sink", "std"] }
-futures-sink = { version = "0.3", default-features = false, features = ["std"] }
-futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
-hashbrown-9067fe90e8c1f593 = { package = "hashbrown", version = "0.17" }
-hotpath = { version = "0.18", features = ["hotpath", "hotpath-alloc"] }
-indexmap = { version = "2", features = ["serde"] }
-memchr = { version = "2" }
-num-integer = { version = "0.1", features = ["i128"] }
-num-traits = { version = "0.2", features = ["i128", "libm"] }
-once_cell = { version = "1" }
-portable-atomic = { version = "1", default-features = false, features = ["fallback", "float", "require-cas", "std"] }
-proc-macro2 = { version = "1", features = ["span-locations"] }
-quote = { version = "1" }
-reqwest = { version = "0.13", default-features = false, features = ["brotli", "cookies", "deflate", "gzip", "native-tls", "rustls", "stream", "zstd"] }
-ringbuf = { version = "0.4", features = ["portable-atomic"] }
-rustfft = { version = "6" }
-semver = { version = "1", features = ["serde"] }
-serde = { version = "1", features = ["alloc", "derive"] }
-serde_core = { version = "1", features = ["alloc"] }
-serde_json = { version = "1", features = ["alloc", "unbounded_depth"] }
-smallvec = { version = "1", default-features = false, features = ["const_new", "union"] }
-syn = { version = "2", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
-thiserror = { version = "2" }
-thunderdome = { version = "0.6", default-features = false, features = ["std"] }
-toml_parser = { version = "1" }
-
-[target.aarch64-apple-darwin.build-dependencies]
-aho-corasick = { version = "1" }
-bit-set = { version = "0.8" }
-bit-vec = { version = "0.8" }
-bitflags = { version = "2", default-features = false, features = ["std"] }
-block2 = { version = "0.6" }
-bytemuck = { version = "1", default-features = false, features = ["aarch64_simd", "derive", "extern_crate_alloc", "min_const_generics"] }
-cc = { version = "1", default-features = false, features = ["parallel"] }
-clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "runtime"] }
-clap = { version = "4", features = ["derive", "env"] }
-clap_builder = { version = "4", default-features = false, features = ["color", "env", "help", "std", "suggestions", "usage"] }
-dasp_sample = { version = "0.11" }
-derive_more = { version = "2", features = ["from", "is_variant"] }
-derive_more-impl = { version = "2", features = ["from", "is_variant"] }
-either = { version = "1", default-features = false, features = ["use_std"] }
-errno = { version = "0.3" }
-form_urlencoded = { version = "1" }
-futures = { version = "0.3", features = ["thread-pool"] }
-futures-channel = { version = "0.3" }
-futures-core = { version = "0.3" }
-futures-executor = { version = "0.3", default-features = false, features = ["thread-pool"] }
-futures-sink = { version = "0.3" }
-getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
-half = { version = "2", features = ["num-traits"] }
-hashbrown-986da7b5efc2b80e = { package = "hashbrown", version = "0.16" }
-hotpath-macros = { version = "0.18", features = ["hotpath"] }
-hyper = { version = "1", features = ["client", "http1", "server"] }
-hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "http1", "server", "service"] }
-idna = { version = "1" }
-itertools = { version = "0.13" }
-libc = { version = "0.2" }
-log = { version = "0.4", default-features = false, features = ["std"] }
-miniz_oxide = { version = "0.8", features = ["simd"] }
-mio = { version = "1", features = ["net", "os-ext"] }
-objc2-foundation = { version = "0.3" }
-percent-encoding = { version = "2" }
-prettyplease = { version = "0.2", default-features = false, features = ["verbatim"] }
-regex = { version = "1" }
-regex-automata = { version = "0.4", default-features = false, features = ["dfa-build", "dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
-regex-syntax = { version = "0.8" }
-rustc-hash = { version = "1" }
-rustix = { version = "1", features = ["fs", "stdio", "termios"] }
-rustls-pki-types = { version = "1", features = ["std"] }
-serde_json = { version = "1", default-features = false, features = ["raw_value"] }
-simd-adler32 = { version = "0.3" }
-slab = { version = "0.4" }
-symphonia-core = { version = "0.6", features = ["opt-simd-avx", "opt-simd-neon", "opt-simd-sse"] }
-sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
-time = { version = "0.3", features = ["formatting", "local-offset", "macros", "parsing"] }
-tokio-util = { version = "0.7", features = ["codec", "io"] }
-tower = { version = "0.5", default-features = false, features = ["log", "make", "retry", "timeout"] }
-tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
-zstd = { version = "0.13" }
-zstd-safe = { version = "7", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
-zstd-sys = { version = "2", default-features = false, features = ["legacy", "std", "zdict_builder"] }
-
-[target.aarch64-apple-ios.build-dependencies]
-aho-corasick = { version = "1" }
-bitflags = { version = "2", default-features = false, features = ["std"] }
-block2 = { version = "0.6" }
-cc = { version = "1", default-features = false, features = ["parallel"] }
-clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "runtime"] }
-clap = { version = "4", features = ["derive", "env"] }
-clap_builder = { version = "4", default-features = false, features = ["color", "env", "help", "std", "suggestions", "usage"] }
-dasp_sample = { version = "0.11" }
-either = { version = "1", default-features = false, features = ["use_std"] }
-errno = { version = "0.3" }
-form_urlencoded = { version = "1" }
-futures-channel = { version = "0.3" }
-futures-core = { version = "0.3" }
-futures-sink = { version = "0.3" }
-hotpath-macros = { version = "0.18", features = ["hotpath"] }
-hyper = { version = "1", features = ["client", "http1", "server"] }
-hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "http1", "server", "service"] }
-idna = { version = "1" }
-itertools = { version = "0.13" }
-libc = { version = "0.2" }
-objc2-foundation = { version = "0.3" }
-percent-encoding = { version = "2" }
-prettyplease = { version = "0.2", default-features = false, features = ["verbatim"] }
-regex = { version = "1" }
-regex-automata = { version = "0.4", default-features = false, features = ["dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
-regex-syntax = { version = "0.8" }
-serde_json = { version = "1", default-features = false, features = ["raw_value"] }
-slab = { version = "0.4" }
-sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
-time = { version = "0.3", features = ["formatting", "macros", "parsing"] }
-tokio-util = { version = "0.7", features = ["codec", "io"] }
-tower = { version = "0.5", default-features = false, features = ["log", "make", "retry", "timeout"] }
-tracing = { version = "0.1", features = ["log"] }
 zstd = { version = "0.13" }
 zstd-safe = { version = "7", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
 zstd-sys = { version = "2", default-features = false, features = ["legacy", "std", "zdict_builder"] }
@@ -390,7 +269,7 @@ futures-sink = { version = "0.3" }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 half = { version = "2", features = ["num-traits"] }
 hashbrown-986da7b5efc2b80e = { package = "hashbrown", version = "0.16" }
-hotpath-macros = { version = "0.18", features = ["hotpath"] }
+hotpath-macros = { version = "0.19", features = ["hotpath"] }
 hyper = { version = "1", features = ["client", "http1", "server"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "http1", "server", "service"] }
 idna = { version = "1" }
@@ -414,6 +293,7 @@ slab = { version = "0.4" }
 symphonia-core = { version = "0.6", features = ["opt-simd-avx", "opt-simd-neon", "opt-simd-sse"] }
 sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
 time = { version = "0.3", features = ["formatting", "local-offset", "macros", "parsing"] }
+tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-util = { version = "0.7", features = ["codec", "io"] }
 tower = { version = "0.5", default-features = false, features = ["log", "make", "retry", "timeout"] }
 tracing = { version = "0.1", features = ["log"] }
@@ -422,11 +302,65 @@ zstd = { version = "0.13" }
 zstd-safe = { version = "7", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
 zstd-sys = { version = "2", default-features = false, features = ["legacy", "std", "zdict_builder"] }
 
-[target.x86_64-unknown-linux-gnu.build-dependencies]
+[target.aarch64-apple-darwin.dependencies]
 aho-corasick = { version = "1" }
 bit-set = { version = "0.8" }
 bit-vec = { version = "0.8" }
 bitflags = { version = "2", default-features = false, features = ["std"] }
+block2 = { version = "0.6" }
+bytemuck = { version = "1", default-features = false, features = ["aarch64_simd", "derive", "extern_crate_alloc", "min_const_generics"] }
+clap = { version = "4", features = ["derive", "env"] }
+clap_builder = { version = "4", default-features = false, features = ["color", "env", "help", "std", "suggestions", "usage"] }
+dasp_sample = { version = "0.11" }
+derive_more = { version = "2", features = ["from", "is_variant"] }
+either = { version = "1", default-features = false, features = ["use_std"] }
+errno = { version = "0.3" }
+form_urlencoded = { version = "1" }
+futures = { version = "0.3", features = ["thread-pool"] }
+futures-channel = { version = "0.3" }
+futures-core = { version = "0.3" }
+futures-executor = { version = "0.3", default-features = false, features = ["thread-pool"] }
+futures-sink = { version = "0.3" }
+getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
+half = { version = "2", features = ["num-traits"] }
+hashbrown-986da7b5efc2b80e = { package = "hashbrown", version = "0.16" }
+hyper = { version = "1", features = ["client", "http1", "server"] }
+hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "http1", "server", "service"] }
+idna = { version = "1" }
+itertools = { version = "0.13" }
+libc = { version = "0.2" }
+log = { version = "0.4", default-features = false, features = ["std"] }
+miniz_oxide = { version = "0.8", features = ["simd"] }
+mio = { version = "1", features = ["net", "os-ext"] }
+objc2-foundation = { version = "0.3" }
+percent-encoding = { version = "2" }
+regex = { version = "1" }
+regex-automata = { version = "0.4", default-features = false, features = ["dfa-build", "dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
+regex-syntax = { version = "0.8" }
+rustc-hash = { version = "1" }
+rustix = { version = "1", features = ["fs", "stdio", "termios"] }
+rustls-pki-types = { version = "1", features = ["std"] }
+serde_json = { version = "1", default-features = false, features = ["raw_value"] }
+simd-adler32 = { version = "0.3" }
+slab = { version = "0.4" }
+symphonia-core = { version = "0.6", features = ["opt-simd-avx", "opt-simd-neon", "opt-simd-sse"] }
+sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
+time = { version = "0.3", features = ["formatting", "local-offset", "macros", "parsing"] }
+tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
+tokio-util = { version = "0.7", features = ["codec", "io"] }
+tower = { version = "0.5", default-features = false, features = ["log", "make", "retry", "timeout"] }
+tracing = { version = "0.1", features = ["log"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
+zstd = { version = "0.13" }
+zstd-safe = { version = "7", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
+zstd-sys = { version = "2", default-features = false, features = ["legacy", "std", "zdict_builder"] }
+
+[target.aarch64-apple-darwin.build-dependencies]
+aho-corasick = { version = "1" }
+bit-set = { version = "0.8" }
+bit-vec = { version = "0.8" }
+bitflags = { version = "2", default-features = false, features = ["std"] }
+block2 = { version = "0.6" }
 bytemuck = { version = "1", default-features = false, features = ["aarch64_simd", "derive", "extern_crate_alloc", "min_const_generics"] }
 cc = { version = "1", default-features = false, features = ["parallel"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "runtime"] }
@@ -436,45 +370,119 @@ dasp_sample = { version = "0.11" }
 derive_more = { version = "2", features = ["from", "is_variant"] }
 derive_more-impl = { version = "2", features = ["from", "is_variant"] }
 either = { version = "1", default-features = false, features = ["use_std"] }
+errno = { version = "0.3" }
 form_urlencoded = { version = "1" }
 futures = { version = "0.3", features = ["thread-pool"] }
 futures-channel = { version = "0.3" }
 futures-core = { version = "0.3" }
 futures-executor = { version = "0.3", default-features = false, features = ["thread-pool"] }
-futures-io = { version = "0.3" }
 futures-sink = { version = "0.3" }
-getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 half = { version = "2", features = ["num-traits"] }
 hashbrown-986da7b5efc2b80e = { package = "hashbrown", version = "0.16" }
-hotpath-macros = { version = "0.18", features = ["hotpath"] }
+hotpath-macros = { version = "0.19", features = ["hotpath"] }
 hyper = { version = "1", features = ["client", "http1", "server"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "http1", "server", "service"] }
 idna = { version = "1" }
 itertools = { version = "0.13" }
 libc = { version = "0.2" }
-linux-raw-sys = { version = "0.12", default-features = false, features = ["auxvec", "elf", "errno", "general", "if_ether", "ioctl", "net", "netlink", "no_std", "prctl", "system", "xdp"] }
 log = { version = "0.4", default-features = false, features = ["std"] }
 miniz_oxide = { version = "0.8", features = ["simd"] }
 mio = { version = "1", features = ["net", "os-ext"] }
+objc2-foundation = { version = "0.3" }
 percent-encoding = { version = "2" }
 prettyplease = { version = "0.2", default-features = false, features = ["verbatim"] }
 regex = { version = "1" }
 regex-automata = { version = "0.4", default-features = false, features = ["dfa-build", "dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
 regex-syntax = { version = "0.8" }
 rustc-hash = { version = "1" }
-rustix = { version = "1", features = ["event", "mm", "net", "pipe", "process", "shm", "stdio", "system", "termios", "time"] }
+rustix = { version = "1", features = ["fs", "stdio", "termios"] }
+rustls-pki-types = { version = "1", features = ["std"] }
 serde_json = { version = "1", default-features = false, features = ["raw_value"] }
 simd-adler32 = { version = "0.3" }
 slab = { version = "0.4" }
+symphonia-core = { version = "0.6", features = ["opt-simd-avx", "opt-simd-neon", "opt-simd-sse"] }
 sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
 time = { version = "0.3", features = ["formatting", "local-offset", "macros", "parsing"] }
+tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-util = { version = "0.7", features = ["codec", "io"] }
-toml_datetime = { version = "1", features = ["serde"] }
 tower = { version = "0.5", default-features = false, features = ["log", "make", "retry", "timeout"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
-winnow = { version = "1" }
+zstd = { version = "0.13" }
+zstd-safe = { version = "7", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
+zstd-sys = { version = "2", default-features = false, features = ["legacy", "std", "zdict_builder"] }
+
+[target.aarch64-apple-ios.dependencies]
+aho-corasick = { version = "1" }
+bitflags = { version = "2", default-features = false, features = ["std"] }
+block2 = { version = "0.6" }
+clap = { version = "4", features = ["derive", "env"] }
+clap_builder = { version = "4", default-features = false, features = ["color", "env", "help", "std", "suggestions", "usage"] }
+dasp_sample = { version = "0.11" }
+either = { version = "1", default-features = false, features = ["use_std"] }
+errno = { version = "0.3" }
+form_urlencoded = { version = "1" }
+futures-channel = { version = "0.3" }
+futures-core = { version = "0.3" }
+futures-sink = { version = "0.3" }
+hyper = { version = "1", features = ["client", "http1", "server"] }
+hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "http1", "server", "service"] }
+idna = { version = "1" }
+itertools = { version = "0.13" }
+libc = { version = "0.2" }
+objc2-foundation = { version = "0.3" }
+percent-encoding = { version = "2" }
+regex = { version = "1" }
+regex-automata = { version = "0.4", default-features = false, features = ["dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
+regex-syntax = { version = "0.8" }
+serde_json = { version = "1", default-features = false, features = ["raw_value"] }
+slab = { version = "0.4" }
+sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
+time = { version = "0.3", features = ["formatting", "macros", "parsing"] }
+tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
+tokio-util = { version = "0.7", features = ["codec", "io"] }
+tower = { version = "0.5", default-features = false, features = ["log", "make", "retry", "timeout"] }
+tracing = { version = "0.1", features = ["log"] }
+zstd = { version = "0.13" }
+zstd-safe = { version = "7", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
+zstd-sys = { version = "2", default-features = false, features = ["legacy", "std", "zdict_builder"] }
+
+[target.aarch64-apple-ios.build-dependencies]
+aho-corasick = { version = "1" }
+bitflags = { version = "2", default-features = false, features = ["std"] }
+block2 = { version = "0.6" }
+cc = { version = "1", default-features = false, features = ["parallel"] }
+clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "runtime"] }
+clap = { version = "4", features = ["derive", "env"] }
+clap_builder = { version = "4", default-features = false, features = ["color", "env", "help", "std", "suggestions", "usage"] }
+dasp_sample = { version = "0.11" }
+either = { version = "1", default-features = false, features = ["use_std"] }
+errno = { version = "0.3" }
+form_urlencoded = { version = "1" }
+futures-channel = { version = "0.3" }
+futures-core = { version = "0.3" }
+futures-sink = { version = "0.3" }
+hotpath-macros = { version = "0.19", features = ["hotpath"] }
+hyper = { version = "1", features = ["client", "http1", "server"] }
+hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "http1", "server", "service"] }
+idna = { version = "1" }
+itertools = { version = "0.13" }
+libc = { version = "0.2" }
+objc2-foundation = { version = "0.3" }
+percent-encoding = { version = "2" }
+prettyplease = { version = "0.2", default-features = false, features = ["verbatim"] }
+regex = { version = "1" }
+regex-automata = { version = "0.4", default-features = false, features = ["dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
+regex-syntax = { version = "0.8" }
+serde_json = { version = "1", default-features = false, features = ["raw_value"] }
+slab = { version = "0.4" }
+sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
+time = { version = "0.3", features = ["formatting", "macros", "parsing"] }
+tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
+tokio-util = { version = "0.7", features = ["codec", "io"] }
+tower = { version = "0.5", default-features = false, features = ["log", "make", "retry", "timeout"] }
+tracing = { version = "0.1", features = ["log"] }
 zstd = { version = "0.13" }
 zstd-safe = { version = "7", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
 zstd-sys = { version = "2", default-features = false, features = ["legacy", "std", "zdict_builder"] }

--- a/crates/kithara-workspace-hack/Cargo.toml
+++ b/crates/kithara-workspace-hack/Cargo.toml
@@ -47,38 +47,146 @@ thiserror = { version = "2" }
 thunderdome = { version = "0.6", default-features = false, features = ["std"] }
 toml_parser = { version = "1" }
 
-[build-dependencies]
-arrayvec = { version = "0.7" }
-cpal = { version = "0.17", default-features = false, features = ["wasm-bindgen"] }
-crossbeam-utils = { version = "0.8" }
-firewheel = { version = "0.10", default-features = false, features = ["cpal", "tracing", "wasm-bindgen"] }
-firewheel-cpal = { version = "0.10", default-features = false, features = ["tracing", "wasm-bindgen"] }
-foldhash = { version = "0.2", default-features = false, features = ["std"] }
-futures-channel = { version = "0.3", default-features = false, features = ["sink", "std"] }
-futures-sink = { version = "0.3", default-features = false, features = ["std"] }
-futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
-hashbrown-9067fe90e8c1f593 = { package = "hashbrown", version = "0.17" }
-hotpath = { version = "0.19", features = ["hotpath", "hotpath-alloc"] }
-indexmap = { version = "2", features = ["serde"] }
-memchr = { version = "2" }
-num-integer = { version = "0.1", features = ["i128"] }
-num-traits = { version = "0.2", features = ["i128", "libm"] }
-once_cell = { version = "1" }
-portable-atomic = { version = "1", default-features = false, features = ["fallback", "float", "require-cas", "std"] }
-proc-macro2 = { version = "1", features = ["span-locations"] }
-quote = { version = "1" }
-reqwest = { version = "0.13", default-features = false, features = ["brotli", "cookies", "deflate", "gzip", "native-tls", "rustls", "stream", "zstd"] }
-ringbuf = { version = "0.4", features = ["portable-atomic"] }
-rustfft = { version = "6" }
-semver = { version = "1", features = ["serde"] }
-serde = { version = "1", features = ["alloc", "derive"] }
-serde_core = { version = "1", features = ["alloc"] }
-serde_json = { version = "1", features = ["alloc", "unbounded_depth"] }
-smallvec = { version = "1", default-features = false, features = ["const_new", "union"] }
-syn = { version = "2", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
-thiserror = { version = "2" }
-thunderdome = { version = "0.6", default-features = false, features = ["std"] }
-toml_parser = { version = "1" }
+[target.aarch64-apple-darwin.dependencies]
+aho-corasick = { version = "1" }
+bit-set = { version = "0.8" }
+bit-vec = { version = "0.8" }
+bitflags = { version = "2", default-features = false, features = ["std"] }
+block2 = { version = "0.6" }
+bytemuck = { version = "1", default-features = false, features = ["aarch64_simd", "derive", "extern_crate_alloc", "min_const_generics"] }
+clap = { version = "4", features = ["derive", "env"] }
+clap_builder = { version = "4", default-features = false, features = ["color", "env", "help", "std", "suggestions", "usage"] }
+dasp_sample = { version = "0.11" }
+derive_more = { version = "2", features = ["from", "is_variant"] }
+either = { version = "1", default-features = false, features = ["use_std"] }
+errno = { version = "0.3" }
+form_urlencoded = { version = "1" }
+futures = { version = "0.3", features = ["thread-pool"] }
+futures-channel = { version = "0.3" }
+futures-core = { version = "0.3" }
+futures-executor = { version = "0.3", default-features = false, features = ["thread-pool"] }
+futures-sink = { version = "0.3" }
+getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
+half = { version = "2", features = ["num-traits"] }
+hashbrown-986da7b5efc2b80e = { package = "hashbrown", version = "0.16" }
+hyper = { version = "1", features = ["client", "http1", "server"] }
+hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "http1", "server", "service"] }
+idna = { version = "1" }
+itertools = { version = "0.13" }
+libc = { version = "0.2" }
+log = { version = "0.4", default-features = false, features = ["std"] }
+miniz_oxide = { version = "0.8", features = ["simd"] }
+mio = { version = "1", features = ["net", "os-ext"] }
+objc2-foundation = { version = "0.3" }
+percent-encoding = { version = "2" }
+regex = { version = "1" }
+regex-automata = { version = "0.4", default-features = false, features = ["dfa-build", "dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
+regex-syntax = { version = "0.8" }
+rustc-hash = { version = "1" }
+rustix = { version = "1", features = ["fs", "stdio", "termios"] }
+rustls-pki-types = { version = "1", features = ["std"] }
+serde_json = { version = "1", default-features = false, features = ["raw_value"] }
+simd-adler32 = { version = "0.3" }
+slab = { version = "0.4" }
+symphonia-core = { version = "0.6", features = ["opt-simd-avx", "opt-simd-neon", "opt-simd-sse"] }
+sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
+time = { version = "0.3", features = ["formatting", "local-offset", "macros", "parsing"] }
+tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
+tokio-util = { version = "0.7", features = ["codec", "io"] }
+tower = { version = "0.5", default-features = false, features = ["log", "make", "retry", "timeout"] }
+tracing = { version = "0.1", features = ["log"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
+zstd = { version = "0.13" }
+zstd-safe = { version = "7", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
+zstd-sys = { version = "2", default-features = false, features = ["legacy", "std", "zdict_builder"] }
+
+[target.aarch64-apple-ios.dependencies]
+aho-corasick = { version = "1" }
+bitflags = { version = "2", default-features = false, features = ["std"] }
+block2 = { version = "0.6" }
+clap = { version = "4", features = ["derive", "env"] }
+clap_builder = { version = "4", default-features = false, features = ["color", "env", "help", "std", "suggestions", "usage"] }
+dasp_sample = { version = "0.11" }
+either = { version = "1", default-features = false, features = ["use_std"] }
+errno = { version = "0.3" }
+form_urlencoded = { version = "1" }
+futures-channel = { version = "0.3" }
+futures-core = { version = "0.3" }
+futures-sink = { version = "0.3" }
+hyper = { version = "1", features = ["client", "http1", "server"] }
+hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "http1", "server", "service"] }
+idna = { version = "1" }
+itertools = { version = "0.13" }
+libc = { version = "0.2" }
+objc2-foundation = { version = "0.3" }
+percent-encoding = { version = "2" }
+regex = { version = "1" }
+regex-automata = { version = "0.4", default-features = false, features = ["dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
+regex-syntax = { version = "0.8" }
+serde_json = { version = "1", default-features = false, features = ["raw_value"] }
+slab = { version = "0.4" }
+sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
+time = { version = "0.3", features = ["formatting", "macros", "parsing"] }
+tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
+tokio-util = { version = "0.7", features = ["codec", "io"] }
+tower = { version = "0.5", default-features = false, features = ["log", "make", "retry", "timeout"] }
+tracing = { version = "0.1", features = ["log"] }
+zstd = { version = "0.13" }
+zstd-safe = { version = "7", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
+zstd-sys = { version = "2", default-features = false, features = ["legacy", "std", "zdict_builder"] }
+
+[target.x86_64-apple-darwin.dependencies]
+aho-corasick = { version = "1" }
+bit-set = { version = "0.8" }
+bit-vec = { version = "0.8" }
+bitflags = { version = "2", default-features = false, features = ["std"] }
+block2 = { version = "0.6" }
+bytemuck = { version = "1", default-features = false, features = ["aarch64_simd", "derive", "extern_crate_alloc", "min_const_generics"] }
+clap = { version = "4", features = ["derive", "env"] }
+clap_builder = { version = "4", default-features = false, features = ["color", "env", "help", "std", "suggestions", "usage"] }
+dasp_sample = { version = "0.11" }
+derive_more = { version = "2", features = ["from", "is_variant"] }
+either = { version = "1", default-features = false, features = ["use_std"] }
+errno = { version = "0.3" }
+form_urlencoded = { version = "1" }
+futures = { version = "0.3", features = ["thread-pool"] }
+futures-channel = { version = "0.3" }
+futures-core = { version = "0.3" }
+futures-executor = { version = "0.3", default-features = false, features = ["thread-pool"] }
+futures-sink = { version = "0.3" }
+getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
+half = { version = "2", features = ["num-traits"] }
+hashbrown-986da7b5efc2b80e = { package = "hashbrown", version = "0.16" }
+hyper = { version = "1", features = ["client", "http1", "server"] }
+hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "http1", "server", "service"] }
+idna = { version = "1" }
+itertools = { version = "0.13" }
+libc = { version = "0.2" }
+log = { version = "0.4", default-features = false, features = ["std"] }
+miniz_oxide = { version = "0.8", features = ["simd"] }
+mio = { version = "1", features = ["net", "os-ext"] }
+objc2-foundation = { version = "0.3" }
+percent-encoding = { version = "2" }
+regex = { version = "1" }
+regex-automata = { version = "0.4", default-features = false, features = ["dfa-build", "dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
+regex-syntax = { version = "0.8" }
+rustc-hash = { version = "1" }
+rustix = { version = "1", features = ["fs", "stdio", "termios"] }
+rustls-pki-types = { version = "1", features = ["std"] }
+serde_json = { version = "1", default-features = false, features = ["raw_value"] }
+simd-adler32 = { version = "0.3" }
+slab = { version = "0.4" }
+symphonia-core = { version = "0.6", features = ["opt-simd-avx", "opt-simd-neon", "opt-simd-sse"] }
+sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
+time = { version = "0.3", features = ["formatting", "local-offset", "macros", "parsing"] }
+tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
+tokio-util = { version = "0.7", features = ["codec", "io"] }
+tower = { version = "0.5", default-features = false, features = ["log", "make", "retry", "timeout"] }
+tracing = { version = "0.1", features = ["log"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
+zstd = { version = "0.13" }
+zstd-safe = { version = "7", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
+zstd-sys = { version = "2", default-features = false, features = ["legacy", "std", "zdict_builder"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 aho-corasick = { version = "1" }
@@ -133,11 +241,45 @@ zstd = { version = "0.13" }
 zstd-safe = { version = "7", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
 zstd-sys = { version = "2", default-features = false, features = ["legacy", "std", "zdict_builder"] }
 
-[target.x86_64-unknown-linux-gnu.build-dependencies]
+[build-dependencies]
+arrayvec = { version = "0.7" }
+cpal = { version = "0.17", default-features = false, features = ["wasm-bindgen"] }
+crossbeam-utils = { version = "0.8" }
+firewheel = { version = "0.10", default-features = false, features = ["cpal", "tracing", "wasm-bindgen"] }
+firewheel-cpal = { version = "0.10", default-features = false, features = ["tracing", "wasm-bindgen"] }
+foldhash = { version = "0.2", default-features = false, features = ["std"] }
+futures-channel = { version = "0.3", default-features = false, features = ["sink", "std"] }
+futures-sink = { version = "0.3", default-features = false, features = ["std"] }
+futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
+hashbrown-9067fe90e8c1f593 = { package = "hashbrown", version = "0.17" }
+hotpath = { version = "0.19", features = ["hotpath", "hotpath-alloc"] }
+indexmap = { version = "2", features = ["serde"] }
+memchr = { version = "2" }
+num-integer = { version = "0.1", features = ["i128"] }
+num-traits = { version = "0.2", features = ["i128", "libm"] }
+once_cell = { version = "1" }
+portable-atomic = { version = "1", default-features = false, features = ["fallback", "float", "require-cas", "std"] }
+proc-macro2 = { version = "1", features = ["span-locations"] }
+quote = { version = "1" }
+reqwest = { version = "0.13", default-features = false, features = ["brotli", "cookies", "deflate", "gzip", "native-tls", "rustls", "stream", "zstd"] }
+ringbuf = { version = "0.4", features = ["portable-atomic"] }
+rustfft = { version = "6" }
+semver = { version = "1", features = ["serde"] }
+serde = { version = "1", features = ["alloc", "derive"] }
+serde_core = { version = "1", features = ["alloc"] }
+serde_json = { version = "1", features = ["alloc", "unbounded_depth"] }
+smallvec = { version = "1", default-features = false, features = ["const_new", "union"] }
+syn = { version = "2", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
+thiserror = { version = "2" }
+thunderdome = { version = "0.6", default-features = false, features = ["std"] }
+toml_parser = { version = "1" }
+
+[target.aarch64-apple-darwin.build-dependencies]
 aho-corasick = { version = "1" }
 bit-set = { version = "0.8" }
 bit-vec = { version = "0.8" }
 bitflags = { version = "2", default-features = false, features = ["std"] }
+block2 = { version = "0.6" }
 bytemuck = { version = "1", default-features = false, features = ["aarch64_simd", "derive", "extern_crate_alloc", "min_const_generics"] }
 cc = { version = "1", default-features = false, features = ["parallel"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "runtime"] }
@@ -146,62 +288,6 @@ clap_builder = { version = "4", default-features = false, features = ["color", "
 dasp_sample = { version = "0.11" }
 derive_more = { version = "2", features = ["from", "is_variant"] }
 derive_more-impl = { version = "2", features = ["from", "is_variant"] }
-either = { version = "1", default-features = false, features = ["use_std"] }
-form_urlencoded = { version = "1" }
-futures = { version = "0.3", features = ["thread-pool"] }
-futures-channel = { version = "0.3" }
-futures-core = { version = "0.3" }
-futures-executor = { version = "0.3", default-features = false, features = ["thread-pool"] }
-futures-io = { version = "0.3" }
-futures-sink = { version = "0.3" }
-getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
-getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
-half = { version = "2", features = ["num-traits"] }
-hashbrown-986da7b5efc2b80e = { package = "hashbrown", version = "0.16" }
-hotpath-macros = { version = "0.19", features = ["hotpath"] }
-hyper = { version = "1", features = ["client", "http1", "server"] }
-hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "http1", "server", "service"] }
-idna = { version = "1" }
-itertools = { version = "0.13" }
-libc = { version = "0.2" }
-linux-raw-sys = { version = "0.12", default-features = false, features = ["auxvec", "elf", "errno", "general", "if_ether", "ioctl", "net", "netlink", "no_std", "prctl", "system", "xdp"] }
-log = { version = "0.4", default-features = false, features = ["std"] }
-miniz_oxide = { version = "0.8", features = ["simd"] }
-mio = { version = "1", features = ["net", "os-ext"] }
-percent-encoding = { version = "2" }
-prettyplease = { version = "0.2", default-features = false, features = ["verbatim"] }
-regex = { version = "1" }
-regex-automata = { version = "0.4", default-features = false, features = ["dfa-build", "dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
-regex-syntax = { version = "0.8" }
-rustc-hash = { version = "1" }
-rustix = { version = "1", features = ["event", "mm", "net", "pipe", "process", "shm", "stdio", "system", "termios", "time"] }
-serde_json = { version = "1", default-features = false, features = ["raw_value"] }
-simd-adler32 = { version = "0.3" }
-slab = { version = "0.4" }
-sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
-time = { version = "0.3", features = ["formatting", "local-offset", "macros", "parsing"] }
-tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
-tokio-util = { version = "0.7", features = ["codec", "io"] }
-toml_datetime = { version = "1", features = ["serde"] }
-tower = { version = "0.5", default-features = false, features = ["log", "make", "retry", "timeout"] }
-tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
-winnow = { version = "1" }
-zstd = { version = "0.13" }
-zstd-safe = { version = "7", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
-zstd-sys = { version = "2", default-features = false, features = ["legacy", "std", "zdict_builder"] }
-
-[target.x86_64-apple-darwin.dependencies]
-aho-corasick = { version = "1" }
-bit-set = { version = "0.8" }
-bit-vec = { version = "0.8" }
-bitflags = { version = "2", default-features = false, features = ["std"] }
-block2 = { version = "0.6" }
-bytemuck = { version = "1", default-features = false, features = ["aarch64_simd", "derive", "extern_crate_alloc", "min_const_generics"] }
-clap = { version = "4", features = ["derive", "env"] }
-clap_builder = { version = "4", default-features = false, features = ["color", "env", "help", "std", "suggestions", "usage"] }
-dasp_sample = { version = "0.11" }
-derive_more = { version = "2", features = ["from", "is_variant"] }
 either = { version = "1", default-features = false, features = ["use_std"] }
 errno = { version = "0.3" }
 form_urlencoded = { version = "1" }
@@ -213,6 +299,7 @@ futures-sink = { version = "0.3" }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 half = { version = "2", features = ["num-traits"] }
 hashbrown-986da7b5efc2b80e = { package = "hashbrown", version = "0.16" }
+hotpath-macros = { version = "0.19", features = ["hotpath"] }
 hyper = { version = "1", features = ["client", "http1", "server"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "http1", "server", "service"] }
 idna = { version = "1" }
@@ -223,6 +310,7 @@ miniz_oxide = { version = "0.8", features = ["simd"] }
 mio = { version = "1", features = ["net", "os-ext"] }
 objc2-foundation = { version = "0.3" }
 percent-encoding = { version = "2" }
+prettyplease = { version = "0.2", default-features = false, features = ["verbatim"] }
 regex = { version = "1" }
 regex-automata = { version = "0.4", default-features = false, features = ["dfa-build", "dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
 regex-syntax = { version = "0.8" }
@@ -240,6 +328,45 @@ tokio-util = { version = "0.7", features = ["codec", "io"] }
 tower = { version = "0.5", default-features = false, features = ["log", "make", "retry", "timeout"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
+zstd = { version = "0.13" }
+zstd-safe = { version = "7", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
+zstd-sys = { version = "2", default-features = false, features = ["legacy", "std", "zdict_builder"] }
+
+[target.aarch64-apple-ios.build-dependencies]
+aho-corasick = { version = "1" }
+bitflags = { version = "2", default-features = false, features = ["std"] }
+block2 = { version = "0.6" }
+cc = { version = "1", default-features = false, features = ["parallel"] }
+clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "runtime"] }
+clap = { version = "4", features = ["derive", "env"] }
+clap_builder = { version = "4", default-features = false, features = ["color", "env", "help", "std", "suggestions", "usage"] }
+dasp_sample = { version = "0.11" }
+either = { version = "1", default-features = false, features = ["use_std"] }
+errno = { version = "0.3" }
+form_urlencoded = { version = "1" }
+futures-channel = { version = "0.3" }
+futures-core = { version = "0.3" }
+futures-sink = { version = "0.3" }
+hotpath-macros = { version = "0.19", features = ["hotpath"] }
+hyper = { version = "1", features = ["client", "http1", "server"] }
+hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "http1", "server", "service"] }
+idna = { version = "1" }
+itertools = { version = "0.13" }
+libc = { version = "0.2" }
+objc2-foundation = { version = "0.3" }
+percent-encoding = { version = "2" }
+prettyplease = { version = "0.2", default-features = false, features = ["verbatim"] }
+regex = { version = "1" }
+regex-automata = { version = "0.4", default-features = false, features = ["dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
+regex-syntax = { version = "0.8" }
+serde_json = { version = "1", default-features = false, features = ["raw_value"] }
+slab = { version = "0.4" }
+sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
+time = { version = "0.3", features = ["formatting", "macros", "parsing"] }
+tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
+tokio-util = { version = "0.7", features = ["codec", "io"] }
+tower = { version = "0.5", default-features = false, features = ["log", "make", "retry", "timeout"] }
+tracing = { version = "0.1", features = ["log"] }
 zstd = { version = "0.13" }
 zstd-safe = { version = "7", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
 zstd-sys = { version = "2", default-features = false, features = ["legacy", "std", "zdict_builder"] }
@@ -302,65 +429,11 @@ zstd = { version = "0.13" }
 zstd-safe = { version = "7", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
 zstd-sys = { version = "2", default-features = false, features = ["legacy", "std", "zdict_builder"] }
 
-[target.aarch64-apple-darwin.dependencies]
+[target.x86_64-unknown-linux-gnu.build-dependencies]
 aho-corasick = { version = "1" }
 bit-set = { version = "0.8" }
 bit-vec = { version = "0.8" }
 bitflags = { version = "2", default-features = false, features = ["std"] }
-block2 = { version = "0.6" }
-bytemuck = { version = "1", default-features = false, features = ["aarch64_simd", "derive", "extern_crate_alloc", "min_const_generics"] }
-clap = { version = "4", features = ["derive", "env"] }
-clap_builder = { version = "4", default-features = false, features = ["color", "env", "help", "std", "suggestions", "usage"] }
-dasp_sample = { version = "0.11" }
-derive_more = { version = "2", features = ["from", "is_variant"] }
-either = { version = "1", default-features = false, features = ["use_std"] }
-errno = { version = "0.3" }
-form_urlencoded = { version = "1" }
-futures = { version = "0.3", features = ["thread-pool"] }
-futures-channel = { version = "0.3" }
-futures-core = { version = "0.3" }
-futures-executor = { version = "0.3", default-features = false, features = ["thread-pool"] }
-futures-sink = { version = "0.3" }
-getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
-half = { version = "2", features = ["num-traits"] }
-hashbrown-986da7b5efc2b80e = { package = "hashbrown", version = "0.16" }
-hyper = { version = "1", features = ["client", "http1", "server"] }
-hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "http1", "server", "service"] }
-idna = { version = "1" }
-itertools = { version = "0.13" }
-libc = { version = "0.2" }
-log = { version = "0.4", default-features = false, features = ["std"] }
-miniz_oxide = { version = "0.8", features = ["simd"] }
-mio = { version = "1", features = ["net", "os-ext"] }
-objc2-foundation = { version = "0.3" }
-percent-encoding = { version = "2" }
-regex = { version = "1" }
-regex-automata = { version = "0.4", default-features = false, features = ["dfa-build", "dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
-regex-syntax = { version = "0.8" }
-rustc-hash = { version = "1" }
-rustix = { version = "1", features = ["fs", "stdio", "termios"] }
-rustls-pki-types = { version = "1", features = ["std"] }
-serde_json = { version = "1", default-features = false, features = ["raw_value"] }
-simd-adler32 = { version = "0.3" }
-slab = { version = "0.4" }
-symphonia-core = { version = "0.6", features = ["opt-simd-avx", "opt-simd-neon", "opt-simd-sse"] }
-sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
-time = { version = "0.3", features = ["formatting", "local-offset", "macros", "parsing"] }
-tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
-tokio-util = { version = "0.7", features = ["codec", "io"] }
-tower = { version = "0.5", default-features = false, features = ["log", "make", "retry", "timeout"] }
-tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
-zstd = { version = "0.13" }
-zstd-safe = { version = "7", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
-zstd-sys = { version = "2", default-features = false, features = ["legacy", "std", "zdict_builder"] }
-
-[target.aarch64-apple-darwin.build-dependencies]
-aho-corasick = { version = "1" }
-bit-set = { version = "0.8" }
-bit-vec = { version = "0.8" }
-bitflags = { version = "2", default-features = false, features = ["std"] }
-block2 = { version = "0.6" }
 bytemuck = { version = "1", default-features = false, features = ["aarch64_simd", "derive", "extern_crate_alloc", "min_const_generics"] }
 cc = { version = "1", default-features = false, features = ["parallel"] }
 clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "runtime"] }
@@ -370,13 +443,14 @@ dasp_sample = { version = "0.11" }
 derive_more = { version = "2", features = ["from", "is_variant"] }
 derive_more-impl = { version = "2", features = ["from", "is_variant"] }
 either = { version = "1", default-features = false, features = ["use_std"] }
-errno = { version = "0.3" }
 form_urlencoded = { version = "1" }
 futures = { version = "0.3", features = ["thread-pool"] }
 futures-channel = { version = "0.3" }
 futures-core = { version = "0.3" }
 futures-executor = { version = "0.3", default-features = false, features = ["thread-pool"] }
+futures-io = { version = "0.3" }
 futures-sink = { version = "0.3" }
+getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 half = { version = "2", features = ["num-traits"] }
 hashbrown-986da7b5efc2b80e = { package = "hashbrown", version = "0.16" }
@@ -386,103 +460,29 @@ hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "ht
 idna = { version = "1" }
 itertools = { version = "0.13" }
 libc = { version = "0.2" }
+linux-raw-sys = { version = "0.12", default-features = false, features = ["auxvec", "elf", "errno", "general", "if_ether", "ioctl", "net", "netlink", "no_std", "prctl", "system", "xdp"] }
 log = { version = "0.4", default-features = false, features = ["std"] }
 miniz_oxide = { version = "0.8", features = ["simd"] }
 mio = { version = "1", features = ["net", "os-ext"] }
-objc2-foundation = { version = "0.3" }
 percent-encoding = { version = "2" }
 prettyplease = { version = "0.2", default-features = false, features = ["verbatim"] }
 regex = { version = "1" }
 regex-automata = { version = "0.4", default-features = false, features = ["dfa-build", "dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
 regex-syntax = { version = "0.8" }
 rustc-hash = { version = "1" }
-rustix = { version = "1", features = ["fs", "stdio", "termios"] }
-rustls-pki-types = { version = "1", features = ["std"] }
+rustix = { version = "1", features = ["event", "mm", "net", "pipe", "process", "shm", "stdio", "system", "termios", "time"] }
 serde_json = { version = "1", default-features = false, features = ["raw_value"] }
 simd-adler32 = { version = "0.3" }
 slab = { version = "0.4" }
-symphonia-core = { version = "0.6", features = ["opt-simd-avx", "opt-simd-neon", "opt-simd-sse"] }
 sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
 time = { version = "0.3", features = ["formatting", "local-offset", "macros", "parsing"] }
 tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-util = { version = "0.7", features = ["codec", "io"] }
+toml_datetime = { version = "1", features = ["serde"] }
 tower = { version = "0.5", default-features = false, features = ["log", "make", "retry", "timeout"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
-zstd = { version = "0.13" }
-zstd-safe = { version = "7", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
-zstd-sys = { version = "2", default-features = false, features = ["legacy", "std", "zdict_builder"] }
-
-[target.aarch64-apple-ios.dependencies]
-aho-corasick = { version = "1" }
-bitflags = { version = "2", default-features = false, features = ["std"] }
-block2 = { version = "0.6" }
-clap = { version = "4", features = ["derive", "env"] }
-clap_builder = { version = "4", default-features = false, features = ["color", "env", "help", "std", "suggestions", "usage"] }
-dasp_sample = { version = "0.11" }
-either = { version = "1", default-features = false, features = ["use_std"] }
-errno = { version = "0.3" }
-form_urlencoded = { version = "1" }
-futures-channel = { version = "0.3" }
-futures-core = { version = "0.3" }
-futures-sink = { version = "0.3" }
-hyper = { version = "1", features = ["client", "http1", "server"] }
-hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "http1", "server", "service"] }
-idna = { version = "1" }
-itertools = { version = "0.13" }
-libc = { version = "0.2" }
-objc2-foundation = { version = "0.3" }
-percent-encoding = { version = "2" }
-regex = { version = "1" }
-regex-automata = { version = "0.4", default-features = false, features = ["dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
-regex-syntax = { version = "0.8" }
-serde_json = { version = "1", default-features = false, features = ["raw_value"] }
-slab = { version = "0.4" }
-sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
-time = { version = "0.3", features = ["formatting", "macros", "parsing"] }
-tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
-tokio-util = { version = "0.7", features = ["codec", "io"] }
-tower = { version = "0.5", default-features = false, features = ["log", "make", "retry", "timeout"] }
-tracing = { version = "0.1", features = ["log"] }
-zstd = { version = "0.13" }
-zstd-safe = { version = "7", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
-zstd-sys = { version = "2", default-features = false, features = ["legacy", "std", "zdict_builder"] }
-
-[target.aarch64-apple-ios.build-dependencies]
-aho-corasick = { version = "1" }
-bitflags = { version = "2", default-features = false, features = ["std"] }
-block2 = { version = "0.6" }
-cc = { version = "1", default-features = false, features = ["parallel"] }
-clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "runtime"] }
-clap = { version = "4", features = ["derive", "env"] }
-clap_builder = { version = "4", default-features = false, features = ["color", "env", "help", "std", "suggestions", "usage"] }
-dasp_sample = { version = "0.11" }
-either = { version = "1", default-features = false, features = ["use_std"] }
-errno = { version = "0.3" }
-form_urlencoded = { version = "1" }
-futures-channel = { version = "0.3" }
-futures-core = { version = "0.3" }
-futures-sink = { version = "0.3" }
-hotpath-macros = { version = "0.19", features = ["hotpath"] }
-hyper = { version = "1", features = ["client", "http1", "server"] }
-hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "http1", "server", "service"] }
-idna = { version = "1" }
-itertools = { version = "0.13" }
-libc = { version = "0.2" }
-objc2-foundation = { version = "0.3" }
-percent-encoding = { version = "2" }
-prettyplease = { version = "0.2", default-features = false, features = ["verbatim"] }
-regex = { version = "1" }
-regex-automata = { version = "0.4", default-features = false, features = ["dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "std", "unicode"] }
-regex-syntax = { version = "0.8" }
-serde_json = { version = "1", default-features = false, features = ["raw_value"] }
-slab = { version = "0.4" }
-sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
-time = { version = "0.3", features = ["formatting", "macros", "parsing"] }
-tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
-tokio-util = { version = "0.7", features = ["codec", "io"] }
-tower = { version = "0.5", default-features = false, features = ["log", "make", "retry", "timeout"] }
-tracing = { version = "0.1", features = ["log"] }
+winnow = { version = "1" }
 zstd = { version = "0.13" }
 zstd-safe = { version = "7", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
 zstd-sys = { version = "2", default-features = false, features = ["legacy", "std", "zdict_builder"] }


### PR DESCRIPTION
## Summary
- Upgrade workspace dependency versions, lockfile, and hakari output.
- Update hotpath to 0.19.1 while keeping audioadapter-buffers on 3.0 because 4.0 is incompatible with the current rubato line.
- Keep active file resources pending until commit so shared downloads do not report EOF at a known-length boundary.
- Ignore the workspace-hack crate in Dependabot scans and include the Claude settings update.

## Validation
- cargo hakari verify
- cargo xtask format --check
- cargo check -p kithara-file --all-targets
- cargo xtask test -E 'test(file_source_read_at_active_gap_reports_pending) or test(file_source_phase_at_known_end_waits_until_active_commit)'
- cargo check -p kithara-audio --features perf --all-targets
- cargo check -p kithara-integration-tests --features perf --benches
- pre-push hook: format, clippy --workspace -D warnings, ast-grep, lint arch