### PR TITLE
fix(audio): make post-seek pcm drain epoch-aware to stop dropping seek-target chunks

### DIFF
--- a/crates/kithara-audio/src/audio.rs
+++ b/crates/kithara-audio/src/audio.rs
@@ -732,6 +732,32 @@ impl<S> Audio<S> {
         }
     }
 
+    fn stage_post_seek_fetch(&mut self, fetch: Fetch<PcmChunk>, epoch: u64) {
+        debug_assert_eq!(
+            fetch.epoch, epoch,
+            "PCM ring preserved a fetch from a future seek epoch"
+        );
+        // Decoder emits a terminal marker as the last item for its epoch, so
+        // staging EOF/failure cannot hide same-epoch PCM behind it.
+        match fetch.kind {
+            FetchKind::Data => {
+                let chunk = fetch.into_inner();
+                self.spec = chunk.spec();
+                self.current_chunk = Some(chunk);
+                self.current_chunk_consumed_frames = 0;
+                self.consumer_phase = ConsumerPhase::Playing;
+            }
+            FetchKind::NaturalEof => {
+                self.consumer_phase = ConsumerPhase::AtEof;
+                self.discard_chunk(fetch.into_inner());
+            }
+            FetchKind::Failure => {
+                self.consumer_phase = ConsumerPhase::Failed;
+                self.discard_chunk(fetch.into_inner());
+            }
+        }
+    }
+
     /// Seek to position in the audio stream.
     ///
     /// This method never blocks. Seek coordination flows entirely through
@@ -768,8 +794,14 @@ impl<S> Audio<S> {
         self.consumer_phase = ConsumerPhase::SeekPending { epoch };
 
         while let Some(fetch) = self.pcm_rx.try_pop() {
-            self.discard_chunk(fetch.into_inner());
-            hang_tick!();
+            if fetch.epoch < epoch {
+                self.discard_chunk(fetch.into_inner());
+                hang_tick!();
+                continue;
+            }
+
+            self.stage_post_seek_fetch(fetch, epoch);
+            break;
         }
 
         if let Some(ref worker) = self.worker {
@@ -1791,6 +1823,8 @@ mod tests {
         let mut chunk = PcmChunk::default();
         chunk.samples.clear();
         chunk.samples.extend_from_slice(samples);
+        chunk.meta.spec.channels = 1;
+        chunk.meta.frames = u32::try_from(samples.len()).unwrap_or(u32::MAX);
         chunk
     }
 
@@ -1877,6 +1911,42 @@ mod tests {
 
         assert!(audio.fill_buffer());
         assert_eq!(audio.consumer_phase, ConsumerPhase::Playing);
+    }
+
+    #[kithara::test]
+    fn seek_drain_preserves_new_epoch_chunk_after_stale_chunks() {
+        let (mut audio, mut tx) = audio_with_channel();
+
+        let stale = Fetch::new(make_chunk(&[0.1, 0.2]), false, 0);
+        let fresh = Fetch::new(make_chunk(&[0.7, 0.8]), false, 1);
+        assert!(tx.try_push(stale).is_ok());
+        assert!(tx.try_push(fresh).is_ok());
+
+        audio.seek(Duration::from_secs(5)).ok();
+
+        let mut buf = [0.0; 2];
+        let count = match audio.read(&mut buf) {
+            Ok(ReadOutcome::Frames { count, .. }) => count.get(),
+            other => panic!("expected preserved post-seek frames, got {other:?}"),
+        };
+        assert_eq!(count, 2);
+        assert_eq!(buf, [0.7, 0.8]);
+    }
+
+    #[kithara::test]
+    fn seek_drain_preserves_new_epoch_eof_after_stale_chunks() {
+        let (mut audio, mut tx) = audio_with_channel();
+
+        let stale = Fetch::new(make_chunk(&[0.1, 0.2]), false, 0);
+        let eof = Fetch::new(PcmChunk::default(), true, 1);
+        assert!(tx.try_push(stale).is_ok());
+        assert!(tx.try_push(eof).is_ok());
+
+        audio.seek(Duration::from_secs(5)).ok();
+
+        let mut buf = [0.0; 2];
+        assert!(matches!(audio.read(&mut buf), Ok(ReadOutcome::Eof { .. })));
+        assert_eq!(audio.consumer_phase, ConsumerPhase::AtEof);
     }
 
     #[kithara::test]


### PR DESCRIPTION
## Description

Fixes a pre-existing, load-triggered **audio data-loss race on seek** in `Audio::seek`.

`Audio::seek` published the new seek epoch and then **unconditionally** drained `pcm_rx`. Under CPU
load the decoder could observe the new epoch and enqueue valid **same-epoch** post-seek chunks (the
data at the seek target) *before* the drain ran; the drain then discarded them, so the first
post-seek `read` started N decode blocks (N×4096 frames) past the requested position — an audible
skip / silent data loss on seek.

**Fix (epoch-aware drain):** discard only *stale* chunks (`fetch.epoch < new_seek_epoch`) and **stage
the first same-epoch chunk** as the current deliverable (`stage_post_seek_fetch`: Data → spec /
current_chunk / Playing; NaturalEof → AtEof; Failure → Failed), leaving the remaining same-epoch
chunks queued in order. Safe because the decoder is a single monotonic-epoch producer: stale chunks
always precede fresh ones in the ring, and a terminal marker is the last item of its epoch (both
documented at the staging site).

Surfaced by the test-suite-speedup campaign: the `stress_seek_audio` position-mismatch flake, whose
deltas were always whole 4096-multiples (actual ahead of target, load-dependent), pinpointed the
dropped post-seek blocks.

## Type of Change

- [x] Bug fix

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes (clippy -p kithara-audio clean; workspace lint-fast green on push)
- [x] Tests added/updated (2 unit tests: same-epoch Data + EOF preservation after stale-chunk drain)
- [x] No `unwrap()`/`expect()` in production code
- [ ] Documentation updated (if applicable) — inline contract comment at the staging site

## Verification

- Repro (before): `nextest --stress-count` on the paired ephemeral `stress_seek_audio` variants under
  6 background CPU burners reproduced within ~10 iterations.
- After the fix: **40/40** paired-ephemeral runs under load green (0 mismatches) in both `flash-on-wreq`
  and `flash-off-apple` lanes; **290/290** seek/abr/audio regression filters green in both flash modes.
- Reviewed by an architecture pass focused on the seek/epoch contract and RT-safety: clean (the staged
  transition is byte-for-byte equivalent to the normal `fill_buffer` path; `seek()` is the off-RT
  control path; no new allocation/blocking).
- Verified to build and pass `cargo test -p kithara-audio` (215 passed) on top of the current
  production `main`.
