### PR TITLE
test-suite: green suite + seek data-loss fix + profiler-driven perf (xtask perf, RP2/RP4/RP5)

### DIFF
--- a/.config/arch/thresholds.toml
+++ b/.config/arch/thresholds.toml
@@ -457,6 +457,12 @@ export_attrs = ["no_mangle", "export_name", "wasm_bindgen", "uniffi"]
 #   notifications for *_internal ordering assertions; the public PlayerEvent bus
 #   path consumes-and-converts, losing the raw-notification granularity these
 #   tests assert.
+#   test_session: cfg(test)-only NoopBackend session dispatcher injected through
+#   PlayerConfig::session so engine-starting player unit tests never open the
+#   real CoreAudio device; production always resolves the process-wide cpal
+#   session_client — no production reader by design. Shared by the core.rs and
+#   queue.rs test modules, so it cannot relocate into either without
+#   duplicating the backend mock.
 exempt = [
   "advance_to_next_item",
   "ensure_thread_pool",
@@ -465,6 +471,7 @@ exempt = [
   "track_mut",
   "try_pop_notification",
   "drain_notifications",
+  "test_session",
 ]
 # Path fragments whose defs `--fix` must never auto-delete: platform-gated
 # module dirs whose callers live in cfg-disabled or non-Rust (JNI) code the

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -67,3 +67,8 @@ leak-timeout = "2s"
 [[profile.cache.scripts]]
 filter = 'package(kithara-integration-tests)'
 setup = ['fixture-cache']
+
+# Perf-measurement profile: behavior identical to default (profiles inherit
+# it); adds JUnit so `cargo xtask perf` gets exact per-test timings.
+[profile.perf.junit]
+path = "junit.xml"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11463,6 +11463,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
+ "roxmltree",
  "rustdoc-types",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -307,6 +307,7 @@ regex = "1"
 reqwest = { version = "0.13.4", default-features = false }
 ringbuf = "0.5.0"
 rkyv = "0.8.17"
+roxmltree = "0.20"
 rstest = { version = "0.26.1", features = ["async-timeout", "crate-name"] }
 # Beat detection NN inference (kithara-beat).
 rten = { version = "0.24", features = ["fft"] }

--- a/crates/kithara-audio/src/audio.rs
+++ b/crates/kithara-audio/src/audio.rs
@@ -732,6 +732,32 @@ impl<S> Audio<S> {
         }
     }
 
+    fn stage_post_seek_fetch(&mut self, fetch: Fetch<PcmChunk>, epoch: u64) {
+        debug_assert_eq!(
+            fetch.epoch, epoch,
+            "PCM ring preserved a fetch from a future seek epoch"
+        );
+        // Decoder emits a terminal marker as the last item for its epoch, so
+        // staging EOF/failure cannot hide same-epoch PCM behind it.
+        match fetch.kind {
+            FetchKind::Data => {
+                let chunk = fetch.into_inner();
+                self.spec = chunk.spec();
+                self.current_chunk = Some(chunk);
+                self.current_chunk_consumed_frames = 0;
+                self.consumer_phase = ConsumerPhase::Playing;
+            }
+            FetchKind::NaturalEof => {
+                self.consumer_phase = ConsumerPhase::AtEof;
+                self.discard_chunk(fetch.into_inner());
+            }
+            FetchKind::Failure => {
+                self.consumer_phase = ConsumerPhase::Failed;
+                self.discard_chunk(fetch.into_inner());
+            }
+        }
+    }
+
     /// Seek to position in the audio stream.
     ///
     /// This method never blocks. Seek coordination flows entirely through
@@ -768,8 +794,14 @@ impl<S> Audio<S> {
         self.consumer_phase = ConsumerPhase::SeekPending { epoch };
 
         while let Some(fetch) = self.pcm_rx.try_pop() {
-            self.discard_chunk(fetch.into_inner());
-            hang_tick!();
+            if fetch.epoch < epoch {
+                self.discard_chunk(fetch.into_inner());
+                hang_tick!();
+                continue;
+            }
+
+            self.stage_post_seek_fetch(fetch, epoch);
+            break;
         }
 
         if let Some(ref worker) = self.worker {
@@ -1791,6 +1823,8 @@ mod tests {
         let mut chunk = PcmChunk::default();
         chunk.samples.clear();
         chunk.samples.extend_from_slice(samples);
+        chunk.meta.spec.channels = 1;
+        chunk.meta.frames = u32::try_from(samples.len()).unwrap_or(u32::MAX);
         chunk
     }
 
@@ -1877,6 +1911,42 @@ mod tests {
 
         assert!(audio.fill_buffer());
         assert_eq!(audio.consumer_phase, ConsumerPhase::Playing);
+    }
+
+    #[kithara::test]
+    fn seek_drain_preserves_new_epoch_chunk_after_stale_chunks() {
+        let (mut audio, mut tx) = audio_with_channel();
+
+        let stale = Fetch::new(make_chunk(&[0.1, 0.2]), false, 0);
+        let fresh = Fetch::new(make_chunk(&[0.7, 0.8]), false, 1);
+        assert!(tx.try_push(stale).is_ok());
+        assert!(tx.try_push(fresh).is_ok());
+
+        audio.seek(Duration::from_secs(5)).ok();
+
+        let mut buf = [0.0; 2];
+        let count = match audio.read(&mut buf) {
+            Ok(ReadOutcome::Frames { count, .. }) => count.get(),
+            other => panic!("expected preserved post-seek frames, got {other:?}"),
+        };
+        assert_eq!(count, 2);
+        assert_eq!(buf, [0.7, 0.8]);
+    }
+
+    #[kithara::test]
+    fn seek_drain_preserves_new_epoch_eof_after_stale_chunks() {
+        let (mut audio, mut tx) = audio_with_channel();
+
+        let stale = Fetch::new(make_chunk(&[0.1, 0.2]), false, 0);
+        let eof = Fetch::new(PcmChunk::default(), true, 1);
+        assert!(tx.try_push(stale).is_ok());
+        assert!(tx.try_push(eof).is_ok());
+
+        audio.seek(Duration::from_secs(5)).ok();
+
+        let mut buf = [0.0; 2];
+        assert!(matches!(audio.read(&mut buf), Ok(ReadOutcome::Eof { .. })));
+        assert_eq!(audio.consumer_phase, ConsumerPhase::AtEof);
     }
 
     #[kithara::test]

--- a/crates/kithara-net/src/backend/apple/tests.rs
+++ b/crates/kithara-net/src/backend/apple/tests.rs
@@ -7,7 +7,7 @@ use std::{
     net::SocketAddr,
     sync::{
         Arc,
-        atomic::{AtomicU32, Ordering},
+        atomic::{AtomicU32, AtomicUsize, Ordering},
     },
 };
 
@@ -106,6 +106,14 @@ fn stream_options(inactivity_ms: u64) -> NetOptions {
         .build()
 }
 
+fn range_start(request: &str) -> Option<usize> {
+    request
+        .lines()
+        .find_map(|line| line.strip_prefix("Range: bytes="))
+        .and_then(|range| range.split_once('-').map(|(start, _)| start))
+        .and_then(|start| start.parse().ok())
+}
+
 async fn collect(mut stream: crate::ByteStream) -> Result<Bytes, NetError> {
     let mut out = Vec::new();
     while let Some(chunk) = stream.next().await {
@@ -177,33 +185,62 @@ async fn apple_open_ended_stream_delivers_chunks() {
 
 #[kithara::test(tokio, timeout(Duration::from_secs(5)))]
 async fn apple_short_body_yields_before_premature_eof_under_flash() {
-    let url = spawn_server(|mut socket, request| async move {
-        if request.contains("Range: bytes=0-") {
-            write_raw(
-                socket,
-                b"HTTP/1.1 206 Partial Content\r\nContent-Length: 6\r\nContent-Range: bytes 0-5/6\r\nConnection: close\r\n\r\nabcdef",
-            )
-            .await;
-        } else if request.contains("Range: bytes=3-") {
-            write_raw(
-                socket,
-                b"HTTP/1.1 206 Partial Content\r\nContent-Length: 3\r\nContent-Range: bytes 3-5/6\r\nConnection: close\r\n\r\ndef",
-            )
-            .await;
-        } else {
-            socket
-                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 6\r\nAccept-Ranges: bytes\r\nConnection: close\r\n\r\nabc")
-                .await
-                .expect("write short body");
+    const BODY_LEN: usize = 2 * 1024 * 1024;
+    const FIRST_WRITE_LEN: usize = 1024 * 1024;
+
+    let body = Arc::new(
+        (0..BODY_LEN)
+            .map(|i| u8::try_from(i % 251).expect("modulo value fits in u8"))
+            .collect::<Vec<_>>(),
+    );
+    let resume_offset = Arc::new(AtomicUsize::new(usize::MAX));
+    let served_body = Arc::clone(&body);
+    let seen_resume = Arc::clone(&resume_offset);
+    let url = spawn_server(move |mut socket, request| {
+        let body = Arc::clone(&served_body);
+        let resume_offset = Arc::clone(&seen_resume);
+        async move {
+            if let Some(offset) = range_start(&request) {
+                resume_offset.store(offset, Ordering::SeqCst);
+                let tail = &body[offset.min(body.len())..];
+                let head = format!(
+                    "HTTP/1.1 206 Partial Content\r\nContent-Length: {}\r\nContent-Range: bytes {}-{}/{}\r\nConnection: close\r\n\r\n",
+                    tail.len(),
+                    offset,
+                    body.len() - 1,
+                    body.len()
+                );
+                socket
+                    .write_all(head.as_bytes())
+                    .await
+                    .expect("write range head");
+                socket.write_all(tail).await.expect("write range body");
+            } else {
+                let head = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nAccept-Ranges: bytes\r\nConnection: close\r\n\r\n",
+                    body.len()
+                );
+                socket.write_all(head.as_bytes()).await.expect("write head");
+                socket
+                    .write_all(&body[..FIRST_WRITE_LEN])
+                    .await
+                    .expect("write short body");
+                kithara_platform::time::sleep(Duration::from_millis(20)).await;
+            }
         }
     })
     .await;
 
     let client = AppleNet::new(fast_options(1), CancelToken::never());
     let stream = client.stream(url, None).await.expect("stream");
-    let body = collect(stream).await.expect("body");
+    let body_out = collect(stream).await.expect("body");
 
-    assert_eq!(&body[..], b"abcdef");
+    let actual_resume = resume_offset.load(Ordering::SeqCst);
+    assert!(
+        (1..BODY_LEN).contains(&actual_resume),
+        "resume must start after delivered partial bytes, got {actual_resume}"
+    );
+    assert_eq!(&body_out[..], &body[..]);
 }
 
 #[kithara::test(tokio, timeout(Duration::from_secs(5)))]

--- a/crates/kithara-platform/src/flash/system/inner.rs
+++ b/crates/kithara-platform/src/flash/system/inner.rs
@@ -5,6 +5,7 @@ use std::{
         Arc, LazyLock, OnceLock, Weak,
         atomic::{AtomicU64, Ordering},
     },
+    thread::Thread,
 };
 
 use super::{pace::Pacer, sched::Entry, wake::Wake};
@@ -197,6 +198,13 @@ pub(in crate::flash) struct Scheduler {
     /// The pace limit is `anchor_virtual + (real_now - anchor_real)`; cleared
     /// when the last op completes so full-speed collapse resumes at once.
     pub(super) pace_anchor: Option<(RealInstant, u64)>,
+    /// Pacer thread handle published by `pace_run` before its first park.
+    /// Scheduler defer edges use it for lock-free wakeups from under `core`.
+    pub(super) pacer_wake: Option<Thread>,
+    /// Test-only count of pacer park returns. It proves event-driven pacing does
+    /// not poll at a fixed interval while real I/O is in flight.
+    #[cfg(test)]
+    pub(super) pacer_wake_count: usize,
     /// Test-only oracle: the sequence of clock values the engine jumped
     /// to, recorded under the `core` lock alongside each advance. Proves
     /// min-jump, tie-batching (fewer entries than waiters), and determinism
@@ -238,6 +246,9 @@ impl Core {
                 notify_permits: BTreeSet::new(),
                 real_io: 0,
                 pace_anchor: None,
+                pacer_wake: None,
+                #[cfg(test)]
+                pacer_wake_count: 0,
                 #[cfg(test)]
                 advance_log: Vec::new(),
             },
@@ -254,8 +265,8 @@ impl Core {
 pub(in crate::flash) struct FlashInner {
     /// The ONE engine lock (former global `SCHED`).
     pub(super) core: Mutex<Core>,
-    /// Real-I/O pacer state + its lazily-spawned eternal thread. Lock order:
-    /// `pacer.armed` is taken BEFORE `core`, never the other way.
+    /// Real-I/O pacer state + its lazily-spawned eternal thread. The scheduler
+    /// wakes it lock-free via `Thread::unpark` from under `core`.
     pub(super) pacer: Pacer,
     pub(in crate::flash) clock: Clock,
 }
@@ -282,12 +293,15 @@ impl FlashInner {
     /// in-process test harness; nextest gives production tests per-process
     /// isolation). Order matters: store the base first, then drop the engine
     /// state, so afterwards the clock reads `Instant::BASE_NANOS` and the
-    /// engine is empty. Deliberately untouched (exactly as before W2): the
-    /// pacer's `armed` flag (disarmed only by `real_io_exit`), the real-clock
-    /// anchor, and the per-thread credit cells (separate `reset_credit()`).
+    /// engine is empty. Deliberately untouched: the pacer's published wake
+    /// handle, the real-clock anchor, and the per-thread credit cells (separate
+    /// `reset_credit()`).
     pub(in crate::flash) fn reset(&self) {
         self.clock.reset();
-        *self.core.lock() = Core::new();
+        let mut core = self.core.lock();
+        let wake = core.sched.pacer_wake.take();
+        *core = Core::new();
+        core.sched.pacer_wake = wake;
     }
 }
 

--- a/crates/kithara-platform/src/flash/system/pace.rs
+++ b/crates/kithara-platform/src/flash/system/pace.rs
@@ -1,20 +1,11 @@
 use std::sync::{Once, Weak};
 
 use super::{FLASH, FlashInner};
-use crate::{
-    common::time::Instant as RealInstant,
-    flash::Duration,
-    native::sync::{Condvar, Mutex, MutexGuard},
-};
+use crate::common::time::Instant as RealInstant;
 
-/// Per-instance pacer arming flag + wakeup + the lazily-spawned pacer thread.
-/// `armed` is locked BEFORE `core` (strict `armed -> core` order shared by
-/// [`FlashInner::real_io_enter`], [`FlashInner::real_io_exit`] and the pacer
-/// loop), so a disarm racing a fresh enter can never leave the pacer asleep
-/// while `real_io > 0`.
+/// Per-instance lazily-spawned pacer thread. The pacer is woken lock-free via
+/// `Thread::unpark` from under `core` using `sched.pacer_wake`.
 pub(super) struct Pacer {
-    cv: Condvar,
-    armed: Mutex<bool>,
     /// One-shot lazy spawn of the pacer thread, on the first arm
     /// ([`FlashInner::real_io_enter`]).
     spawn: Once,
@@ -25,16 +16,9 @@ pub(super) struct Pacer {
 }
 
 impl Pacer {
-    /// Real-time tick between deferred-advance retries while real I/O is in
-    /// flight: a paced deadline fires within one tick of the equivalent real
-    /// time having passed.
-    const TICK: Duration = Duration::from_millis(1);
-
     pub(super) fn new(owner: Weak<FlashInner>) -> Self {
         Self {
             owner,
-            armed: Mutex::default(),
-            cv: Condvar::default(),
             spawn: Once::new(),
         }
     }
@@ -42,15 +26,27 @@ impl Pacer {
 
 impl FlashInner {
     /// Eternal pacer loop, run on the raw pacer thread holding a strong `Arc`
-    /// to this instance. The disarmed park ([`wait_armed`]) is UNTIMED on
-    /// purpose: a disarmed pacer consumes zero CPU until the next arm.
+    /// to this instance. Untimed parks are deliberate: when there is no paced
+    /// target the pacer consumes zero CPU until the scheduler unparks it.
     fn pace_run(&self) {
-        loop {
-            wait_armed(&self.pacer.cv, self.pacer.armed.lock());
-            // REAL sleep: the pacer exists precisely to feed real time into
-            // the engine while real I/O is in flight.
-            crate::native::thread::sleep(Pacer::TICK);
+        {
             let mut s = self.core.lock();
+            s.sched.pacer_wake = Some(std::thread::current());
+        }
+        loop {
+            let target = {
+                let s = self.core.lock();
+                s.pace_target(&self.clock)
+            };
+            match target {
+                None => std::thread::park(),
+                Some(d) => std::thread::park_timeout(d),
+            }
+            let mut s = self.core.lock();
+            #[cfg(test)]
+            {
+                s.sched.pacer_wake_count += 1;
+            }
             let adv = s.try_advance(&self.clock);
             drop(s);
             adv.fire();
@@ -58,8 +54,7 @@ impl FlashInner {
     }
 
     /// Mark ONE real I/O operation in flight. The first op anchors the pace to
-    /// the current (real, virtual) instant and arms the pacer thread (spawned
-    /// lazily on the first arm).
+    /// the current (real, virtual) instant and spawns the pacer thread lazily.
     pub(in crate::flash) fn real_io_enter(&self) {
         self.pacer.spawn.call_once(|| {
             let owner = self
@@ -75,27 +70,16 @@ impl FlashInner {
                 .spawn(move || owner.pace_run())
                 .expect("BUG: spawning the flash io-pacer thread cannot fail");
         });
-        let mut armed = self.pacer.armed.lock();
         let mut s = self.core.lock();
         s.sched.real_io += 1;
         if s.sched.real_io == 1 {
             s.sched.pace_anchor = Some((RealInstant::now(), self.clock.now_nanos()));
         }
-        drop(s);
-        if !*armed {
-            // Set under the lock, notify after release: the pacer re-checks
-            // `*armed` under the same lock, so the wakeup cannot be lost.
-            *armed = true;
-            drop(armed);
-            self.pacer.cv.notify_one();
-        }
     }
 
-    /// Complete ONE real I/O operation. The last completion clears the anchor,
-    /// disarms the pacer and immediately re-runs the advance rule: full-speed
-    /// collapse resumes.
+    /// Complete ONE real I/O operation. The last completion clears the anchor
+    /// and immediately re-runs the advance rule: full-speed collapse resumes.
     pub(in crate::flash) fn real_io_exit(&self) {
-        let mut armed = self.pacer.armed.lock();
         let mut s = self.core.lock();
         debug_assert!(s.sched.real_io > 0, "real_io exit without a matching enter");
         s.sched.real_io = s.sched.real_io.saturating_sub(1);
@@ -103,24 +87,9 @@ impl FlashInner {
             return;
         }
         s.sched.pace_anchor = None;
-        *armed = false;
         let adv = s.try_advance(&self.clock);
         drop(s);
-        drop(armed);
         adv.fire();
-    }
-}
-
-/// The disarmed park of [`FlashInner::pace_run`]: `armed` is checked under the
-/// lock before every block and re-checked after every wake; UNTIMED on purpose
-/// (a disarmed pacer consumes zero CPU until the next arm). The guard enters
-/// as a parameter and drops on return — released before the caller's real-time
-/// tick, preserving the strict `armed -> core` lock order (parameter form
-/// keeps clippy's `significant_drop_tightening` from mis-suggesting an early
-/// drop inside the loop).
-fn wait_armed(cv: &Condvar, mut armed: MutexGuard<'_, bool>) {
-    while !*armed {
-        armed = cv.wait(armed);
     }
 }
 
@@ -132,4 +101,236 @@ pub(in crate::flash) fn real_io_enter() {
 /// Process-engine forward of [`FlashInner::real_io_exit`].
 pub(in crate::flash) fn real_io_exit() {
     FLASH.real_io_exit();
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{Arc, Mutex, MutexGuard, PoisonError, mpsc},
+        thread,
+        time::Instant as RealInstant,
+    };
+
+    use super::*;
+    use crate::flash::{Duration, system::credit};
+
+    fn ms(n: u64) -> u64 {
+        n * 1_000_000
+    }
+
+    static GUARD: Mutex<()> = Mutex::new(());
+
+    impl FlashInner {
+        fn pacer_wake_count(&self) -> usize {
+            self.core.lock().sched.pacer_wake_count
+        }
+
+        fn pacer_wake_published(&self) -> bool {
+            self.core.lock().sched.pacer_wake.is_some()
+        }
+    }
+
+    fn guard() -> MutexGuard<'static, ()> {
+        GUARD.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    fn bracketed_on<F: FnOnce()>(flash: &FlashInner, body: F) {
+        credit::reset_credit();
+        flash.pre_count_dedicated();
+        credit::mark_dedicated();
+        body();
+        flash.on_participant_exit();
+    }
+
+    fn spawn_park_for(flash: &Arc<FlashInner>, duration: Duration) -> thread::JoinHandle<()> {
+        let flash = Arc::clone(flash);
+        thread::spawn(move || bracketed_on(&flash, || flash.park_for(duration)))
+    }
+
+    fn wait_until(mut ready: impl FnMut() -> bool, message: &str) {
+        let start = RealInstant::now();
+        while !ready() {
+            assert!(
+                start.elapsed() < Duration::from_secs(2),
+                "timed out waiting for {message}"
+            );
+            thread::yield_now();
+        }
+    }
+
+    fn wait_for_timed_count(flash: &FlashInner, count: usize) {
+        wait_until(|| flash.timed_count() == count, "timed waiter count");
+    }
+
+    fn assert_paced_elapsed(elapsed: Duration, target_ms: u64) {
+        let lower = Duration::from_millis(target_ms.saturating_sub(10));
+        assert!(
+            elapsed >= lower,
+            "paced deadline fired too early for {target_ms}ms target: {elapsed:?}"
+        );
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "paced deadline did not fire promptly for {target_ms}ms target: {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn pacer_fires_on_time_under_pacing() {
+        let _guard = guard();
+        let flash = FlashInner::new_arc();
+        let base = flash.clock.now_nanos();
+
+        flash.real_io_enter();
+        let start = RealInstant::now();
+        let waiter = spawn_park_for(&flash, Duration::from_millis(30));
+        waiter.join().expect("waiter thread panicked");
+        let elapsed = start.elapsed();
+        flash.real_io_exit();
+
+        assert_paced_elapsed(elapsed, 30);
+        assert_eq!(flash.clock.now_nanos(), base + ms(30));
+        assert_eq!(
+            flash.advance_log(),
+            vec![base + ms(30)],
+            "paced advance sequence must stay deterministic"
+        );
+    }
+
+    #[test]
+    fn pacer_has_near_zero_wakes_for_far_deadline() {
+        let _guard = guard();
+        let flash = FlashInner::new_arc();
+
+        flash.real_io_enter();
+        let before = flash.pacer_wake_count();
+        let waiter = spawn_park_for(&flash, Duration::from_millis(120));
+        waiter.join().expect("waiter thread panicked");
+        flash.real_io_exit();
+
+        let wakes = flash.pacer_wake_count().saturating_sub(before);
+        assert!(
+            wakes <= 5,
+            "event-driven pacer should wake O(1) times, not poll every millisecond: {wakes}"
+        );
+    }
+
+    #[test]
+    fn pacer_retargets_earlier_deadline_mid_wait() {
+        let _guard = guard();
+        let flash = FlashInner::new_arc();
+        let base = flash.clock.now_nanos();
+
+        flash.real_io_enter();
+        let start = RealInstant::now();
+        let far = spawn_park_for(&flash, Duration::from_millis(350));
+        wait_for_timed_count(&flash, 1);
+        thread::sleep(Duration::from_millis(30));
+
+        let near = spawn_park_for(&flash, Duration::from_millis(120));
+        near.join().expect("near waiter thread panicked");
+        let elapsed = start.elapsed();
+
+        assert_paced_elapsed(elapsed, 120);
+        assert!(
+            elapsed < Duration::from_millis(250),
+            "near deadline waited for the original far target: {elapsed:?}"
+        );
+        assert_eq!(flash.clock.now_nanos(), base + ms(120));
+
+        flash.real_io_exit();
+        far.join().expect("far waiter thread panicked");
+        assert_eq!(flash.advance_log(), vec![base + ms(120), base + ms(350)]);
+    }
+
+    #[test]
+    fn pacer_wakes_on_quiescence_edge() {
+        let _guard = guard();
+        let flash = FlashInner::new_arc();
+        let base = flash.clock.now_nanos();
+        let (release_tx, release_rx) = mpsc::channel();
+        let (running_tx, running_rx) = mpsc::channel();
+
+        flash.real_io_enter();
+        let blocker = {
+            let flash = Arc::clone(&flash);
+            thread::spawn(move || {
+                bracketed_on(&flash, || {
+                    running_tx.send(()).expect("send blocker running");
+                    release_rx.recv().expect("receive blocker release");
+                    flash.park_for(Duration::from_millis(300));
+                });
+            })
+        };
+        running_rx.recv().expect("receive blocker running");
+
+        let start = RealInstant::now();
+        let waiter = spawn_park_for(&flash, Duration::from_millis(80));
+        wait_for_timed_count(&flash, 1);
+        release_tx.send(()).expect("release blocker");
+
+        waiter.join().expect("waiter thread panicked");
+        let elapsed = start.elapsed();
+        assert_paced_elapsed(elapsed, 80);
+        assert_eq!(flash.clock.now_nanos(), base + ms(80));
+
+        flash.real_io_exit();
+        blocker.join().expect("blocker thread panicked");
+    }
+
+    #[test]
+    fn pacer_disarms_to_zero_and_rearms() {
+        let _guard = guard();
+        let flash = FlashInner::new_arc();
+        let base = flash.clock.now_nanos();
+
+        flash.real_io_enter();
+        let first = spawn_park_for(&flash, Duration::from_millis(30));
+        first.join().expect("first waiter thread panicked");
+        flash.real_io_exit();
+        assert_eq!(flash.clock.now_nanos(), base + ms(30));
+
+        let collapse_start = RealInstant::now();
+        let unpaced = spawn_park_for(&flash, Duration::from_secs(5));
+        unpaced.join().expect("unpaced waiter thread panicked");
+        assert!(
+            collapse_start.elapsed() < Duration::from_secs(2),
+            "deadline should collapse immediately after real_io exits"
+        );
+        let rearm_base = flash.clock.now_nanos();
+
+        flash.real_io_enter();
+        let start = RealInstant::now();
+        let second = spawn_park_for(&flash, Duration::from_millis(30));
+        second.join().expect("second waiter thread panicked");
+        let elapsed = start.elapsed();
+        flash.real_io_exit();
+
+        assert_paced_elapsed(elapsed, 30);
+        assert_eq!(flash.clock.now_nanos(), rearm_base + ms(30));
+    }
+
+    #[test]
+    fn reset_preserves_pacer_wake() {
+        let _guard = guard();
+        let flash = FlashInner::new_arc();
+
+        flash.real_io_enter();
+        wait_until(
+            || flash.pacer_wake_published(),
+            "pacer wake handle publication",
+        );
+        flash.real_io_exit();
+        flash.reset();
+
+        let base = flash.clock.now_nanos();
+        flash.real_io_enter();
+        let start = RealInstant::now();
+        let waiter = spawn_park_for(&flash, Duration::from_millis(30));
+        waiter.join().expect("waiter thread panicked");
+        let elapsed = start.elapsed();
+        flash.real_io_exit();
+
+        assert_paced_elapsed(elapsed, 30);
+        assert_eq!(flash.clock.now_nanos(), base + ms(30));
+    }
 }

--- a/crates/kithara-platform/src/flash/system/pace.rs
+++ b/crates/kithara-platform/src/flash/system/pace.rs
@@ -208,9 +208,13 @@ mod tests {
         flash.real_io_exit();
 
         let wakes = flash.pacer_wake_count().saturating_sub(before);
+        // A 1ms poll over a 120ms deadline would wake ~120 times; a self-unpark
+        // busy-spin woke ~1e6. Event-driven wakes O(1): once at the deadline plus
+        // the odd spurious `park_timeout` return under load. Bound well below the
+        // poll count so a regression to either failure mode is still caught.
         assert!(
-            wakes <= 5,
-            "event-driven pacer should wake O(1) times, not poll every millisecond: {wakes}"
+            wakes < 20,
+            "event-driven pacer should wake O(1) times, not poll or busy-spin: {wakes}"
         );
     }
 

--- a/crates/kithara-platform/src/flash/system/sched.rs
+++ b/crates/kithara-platform/src/flash/system/sched.rs
@@ -146,7 +146,15 @@ impl Core {
             // the next computed real deadline.
             let elapsed = u64::try_from(anchor_real.elapsed().as_nanos()).unwrap_or(u64::MAX);
             if min > anchor_virtual.saturating_add(elapsed) {
-                if let Some(t) = &self.sched.pacer_wake {
+                // Wake the pacer to re-target the next real deadline — but NEVER
+                // the pacer waking itself. The pacer runs this same advance rule
+                // after each park, and a self-unpark would arm its own park token,
+                // so the following `park_timeout` returns immediately → busy-spin
+                // until the deadline comes due. Its own deferred advance is already
+                // followed by a fresh `pace_target` + re-park, so it needs no wake.
+                if let Some(t) = &self.sched.pacer_wake
+                    && t.id() != std::thread::current().id()
+                {
                     t.unpark();
                 }
                 return WakeBatch(Vec::new());

--- a/crates/kithara-platform/src/flash/system/sched.rs
+++ b/crates/kithara-platform/src/flash/system/sched.rs
@@ -5,6 +5,7 @@ use std::{
         atomic::{AtomicBool, Ordering},
     },
     task::Waker,
+    time::Duration as StdDuration,
 };
 
 use super::{
@@ -141,9 +142,13 @@ impl Core {
             // PACE while real I/O is in flight: virtual time may not outrun real
             // time, so the earliest deadline fires only once the equivalent REAL
             // time has accrued since the first in-flight op anchored the pace.
-            // Deferred advances are re-attempted by the pace tick (`pace.rs`).
+            // Deferred advances unpark the event-driven pacer to re-evaluate at
+            // the next computed real deadline.
             let elapsed = u64::try_from(anchor_real.elapsed().as_nanos()).unwrap_or(u64::MAX);
             if min > anchor_virtual.saturating_add(elapsed) {
+                if let Some(t) = &self.sched.pacer_wake {
+                    t.unpark();
+                }
                 return WakeBatch(Vec::new());
             }
         }
@@ -173,6 +178,20 @@ impl Core {
         }
         self.registry.account_woken(&woken);
         WakeBatch(woken)
+    }
+
+    pub(super) fn pace_target(&self, _clock: &Clock) -> Option<StdDuration> {
+        if self.registry.active != 0 || self.registry.active_async != 0 {
+            return None;
+        }
+        if self.sched.real_io == 0 {
+            return None;
+        }
+        let (anchor_real, anchor_virtual) = self.sched.pace_anchor?;
+        let (&(min, _), _) = self.sched.timed.iter().next()?;
+        let need = min.saturating_sub(anchor_virtual);
+        let have = u64::try_from(anchor_real.elapsed().as_nanos()).unwrap_or(u64::MAX);
+        Some(StdDuration::from_nanos(need.saturating_sub(have)))
     }
 }
 

--- a/crates/kithara-play/src/impls/player/core.rs
+++ b/crates/kithara-play/src/impls/player/core.rs
@@ -620,7 +620,10 @@ mod tests {
     use kithara_test_utils::kithara;
 
     use super::*;
-    use crate::{impls::player_processor::PlayerCmd, types::SlotId};
+    use crate::{
+        impls::{player_processor::PlayerCmd, session::testing},
+        types::SlotId,
+    };
 
     #[derive(Clone, Copy)]
     enum PlayerBasicScenario {
@@ -880,7 +883,10 @@ mod tests {
 
     #[kithara::test]
     fn timestretch_is_address_stable_across_play_pause() {
-        let player = PlayerImpl::new(PlayerConfig::default());
+        let player = PlayerImpl::new(PlayerConfig {
+            session: Some(testing::test_session()),
+            ..PlayerConfig::default()
+        });
         let ptr_before = Arc::as_ptr(&player.core.config.timestretch);
         player.play();
         player.pause();

--- a/crates/kithara-play/src/impls/player/queue.rs
+++ b/crates/kithara-play/src/impls/player/queue.rs
@@ -404,6 +404,7 @@ mod tests {
     use crate::impls::{
         player::PlayerConfig,
         player_notification::{PlayerNotification, TrackPlaybackStopReason},
+        session::testing,
     };
 
     #[kithara::test]
@@ -435,7 +436,10 @@ mod tests {
 
     #[kithara::test]
     fn commit_next_publishes_snapshot_before_current_item_changed() {
-        let player = PlayerImpl::new(PlayerConfig::default());
+        let player = PlayerImpl::new(PlayerConfig {
+            session: Some(testing::test_session()),
+            ..PlayerConfig::default()
+        });
         player
             .ensure_engine_started()
             .expect("engine start must succeed");

--- a/crates/kithara-play/src/impls/session/mod.rs
+++ b/crates/kithara-play/src/impls/session/mod.rs
@@ -7,6 +7,8 @@
 
 pub mod client;
 pub mod state;
+#[cfg(test)]
+pub(crate) mod testing;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub mod host_native;

--- a/crates/kithara-play/src/impls/session/testing.rs
+++ b/crates/kithara-play/src/impls/session/testing.rs
@@ -1,0 +1,98 @@
+use std::{cell::RefCell, num::NonZeroU32, sync::Arc};
+
+use firewheel::{FirewheelCtx, StreamInfo, backend::AudioBackend, processor::FirewheelProcessor};
+
+use super::{Cmd, Reply, SessionDispatcher, SessionState, run_cmd};
+use crate::error::PlayError;
+
+struct NoopBackend {
+    _processor: Option<FirewheelProcessor<Self>>,
+}
+
+#[derive(Clone)]
+struct NoopConfig {
+    sample_rate: u32,
+}
+
+impl Default for NoopConfig {
+    fn default() -> Self {
+        Self {
+            sample_rate: SessionState::<NoopBackend>::DEFAULT_SAMPLE_RATE,
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("noop backend error")]
+struct NoopBackendError;
+
+impl AudioBackend for NoopBackend {
+    type Config = NoopConfig;
+    type Enumerator = ();
+    type Instant = kithara_platform::time::Instant;
+    type StartStreamError = NoopBackendError;
+    type StreamError = NoopBackendError;
+
+    fn delay_from_last_process(
+        &self,
+        _process_timestamp: Self::Instant,
+    ) -> Option<kithara_platform::time::Duration> {
+        None
+    }
+
+    fn enumerator() -> Self::Enumerator {}
+
+    fn poll_status(&mut self) -> Result<(), Self::StreamError> {
+        Ok(())
+    }
+
+    fn set_processor(&mut self, processor: FirewheelProcessor<Self>) {
+        self._processor = Some(processor);
+    }
+
+    fn start_stream(config: Self::Config) -> Result<(Self, StreamInfo), Self::StartStreamError> {
+        let sample_rate = NonZeroU32::new(config.sample_rate).ok_or(NoopBackendError)?;
+        let max_block_frames = NonZeroU32::new(512).ok_or(NoopBackendError)?;
+        let stream_info = StreamInfo {
+            sample_rate,
+            sample_rate_recip: 1.0 / f64::from(config.sample_rate),
+            prev_sample_rate: sample_rate,
+            max_block_frames,
+            num_stream_in_channels: 0,
+            num_stream_out_channels: 2,
+            input_to_output_latency_seconds: 0.0,
+            declick_frames: max_block_frames,
+            output_device_id: String::from("test-noop"),
+            input_device_id: None,
+        };
+        Ok((Self { _processor: None }, stream_info))
+    }
+}
+
+fn start_noop_stream(ctx: &mut FirewheelCtx<NoopBackend>, sample_rate: u32) -> Result<(), String> {
+    ctx.start_stream(NoopConfig { sample_rate })
+        .map_err(|err| err.to_string())
+}
+
+thread_local! {
+    static TEST_STATE: RefCell<SessionState<NoopBackend>> =
+        RefCell::new(SessionState::new(start_noop_stream));
+}
+
+struct TestSession;
+
+impl SessionDispatcher for TestSession {
+    fn exec(&self, cmd: Cmd) -> Result<Reply, PlayError> {
+        TEST_STATE.with(|state| {
+            let mut state = state
+                .try_borrow_mut()
+                .map_err(|_| PlayError::Internal("test session is already borrowed".into()))?;
+            Ok(run_cmd(&mut state, cmd))
+        })
+    }
+}
+
+pub(crate) fn test_session() -> Arc<dyn SessionDispatcher> {
+    TEST_STATE.with(|state| state.replace(SessionState::new(start_noop_stream)));
+    Arc::new(TestSession)
+}

--- a/crates/kithara-stream/src/dl/tests.rs
+++ b/crates/kithara-stream/src/dl/tests.rs
@@ -562,6 +562,7 @@ async fn shared_client_keepalive_bounds_connection_count() {
 
     let mut total_ok = 0;
     let mut all_failures: Vec<String> = Vec::new();
+    let mut connection_history: Vec<String> = Vec::with_capacity(WAVES);
     let total_dls = WAVES * PARALLEL_DLS;
     for wave in 0..WAVES {
         let mut tasks = Vec::with_capacity(PARALLEL_DLS);
@@ -599,6 +600,11 @@ async fn shared_client_keepalive_bounds_connection_count() {
                 ));
             }
         }
+        connection_history.push(format!(
+            "wave {wave}: client_connections={}, served={}, ok={total_ok}",
+            shared_client.connection_count(),
+            total_served.load(Ordering::SeqCst)
+        ));
     }
 
     let expected = total_dls * REQUESTS_PER_DL;
@@ -616,7 +622,9 @@ async fn shared_client_keepalive_bounds_connection_count() {
          for {expected} requests \
          across {WAVES} waves of {PARALLEL_DLS} downloaders \
          (expected ≤ {MAX_CLIENT_CONNECTIONS}). Successive Downloaders should reuse sockets \
-         from the shared pool; this many indicates per-Downloader clients or severe churn."
+         from the shared pool; this many indicates per-Downloader clients or severe churn. \
+         Per-wave opened-connection history:\n{}",
+        connection_history.join("\n")
     );
 }
 

--- a/crates/kithara-test-utils/src/probe/capture/event.rs
+++ b/crates/kithara-test-utils/src/probe/capture/event.rs
@@ -6,9 +6,9 @@ use kithara_platform::time::Instant;
 #[derive(Clone)]
 pub struct ProbeEvent {
     /// Numeric / boolean fields, keyed by name.
-    pub fields: HashMap<String, u64>,
+    pub fields: HashMap<&'static str, u64>,
     /// Field values that arrived as strings (e.g. `probe = "enqueued"`).
-    pub string_fields: HashMap<String, String>,
+    pub string_fields: HashMap<&'static str, String>,
     /// Wall-clock timestamp of the probe firing.
     pub at: Instant,
     /// Target string of the captured tracing event (e.g.
@@ -65,10 +65,11 @@ impl std::fmt::Debug for ProbeEvent {
         if let Some(seq) = self.seq() {
             s.field("seq", &seq);
         }
-        let mut numeric_keys: Vec<&String> = self
+        let mut numeric_keys: Vec<&'static str> = self
             .fields
             .keys()
-            .filter(|k| !debug_keys::NUMERIC_SERVICE.contains(&k.as_str()))
+            .copied()
+            .filter(|k| !debug_keys::NUMERIC_SERVICE.contains(k))
             .collect();
         numeric_keys.sort();
         for key in numeric_keys {
@@ -79,10 +80,11 @@ impl std::fmt::Debug for ProbeEvent {
         if let Some(caller_fn) = self.caller_fn() {
             s.field("caller_fn", &caller_fn);
         }
-        let mut string_keys: Vec<&String> = self
+        let mut string_keys: Vec<&'static str> = self
             .string_fields
             .keys()
-            .filter(|k| !debug_keys::STRING_SERVICE.contains(&k.as_str()))
+            .copied()
+            .filter(|k| !debug_keys::STRING_SERVICE.contains(k))
             .collect();
         string_keys.sort();
         for key in string_keys {

--- a/crates/kithara-test-utils/src/probe/capture/layer.rs
+++ b/crates/kithara-test-utils/src/probe/capture/layer.rs
@@ -45,41 +45,39 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for ProbeLayer {
 
 #[derive(Default)]
 struct ProbeVisitor {
-    numeric: HashMap<String, u64>,
-    strings: HashMap<String, String>,
+    numeric: HashMap<&'static str, u64>,
+    strings: HashMap<&'static str, String>,
 }
 
 impl Visit for ProbeVisitor {
     fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
-        self.numeric
-            .insert(field.name().to_string(), u64::from(value));
+        self.numeric.insert(field.name(), u64::from(value));
     }
     fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
         let formatted = format!("{value:?}");
         if let Ok(parsed) = formatted.parse::<u64>() {
-            self.numeric.insert(field.name().to_string(), parsed);
+            self.numeric.insert(field.name(), parsed);
         } else if let Ok(parsed) = formatted.parse::<i64>() {
             if parsed >= 0 {
                 self.numeric
-                    .insert(field.name().to_string(), u64::try_from(parsed).unwrap_or(0));
+                    .insert(field.name(), u64::try_from(parsed).unwrap_or(0));
             } else {
-                self.strings.insert(field.name().to_string(), formatted);
+                self.strings.insert(field.name(), formatted);
             }
         } else {
-            self.strings.insert(field.name().to_string(), formatted);
+            self.strings.insert(field.name(), formatted);
         }
     }
     fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
         if value >= 0 {
             self.numeric
-                .insert(field.name().to_string(), u64::try_from(value).unwrap_or(0));
+                .insert(field.name(), u64::try_from(value).unwrap_or(0));
         }
     }
     fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
-        self.strings
-            .insert(field.name().to_string(), value.to_string());
+        self.strings.insert(field.name(), value.to_string());
     }
     fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
-        self.numeric.insert(field.name().to_string(), value);
+        self.numeric.insert(field.name(), value);
     }
 }

--- a/tests/src/hls_server.rs
+++ b/tests/src/hls_server.rs
@@ -363,6 +363,157 @@ impl HlsTestServer {
         }
     }
 
+    pub fn for_each_expected_byte_mismatch(
+        &self,
+        variant: usize,
+        offset: u64,
+        actual: &[u8],
+        mut mismatch: impl FnMut(usize, u8, u8),
+    ) {
+        let init_data = self
+            .config
+            .init_data_per_variant
+            .as_ref()
+            .and_then(|data| data.get(variant));
+        let init_len = init_data.map_or(0u64, |data| data.len() as u64);
+
+        let mut checked = 0usize;
+        if offset < init_len {
+            let init_count = match usize::try_from(init_len - offset) {
+                Ok(remaining) => actual.len().min(remaining),
+                Err(_) => actual.len(),
+            };
+            if let Some(data) = init_data {
+                Self::scan_data_mismatches(data, offset, &actual[..init_count], 0, &mut mismatch);
+            } else {
+                Self::scan_repeated_mismatches(0, &actual[..init_count], 0, &mut mismatch);
+            }
+            checked = init_count;
+        }
+
+        if checked == actual.len() {
+            return;
+        }
+
+        let media_offset = offset.saturating_sub(init_len);
+        let media_actual = &actual[checked..];
+        if let Some(ref per_variant) = self.config.custom_data_per_variant
+            && let Some(data) = per_variant.get(variant)
+        {
+            Self::scan_data_mismatches(data, media_offset, media_actual, checked, &mut mismatch);
+            return;
+        }
+        if let Some(data) = &self.config.custom_data {
+            Self::scan_data_mismatches(data, media_offset, media_actual, checked, &mut mismatch);
+            return;
+        }
+
+        self.scan_generated_mismatches(variant, media_offset, media_actual, checked, &mut mismatch);
+    }
+
+    fn scan_data_mismatches(
+        data: &[u8],
+        data_offset: u64,
+        actual: &[u8],
+        base_index: usize,
+        mismatch: &mut impl FnMut(usize, u8, u8),
+    ) {
+        let Ok(data_offset) = usize::try_from(data_offset) else {
+            Self::scan_repeated_mismatches(0, actual, base_index, mismatch);
+            return;
+        };
+
+        if data_offset >= data.len() {
+            Self::scan_repeated_mismatches(0, actual, base_index, mismatch);
+            return;
+        }
+
+        let data_len = actual.len().min(data.len() - data_offset);
+        Self::scan_slice_mismatches(
+            &data[data_offset..data_offset + data_len],
+            &actual[..data_len],
+            base_index,
+            mismatch,
+        );
+        if data_len < actual.len() {
+            Self::scan_repeated_mismatches(0, &actual[data_len..], base_index + data_len, mismatch);
+        }
+    }
+
+    fn scan_generated_mismatches(
+        &self,
+        variant: usize,
+        mut media_offset: u64,
+        actual: &[u8],
+        base_index: usize,
+        mismatch: &mut impl FnMut(usize, u8, u8),
+    ) {
+        let segment_size = self.config.segment_size as u64;
+        let mut checked = 0usize;
+        while checked < actual.len() {
+            let seg_idx = (media_offset / segment_size) as usize;
+            let off_in_seg = (media_offset % segment_size) as usize;
+            let remaining_in_segment = self.config.segment_size - off_in_seg;
+            let n = remaining_in_segment.min(actual.len() - checked);
+            let prefix = format!("V{variant}-SEG-{seg_idx}:TEST_SEGMENT_DATA");
+            let prefix_bytes = prefix.as_bytes();
+
+            if off_in_seg < prefix_bytes.len() {
+                let prefix_len = n.min(prefix_bytes.len() - off_in_seg);
+                Self::scan_slice_mismatches(
+                    &prefix_bytes[off_in_seg..off_in_seg + prefix_len],
+                    &actual[checked..checked + prefix_len],
+                    base_index + checked,
+                    mismatch,
+                );
+                if prefix_len < n {
+                    Self::scan_repeated_mismatches(
+                        0xFF,
+                        &actual[checked + prefix_len..checked + n],
+                        base_index + checked + prefix_len,
+                        mismatch,
+                    );
+                }
+            } else {
+                Self::scan_repeated_mismatches(
+                    0xFF,
+                    &actual[checked..checked + n],
+                    base_index + checked,
+                    mismatch,
+                );
+            }
+
+            checked += n;
+            media_offset += n as u64;
+        }
+    }
+
+    fn scan_slice_mismatches(
+        expected: &[u8],
+        actual: &[u8],
+        base_index: usize,
+        mismatch: &mut impl FnMut(usize, u8, u8),
+    ) {
+        for (index, (&expected_byte, &actual_byte)) in expected.iter().zip(actual).enumerate() {
+            if actual_byte != expected_byte {
+                mismatch(base_index + index, expected_byte, actual_byte);
+            }
+        }
+    }
+
+    fn scan_repeated_mismatches(
+        expected: u8,
+        actual: &[u8],
+        base_index: usize,
+        mismatch: &mut impl FnMut(usize, u8, u8),
+    ) {
+        for (index, &actual_byte) in actual.iter().enumerate() {
+            if actual_byte != expected {
+                mismatch(base_index + index, expected, actual_byte);
+            }
+        }
+    }
+
     #[must_use]
     pub fn init_len(&self) -> u64 {
         self.config

--- a/tests/src/hls_server.rs
+++ b/tests/src/hls_server.rs
@@ -506,11 +506,28 @@ impl PackagedTestServer {
         variant: usize,
         segment: usize,
     ) -> (Self, crate::SegmentGateHandle) {
-        let server = Self::new().await;
-        let handle = server
-            ._helper
-            .register_segment_gate(server.plain.token(), variant, segment);
+        let (server, mut handles) = Self::with_segment_gates(&[(variant, segment)]).await;
+        let handle = handles.pop().expect("one segment gate handle");
         (server, handle)
+    }
+
+    /// Build a packaged server whose `plain` fixture withholds each listed
+    /// `(variant, segment)` GET body until its corresponding handle releases it.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[must_use]
+    pub async fn with_segment_gates(
+        gates: &[(usize, usize)],
+    ) -> (Self, Vec<crate::SegmentGateHandle>) {
+        let server = Self::new().await;
+        let handles = gates
+            .iter()
+            .map(|&(variant, segment)| {
+                server
+                    ._helper
+                    .register_segment_gate(server.plain.token(), variant, segment)
+            })
+            .collect();
+        (server, handles)
     }
 
     /// Build a packaged server whose `plain` fixture withholds the **size**

--- a/tests/tests/kithara_file/shared_download.rs
+++ b/tests/tests/kithara_file/shared_download.rs
@@ -8,7 +8,7 @@
 //! shared bytes through the same `AssetResource`.
 
 use std::{
-    io::Read,
+    io::{self, Read},
     sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
@@ -44,17 +44,17 @@ async fn serve_full(State(state): State<CountState>) -> Response {
         .expect("valid response")
 }
 
-fn read_to_end(mut stream: Stream<File>) -> Vec<u8> {
+fn read_to_end(mut stream: Stream<File>) -> io::Result<Vec<u8>> {
     let mut out = Vec::new();
     let mut buf = [0u8; 16];
     loop {
         match stream.read(&mut buf) {
             Ok(0) => break,
             Ok(n) => out.extend_from_slice(&buf[..n]),
-            Err(_) => break,
+            Err(err) => return Err(err),
         }
     }
-    out
+    Ok(out)
 }
 
 #[kithara::test(
@@ -104,6 +104,8 @@ async fn shared_store_one_get() {
     })
     .await
     .expect("blocking read task");
+    let waveform_bytes = waveform_bytes.expect("whole-file read must complete");
+    let player_bytes = player_bytes.expect("bounded read must complete");
 
     assert_eq!(
         waveform_bytes, BODY,

--- a/tests/tests/kithara_hls/abr_mode_switch.rs
+++ b/tests/tests/kithara_hls/abr_mode_switch.rs
@@ -104,6 +104,7 @@ struct EventCollector {
     reader_segments: Mutex<Vec<(usize, usize)>>,
     applied_targets: Mutex<Vec<usize>>,
     audio_trace: Mutex<Vec<String>>,
+    event_tail: Mutex<Vec<String>>,
     switch_count: AtomicUsize,
 }
 
@@ -116,6 +117,7 @@ impl EventCollector {
             reader_segments: Mutex::new(Vec::new()),
             applied_targets: Mutex::new(Vec::new()),
             audio_trace: Mutex::new(Vec::new()),
+            event_tail: Mutex::new(Vec::new()),
             switch_count: AtomicUsize::new(0),
         }
     }
@@ -125,6 +127,14 @@ impl EventCollector {
         if trace.len() < 64 {
             trace.push(entry);
         }
+    }
+
+    fn push_event_tail(&self, entry: String) {
+        let mut tail = self.event_tail.lock();
+        if tail.len() >= 64 {
+            tail.remove(0);
+        }
+        tail.push(entry);
     }
 
     /// Fold every event published since the last drain into the accumulators.
@@ -139,6 +149,7 @@ impl EventCollector {
                 Err(TryRecvError::Lagged(_)) => continue,
                 Err(TryRecvError::Empty | TryRecvError::Closed) => break,
             };
+            self.push_event_tail(format!("{ev:?}"));
             match &ev {
                 Event::Downloader(DownloaderEvent::RequestEnqueued {
                     request_id, url, ..
@@ -235,9 +246,27 @@ impl EventCollector {
         self.switch_count.load(Ordering::Acquire)
     }
 
+    fn reader_reached_segment(&self, segment_index: usize) -> bool {
+        self.drain();
+        self.reader_segments
+            .lock()
+            .iter()
+            .any(|(_, s)| *s >= segment_index)
+    }
+
+    fn reader_segments(&self) -> Vec<(usize, usize)> {
+        self.drain();
+        self.reader_segments.lock().clone()
+    }
+
     fn applied_targets(&self) -> Vec<usize> {
         self.drain();
         self.applied_targets.lock().clone()
+    }
+
+    fn event_tail(&self) -> Vec<String> {
+        self.drain();
+        self.event_tail.lock().clone()
     }
 
     fn audio_trace(&self) -> Vec<String> {
@@ -297,6 +326,74 @@ fn read_phase_until_samples<S: StreamType>(
     }
 
     stats
+}
+
+async fn read_until_samples_blocking<S>(
+    mut audio: Audio<Stream<S>>,
+    target_samples: u64,
+    label: &str,
+) -> (Audio<Stream<S>>, u64)
+where
+    S: StreamType + 'static,
+    Audio<Stream<S>>: Send + 'static,
+{
+    spawn_blocking(move || {
+        let samples = read_until_samples(&mut audio, target_samples);
+        (audio, samples)
+    })
+    .await
+    .unwrap_or_else(|err| panic!("{label}: spawn_blocking failed: {err}"))
+}
+
+#[derive(Clone, Copy, Debug)]
+struct BlockingReadStep {
+    samples: u64,
+    saw_eof: bool,
+}
+
+async fn read_one_chunk_blocking<S>(
+    mut audio: Audio<Stream<S>>,
+    label: &str,
+) -> (Audio<Stream<S>>, BlockingReadStep)
+where
+    S: StreamType + 'static,
+    Audio<Stream<S>>: Send + 'static,
+{
+    let read_label = label.to_owned();
+    let join_label = read_label.clone();
+    spawn_blocking(move || {
+        let mut buf = vec![0f32; 4096];
+        loop {
+            match audio.read(&mut buf) {
+                Ok(ReadOutcome::Pending { .. }) => continue,
+                Ok(ReadOutcome::Frames { count, .. }) => {
+                    let n = count.get();
+                    for &sample in &buf[..n] {
+                        assert!(sample.is_finite(), "{read_label}: non-finite sample");
+                    }
+                    return (
+                        audio,
+                        BlockingReadStep {
+                            samples: n as u64,
+                            saw_eof: false,
+                        },
+                    );
+                }
+                Ok(ReadOutcome::Eof { .. }) => {
+                    return (
+                        audio,
+                        BlockingReadStep {
+                            samples: 0,
+                            saw_eof: true,
+                        },
+                    );
+                }
+                Err(err) => panic!("{read_label}: decode error: {err}"),
+            }
+        }
+    })
+    .await
+    .unwrap_or_else(|err| panic!("{join_label}: spawn_blocking failed: {err}"))
 }
 
 /// Wait until every v0 media segment has been network-fetched (the all-cached
@@ -398,7 +495,16 @@ async fn vod_manual_switch_affects_future_segments() {
     );
 
     assert!(total > 0, "expected audio output");
-    assert!(switches > 0, "ABR must switch at least once");
+    let targets = collector.applied_targets();
+    let reader_segments = collector.reader_segments();
+    let event_tail = collector.event_tail();
+    assert!(
+        switches > 0,
+        "ABR must switch at least once. switch_count={switches}, \
+         applied_targets={targets:?}, reader_segments={reader_segments:?}, \
+         segments={segments:?}, last_events:\n{}",
+        event_tail.join("\n")
+    );
 
     let first_v0 = segments.iter().any(|s| s.variant == 0);
     let has_v1 = segments.iter().any(|s| s.variant == 1);
@@ -884,24 +990,16 @@ async fn runtime_manual_switch_via_handle_changes_playing_variant() {
         .events(bus)
         .media_info(wav_info)
         .build();
-    let mut audio = Audio::<Stream<Hls>>::new(config)
+    let audio = Audio::<Stream<Hls>>::new(config)
         .await
         .expect("create audio");
 
     // Warm up a couple of segments so the reader is past the boundary
     // commit gate, then trigger a Manual switch via the handle. The
-    // blocking `read` parks until the worker commits frames, so the loop
-    // waits on real decoded audio (the `total` gate), not a wall clock.
-    let mut buf = vec![0.0f32; 4096];
-    let mut total = 0u64;
-    while total < 8_192 {
-        match audio.read(&mut buf) {
-            Ok(ReadOutcome::Frames { count, .. }) => total += count.get() as u64,
-            Ok(ReadOutcome::Pending { .. }) => {}
-            Ok(ReadOutcome::Eof { .. }) => break,
-            Err(e) => panic!("decode error in warmup: {e}"),
-        }
-    }
+    // blocking `read` parks until the worker commits frames, so run it on
+    // the blocking pool and wait on real decoded audio, not a wall clock.
+    let (mut audio, total) =
+        read_until_samples_blocking(audio, 8_192, "runtime manual warmup").await;
     assert!(total > 0, "warmup must yield audio before the Manual flip");
 
     let handle = audio
@@ -975,13 +1073,14 @@ async fn runtime_cross_codec_manual_switch_no_hang() {
     let config = AudioConfig::<Hls>::for_stream(hls_config)
         .events(bus)
         .build();
-    let mut audio = Audio::<Stream<Hls>>::new(config)
+    let audio = Audio::<Stream<Hls>>::new(config)
         .await
         .expect("create audio");
 
     // Warmup: read until enough AAC samples are produced (state target, not a
     // wall-clock deadline). The outer test timeout is the only backstop.
-    let pre_total = read_until_samples(&mut audio, 16_384);
+    let (mut audio, pre_total) =
+        read_until_samples_blocking(audio, 16_384, "cross-codec manual warmup").await;
     assert!(
         pre_total > 0,
         "warmup must produce AAC samples before the cross-codec flip"
@@ -1086,24 +1185,14 @@ async fn runtime_manual_switch_works_when_all_segments_cached() {
         .media_info(wav_info)
         .block_on_underrun(true)
         .build();
-    let mut audio = Audio::<Stream<Hls>>::new(config)
+    let audio = Audio::<Stream<Hls>>::new(config)
         .await
         .expect("create audio");
 
-    // Tiny warmup read — kicks off the peer's prefetch, then drops the
-    // reader so the prefetch can finish on its own thread.
-    let mut buf = vec![0.0f32; 4096];
-    let mut warmup_samples = 0u64;
-    while warmup_samples < 8_192 {
-        match audio.read(&mut buf) {
-            Ok(ReadOutcome::Frames { count, .. }) => {
-                warmup_samples += count.get() as u64;
-            }
-            Ok(ReadOutcome::Eof { .. }) => break,
-            Ok(ReadOutcome::Pending { .. }) => {}
-            Err(e) => panic!("decode error in warmup: {e}"),
-        }
-    }
+    // Tiny warmup read on the blocking pool so the current-thread runtime
+    // remains free to drive the peer prefetch.
+    let (audio, warmup_samples) =
+        read_until_samples_blocking(audio, 8_192, "all-cached manual warmup").await;
     assert!(warmup_samples > 0, "warmup must produce some audio");
 
     // The downloader must finish prefetching every v0 segment — the
@@ -1221,13 +1310,14 @@ async fn runtime_manual_switch_works_after_cache_and_seek() {
         .events(bus)
         .media_info(wav_info)
         .build();
-    let mut audio = Audio::<Stream<Hls>>::new(config)
+    let audio = Audio::<Stream<Hls>>::new(config)
         .await
         .expect("create audio");
 
-    // Tiny warmup so the peer is actually pumping. Drop the reader to
-    // let the prefetch finish in the background.
-    let warmup_samples = read_until_samples(&mut audio, 8_192);
+    // Tiny warmup on the blocking pool so the peer is actually pumping while
+    // the current-thread runtime remains free to drive downloader tasks.
+    let (mut audio, warmup_samples) =
+        read_until_samples_blocking(audio, 8_192, "cache-and-seek manual warmup").await;
     assert!(warmup_samples > 0, "warmup must produce some audio");
 
     // Wait on the real prefetch state (one net fetch per v0 segment), not a
@@ -1381,28 +1471,26 @@ async fn auto_does_not_up_switch_on_first_boundary_with_defaults() {
         .events(bus)
         .media_info(wav_info)
         .build();
-    let mut audio = Audio::<Stream<Hls>>::new(config)
+    let audio = Audio::<Stream<Hls>>::new(config)
         .await
         .expect("create audio");
 
-    // Read just enough to cross the first segment boundary — the reader
-    // moves from byte 0 into segment 1. We do NOT exhaust the fixture
-    // (large enough sample budget but bounded).
-    let mut buf = vec![0.0f32; 4096];
+    // Read until the reader itself enters segment 1. The read pump runs on the
+    // blocking pool so it cannot park the current-thread runtime that drives
+    // the HLS producer tasks.
+    let mut audio = audio;
     let mut samples = 0u64;
-    let single_segment_frames = (D.segment_size / 4) as u64; // 200 KB / (stereo i16) ≈ 50_000 frames
-    // Engine-aware blocking read parks until each chunk commits, so wait on
-    // the *fact* of two segments' worth of samples — not a wall-clock window
-    // (a virtual deadline would race the clock past in-flight real bytes
-    // under flash). A genuine wedge is bounded by `KITHARA_HANG_TIMEOUT_SECS`.
-    while samples < single_segment_frames * 2 {
-        match audio.read(&mut buf) {
-            Ok(ReadOutcome::Frames { count, .. }) => samples += count.get() as u64,
-            Ok(ReadOutcome::Eof { .. }) => break,
-            Ok(ReadOutcome::Pending { .. }) => {}
-            Err(e) => panic!("decode error: {e}"),
-        }
+    while !collector.reader_reached_segment(1) {
+        let (next_audio, step) =
+            read_one_chunk_blocking(audio, "auto defaults first-boundary read").await;
+        audio = next_audio;
+        samples += step.samples;
+        assert!(
+            !step.saw_eof,
+            "test reached EOF before the reader crossed the first segment boundary"
+        );
     }
+    drop(audio);
 
     let switches = collector.switch_count();
     let segments = collector.segments();
@@ -1476,12 +1564,13 @@ async fn rapid_cross_codec_then_same_codec_switch_no_false_eof() {
     let config = AudioConfig::<Hls>::for_stream(hls_config)
         .events(bus)
         .build();
-    let mut audio = Audio::<Stream<Hls>>::new(config)
+    let audio = Audio::<Stream<Hls>>::new(config)
         .await
         .expect("create audio");
 
     // Warmup on v=0 (AAC).
-    let warmup_total = read_until_samples(&mut audio, 16_384);
+    let (mut audio, warmup_total) =
+        read_until_samples_blocking(audio, 16_384, "rapid switch warmup").await;
     assert!(warmup_total > 0, "warmup must produce AAC samples");
 
     let handle = audio

--- a/tests/tests/kithara_hls/basic_playback.rs
+++ b/tests/tests/kithara_hls/basic_playback.rs
@@ -167,7 +167,7 @@ async fn test_hls_with_different_options(
     timeout(Duration::from_secs(5)),
     env(KITHARA_HANG_TIMEOUT_SECS = "1")
 )]
-#[case("http://invalid-domain-that-does-not-exist-12345.com/master.m3u8")]
+#[case("http://127.0.0.1:9/master.m3u8")]
 #[case("not-a-valid-url")]
 #[case("")]
 async fn test_hls_invalid_url_handling(

--- a/tests/tests/kithara_hls/keys_integration.rs
+++ b/tests/tests/kithara_hls/keys_integration.rs
@@ -106,7 +106,7 @@ async fn key_store_with_different_processors(
 async fn key_store_error_handling(assets_fixture: TestAssets) -> HlsResult<()> {
     let key_store = test_key_store(&assets_fixture, None);
 
-    let invalid_url = Url::parse("http://invalid-domain-that-does-not-exist-12345.com/master.m3u8")
+    let invalid_url = Url::parse("http://127.0.0.1:9/master.m3u8")
         .map_err(|e| HlsError::InvalidUrl(e.to_string()))?;
 
     let result: HlsResult<Bytes> = key_store.get_raw_key(&invalid_url, None).await;

--- a/tests/tests/kithara_hls/red_flaky_small_cache_hot_refetch.rs
+++ b/tests/tests/kithara_hls/red_flaky_small_cache_hot_refetch.rs
@@ -6,10 +6,10 @@ use kithara::{
     assets::{StorageBackend, StoreOptions},
     audio::{Audio, AudioConfig, ChunkOutcome, PcmReader},
     hls::{Hls, HlsConfig},
-    platform::{thread, time::Duration, tokio::task::spawn_blocking},
+    platform::{time::Duration, tokio::task::spawn_blocking},
     stream::Stream,
 };
-use kithara_integration_tests::{TestServerHelper, auto};
+use kithara_integration_tests::{TestServerHelper, auto, flash_pace::virtual_pace};
 use tracing::info;
 
 struct Consts;
@@ -68,7 +68,7 @@ async fn red_flaky_small_cache_hot_refetch_behind_reader() {
                 Ok(ChunkOutcome::Chunk(_)) => chunks_read += 1,
                 Ok(ChunkOutcome::Eof { .. }) => break,
                 Ok(ChunkOutcome::Pending { .. }) => {
-                    thread::sleep(Duration::from_micros(100));
+                    virtual_pace(Duration::from_micros(100));
                 }
                 Err(e) => panic!("warmup decode error: {e}"),
             }
@@ -83,13 +83,13 @@ async fn red_flaky_small_cache_hot_refetch_behind_reader() {
                     drained += 1;
                     // Load-bearing pacing: the reader must lag the network so
                     // the cap=1 LRU evicts segments behind/under the reader.
-                    thread::sleep(Duration::from_millis(Consts::READER_SLEEP_MS));
+                    virtual_pace(Duration::from_millis(Consts::READER_SLEEP_MS));
                 }
                 Ok(ChunkOutcome::Eof { .. }) => {
                     reached_eof = true;
                 }
                 Ok(ChunkOutcome::Pending { .. }) => {
-                    thread::sleep(Duration::from_micros(100));
+                    virtual_pace(Duration::from_micros(100));
                 }
                 Err(e) => panic!("drain decode error: {e}"),
             }

--- a/tests/tests/kithara_hls/smoke_test.rs
+++ b/tests/tests/kithara_hls/smoke_test.rs
@@ -142,7 +142,7 @@ async fn test_hls_session_events_consumption(
 async fn test_hls_invalid_url_handling(
     temp_dir: TestTempDir,
 ) -> Result<(), Box<dyn StdError + Send + Sync>> {
-    let invalid_url = "http://invalid-domain-that-does-not-exist-12345.com/master.m3u8";
+    let invalid_url = "http://127.0.0.1:9/master.m3u8";
     let url_result = Url::parse(invalid_url);
 
     if let Ok(url) = url_result {

--- a/tests/tests/kithara_hls/stress_seek_audio.rs
+++ b/tests/tests/kithara_hls/stress_seek_audio.rs
@@ -526,8 +526,10 @@ async fn stress_seek_audio_hls(
         let mut channel_mismatches = 0u64;
         let mut continuity_errors = 0u64;
         let mut position_errors = 0u64;
+        let mut position_error_details: Vec<String> = Vec::new();
 
         let channels = spec.channels as usize;
+        let bytes_per_frame = usize::from(Consts::D.channels) * 2;
 
         for (i, &pos_secs) in seek_positions.iter().enumerate() {
             let position = Duration::from_secs_f64(pos_secs);
@@ -601,6 +603,16 @@ async fn stress_seek_audio_hls(
             let dist = phase_distance(actual_phase, expected_phase);
             if dist > 1200 {
                 position_errors += 1;
+                if position_error_details.len() < 10 {
+                    let requested_byte = 44 + expected_frame_idx * bytes_per_frame;
+                    let segment_index =
+                        (requested_byte / Consts::D.segment_size).min(segment_count - 1);
+                    position_error_details.push(format!(
+                        "#{i}: requested={pos_secs:.6}s expected_frame={expected_frame_idx} \
+                         expected_phase={expected_phase} actual_phase={actual_phase} \
+                         delta={dist} segment={segment_index}"
+                    ));
+                }
                 if position_errors <= 3 {
                     info!(
                         iteration = i,
@@ -668,7 +680,9 @@ async fn stress_seek_audio_hls(
         }
         assert!(
             position_errors <= 3,
-            "{position_errors} position mismatches (>3 tolerance) - seek landed in wrong place"
+            "{position_errors} position mismatches (>3 tolerance) - seek landed in wrong place. \
+             First mismatches (capped at 10):\n{}",
+            position_error_details.join("\n")
         );
 
         let final_seek_secs = total_secs - chunk_duration_secs;

--- a/tests/tests/kithara_hls/stress_seek_audio.rs
+++ b/tests/tests/kithara_hls/stress_seek_audio.rs
@@ -44,10 +44,6 @@ impl Consts {
 /// the fMP4 init segment plus a few acquire-then-open double-touches before
 /// the cache settles (observed overhead is ~+4..+5).
 const FULL_CACHE_OPEN_SLACK: usize = 10;
-/// Upper-bound multiplier for the capped-cache (over-CAP) case: backend
-/// opens must stay well under per-seek thrash over `SEEK_ITERATIONS` seeks.
-const THRASH_GUARD_MULTIPLIER: usize = 6;
-
 #[derive(Clone, Copy, Debug)]
 enum SeekAudioFixture {
     WavFileLike,
@@ -141,41 +137,66 @@ fn assert_seek_size_probes(fixture: SeekAudioFixture, counter: &SizeProbeCounter
     }
 }
 
-/// Count real asset-store backend opens during the run: each cache miss
-/// reaches `EvictAssets::{acquire,open}_resource_with_ctx`, which fire the
-/// `kithara_assets_probe` USDT probe. Cache hits short-circuit above this
-/// layer (in `CachedAssets`) and are not counted, so this is the exact
-/// number of file-handle opens the LRU cache failed to absorb.
-fn count_assets_opens(recorder: &Recorder) -> usize {
-    recorder
-        .snapshot()
-        .into_iter()
-        .filter(|e| {
-            e.target == "kithara_assets_probe"
-                && matches!(
-                    e.probe_name(),
-                    Some("acquire_resource_with_ctx") | Some("open_resource_with_ctx")
-                )
-        })
-        .count()
+#[derive(Debug, Default)]
+struct AssetOpenStats {
+    total: usize,
+    acquire: usize,
+    open: usize,
+}
+
+impl AssetOpenStats {
+    fn record_acquire(&mut self) {
+        self.total += 1;
+        self.acquire += 1;
+    }
+
+    fn record_open(&mut self) {
+        self.total += 1;
+        self.open += 1;
+    }
+}
+
+/// Real asset-store backend opens during the run: each cache miss reaches
+/// `EvictAssets::{acquire,open}_resource_with_ctx`, which fire the
+/// `kithara_assets_probe` probe. Cache hits short-circuit above this layer.
+fn asset_open_stats(recorder: &Recorder) -> AssetOpenStats {
+    let mut stats = AssetOpenStats::default();
+    for event in recorder.snapshot() {
+        if event.target != "kithara_assets_probe" {
+            continue;
+        }
+        match event.probe_name() {
+            Some("acquire_resource_with_ctx") => stats.record_acquire(),
+            Some("open_resource_with_ctx") => stats.record_open(),
+            _ => {}
+        }
+    }
+    stats
 }
 
 /// Open-count contract. With a cache sized to hold every segment, each
 /// backend resource is opened ~once for the whole run regardless of the
 /// 1000 seek iterations (no re-open thrash). With a capped cache over a
-/// larger track, opens are reduced by frequency eviction but not zero — the
-/// ceiling guards against a regression back to per-seek thrash.
+/// larger track, aggregate opens are schedule-sensitive because background
+/// prefetch and frequency eviction can legitimately displace mmap handles
+/// before later random seeks reuse them. The deterministic capped-cache
+/// contract is therefore write-side: segment acquisition must stay near one
+/// backend open per resource, proving capped read-handle churn does not turn
+/// into re-fetch/re-acquire thrash.
 fn assert_backend_open_count(
     fixture: SeekAudioFixture,
     segment_count: usize,
     cache_capacity_override: Option<usize>,
     recorder: &Recorder,
 ) {
-    let opens = count_assets_opens(recorder);
+    let stats = asset_open_stats(recorder);
+    let opens = stats.total;
     let full_cache = cache_capacity_override.is_some_and(|cap| cap >= segment_count);
     info!(
         ?fixture,
         opens,
+        acquire_opens = stats.acquire,
+        read_opens = stats.open,
         segment_count,
         ?cache_capacity_override,
         full_cache,
@@ -189,11 +210,16 @@ fn assert_backend_open_count(
              segment_count={segment_count}, bound={bound}"
         );
     } else {
-        let bound = segment_count * THRASH_GUARD_MULTIPLIER;
+        let bound = segment_count + FULL_CACHE_OPEN_SLACK;
         assert!(
-            opens <= bound,
-            "capped cache opens must stay well under per-seek thrash: opens={opens}, \
-             bound={bound} (segment_count={segment_count})"
+            stats.acquire <= bound,
+            "capped cache must not re-acquire segment resources repeatedly: \
+             acquire_opens={}, read_opens={}, total_opens={}, bound={} \
+             (segment_count={segment_count})",
+            stats.acquire,
+            stats.open,
+            stats.total,
+            bound
         );
     }
 }

--- a/tests/tests/kithara_hls/stress_seek_random.rs
+++ b/tests/tests/kithara_hls/stress_seek_random.rs
@@ -23,7 +23,7 @@ use tracing::info;
 /// 3. Compute total byte length from server config
 /// 4. Compute optimal random chunk size proportional to stream
 /// 5. Sample `seek_iterations` random seek positions in `(0, len - chunk_size)`
-/// 6. For each: seek → read → verify every byte matches `expected_byte_at`
+/// 6. For each: seek → read → verify every byte matches the fixture data
 /// 7. Final: seek to `len - chunk_size`, read all → verify EOF
 #[kithara::test(
     tokio,
@@ -178,21 +178,18 @@ async fn stress_random_seek_read_hls(
             );
 
             if !with_encryption {
-                for (j, &byte) in buf[..n].iter().enumerate() {
-                    let expected = server.expected_byte_at(0, pos + j as u64);
-                    if byte != expected {
-                        byte_mismatches += 1;
-                        if byte_mismatches <= 5 {
-                            info!(
-                                iteration = i,
-                                offset = pos + j as u64,
-                                expected,
-                                actual = byte,
-                                "Byte mismatch"
-                            );
-                        }
+                server.for_each_expected_byte_mismatch(0, pos, &buf[..n], |j, expected, byte| {
+                    byte_mismatches += 1;
+                    if byte_mismatches <= 5 {
+                        info!(
+                            iteration = i,
+                            offset = pos + j as u64,
+                            expected,
+                            actual = byte,
+                            "Byte mismatch"
+                        );
                     }
-                }
+                });
             }
 
             successful_reads += 1;
@@ -238,16 +235,19 @@ async fn stress_random_seek_read_hls(
                     break;
                 }
 
-                for (j, &byte) in buf[..n].iter().enumerate() {
-                    let expected =
-                        server.expected_byte_at(0, final_seek + remaining_bytes + j as u64);
-                    assert_eq!(
-                        byte,
-                        expected,
-                        "tail byte mismatch at offset {}",
-                        final_seek + remaining_bytes + j as u64
-                    );
-                }
+                server.for_each_expected_byte_mismatch(
+                    0,
+                    final_seek + remaining_bytes,
+                    &buf[..n],
+                    |j, expected, byte| {
+                        assert_eq!(
+                            byte,
+                            expected,
+                            "tail byte mismatch at offset {}",
+                            final_seek + remaining_bytes + j as u64
+                        );
+                    },
+                );
                 remaining_bytes += n as u64;
             }
 

--- a/tests/tests/kithara_hls/wait_range_contract.rs
+++ b/tests/tests/kithara_hls/wait_range_contract.rs
@@ -105,15 +105,19 @@ async fn seek_burst_then_tail_read_stays_contiguous(#[case] ephemeral: bool) {
                 break;
             }
 
-            for (i, &byte) in tail_buf[..n].iter().enumerate() {
-                let expected = server.expected_byte_at(0, offset + i as u64);
-                assert_eq!(
-                    byte,
-                    expected,
-                    "tail byte mismatch at absolute offset {}",
-                    offset + i as u64
-                );
-            }
+            server.for_each_expected_byte_mismatch(
+                0,
+                offset,
+                &tail_buf[..n],
+                |i, expected, byte| {
+                    assert_eq!(
+                        byte,
+                        expected,
+                        "tail byte mismatch at absolute offset {}",
+                        offset + i as u64
+                    );
+                },
+            );
 
             offset += n as u64;
             total_read += n as u64;

--- a/tests/tests/kithara_play/hls_seek_middle_no_queue.rs
+++ b/tests/tests/kithara_play/hls_seek_middle_no_queue.rs
@@ -1,17 +1,20 @@
 #![forbid(unsafe_code)]
 
 use kithara::{
+    abr::AbrMode,
     assets::StoreOptions,
     net::{HttpClient, NetOptions},
     platform::{
         CancelToken,
         time::{Duration, sleep},
+        tokio::task::yield_now,
     },
     play::{Resource, ResourceConfig},
     stream::dl::{Downloader, DownloaderConfig},
 };
 use kithara_integration_tests::{
-    PackagedTestServer, fixture_protocol::DelayRule, offline::OfflinePlayer, temp_dir,
+    PackagedTestServer, SegmentGateHandle, fixture_protocol::DelayRule, offline::OfflinePlayer,
+    temp_dir,
 };
 
 use crate::common::test_defaults::Consts as Shared;
@@ -30,6 +33,43 @@ impl Consts {
     /// because the warmup only covers segments 0–1.
     const SEEK_TARGET_SECS: f64 = 9.0;
     const MIN_POSITION_ADVANCE_POST_SEEK_SECS: f64 = 1.0;
+    const GATED_VARIANT: usize = 0;
+    const GATED_SEGMENT: usize = 2;
+    const GATE_REQUEST_TICKS: u32 = 2_000;
+}
+
+#[derive(Clone, Copy, Debug)]
+enum SeekScenario {
+    NoDelay,
+    RealDelay {
+        delay_ms: u64,
+    },
+    Gated {
+        label: &'static str,
+        nominal_delay_ms: u64,
+        hold_ticks: u32,
+    },
+}
+
+impl SeekScenario {
+    fn label(self) -> &'static str {
+        match self {
+            Self::NoDelay => "no_delay",
+            Self::RealDelay { delay_ms: 2_000 } => "congested_2s",
+            Self::RealDelay { .. } => "real_delay",
+            Self::Gated { label, .. } => label,
+        }
+    }
+
+    fn nominal_delay_ms(self) -> u64 {
+        match self {
+            Self::NoDelay => 0,
+            Self::RealDelay { delay_ms } => delay_ms,
+            Self::Gated {
+                nominal_delay_ms, ..
+            } => nominal_delay_ms,
+        }
+    }
 }
 
 fn blocks_for_seconds(secs: f64) -> u32 {
@@ -51,6 +91,7 @@ fn blocks_for_seconds(secs: f64) -> u32 {
 /// budget — the `#[kithara::test(... timeout(90s))]` attribute is the
 /// only safety bound, so the success path is always the real state
 /// (position) being reached rather than a collapsed timer expiring.
+#[kithara::flash(true)]
 async fn render_until_position(player: &mut OfflinePlayer, min_blocks: u32, until_position: f64) {
     const BATCH: u32 = 16;
     const TICK_MS: u64 = 25;
@@ -68,24 +109,89 @@ async fn render_until_position(player: &mut OfflinePlayer, min_blocks: u32, unti
     }
 }
 
+#[kithara::flash(true)]
+async fn render_until_gate_requested(
+    player: &mut OfflinePlayer,
+    gate: &SegmentGateHandle,
+    post_target: f64,
+    hold_ticks: u32,
+    label: &str,
+) {
+    const BATCH: u32 = 16;
+    for _ in 0..Consts::GATE_REQUEST_TICKS {
+        for _ in 0..BATCH {
+            let _ = player.render(Consts::BLOCK_FRAMES);
+        }
+        let position = player.position();
+        assert!(
+            position < post_target,
+            "{label}: seek advanced to {position:.3}s while gated segment was unavailable \
+             (post target {post_target:.3}s)"
+        );
+        if gate.requested() > 0 {
+            for _ in 0..hold_ticks {
+                for _ in 0..BATCH {
+                    let _ = player.render(Consts::BLOCK_FRAMES);
+                }
+                let held_position = player.position();
+                assert!(
+                    held_position < post_target,
+                    "{label}: seek advanced to {held_position:.3}s before gate release \
+                     (post target {post_target:.3}s)"
+                );
+                sleep(Duration::from_millis(1)).await;
+            }
+            return;
+        }
+        yield_now().await;
+    }
+    panic!(
+        "{label}: gated segment v{} s{} was never requested before release",
+        Consts::GATED_VARIANT,
+        Consts::GATED_SEGMENT
+    );
+}
+
 #[kithara::test(tokio, multi_thread, timeout(Duration::from_secs(90)))]
-#[case::no_delay(0)]
-#[case::good_4g_500ms(500)]
-#[case::congested_2s(2_000)]
-#[case::very_slow_5s(5_000)]
-#[case::near_broken_10s(10_000)]
-async fn hls_seek_middle_lands_under_simulated_slow_connection(#[case] delay_ms: u64) {
-    let server = PackagedTestServer::with_delay_rules(if delay_ms == 0 {
-        Vec::new()
-    } else {
-        vec![DelayRule {
-            variant: None,
-            segment_eq: None,
-            segment_gte: Some(2),
-            delay_ms,
-        }]
-    })
-    .await;
+#[case::no_delay(SeekScenario::NoDelay)]
+#[case::good_4g_500ms(SeekScenario::Gated {
+    label: "good_4g_500ms_gate",
+    nominal_delay_ms: 500,
+    hold_ticks: 4,
+})]
+#[case::congested_2s(SeekScenario::RealDelay { delay_ms: 2_000 })]
+#[case::very_slow_5s(SeekScenario::Gated {
+    label: "very_slow_5s_gate",
+    nominal_delay_ms: 5_000,
+    hold_ticks: 8,
+})]
+#[case::near_broken_10s(SeekScenario::Gated {
+    label: "near_broken_10s_gate",
+    nominal_delay_ms: 10_000,
+    hold_ticks: 16,
+})]
+async fn hls_seek_middle_lands_under_simulated_slow_connection(#[case] scenario: SeekScenario) {
+    let (server, gate) = match scenario {
+        SeekScenario::NoDelay => (PackagedTestServer::new().await, None),
+        SeekScenario::RealDelay { delay_ms } => (
+            PackagedTestServer::with_delay_rules(vec![DelayRule {
+                variant: None,
+                segment_eq: None,
+                segment_gte: Some(Consts::GATED_SEGMENT),
+                delay_ms,
+            }])
+            .await,
+            None,
+        ),
+        SeekScenario::Gated { .. } => {
+            let (server, gate) =
+                PackagedTestServer::with_segment_gate(Consts::GATED_VARIANT, Consts::GATED_SEGMENT)
+                    .await;
+            (server, Some(gate))
+        }
+    };
+    let delay_ms = scenario.nominal_delay_ms();
+    let label = scenario.label();
     let master = server.url("/master.m3u8");
 
     let temp = temp_dir();
@@ -95,12 +201,20 @@ async fn hls_seek_middle_lands_under_simulated_slow_connection(#[case] delay_ms:
             .build(),
     );
 
-    let cfg = ResourceConfig::for_src(master.as_str())
-        .expect("valid master URL")
-        .downloader(downloader.clone())
-        .name("t0".to_string())
-        .store(store)
-        .build();
+    let cfg = {
+        let builder = ResourceConfig::for_src(master.as_str())
+            .expect("valid master URL")
+            .downloader(downloader.clone())
+            .name("t0".to_string())
+            .store(store);
+        if gate.is_some() {
+            builder
+                .initial_abr_mode(AbrMode::manual(Consts::GATED_VARIANT))
+                .build()
+        } else {
+            builder.build()
+        }
+    };
 
     let resource = Resource::new(cfg)
         .await
@@ -117,7 +231,9 @@ async fn hls_seek_middle_lands_under_simulated_slow_connection(#[case] delay_ms:
     )
     .await;
     let pos_before_seek = player.position();
-    eprintln!("[delay_ms={delay_ms}] pre-seek position = {pos_before_seek:.3}s (expected >0)");
+    eprintln!(
+        "[{label} delay_ms={delay_ms}] pre-seek position = {pos_before_seek:.3}s (expected >0)"
+    );
     assert!(
         pos_before_seek > 0.2,
         "decoder never produced PCM before the seek \
@@ -126,11 +242,20 @@ async fn hls_seek_middle_lands_under_simulated_slow_connection(#[case] delay_ms:
 
     player.seek(Consts::SEEK_TARGET_SECS, 1);
     eprintln!(
-        "[delay_ms={delay_ms}] seek issued target={:.1}s epoch=1",
+        "[{label} delay_ms={delay_ms}] seek issued target={:.1}s epoch=1",
         Consts::SEEK_TARGET_SECS
     );
 
     let post_target = Consts::SEEK_TARGET_SECS + Consts::MIN_POSITION_ADVANCE_POST_SEEK_SECS;
+    if let Some(gate) = gate.as_ref() {
+        let hold_ticks = match scenario {
+            SeekScenario::Gated { hold_ticks, .. } => hold_ticks,
+            SeekScenario::NoDelay | SeekScenario::RealDelay { .. } => 0,
+        };
+        render_until_gate_requested(&mut player, gate, post_target, hold_ticks, label).await;
+        gate.release();
+    }
+
     render_until_position(
         &mut player,
         blocks_for_seconds(Consts::POST_SEEK_AUDIO_SECS),
@@ -138,7 +263,7 @@ async fn hls_seek_middle_lands_under_simulated_slow_connection(#[case] delay_ms:
     )
     .await;
     let pos_after = player.position();
-    eprintln!("[delay_ms={delay_ms}] post-seek position = {pos_after:.3}s");
+    eprintln!("[{label} delay_ms={delay_ms}] post-seek position = {pos_after:.3}s");
 
     let advance = pos_after - Consts::SEEK_TARGET_SECS;
     assert!(

--- a/tests/tests/kithara_play/hls_seek_middle_stress_long.rs
+++ b/tests/tests/kithara_play/hls_seek_middle_stress_long.rs
@@ -1,16 +1,21 @@
 #![forbid(unsafe_code)]
 
 use kithara::{
+    abr::AbrMode,
     assets::StoreOptions,
     decode::DecoderBackend,
     net::{HttpClient, NetOptions},
-    platform::{CancelToken, time::Duration},
+    platform::{
+        CancelToken,
+        time::{Duration, sleep},
+        tokio::task::yield_now,
+    },
     play::{Resource, ResourceConfig},
     stream::dl::{Downloader, DownloaderConfig},
 };
 use kithara_integration_tests::{
-    PackagedTestServer, fixture_protocol::DelayRule, offline::OfflinePlayer, temp_dir,
-    waits::render_until_position,
+    PackagedTestServer, SegmentGateHandle, offline::OfflinePlayer, temp_dir,
+    waits::render_until_position as raw_render_until_position,
 };
 
 use crate::common::test_defaults::Consts as Shared;
@@ -27,6 +32,16 @@ impl Consts {
     const STRESS_DELAY_MS: u64 = 500;
     const SEEK_TARGETS: [f64; 5] = [9.0, 5.0, 7.5, 11.0, 8.1];
     const STRESS_ITERATIONS: u32 = 20;
+    const GATED_VARIANT: usize = 0;
+    const GATED_SEGMENTS: [usize; 2] = [1, 2];
+    const GATE_REQUEST_TICKS: u32 = 2_000;
+    const GATE_HOLD_TICKS: u32 = 4;
+}
+
+struct ControlledGate {
+    segment: usize,
+    handle: SegmentGateHandle,
+    released: bool,
 }
 
 fn blocks_for_seconds(secs: f64) -> u32 {
@@ -40,6 +55,49 @@ fn blocks_for_seconds(secs: f64) -> u32 {
     result
 }
 
+#[kithara::flash(true)]
+async fn render_until_position(
+    player: &mut OfflinePlayer,
+    max_blocks: u32,
+    until_position: f64,
+    block_frames: usize,
+    min_wall_ms: u64,
+) {
+    raw_render_until_position(
+        player,
+        max_blocks,
+        until_position,
+        block_frames,
+        min_wall_ms,
+    )
+    .await;
+}
+
+fn segment_for_target(target: f64) -> usize {
+    if target < 8.0 { 1 } else { 2 }
+}
+
+#[kithara::flash(true)]
+async fn wait_for_gate_request(player: &mut OfflinePlayer, gate: &SegmentGateHandle, label: &str) {
+    const BATCH: u32 = 16;
+    for _ in 0..Consts::GATE_REQUEST_TICKS {
+        for _ in 0..BATCH {
+            let _ = player.render(Consts::BLOCK_FRAMES);
+        }
+        if gate.requested() > 0 {
+            for _ in 0..Consts::GATE_HOLD_TICKS {
+                for _ in 0..BATCH {
+                    let _ = player.render(Consts::BLOCK_FRAMES);
+                }
+                sleep(Duration::from_millis(1)).await;
+            }
+            return;
+        }
+        yield_now().await;
+    }
+    panic!("{label}: gated segment GET was never requested before release");
+}
+
 #[kithara::test(tokio, multi_thread, timeout(Duration::from_secs(60)))]
 #[case::symphonia(DecoderBackend::Symphonia)]
 #[cfg_attr(
@@ -51,13 +109,17 @@ async fn hls_seek_middle_repeated_seeks_long_stress(#[case] backend: DecoderBack
     #[cfg(any(target_os = "macos", target_os = "ios"))]
     kithara_integration_tests::apple_warmup::warm_if_apple(backend);
 
-    let server = PackagedTestServer::with_delay_rules(vec![DelayRule {
-        variant: None,
-        segment_eq: None,
-        segment_gte: Some(1),
-        delay_ms: Consts::STRESS_DELAY_MS,
-    }])
-    .await;
+    let gate_specs = Consts::GATED_SEGMENTS.map(|segment| (Consts::GATED_VARIANT, segment));
+    let (server, handles) = PackagedTestServer::with_segment_gates(&gate_specs).await;
+    let mut gates: Vec<ControlledGate> = Consts::GATED_SEGMENTS
+        .into_iter()
+        .zip(handles)
+        .map(|(segment, handle)| ControlledGate {
+            segment,
+            handle,
+            released: false,
+        })
+        .collect();
     let master = server.url("/master.m3u8");
 
     let temp = temp_dir();
@@ -73,6 +135,7 @@ async fn hls_seek_middle_repeated_seeks_long_stress(#[case] backend: DecoderBack
         .name("t0".to_string())
         .store(store)
         .decoder_backend(backend)
+        .initial_abr_mode(AbrMode::manual(Consts::GATED_VARIANT))
         .build();
 
     let resource = Resource::new(cfg)
@@ -101,6 +164,17 @@ async fn hls_seek_middle_repeated_seeks_long_stress(#[case] backend: DecoderBack
         let target = Consts::SEEK_TARGETS[(iter as usize) % Consts::SEEK_TARGETS.len()];
         let pos_before = player.position();
         player.seek(target, u64::from(1 + iter));
+        let segment = segment_for_target(target);
+        if let Some(index) = gates
+            .iter()
+            .position(|gate| gate.segment == segment && !gate.released)
+        {
+            let gate = gates[index].handle.clone();
+            let label = format!("iter {iter} target {target:.2}s segment {segment}");
+            wait_for_gate_request(&mut player, &gate, &label).await;
+            gate.release();
+            gates[index].released = true;
+        }
         let post_target = target + Consts::MIN_POSITION_ADVANCE_POST_SEEK_SECS;
         render_until_position(
             &mut player,

--- a/tests/tests/phase_continuity/common.rs
+++ b/tests/tests/phase_continuity/common.rs
@@ -191,6 +191,11 @@ where
     }
 }
 
+#[kithara::flash(true)]
+async fn consumer_pace(duration: Duration) {
+    sleep(duration).await;
+}
+
 /// Check phase continuity vs the **previous** scan, not a fixed anchor.
 ///
 /// "Continuity" = no sudden glitch (sample drop, fragment skip, decoder
@@ -393,7 +398,7 @@ where
                 break;
             };
             if let Some(p) = pace {
-                sleep(p).await;
+                consumer_pace(p).await;
             }
             let frames_this_read = (n / chan) as u64;
             if consumed >= next_scan_at {

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -20,6 +20,7 @@ plist = { workspace = true }
 proc-macro2 = { workspace = true, features = ["span-locations"] }
 quote = { workspace = true }
 regex = { workspace = true }
+roxmltree = { workspace = true }
 rustdoc-types = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -15,6 +15,7 @@ mod idioms;
 mod lint;
 mod manifest;
 mod orphans;
+mod perf;
 mod perf_compare;
 mod publish;
 mod quality;
@@ -37,6 +38,7 @@ use health::HealthArgs;
 use lint::LintArgs;
 use manifest::ManifestArgs;
 use orphans::OrphansArgs;
+use perf::PerfArgs;
 use publish::PublishArgs;
 use quality::QualityCommand;
 use release::ReleaseArgs;
@@ -71,6 +73,8 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Command {
+    /// Test-suite performance measurement pipeline (matrix/slow/profile/report/trace).
+    Perf(PerfArgs),
     /// Compare perf results.
     PerfCompare {
         /// Path to the current results file.
@@ -141,6 +145,7 @@ fn main() -> anyhow::Result<()> {
             baseline,
             threshold,
         } => perf_compare::run(&current, &baseline, threshold),
+        Command::Perf(ref args) => perf::run(args),
         Command::Lint(ref args) => lint::run(args),
         Command::Quality { command } => quality::run(command),
         Command::Android { command } => android::run(command),

--- a/xtask/src/perf/cli.rs
+++ b/xtask/src/perf/cli.rs
@@ -9,7 +9,7 @@ use clap::{Args, Subcommand};
 use crate::perf::{
     matrix::{self, MatrixParams},
     profile::{self, ProfileParams},
-    slow,
+    report, slow,
 };
 
 #[derive(Debug, Args)]
@@ -24,6 +24,8 @@ enum PerfCommand {
     Matrix(MatrixCli),
     /// Profile every slow-list test in isolation under samply.
     Profile(ProfileCli),
+    /// Render merged slow/profile report markdown.
+    Report(ReportCli),
     /// Aggregate matrix `JUnit` data into `slow.json` / `slow.md`.
     Slow(SlowCli),
 }
@@ -80,6 +82,17 @@ struct ProfileCli {
     limit: Option<usize>,
 }
 
+#[derive(Debug, Args)]
+struct ReportCli {
+    #[arg(long)]
+    data_dir: PathBuf,
+    #[arg(long)]
+    run_id: String,
+    /// Lane whose isolated profiles are read.
+    #[arg(long, default_value = "flash-on-wreq")]
+    lane: String,
+}
+
 pub(crate) fn run(args: &PerfArgs) -> Result<()> {
     match &args.command {
         PerfCommand::Matrix(cli) => {
@@ -108,6 +121,7 @@ pub(crate) fn run(args: &PerfArgs) -> Result<()> {
             };
             profile::run(&params)
         }
+        PerfCommand::Report(cli) => report::run(&cli.data_dir, &cli.run_id, &cli.lane),
         PerfCommand::Slow(cli) => slow::run(&cli.data_dir, &cli.run_id, cli.threshold_ms),
     }
 }

--- a/xtask/src/perf/cli.rs
+++ b/xtask/src/perf/cli.rs
@@ -1,0 +1,71 @@
+use std::{
+    path::PathBuf,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use anyhow::{Context, Result};
+use clap::{Args, Subcommand};
+
+use crate::perf::matrix::{self, MatrixParams};
+
+#[derive(Debug, Args)]
+pub(crate) struct PerfArgs {
+    #[command(subcommand)]
+    command: PerfCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum PerfCommand {
+    /// Run the full suite across feature lanes, saving `JUnit` + metadata.
+    Matrix(MatrixCli),
+}
+
+#[derive(Debug, Args)]
+struct MatrixCli {
+    /// Root directory for measurement data (outside the repo).
+    #[arg(long)]
+    data_dir: PathBuf,
+    /// Identifier for this measurement run; default: run-<unix-secs>.
+    #[arg(long)]
+    run_id: Option<String>,
+    /// Root for per-lane `CARGO_TARGET_DIRs`.
+    #[arg(long)]
+    target_root: PathBuf,
+    /// Full-suite repetitions per lane.
+    #[arg(long, default_value_t = 3)]
+    repeats: u32,
+    /// Lane subset (repeatable); default: all four lanes.
+    #[arg(long = "lane")]
+    lanes: Vec<String>,
+    /// Extra args passed through to `cargo nextest run` (e.g. `-p kithara-hls`).
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+    extra: Vec<String>,
+}
+
+pub(crate) fn run(args: &PerfArgs) -> Result<()> {
+    match &args.command {
+        PerfCommand::Matrix(cli) => {
+            let run_id = match &cli.run_id {
+                Some(id) => id.clone(),
+                None => default_run_id()?,
+            };
+            let params = MatrixParams {
+                data_dir: cli.data_dir.clone(),
+                run_id,
+                target_root: cli.target_root.clone(),
+                repeats: cli.repeats,
+                lanes: cli.lanes.clone(),
+                extra: cli.extra.clone(),
+            };
+            matrix::run(&params)
+        }
+    }
+}
+
+fn default_run_id() -> Result<String> {
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("clock before epoch")?
+        .as_secs();
+    Ok(format!("run-{secs}"))
+}

--- a/xtask/src/perf/cli.rs
+++ b/xtask/src/perf/cli.rs
@@ -8,6 +8,7 @@ use clap::{Args, Subcommand};
 
 use crate::perf::{
     matrix::{self, MatrixParams},
+    profile::{self, ProfileParams},
     slow,
 };
 
@@ -21,6 +22,8 @@ pub(crate) struct PerfArgs {
 enum PerfCommand {
     /// Run the full suite across feature lanes, saving `JUnit` + metadata.
     Matrix(MatrixCli),
+    /// Profile every slow-list test in isolation under samply.
+    Profile(ProfileCli),
     /// Aggregate matrix `JUnit` data into `slow.json` / `slow.md`.
     Slow(SlowCli),
 }
@@ -58,6 +61,25 @@ struct SlowCli {
     threshold_ms: f64,
 }
 
+#[derive(Debug, Args)]
+struct ProfileCli {
+    #[arg(long)]
+    data_dir: PathBuf,
+    #[arg(long)]
+    run_id: String,
+    #[arg(long)]
+    target_root: PathBuf,
+    /// Lane whose build/list is used for binaries (default: primary).
+    #[arg(long, default_value = "flash-on-wreq")]
+    lane: String,
+    /// Kill a profiled test after this many seconds.
+    #[arg(long, default_value_t = 180)]
+    timeout_secs: u64,
+    /// Profile only the first N slow tests (pilot use).
+    #[arg(long)]
+    limit: Option<usize>,
+}
+
 pub(crate) fn run(args: &PerfArgs) -> Result<()> {
     match &args.command {
         PerfCommand::Matrix(cli) => {
@@ -74,6 +96,17 @@ pub(crate) fn run(args: &PerfArgs) -> Result<()> {
                 extra: cli.extra.clone(),
             };
             matrix::run(&params)
+        }
+        PerfCommand::Profile(cli) => {
+            let params = ProfileParams {
+                data_dir: cli.data_dir.clone(),
+                run_id: cli.run_id.clone(),
+                target_root: cli.target_root.clone(),
+                lane: cli.lane.clone(),
+                timeout_secs: cli.timeout_secs,
+                limit: cli.limit,
+            };
+            profile::run(&params)
         }
         PerfCommand::Slow(cli) => slow::run(&cli.data_dir, &cli.run_id, cli.threshold_ms),
     }

--- a/xtask/src/perf/cli.rs
+++ b/xtask/src/perf/cli.rs
@@ -10,6 +10,7 @@ use crate::perf::{
     matrix::{self, MatrixParams},
     profile::{self, ProfileParams},
     report, slow,
+    trace::{self, TraceParams},
 };
 
 #[derive(Debug, Args)]
@@ -28,6 +29,8 @@ enum PerfCommand {
     Report(ReportCli),
     /// Aggregate matrix `JUnit` data into `slow.json` / `slow.md`.
     Slow(SlowCli),
+    /// Record one test under Instruments Time Profiler.
+    Trace(TraceCli),
 }
 
 #[derive(Debug, Args)]
@@ -93,6 +96,22 @@ struct ReportCli {
     lane: String,
 }
 
+#[derive(Debug, Args)]
+struct TraceCli {
+    #[arg(long)]
+    data_dir: PathBuf,
+    #[arg(long)]
+    run_id: String,
+    #[arg(long)]
+    target_root: PathBuf,
+    #[arg(long)]
+    lane: String,
+    #[arg(long)]
+    suite: String,
+    #[arg(long)]
+    test: String,
+}
+
 pub(crate) fn run(args: &PerfArgs) -> Result<()> {
     match &args.command {
         PerfCommand::Matrix(cli) => {
@@ -123,6 +142,17 @@ pub(crate) fn run(args: &PerfArgs) -> Result<()> {
         }
         PerfCommand::Report(cli) => report::run(&cli.data_dir, &cli.run_id, &cli.lane),
         PerfCommand::Slow(cli) => slow::run(&cli.data_dir, &cli.run_id, cli.threshold_ms),
+        PerfCommand::Trace(cli) => {
+            let params = TraceParams {
+                data_dir: cli.data_dir.clone(),
+                run_id: cli.run_id.clone(),
+                target_root: cli.target_root.clone(),
+                lane: cli.lane.clone(),
+                suite: cli.suite.clone(),
+                test: cli.test.clone(),
+            };
+            trace::run(&params)
+        }
     }
 }
 

--- a/xtask/src/perf/cli.rs
+++ b/xtask/src/perf/cli.rs
@@ -6,7 +6,10 @@ use std::{
 use anyhow::{Context, Result};
 use clap::{Args, Subcommand};
 
-use crate::perf::matrix::{self, MatrixParams};
+use crate::perf::{
+    matrix::{self, MatrixParams},
+    slow,
+};
 
 #[derive(Debug, Args)]
 pub(crate) struct PerfArgs {
@@ -18,6 +21,8 @@ pub(crate) struct PerfArgs {
 enum PerfCommand {
     /// Run the full suite across feature lanes, saving `JUnit` + metadata.
     Matrix(MatrixCli),
+    /// Aggregate matrix `JUnit` data into `slow.json` / `slow.md`.
+    Slow(SlowCli),
 }
 
 #[derive(Debug, Args)]
@@ -42,6 +47,17 @@ struct MatrixCli {
     extra: Vec<String>,
 }
 
+#[derive(Debug, Args)]
+struct SlowCli {
+    #[arg(long)]
+    data_dir: PathBuf,
+    #[arg(long)]
+    run_id: String,
+    /// Slow threshold in milliseconds.
+    #[arg(long, default_value_t = 1000.0)]
+    threshold_ms: f64,
+}
+
 pub(crate) fn run(args: &PerfArgs) -> Result<()> {
     match &args.command {
         PerfCommand::Matrix(cli) => {
@@ -59,6 +75,7 @@ pub(crate) fn run(args: &PerfArgs) -> Result<()> {
             };
             matrix::run(&params)
         }
+        PerfCommand::Slow(cli) => slow::run(&cli.data_dir, &cli.run_id, cli.threshold_ms),
     }
 }
 

--- a/xtask/src/perf/gecko.rs
+++ b/xtask/src/perf/gecko.rs
@@ -1,0 +1,204 @@
+use std::collections::BTreeMap;
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct Profile {
+    meta: Meta,
+    threads: Vec<Thread>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Meta {
+    interval: f64,
+}
+
+#[derive(Debug, Deserialize)]
+struct Thread {
+    samples: Samples,
+    #[serde(rename = "stackTable")]
+    stack_table: StackTable,
+    #[serde(rename = "frameTable")]
+    frame_table: FrameTable,
+    #[serde(rename = "funcTable")]
+    func_table: FuncTable,
+    #[serde(rename = "stringArray")]
+    string_array: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Samples {
+    stack: Vec<Option<usize>>,
+    #[serde(rename = "threadCPUDelta", default)]
+    thread_cpu_delta: Vec<Option<f64>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StackTable {
+    prefix: Vec<Option<usize>>,
+    frame: Vec<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FrameTable {
+    func: Vec<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FuncTable {
+    name: Vec<usize>,
+}
+
+#[derive(Debug)]
+pub(crate) struct WaitBucket {
+    pub(crate) class: String,
+    pub(crate) attributed: String,
+    pub(crate) ms: f64,
+}
+
+#[derive(Debug)]
+pub(crate) struct FrameBucket {
+    pub(crate) frame: String,
+    pub(crate) ms: f64,
+}
+
+#[derive(Debug)]
+pub(crate) struct ProfileSummary {
+    pub(crate) on_cpu_ms: f64,
+    pub(crate) off_cpu_ms: f64,
+    pub(crate) waits: Vec<WaitBucket>,
+    pub(crate) cpu: Vec<FrameBucket>,
+}
+
+const WAIT_CLASSES: [(&str, &[&str]); 7] = [
+    ("condvar", &["psynch_cvwait", "pthread_cond"]),
+    ("lock", &["ulock_wait", "psynch_mutexwait", "pthread_mutex"]),
+    ("sleep", &["nanosleep", "semwait_signal", "usleep", "sleep"]),
+    ("kevent", &["kevent", "kqueue"]),
+    ("mach", &["mach_msg"]),
+    ("park", &["park"]),
+    ("channel", &["recv"]),
+];
+
+fn wait_class(leaf: &str) -> &'static str {
+    for (class, needles) in WAIT_CLASSES {
+        if needles.iter().any(|needle| leaf.contains(needle)) {
+            return class;
+        }
+    }
+    "other-wait"
+}
+
+fn func_name(thread: &Thread, stack_idx: usize) -> &str {
+    let frame = thread.stack_table.frame[stack_idx];
+    let func = thread.frame_table.func[frame];
+    let name = thread.func_table.name[func];
+    thread.string_array.get(name).map_or("", String::as_str)
+}
+
+fn kithara_frame(thread: &Thread, mut stack: Option<usize>) -> Option<&str> {
+    while let Some(idx) = stack {
+        let name = func_name(thread, idx);
+        if name.contains("kithara") {
+            return Some(name);
+        }
+        stack = thread.stack_table.prefix[idx];
+    }
+    None
+}
+
+pub(crate) fn summarize(profile_json: &str, top: usize) -> Result<ProfileSummary> {
+    let profile: Profile = serde_json::from_str(profile_json).context("parse gecko profile")?;
+    let interval = profile.meta.interval;
+    let mut on_cpu_ms = 0.0;
+    let mut off_cpu_ms = 0.0;
+    let mut waits: BTreeMap<(String, String), f64> = BTreeMap::new();
+    let mut cpu: BTreeMap<String, f64> = BTreeMap::new();
+    for thread in &profile.threads {
+        for (i, stack) in thread.samples.stack.iter().enumerate() {
+            let Some(stack_idx) = *stack else { continue };
+            let cpu_delta = thread
+                .samples
+                .thread_cpu_delta
+                .get(i)
+                .copied()
+                .flatten()
+                .unwrap_or(0.0);
+            let leaf = func_name(thread, stack_idx);
+            let attributed = kithara_frame(thread, Some(stack_idx))
+                .unwrap_or("(no kithara frame)")
+                .to_owned();
+            if cpu_delta > 0.0 {
+                on_cpu_ms += interval;
+                *cpu.entry(attributed).or_default() += interval;
+            } else {
+                off_cpu_ms += interval;
+                let class = wait_class(leaf).to_owned();
+                *waits.entry((class, attributed)).or_default() += interval;
+            }
+        }
+    }
+    let mut waits: Vec<WaitBucket> = waits
+        .into_iter()
+        .map(|((class, attributed), ms)| WaitBucket {
+            class,
+            attributed,
+            ms,
+        })
+        .collect();
+    waits.sort_by(|a, b| b.ms.total_cmp(&a.ms));
+    waits.truncate(top);
+    let mut cpu: Vec<FrameBucket> = cpu
+        .into_iter()
+        .map(|(frame, ms)| FrameBucket { frame, ms })
+        .collect();
+    cpu.sort_by(|a, b| b.ms.total_cmp(&a.ms));
+    cpu.truncate(top);
+    Ok(ProfileSummary {
+        on_cpu_ms,
+        off_cpu_ms,
+        waits,
+        cpu,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PROFILE: &str = r#"{
+      "meta": { "interval": 1.0 },
+      "threads": [{
+        "name": "worker",
+        "samples": {
+          "length": 3,
+          "stack": [1, 2, 2],
+          "threadCPUDelta": [900, 0, 0]
+        },
+        "stackTable": { "length": 3, "prefix": [null, 0, 0], "frame": [0, 1, 2] },
+        "frameTable": { "length": 3, "func": [0, 1, 2] },
+        "funcTable": { "length": 3, "name": [0, 1, 2] },
+        "stringArray": [
+          "kithara_hls::loading::fetch_segment",
+          "core::hash::sip",
+          "__psynch_cvwait"
+        ]
+      }]
+    }"#;
+
+    #[test]
+    fn classifies_on_and_off_cpu() {
+        let summary = summarize(PROFILE, 10).unwrap();
+        assert!((summary.on_cpu_ms - 1.0).abs() < 1e-9);
+        assert!((summary.off_cpu_ms - 2.0).abs() < 1e-9);
+        assert_eq!(summary.waits.len(), 1);
+        assert_eq!(summary.waits[0].class, "condvar");
+        assert_eq!(
+            summary.waits[0].attributed,
+            "kithara_hls::loading::fetch_segment"
+        );
+        assert!((summary.waits[0].ms - 2.0).abs() < 1e-9);
+        assert_eq!(summary.cpu[0].frame, "kithara_hls::loading::fetch_segment");
+    }
+}

--- a/xtask/src/perf/junit.rs
+++ b/xtask/src/perf/junit.rs
@@ -1,0 +1,59 @@
+use anyhow::{Context, Result};
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct CaseTiming {
+    pub(crate) suite: String,
+    pub(crate) name: String,
+    pub(crate) secs: f64,
+    pub(crate) failed: bool,
+}
+
+pub(crate) fn parse_junit(xml: &str) -> Result<Vec<CaseTiming>> {
+    let doc = roxmltree::Document::parse(xml).context("parse junit xml")?;
+    let mut cases = Vec::new();
+    for node in doc.descendants().filter(|n| n.has_tag_name("testcase")) {
+        let name = node.attribute("name").unwrap_or_default().to_owned();
+        let suite = node.attribute("classname").unwrap_or_default().to_owned();
+        let secs: f64 = node
+            .attribute("time")
+            .unwrap_or("0")
+            .parse()
+            .with_context(|| format!("bad time attribute on {suite} {name}"))?;
+        let failed = node
+            .children()
+            .any(|c| c.has_tag_name("failure") || c.has_tag_name("error"));
+        cases.push(CaseTiming {
+            suite,
+            name,
+            secs,
+            failed,
+        });
+    }
+    Ok(cases)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="nextest-run" tests="2" failures="1">
+  <testsuite name="kithara-integration-tests::suite_light" tests="2" failures="1">
+    <testcase name="offline::gapless" classname="kithara-integration-tests::suite_light" time="1.532"/>
+    <testcase name="offline::seek" classname="kithara-integration-tests::suite_light" time="0.201">
+      <failure type="test failure">boom</failure>
+    </testcase>
+  </testsuite>
+</testsuites>"#;
+
+    #[test]
+    fn parses_cases_and_failures() {
+        let cases = parse_junit(XML).unwrap();
+        assert_eq!(cases.len(), 2);
+        assert_eq!(cases[0].suite, "kithara-integration-tests::suite_light");
+        assert_eq!(cases[0].name, "offline::gapless");
+        assert!((cases[0].secs - 1.532).abs() < 1e-9);
+        assert!(!cases[0].failed);
+        assert!(cases[1].failed);
+    }
+}

--- a/xtask/src/perf/lanes.rs
+++ b/xtask/src/perf/lanes.rs
@@ -1,0 +1,145 @@
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct Lane {
+    pub(crate) flash: bool,
+    pub(crate) backend: &'static str,
+}
+
+pub(crate) const LANES: [Lane; 4] = [
+    Lane {
+        flash: true,
+        backend: "wreq",
+    },
+    Lane {
+        flash: false,
+        backend: "wreq",
+    },
+    Lane {
+        flash: true,
+        backend: "apple",
+    },
+    Lane {
+        flash: false,
+        backend: "apple",
+    },
+];
+
+pub(crate) const PRIMARY_LANE: &str = "flash-on-wreq";
+
+impl Lane {
+    pub(crate) fn name(&self) -> String {
+        let flash = if self.flash { "on" } else { "off" };
+        format!("flash-{flash}-{}", self.backend)
+    }
+
+    pub(crate) fn by_name(name: &str) -> Option<Self> {
+        LANES.into_iter().find(|lane| lane.name() == name)
+    }
+}
+
+pub(crate) struct RunPaths {
+    pub(crate) run_dir: PathBuf,
+}
+
+impl RunPaths {
+    pub(crate) fn new(data_dir: &Path, run_id: &str) -> Self {
+        Self {
+            run_dir: data_dir.join(run_id),
+        }
+    }
+
+    pub(crate) fn repeat_dir(&self, lane: &str, repeat: u32) -> PathBuf {
+        self.run_dir
+            .join("matrix")
+            .join(lane)
+            .join(format!("rep{repeat}"))
+    }
+
+    pub(crate) fn matrix_dir(&self) -> PathBuf {
+        self.run_dir.join("matrix")
+    }
+
+    pub(crate) fn slow_json(&self) -> PathBuf {
+        self.run_dir.join("slow.json")
+    }
+
+    pub(crate) fn slow_md(&self) -> PathBuf {
+        self.run_dir.join("slow.md")
+    }
+
+    pub(crate) fn profiles_dir(&self, lane: &str) -> PathBuf {
+        self.run_dir.join("profiles").join(lane)
+    }
+
+    pub(crate) fn report_md(&self) -> PathBuf {
+        self.run_dir.join("report.md")
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct RepeatMeta {
+    pub(crate) run_id: String,
+    pub(crate) lane: String,
+    pub(crate) features: Vec<String>,
+    pub(crate) repeat: u32,
+    pub(crate) commit: String,
+    pub(crate) started_unix: u64,
+    pub(crate) duration_secs: f64,
+    pub(crate) exit_code: Option<i32>,
+}
+
+pub(crate) fn sanitize(name: &str) -> String {
+    name.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use super::*;
+
+    #[test]
+    fn lane_names_round_trip() {
+        assert_eq!(LANES.len(), 4);
+        assert_eq!(LANES[0].name(), "flash-on-wreq");
+        assert_eq!(PRIMARY_LANE, "flash-on-wreq");
+        for lane in LANES {
+            assert_eq!(Lane::by_name(&lane.name()), Some(lane));
+        }
+        assert_eq!(Lane::by_name("flash-maybe-wreq"), None);
+    }
+
+    #[test]
+    fn run_paths_layout() {
+        let p = RunPaths::new(Path::new("/d"), "run-1");
+        assert_eq!(
+            p.repeat_dir("flash-on-wreq", 2),
+            PathBuf::from("/d/run-1/matrix/flash-on-wreq/rep2")
+        );
+        assert_eq!(p.matrix_dir(), PathBuf::from("/d/run-1/matrix"));
+        assert_eq!(p.slow_json(), PathBuf::from("/d/run-1/slow.json"));
+        assert_eq!(p.slow_md(), PathBuf::from("/d/run-1/slow.md"));
+        assert_eq!(
+            p.profiles_dir("flash-on-wreq"),
+            PathBuf::from("/d/run-1/profiles/flash-on-wreq")
+        );
+        assert_eq!(p.report_md(), PathBuf::from("/d/run-1/report.md"));
+    }
+
+    #[test]
+    fn sanitize_test_names() {
+        assert_eq!(sanitize("a::b::c"), "a__b__c");
+        assert_eq!(sanitize("x/y z"), "x_y_z");
+    }
+}

--- a/xtask/src/perf/list.rs
+++ b/xtask/src/perf/list.rs
@@ -1,0 +1,108 @@
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+
+use crate::{common::project::ProjectConfig, test::lane_features};
+
+#[derive(Debug)]
+pub(crate) struct SuiteBin {
+    pub(crate) binary_path: PathBuf,
+    pub(crate) cwd: PathBuf,
+}
+
+#[derive(Debug, Deserialize)]
+struct ListOutput {
+    #[serde(rename = "rust-suites")]
+    rust_suites: BTreeMap<String, ListSuite>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ListSuite {
+    #[serde(rename = "binary-path")]
+    binary_path: PathBuf,
+    cwd: PathBuf,
+}
+
+pub(crate) fn parse_list(json: &str) -> Result<BTreeMap<String, SuiteBin>> {
+    let parsed: ListOutput = serde_json::from_str(json).context("parse nextest list json")?;
+    Ok(parsed
+        .rust_suites
+        .into_iter()
+        .map(|(id, suite)| {
+            (
+                id,
+                SuiteBin {
+                    binary_path: suite.binary_path,
+                    cwd: suite.cwd,
+                },
+            )
+        })
+        .collect())
+}
+
+pub(crate) fn nextest_list(
+    project: &ProjectConfig,
+    flash: bool,
+    backend: &str,
+    target_dir: &Path,
+) -> Result<BTreeMap<String, SuiteBin>> {
+    let test = &project.test;
+    let Some(lane) = test.lanes.get(&test.default_lane) else {
+        bail!("test.default_lane missing from test.lanes");
+    };
+    let mut args = lane.prefix_args.clone();
+    let Some(run_pos) = args.iter().position(|arg| arg == "run") else {
+        bail!("default lane prefix args carry no `run` verb; cannot derive list command");
+    };
+    args[run_pos] = "list".to_owned();
+    let features = lane_features(test, lane, flash, backend)?;
+    let mut cmd = Command::new(&lane.program);
+    cmd.args(&args);
+    if !features.is_empty() {
+        cmd.arg(&test.feature_arg)
+            .arg(features.iter().cloned().collect::<Vec<_>>().join(","));
+    }
+    cmd.args(["--message-format", "json"]);
+    cmd.env("CARGO_TARGET_DIR", target_dir);
+    let out = cmd.output().context("run cargo nextest list")?;
+    if !out.status.success() {
+        bail!(
+            "nextest list failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    parse_list(&String::from_utf8_lossy(&out.stdout))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    const JSON: &str = r#"{
+      "rust-build-meta": {},
+      "test-count": 2,
+      "rust-suites": {
+        "kithara-integration-tests::suite_light": {
+          "package-name": "kithara-integration-tests",
+          "binary-path": "/t/deps/suite_light-abc",
+          "cwd": "/repo/tests",
+          "test-cases": { "offline::gapless": { "ignored": false } }
+        }
+      }
+    }"#;
+
+    #[test]
+    fn parses_suite_binaries() {
+        let suites = parse_list(JSON).unwrap();
+        let s = &suites["kithara-integration-tests::suite_light"];
+        assert_eq!(s.binary_path, PathBuf::from("/t/deps/suite_light-abc"));
+        assert_eq!(s.cwd, PathBuf::from("/repo/tests"));
+    }
+}

--- a/xtask/src/perf/matrix.rs
+++ b/xtask/src/perf/matrix.rs
@@ -1,0 +1,143 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+    time::{Instant, SystemTime, UNIX_EPOCH},
+};
+
+use anyhow::{Context, Result, bail};
+
+use crate::{
+    common::project::ProjectConfig,
+    perf::{
+        junit::parse_junit,
+        lanes::{LANES, Lane, PRIMARY_LANE, RepeatMeta, RunPaths, sanitize},
+    },
+    test::nextest_lane_command,
+};
+
+pub(crate) struct MatrixParams {
+    pub(crate) data_dir: PathBuf,
+    pub(crate) run_id: String,
+    pub(crate) target_root: PathBuf,
+    pub(crate) repeats: u32,
+    pub(crate) lanes: Vec<String>,
+    pub(crate) extra: Vec<String>,
+}
+
+pub(crate) fn run(params: &MatrixParams) -> Result<()> {
+    let project = ProjectConfig::load(Path::new("."))?;
+    let paths = RunPaths::new(&params.data_dir, &params.run_id);
+    let lanes = resolve_lanes(&params.lanes)?;
+    let commit = git_head()?;
+    let matrix_dir = paths.matrix_dir();
+    let slow_json = paths.slow_json();
+    let slow_md = paths.slow_md();
+    let report_md = paths.report_md();
+    fs::create_dir_all(&matrix_dir).with_context(|| format!("create {}", matrix_dir.display()))?;
+    println!(
+        "[perf matrix] run={} matrix={} slow-json={} slow-md={} report={}",
+        params.run_id,
+        matrix_dir.display(),
+        slow_json.display(),
+        slow_md.display(),
+        report_md.display()
+    );
+    let mut broken_lanes = Vec::new();
+    'lanes: for lane in &lanes {
+        let lane_name = lane.name();
+        let target_dir = params.target_root.join(&lane_name);
+        let profiles_dir = paths.profiles_dir(&sanitize(&lane_name));
+        fs::create_dir_all(&profiles_dir)
+            .with_context(|| format!("create {}", profiles_dir.display()))?;
+        for repeat in 1..=params.repeats {
+            let rep_dir = paths.repeat_dir(&lane_name, repeat);
+            fs::create_dir_all(&rep_dir)
+                .with_context(|| format!("create {}", rep_dir.display()))?;
+            let mut extra = vec!["--profile".to_owned(), "perf".to_owned()];
+            extra.extend(params.extra.iter().cloned());
+            let (features, mut cmd) =
+                nextest_lane_command(&project, lane.flash, lane.backend, &extra)?;
+            cmd.env("CARGO_TARGET_DIR", &target_dir);
+            let started_unix = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .context("clock before epoch")?
+                .as_secs();
+            let clock = Instant::now();
+            println!("[perf matrix] {lane_name} rep{repeat}: running full suite");
+            let status = cmd.status().context("spawn nextest")?;
+            let duration_secs = clock.elapsed().as_secs_f64();
+            let junit_src = target_dir.join("nextest").join("perf").join("junit.xml");
+            if !junit_src.exists() {
+                eprintln!(
+                    "[perf matrix] {lane_name}: no junit at {} - lane skipped (build failure?)",
+                    junit_src.display()
+                );
+                broken_lanes.push(lane_name.clone());
+                continue 'lanes;
+            }
+            fs::copy(&junit_src, rep_dir.join("junit.xml"))
+                .with_context(|| format!("copy junit for {lane_name} rep{repeat}"))?;
+            let junit_xml = fs::read_to_string(&junit_src)
+                .with_context(|| format!("read junit for {lane_name} rep{repeat}"))?;
+            let cases = parse_junit(&junit_xml)
+                .with_context(|| format!("parse junit for {lane_name} rep{repeat}"))?;
+            let failed_cases = cases.iter().filter(|case| case.failed).count();
+            let test_secs = cases.iter().map(|case| case.secs).sum::<f64>();
+            let first_failed = cases.iter().find(|case| case.failed).map_or_else(
+                || "-".to_owned(),
+                |case| format!("{}::{}", case.suite, case.name),
+            );
+            let meta = RepeatMeta {
+                run_id: params.run_id.clone(),
+                lane: lane_name.clone(),
+                features: features.clone(),
+                repeat,
+                commit: commit.clone(),
+                started_unix,
+                duration_secs,
+                exit_code: status.code(),
+            };
+            let meta_json = serde_json::to_vec_pretty(&meta).context("serialize meta")?;
+            fs::write(rep_dir.join("meta.json"), meta_json)
+                .with_context(|| format!("write meta for {lane_name} rep{repeat}"))?;
+            println!(
+                "[perf matrix] {lane_name} rep{repeat}: {duration_secs:.1}s exit={:?} cases={} failed={} test-secs={test_secs:.1} first-failed={first_failed}",
+                status.code(),
+                cases.len(),
+                failed_cases
+            );
+        }
+    }
+    if !broken_lanes.is_empty() {
+        bail!("lanes without junit (skipped): {}", broken_lanes.join(", "));
+    }
+    Ok(())
+}
+
+fn resolve_lanes(names: &[String]) -> Result<Vec<Lane>> {
+    debug_assert_eq!(LANES[0].name(), PRIMARY_LANE);
+    if names.is_empty() {
+        return Ok(LANES.to_vec());
+    }
+    names
+        .iter()
+        .map(|n| {
+            Lane::by_name(n).ok_or_else(|| {
+                let valid = LANES.map(|l| l.name()).join(", ");
+                anyhow::anyhow!("unknown lane `{n}`; valid: {valid}")
+            })
+        })
+        .collect()
+}
+
+fn git_head() -> Result<String> {
+    let out = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .context("git rev-parse HEAD")?;
+    if !out.status.success() {
+        bail!("git rev-parse HEAD failed");
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).trim().to_owned())
+}

--- a/xtask/src/perf/matrix.rs
+++ b/xtask/src/perf/matrix.rs
@@ -67,7 +67,11 @@ pub(crate) fn run(params: &MatrixParams) -> Result<()> {
             println!("[perf matrix] {lane_name} rep{repeat}: running full suite");
             let status = cmd.status().context("spawn nextest")?;
             let duration_secs = clock.elapsed().as_secs_f64();
-            let junit_src = target_dir.join("nextest").join("perf").join("junit.xml");
+            // Nextest pins junit to workspace target, not CARGO_TARGET_DIR/--target-dir; sequential lanes copy.
+            let junit_src = Path::new("target")
+                .join("nextest")
+                .join("perf")
+                .join("junit.xml");
             if !junit_src.exists() {
                 eprintln!(
                     "[perf matrix] {lane_name}: no junit at {} - lane skipped (build failure?)",

--- a/xtask/src/perf/mod.rs
+++ b/xtask/src/perf/mod.rs
@@ -1,0 +1,6 @@
+mod cli;
+mod junit;
+mod lanes;
+mod matrix;
+
+pub(crate) use cli::{PerfArgs, run};

--- a/xtask/src/perf/mod.rs
+++ b/xtask/src/perf/mod.rs
@@ -7,5 +7,6 @@ mod matrix;
 mod profile;
 mod report;
 mod slow;
+mod trace;
 
 pub(crate) use cli::{PerfArgs, run};

--- a/xtask/src/perf/mod.rs
+++ b/xtask/src/perf/mod.rs
@@ -1,9 +1,11 @@
 mod cli;
+mod gecko;
 mod junit;
 mod lanes;
 mod list;
 mod matrix;
 mod profile;
+mod report;
 mod slow;
 
 pub(crate) use cli::{PerfArgs, run};

--- a/xtask/src/perf/mod.rs
+++ b/xtask/src/perf/mod.rs
@@ -1,7 +1,9 @@
 mod cli;
 mod junit;
 mod lanes;
+mod list;
 mod matrix;
+mod profile;
 mod slow;
 
 pub(crate) use cli::{PerfArgs, run};

--- a/xtask/src/perf/mod.rs
+++ b/xtask/src/perf/mod.rs
@@ -2,5 +2,6 @@ mod cli;
 mod junit;
 mod lanes;
 mod matrix;
+mod slow;
 
 pub(crate) use cli::{PerfArgs, run};

--- a/xtask/src/perf/profile.rs
+++ b/xtask/src/perf/profile.rs
@@ -1,0 +1,159 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::{Child, Command},
+    time::{Duration, Instant},
+};
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    common::project::ProjectConfig,
+    perf::{
+        lanes::{Lane, RunPaths, sanitize},
+        list::nextest_list,
+        slow::SlowReport,
+    },
+};
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct IsolatedRun {
+    pub(crate) suite: String,
+    pub(crate) name: String,
+    pub(crate) secs: f64,
+    pub(crate) exit_code: Option<i32>,
+    pub(crate) timed_out: bool,
+    pub(crate) profile_path: PathBuf,
+}
+
+pub(crate) struct ProfileParams {
+    pub(crate) data_dir: PathBuf,
+    pub(crate) run_id: String,
+    pub(crate) target_root: PathBuf,
+    pub(crate) lane: String,
+    pub(crate) timeout_secs: u64,
+    pub(crate) limit: Option<usize>,
+}
+
+pub(crate) fn samply_command(out: &Path, binary: &Path, test: &str) -> Command {
+    let mut cmd = Command::new("samply");
+    cmd.arg("record")
+        .arg("--save-only")
+        .arg("--output")
+        .arg(out)
+        .arg("--")
+        .arg(binary)
+        .arg(test)
+        .arg("--exact")
+        .arg("--nocapture");
+    cmd
+}
+
+fn wait_with_timeout(child: &mut Child, timeout: Duration) -> Result<(Option<i32>, bool)> {
+    let start = Instant::now();
+    loop {
+        if let Some(status) = child.try_wait().context("poll samply child")? {
+            return Ok((status.code(), false));
+        }
+        if start.elapsed() >= timeout {
+            child.kill().context("kill timed-out samply child")?;
+            let _ = child.wait();
+            return Ok((None, true));
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+pub(crate) fn run(params: &ProfileParams) -> Result<()> {
+    let paths = RunPaths::new(&params.data_dir, &params.run_id);
+    let slow_json_path = paths.slow_json();
+    let slow_json = fs::read_to_string(&slow_json_path)
+        .with_context(|| format!("read {}", slow_json_path.display()))?;
+    let slow: SlowReport = serde_json::from_str(&slow_json).context("parse slow.json")?;
+    let Some(lane) = Lane::by_name(&params.lane) else {
+        bail!("unknown lane `{}`", params.lane);
+    };
+    let project = ProjectConfig::load(Path::new("."))?;
+    let target_dir = params.target_root.join(&params.lane);
+    let suites = nextest_list(&project, lane.flash, lane.backend, &target_dir)?;
+    let out_root = paths.profiles_dir(&params.lane);
+    let mut isolated = Vec::new();
+    let selected = slow.tests.iter().take(params.limit.unwrap_or(usize::MAX));
+    for test in selected {
+        let Some(suite) = suites.get(&test.suite) else {
+            println!(
+                "[perf profile] SKIP {} {} (suite not in list)",
+                test.suite, test.name
+            );
+            continue;
+        };
+        let dir = out_root.join(sanitize(&test.suite));
+        fs::create_dir_all(&dir).with_context(|| format!("create {}", dir.display()))?;
+        let out = dir.join(format!("{}.profile.json", sanitize(&test.name)));
+        let mut cmd = samply_command(&out, &suite.binary_path, &test.name);
+        cmd.current_dir(&suite.cwd);
+        let clock = Instant::now();
+        let mut child = match cmd.spawn() {
+            Ok(child) => child,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                bail!("samply not found on PATH - install with `cargo install samply`")
+            }
+            Err(err) => return Err(err).context("spawn samply"),
+        };
+        let (exit_code, timed_out) =
+            wait_with_timeout(&mut child, Duration::from_secs(params.timeout_secs))?;
+        let secs = clock.elapsed().as_secs_f64();
+        println!(
+            "[perf profile] {} {}: {secs:.1}s exit={exit_code:?} timed_out={timed_out}",
+            test.suite, test.name
+        );
+        isolated.push(IsolatedRun {
+            suite: test.suite.clone(),
+            name: test.name.clone(),
+            secs,
+            exit_code,
+            timed_out,
+            profile_path: out,
+        });
+    }
+    fs::create_dir_all(&out_root).with_context(|| format!("create {}", out_root.display()))?;
+    let json = serde_json::to_vec_pretty(&isolated).context("serialize isolated runs")?;
+    fs::write(out_root.join("isolated.json"), json).context("write isolated.json")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::*;
+
+    #[test]
+    fn samply_command_shape() {
+        let cmd = samply_command(
+            Path::new("/out/p.profile.json"),
+            Path::new("/bin/suite_light-abc"),
+            "offline::gapless",
+        );
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(cmd.get_program().to_string_lossy(), "samply");
+        assert_eq!(
+            args,
+            [
+                "record",
+                "--save-only",
+                "--output",
+                "/out/p.profile.json",
+                "--",
+                "/bin/suite_light-abc",
+                "offline::gapless",
+                "--exact",
+                "--nocapture"
+            ]
+        );
+    }
+}

--- a/xtask/src/perf/profile.rs
+++ b/xtask/src/perf/profile.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::{BTreeMap, btree_map::Entry},
     fs,
     path::{Path, PathBuf},
     process::{Child, Command},
@@ -7,6 +8,7 @@ use std::{
 
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use crate::{
     common::project::ProjectConfig,
@@ -39,6 +41,7 @@ pub(crate) struct ProfileParams {
 pub(crate) fn samply_command(out: &Path, binary: &Path, test: &str) -> Command {
     let mut cmd = Command::new("samply");
     cmd.arg("record")
+        .arg("--unstable-presymbolicate")
         .arg("--save-only")
         .arg("--output")
         .arg(out)
@@ -48,6 +51,245 @@ pub(crate) fn samply_command(out: &Path, binary: &Path, test: &str) -> Command {
         .arg("--exact")
         .arg("--nocapture");
     cmd
+}
+
+#[derive(Debug, Deserialize)]
+struct SymbolSidecar {
+    string_table: Vec<String>,
+    data: Vec<SymbolLibrary>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SymbolLibrary {
+    debug_name: String,
+    code_id: String,
+    symbol_table: Vec<SymbolEntry>,
+    known_addresses: Vec<(u64, usize)>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SymbolEntry {
+    symbol: usize,
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct LibKey {
+    debug_name: String,
+    code_id: String,
+}
+
+impl LibKey {
+    fn new(debug_name: &str, code_id: &str) -> Self {
+        Self {
+            debug_name: debug_name.to_owned(),
+            code_id: code_id.to_ascii_lowercase(),
+        }
+    }
+}
+
+fn symbolicate_profile_file(profile_path: &Path) -> Result<usize> {
+    let symbols_path = profile_path.with_extension("syms.json");
+    let symbols_json = fs::read_to_string(&symbols_path)
+        .with_context(|| format!("read {}", symbols_path.display()))?;
+    let symbols: SymbolSidecar = serde_json::from_str(&symbols_json)
+        .with_context(|| format!("parse {}", symbols_path.display()))?;
+    let profile_json = fs::read_to_string(profile_path)
+        .with_context(|| format!("read {}", profile_path.display()))?;
+    let mut profile: Value = serde_json::from_str(&profile_json)
+        .with_context(|| format!("parse {}", profile_path.display()))?;
+    let replaced = symbolicate_profile_json_value(&mut profile, &symbols)
+        .with_context(|| format!("symbolicate {}", profile_path.display()))?;
+    let json = serde_json::to_vec(&profile).context("serialize symbolicated gecko profile")?;
+    fs::write(profile_path, json).with_context(|| format!("write {}", profile_path.display()))?;
+    Ok(replaced)
+}
+
+fn symbolicate_profile_json_value(profile: &mut Value, symbols: &SymbolSidecar) -> Result<usize> {
+    let symbol_lookup = symbol_lookup_by_lib(symbols)?;
+    let profile_libs = profile_libs(profile)?;
+    let threads = profile
+        .get_mut("threads")
+        .and_then(Value::as_array_mut)
+        .context("profile threads must be an array")?;
+    let mut replaced = 0;
+    for thread in threads {
+        let function_symbols = function_symbols(thread, &profile_libs, &symbol_lookup)?;
+        replaced += apply_function_symbols(thread, &function_symbols)?;
+    }
+    Ok(replaced)
+}
+
+fn symbol_lookup_by_lib(
+    symbols: &SymbolSidecar,
+) -> Result<BTreeMap<LibKey, BTreeMap<u64, String>>> {
+    let mut lookup = BTreeMap::new();
+    for lib in &symbols.data {
+        let key = LibKey::new(&lib.debug_name, &lib.code_id);
+        let lib_lookup = lookup.entry(key).or_insert_with(BTreeMap::new);
+        for (rva, symbol_index) in &lib.known_addresses {
+            let symbol = lib
+                .symbol_table
+                .get(*symbol_index)
+                .with_context(|| format!("sidecar symbol index {symbol_index} out of range"))?;
+            let name = symbols
+                .string_table
+                .get(symbol.symbol)
+                .with_context(|| format!("sidecar string index {} out of range", symbol.symbol))?;
+            match lib_lookup.entry(*rva) {
+                Entry::Vacant(entry) => {
+                    entry.insert(name.clone());
+                }
+                Entry::Occupied(entry) if entry.get() == name => {}
+                Entry::Occupied(_) => {
+                    bail!("sidecar maps address {rva} to multiple symbols");
+                }
+            }
+        }
+    }
+    Ok(lookup)
+}
+
+fn profile_libs(profile: &Value) -> Result<Vec<Option<LibKey>>> {
+    let libs = profile
+        .get("libs")
+        .and_then(Value::as_array)
+        .context("profile libs must be an array")?;
+    Ok(libs
+        .iter()
+        .map(|lib| {
+            let debug_name = lib.get("debugName").and_then(Value::as_str)?;
+            let code_id = lib.get("codeId").and_then(Value::as_str)?;
+            Some(LibKey::new(debug_name, code_id))
+        })
+        .collect())
+}
+
+fn function_symbols(
+    thread: &Value,
+    profile_libs: &[Option<LibKey>],
+    symbol_lookup: &BTreeMap<LibKey, BTreeMap<u64, String>>,
+) -> Result<BTreeMap<usize, String>> {
+    let resource_libs = array_at(thread, &["resourceTable", "lib"])?;
+    let frame_addresses = array_at(thread, &["frameTable", "address"])?;
+    let frame_funcs = array_at(thread, &["frameTable", "func"])?;
+    let func_resources = array_at(thread, &["funcTable", "resource"])?;
+    if frame_addresses.len() != frame_funcs.len() {
+        bail!("frameTable address and func lengths differ");
+    }
+
+    let mut names = BTreeMap::new();
+    for (frame_idx, frame_func) in frame_funcs.iter().enumerate() {
+        let Some(address) = frame_addresses[frame_idx].as_u64() else {
+            continue;
+        };
+        let Some(func_idx) = value_as_usize(frame_func, "frameTable.func")? else {
+            continue;
+        };
+        let Some(resource_value) = func_resources.get(func_idx) else {
+            continue;
+        };
+        let Some(resource_idx) = value_as_usize(resource_value, "funcTable.resource")? else {
+            continue;
+        };
+        let Some(lib_value) = resource_libs.get(resource_idx) else {
+            continue;
+        };
+        let Some(lib_idx) = value_as_usize(lib_value, "resourceTable.lib")? else {
+            continue;
+        };
+        let Some(Some(lib_key)) = profile_libs.get(lib_idx) else {
+            continue;
+        };
+        let Some(lib_symbols) = symbol_lookup.get(lib_key) else {
+            continue;
+        };
+        let Some(name) = lib_symbols.get(&address) else {
+            continue;
+        };
+        match names.entry(func_idx) {
+            Entry::Vacant(entry) => {
+                entry.insert(name.clone());
+            }
+            Entry::Occupied(entry) if entry.get() == name => {}
+            Entry::Occupied(_) => {
+                bail!("profile function {func_idx} maps to multiple symbols");
+            }
+        }
+    }
+    Ok(names)
+}
+
+fn apply_function_symbols(thread: &mut Value, names: &BTreeMap<usize, String>) -> Result<usize> {
+    let mut assignments = BTreeMap::new();
+    {
+        let string_array = thread
+            .pointer_mut("/stringArray")
+            .and_then(Value::as_array_mut)
+            .context("thread stringArray must be an array")?;
+        let mut string_indexes: BTreeMap<String, usize> = string_array
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, value)| value.as_str().map(|string| (string.to_owned(), idx)))
+            .collect();
+        for (func_idx, name) in names {
+            let name_idx = intern_string(string_array, &mut string_indexes, name);
+            assignments.insert(*func_idx, name_idx);
+        }
+    }
+
+    let func_names = thread
+        .pointer_mut("/funcTable/name")
+        .and_then(Value::as_array_mut)
+        .context("thread funcTable.name must be an array")?;
+    let mut replaced = 0;
+    for (func_idx, name_idx) in assignments {
+        let current = func_names
+            .get_mut(func_idx)
+            .with_context(|| format!("funcTable.name index {func_idx} out of range"))?;
+        let encoded = u64::try_from(name_idx).context("string index does not fit u64")?;
+        if current.as_u64() != Some(encoded) {
+            *current = Value::from(encoded);
+            replaced += 1;
+        }
+    }
+    Ok(replaced)
+}
+
+fn array_at<'a>(value: &'a Value, path: &[&str]) -> Result<&'a Vec<Value>> {
+    let mut current = value;
+    for segment in path {
+        current = current
+            .get(*segment)
+            .with_context(|| format!("missing profile field {}", path.join(".")))?;
+    }
+    current
+        .as_array()
+        .with_context(|| format!("profile field {} must be an array", path.join(".")))
+}
+
+fn value_as_usize(value: &Value, field: &str) -> Result<Option<usize>> {
+    let Some(index) = value.as_u64() else {
+        return Ok(None);
+    };
+    usize::try_from(index)
+        .with_context(|| format!("{field} index does not fit usize"))
+        .map(Some)
+}
+
+fn intern_string(
+    string_array: &mut Vec<Value>,
+    string_indexes: &mut BTreeMap<String, usize>,
+    string: &str,
+) -> usize {
+    match string_indexes.entry(string.to_owned()) {
+        Entry::Occupied(entry) => *entry.get(),
+        Entry::Vacant(entry) => {
+            let idx = string_array.len();
+            string_array.push(Value::from(string));
+            entry.insert(idx);
+            idx
+        }
+    }
 }
 
 fn wait_with_timeout(child: &mut Child, timeout: Duration) -> Result<(Option<i32>, bool)> {
@@ -104,8 +346,13 @@ pub(crate) fn run(params: &ProfileParams) -> Result<()> {
         let (exit_code, timed_out) =
             wait_with_timeout(&mut child, Duration::from_secs(params.timeout_secs))?;
         let secs = clock.elapsed().as_secs_f64();
+        let symbolicated = if timed_out || !out.is_file() {
+            0
+        } else {
+            symbolicate_profile_file(&out)?
+        };
         println!(
-            "[perf profile] {} {}: {secs:.1}s exit={exit_code:?} timed_out={timed_out}",
+            "[perf profile] {} {}: {secs:.1}s exit={exit_code:?} timed_out={timed_out} symbolicated={symbolicated}",
             test.suite, test.name
         );
         isolated.push(IsolatedRun {
@@ -145,6 +392,7 @@ mod tests {
             args,
             [
                 "record",
+                "--unstable-presymbolicate",
                 "--save-only",
                 "--output",
                 "/out/p.profile.json",
@@ -155,5 +403,77 @@ mod tests {
                 "--nocapture"
             ]
         );
+    }
+
+    #[test]
+    fn symbolicates_function_names_from_samply_sidecar() {
+        let mut profile = serde_json::json!({
+            "libs": [
+                {
+                    "debugName": "kithara_bin",
+                    "codeId": "ABCDEF"
+                },
+                {
+                    "debugName": "libsystem_kernel.dylib",
+                    "codeId": "123456"
+                }
+            ],
+            "threads": [{
+                "resourceTable": {
+                    "lib": [0, 1]
+                },
+                "frameTable": {
+                    "address": [4660, 4660],
+                    "func": [0, 1]
+                },
+                "funcTable": {
+                    "name": [0, 0],
+                    "resource": [0, 1]
+                },
+                "stringArray": [
+                    "0x1234",
+                    "kithara_bin",
+                    "libsystem_kernel.dylib"
+                ]
+            }]
+        });
+        let symbols: SymbolSidecar = serde_json::from_value(serde_json::json!({
+            "string_table": [
+                "UNKNOWN",
+                "kithara_mod::do_work",
+                "__psynch_cvwait"
+            ],
+            "data": [
+                {
+                    "debug_name": "kithara_bin",
+                    "code_id": "abcdef",
+                    "symbol_table": [
+                        { "symbol": 1 }
+                    ],
+                    "known_addresses": [[4660, 0]]
+                },
+                {
+                    "debug_name": "libsystem_kernel.dylib",
+                    "code_id": "123456",
+                    "symbol_table": [
+                        { "symbol": 2 }
+                    ],
+                    "known_addresses": [[4660, 0]]
+                }
+            ]
+        }))
+        .unwrap();
+
+        let replaced = symbolicate_profile_json_value(&mut profile, &symbols).unwrap();
+
+        assert_eq!(replaced, 2);
+        let thread = &profile["threads"][0];
+        let strings = thread["stringArray"].as_array().unwrap();
+        let names = thread["funcTable"]["name"].as_array().unwrap();
+        let first_name = usize::try_from(names[0].as_u64().unwrap()).unwrap();
+        let second_name = usize::try_from(names[1].as_u64().unwrap()).unwrap();
+        assert_eq!(strings[first_name], "kithara_mod::do_work");
+        assert_eq!(strings[second_name], "__psynch_cvwait");
+        assert_eq!(strings[0], "0x1234");
     }
 }

--- a/xtask/src/perf/report.rs
+++ b/xtask/src/perf/report.rs
@@ -1,0 +1,200 @@
+use std::{collections::BTreeMap, fs, path::Path};
+
+use anyhow::{Context, Result};
+
+use crate::perf::{
+    gecko::{ProfileSummary, summarize},
+    lanes::RunPaths,
+    profile::IsolatedRun,
+    slow::SlowReport,
+};
+
+pub(crate) fn render_report(
+    slow: &SlowReport,
+    isolated: &[IsolatedRun],
+    summaries: &BTreeMap<(String, String), ProfileSummary>,
+) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("# Test-suite perf report - {}\n\n", slow.run_id));
+    let mut class_totals: BTreeMap<&str, f64> = BTreeMap::new();
+    let (mut total_on, mut total_off) = (0.0, 0.0);
+    for summary in summaries.values() {
+        total_on += summary.on_cpu_ms;
+        total_off += summary.off_cpu_ms;
+        for wait in &summary.waits {
+            *class_totals.entry(wait.class.as_str()).or_default() += wait.ms;
+        }
+    }
+    out.push_str("## Totals across profiled tests\n\n");
+    out.push_str(&format!(
+        "- on-CPU: {:.0}ms, off-CPU (waiting): {:.0}ms\n\n",
+        total_on, total_off
+    ));
+    out.push_str("| wait class | total ms |\n|---|---|\n");
+    let mut classes: Vec<_> = class_totals.into_iter().collect();
+    classes.sort_by(|a, b| b.1.total_cmp(&a.1));
+    for (class, ms) in classes {
+        out.push_str(&format!("| {class} | {ms:.0} |\n"));
+    }
+    let iso: BTreeMap<(String, String), &IsolatedRun> = isolated
+        .iter()
+        .map(|run| ((run.suite.clone(), run.name.clone()), run))
+        .collect();
+    out.push_str("\n## Top-20 cards\n");
+    for test in slow.tests.iter().take(20) {
+        let key = (test.suite.clone(), test.name.clone());
+        out.push_str(&format!("\n### {} {}\n\n", test.suite, test.name));
+        for (lane, stat) in &test.lanes {
+            out.push_str(&format!(
+                "- {lane}: median {:.0}ms (min {:.0} / max {:.0}, {} reps{})\n",
+                stat.median_ms,
+                stat.min_ms,
+                stat.max_ms,
+                stat.repeats,
+                if stat.failed > 0 { ", FAILURES" } else { "" }
+            ));
+        }
+        if let Some(run) = iso.get(&key) {
+            out.push_str(&format!(
+                "- isolated: {:.1}s exit={:?}{}\n",
+                run.secs,
+                run.exit_code,
+                if run.timed_out { " TIMED OUT" } else { "" }
+            ));
+        }
+        if let Some(summary) = summaries.get(&key) {
+            out.push_str(&format!(
+                "- on-CPU {:.0}ms / off-CPU {:.0}ms\n",
+                summary.on_cpu_ms, summary.off_cpu_ms
+            ));
+            for wait in summary.waits.iter().take(5) {
+                out.push_str(&format!(
+                    "  - wait {} {:.0}ms @ {}\n",
+                    wait.class, wait.ms, wait.attributed
+                ));
+            }
+            for frame in summary.cpu.iter().take(5) {
+                out.push_str(&format!("  - cpu {:.0}ms @ {}\n", frame.ms, frame.frame));
+            }
+        } else {
+            out.push_str("- (no profile captured)\n");
+        }
+    }
+    out.push_str("\n## Ranked candidates\n\n| rank score | test |\n|---|---|\n");
+    for test in &slow.tests {
+        out.push_str(&format!(
+            "| {:.0} | {} {} |\n",
+            test.rank_score, test.suite, test.name
+        ));
+    }
+    out
+}
+
+pub(crate) fn run(data_dir: &Path, run_id: &str, lane: &str) -> Result<()> {
+    let paths = RunPaths::new(data_dir, run_id);
+    let slow: SlowReport =
+        serde_json::from_str(&fs::read_to_string(paths.slow_json()).context("read slow.json")?)
+            .context("parse slow.json")?;
+    let iso_path = paths.profiles_dir(lane).join("isolated.json");
+    let isolated: Vec<IsolatedRun> = serde_json::from_str(
+        &fs::read_to_string(&iso_path).with_context(|| format!("read {}", iso_path.display()))?,
+    )
+    .context("parse isolated.json")?;
+    let mut summaries = BTreeMap::new();
+    for run in &isolated {
+        if run.timed_out || !run.profile_path.is_file() {
+            continue;
+        }
+        let json = match fs::read_to_string(&run.profile_path) {
+            Ok(json) => json,
+            Err(err) => {
+                println!(
+                    "[perf report] skip profile {} ({err:#})",
+                    run.profile_path.display()
+                );
+                continue;
+            }
+        };
+        match summarize(&json, 20) {
+            Ok(summary) => {
+                summaries.insert((run.suite.clone(), run.name.clone()), summary);
+            }
+            Err(err) => println!(
+                "[perf report] skip profile {} ({err:#})",
+                run.profile_path.display()
+            ),
+        }
+    }
+    fs::write(
+        paths.report_md(),
+        render_report(&slow, &isolated, &summaries),
+    )
+    .context("write report.md")?;
+    println!("[perf report] wrote {}", paths.report_md().display());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+    use crate::perf::{
+        gecko::{ProfileSummary, WaitBucket},
+        profile::IsolatedRun,
+        slow::{LaneStat, SlowReport, SlowTest},
+    };
+
+    #[test]
+    fn renders_cards_and_ranking() {
+        let mut lanes = BTreeMap::new();
+        lanes.insert(
+            "flash-on-wreq".to_owned(),
+            LaneStat {
+                median_ms: 2500.0,
+                min_ms: 2000.0,
+                max_ms: 3000.0,
+                repeats: 3,
+                failed: 0,
+            },
+        );
+        let slow = SlowReport {
+            run_id: "run-1".to_owned(),
+            threshold_ms: 1000.0,
+            primary_lane: "flash-on-wreq".to_owned(),
+            tests: vec![SlowTest {
+                suite: "s".to_owned(),
+                name: "slow_t".to_owned(),
+                lanes,
+                rank_score: 2500.0,
+            }],
+        };
+        let isolated = vec![IsolatedRun {
+            suite: "s".to_owned(),
+            name: "slow_t".to_owned(),
+            secs: 2.1,
+            exit_code: Some(0),
+            timed_out: false,
+            profile_path: "/p".into(),
+        }];
+        let mut summaries = BTreeMap::new();
+        summaries.insert(
+            ("s".to_owned(), "slow_t".to_owned()),
+            ProfileSummary {
+                on_cpu_ms: 100.0,
+                off_cpu_ms: 2000.0,
+                waits: vec![WaitBucket {
+                    class: "condvar".to_owned(),
+                    attributed: "kithara_x::y".to_owned(),
+                    ms: 1800.0,
+                }],
+                cpu: vec![],
+            },
+        );
+        let out = render_report(&slow, &isolated, &summaries);
+        assert!(out.contains("slow_t"));
+        assert!(out.contains("condvar"));
+        assert!(out.contains("kithara_x::y"));
+        assert!(out.contains("## Ranked candidates"));
+    }
+}

--- a/xtask/src/perf/slow.rs
+++ b/xtask/src/perf/slow.rs
@@ -1,0 +1,264 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs,
+    path::Path,
+};
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+
+use crate::perf::{
+    junit::{CaseTiming, parse_junit},
+    lanes::{PRIMARY_LANE, RunPaths},
+};
+
+type TestKey = (String, String);
+type LaneSamples = BTreeMap<String, (Vec<f64>, u32)>;
+type TestSamples = BTreeMap<TestKey, LaneSamples>;
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct LaneStat {
+    pub(crate) median_ms: f64,
+    pub(crate) min_ms: f64,
+    pub(crate) max_ms: f64,
+    pub(crate) repeats: u32,
+    pub(crate) failed: u32,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct SlowTest {
+    pub(crate) suite: String,
+    pub(crate) name: String,
+    pub(crate) lanes: BTreeMap<String, LaneStat>,
+    pub(crate) rank_score: f64,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct SlowReport {
+    pub(crate) run_id: String,
+    pub(crate) threshold_ms: f64,
+    pub(crate) primary_lane: String,
+    pub(crate) tests: Vec<SlowTest>,
+}
+
+pub(crate) fn median_ms(sorted_secs: &[f64]) -> f64 {
+    let n = sorted_secs.len();
+    let ms = |s: f64| s * 1000.0;
+    if n == 0 {
+        return 0.0;
+    }
+    if n % 2 == 1 {
+        ms(sorted_secs[n / 2])
+    } else {
+        ms((sorted_secs[n / 2 - 1] + sorted_secs[n / 2]) / 2.0)
+    }
+}
+
+pub(crate) fn aggregate(
+    runs: &[(String, Vec<CaseTiming>)],
+    run_id: &str,
+    threshold_ms: f64,
+) -> SlowReport {
+    let mut by_test: TestSamples = BTreeMap::new();
+    for (lane, cases) in runs {
+        for case in cases {
+            let entry = by_test
+                .entry((case.suite.clone(), case.name.clone()))
+                .or_default()
+                .entry(lane.clone())
+                .or_insert_with(|| (Vec::new(), 0));
+            entry.0.push(case.secs);
+            if case.failed {
+                entry.1 += 1;
+            }
+        }
+    }
+    let mut tests = Vec::new();
+    for ((suite, name), lanes_raw) in by_test {
+        let mut lanes = BTreeMap::new();
+        for (lane, (mut secs, failed)) in lanes_raw {
+            secs.sort_by(f64::total_cmp);
+            lanes.insert(
+                lane,
+                LaneStat {
+                    median_ms: median_ms(&secs),
+                    min_ms: secs.first().copied().unwrap_or(0.0) * 1000.0,
+                    max_ms: secs.last().copied().unwrap_or(0.0) * 1000.0,
+                    repeats: u32::try_from(secs.len()).unwrap_or(u32::MAX),
+                    failed,
+                },
+            );
+        }
+        let over = lanes
+            .values()
+            .filter(|stat| stat.median_ms >= threshold_ms)
+            .count();
+        if over == 0 {
+            continue;
+        }
+        let over = u32::try_from(over).unwrap_or(u32::MAX);
+        let primary = lanes.get(PRIMARY_LANE).map_or(0.0, |stat| stat.median_ms);
+        tests.push(SlowTest {
+            suite,
+            name,
+            lanes,
+            rank_score: primary * f64::from(over),
+        });
+    }
+    tests.sort_by(|a, b| {
+        b.rank_score
+            .total_cmp(&a.rank_score)
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    SlowReport {
+        run_id: run_id.to_owned(),
+        threshold_ms,
+        primary_lane: PRIMARY_LANE.to_owned(),
+        tests,
+    }
+}
+
+pub(crate) fn render_md(report: &SlowReport) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "# Slow tests (median >= {:.0}ms in any lane) - {}\n\n",
+        report.threshold_ms, report.run_id
+    ));
+    let lane_names: Vec<String> = report
+        .tests
+        .iter()
+        .flat_map(|test| test.lanes.keys().cloned())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    let header = |out: &mut String| {
+        out.push_str("| test | rank |");
+        for lane in &lane_names {
+            out.push_str(&format!(" {lane} med/min/max ms |"));
+        }
+        out.push('\n');
+        out.push_str("|---|---|");
+        for _ in &lane_names {
+            out.push_str("---|");
+        }
+        out.push('\n');
+    };
+    let row = |out: &mut String, test: &SlowTest| {
+        out.push_str(&format!(
+            "| {} {} | {:.0} |",
+            test.suite, test.name, test.rank_score
+        ));
+        for lane in &lane_names {
+            match test.lanes.get(lane) {
+                Some(stat) => out.push_str(&format!(
+                    " {:.0}/{:.0}/{:.0}{} |",
+                    stat.median_ms,
+                    stat.min_ms,
+                    stat.max_ms,
+                    if stat.failed > 0 { " FAIL" } else { "" }
+                )),
+                None => out.push_str(" - |"),
+            }
+        }
+        out.push('\n');
+    };
+    out.push_str(&format!("## Top 20 of {}\n\n", report.tests.len()));
+    header(&mut out);
+    for test in report.tests.iter().take(20) {
+        row(&mut out, test);
+    }
+    out.push_str("\n## Full list\n\n");
+    header(&mut out);
+    for test in &report.tests {
+        row(&mut out, test);
+    }
+    out
+}
+
+pub(crate) fn run(data_dir: &Path, run_id: &str, threshold_ms: f64) -> Result<()> {
+    let paths = RunPaths::new(data_dir, run_id);
+    let matrix_dir = paths.matrix_dir();
+    if !matrix_dir.is_dir() {
+        bail!("no matrix data at {}", matrix_dir.display());
+    }
+    let mut runs = Vec::new();
+    for lane_entry in fs::read_dir(&matrix_dir).context("read matrix dir")? {
+        let lane_dir = lane_entry.context("lane entry")?.path();
+        let lane = lane_dir
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        if !lane_dir.is_dir() {
+            continue;
+        }
+        for rep_entry in fs::read_dir(&lane_dir).context("read lane dir")? {
+            let junit = rep_entry.context("rep entry")?.path().join("junit.xml");
+            if !junit.is_file() {
+                continue;
+            }
+            let xml =
+                fs::read_to_string(&junit).with_context(|| format!("read {}", junit.display()))?;
+            runs.push((lane.clone(), parse_junit(&xml)?));
+        }
+    }
+    let report = aggregate(&runs, run_id, threshold_ms);
+    fs::write(paths.slow_json(), serde_json::to_vec_pretty(&report)?).context("write slow.json")?;
+    fs::write(paths.slow_md(), render_md(&report)).context("write slow.md")?;
+    println!(
+        "[perf slow] {} tests >= {:.0}ms -> {}",
+        report.tests.len(),
+        threshold_ms,
+        paths.slow_md().display()
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::perf::junit::CaseTiming;
+
+    fn case(suite: &str, name: &str, secs: f64) -> CaseTiming {
+        CaseTiming {
+            suite: suite.into(),
+            name: name.into(),
+            secs,
+            failed: false,
+        }
+    }
+
+    #[test]
+    fn aggregates_median_and_ranks() {
+        let runs = vec![
+            (
+                "flash-on-wreq".to_owned(),
+                vec![case("s", "slow_t", 2.0), case("s", "fast_t", 0.1)],
+            ),
+            (
+                "flash-on-wreq".to_owned(),
+                vec![case("s", "slow_t", 3.0), case("s", "fast_t", 0.1)],
+            ),
+            (
+                "flash-on-wreq".to_owned(),
+                vec![case("s", "slow_t", 2.5), case("s", "fast_t", 0.1)],
+            ),
+            ("flash-off-wreq".to_owned(), vec![case("s", "slow_t", 4.0)]),
+        ];
+        let report = aggregate(&runs, "run-1", 1000.0);
+        assert_eq!(report.tests.len(), 1);
+        let t = &report.tests[0];
+        assert_eq!(t.name, "slow_t");
+        let on = &t.lanes["flash-on-wreq"];
+        assert!((on.median_ms - 2500.0).abs() < 1e-6);
+        assert!((on.min_ms - 2000.0).abs() < 1e-6);
+        assert_eq!(on.repeats, 3);
+        // rank = primary median (2500) x lanes over threshold (2)
+        assert!((t.rank_score - 5000.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn median_even_count_averages() {
+        assert!((median_ms(&[1.0, 3.0]) - 2000.0).abs() < 1e-6);
+        assert!((median_ms(&[1.0, 2.0, 4.0]) - 2000.0).abs() < 1e-6);
+    }
+}

--- a/xtask/src/perf/trace.rs
+++ b/xtask/src/perf/trace.rs
@@ -1,0 +1,101 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use anyhow::{Context, Result, bail};
+
+use crate::{
+    common::project::ProjectConfig,
+    perf::{
+        lanes::{Lane, RunPaths, sanitize},
+        list::nextest_list,
+    },
+};
+
+pub(crate) struct TraceParams {
+    pub(crate) data_dir: PathBuf,
+    pub(crate) run_id: String,
+    pub(crate) target_root: PathBuf,
+    pub(crate) lane: String,
+    pub(crate) suite: String,
+    pub(crate) test: String,
+}
+
+pub(crate) fn xctrace_command(out: &Path, binary: &Path, test: &str) -> Command {
+    let mut cmd = Command::new("xcrun");
+    cmd.arg("xctrace")
+        .arg("record")
+        .arg("--template")
+        .arg("Time Profiler")
+        .arg("--output")
+        .arg(out)
+        .arg("--launch")
+        .arg("--")
+        .arg(binary)
+        .arg(test)
+        .arg("--exact")
+        .arg("--nocapture");
+    cmd
+}
+
+pub(crate) fn run(params: &TraceParams) -> Result<()> {
+    let Some(lane) = Lane::by_name(&params.lane) else {
+        bail!("unknown lane `{}`", params.lane);
+    };
+    let project = ProjectConfig::load(Path::new("."))?;
+    let target_dir = params.target_root.join(&params.lane);
+    let suites = nextest_list(&project, lane.flash, lane.backend, &target_dir)?;
+    let Some(suite) = suites.get(&params.suite) else {
+        bail!("suite `{}` not found in nextest list", params.suite);
+    };
+    let paths = RunPaths::new(&params.data_dir, &params.run_id);
+    let out_dir = paths.run_dir.join("traces");
+    fs::create_dir_all(&out_dir).with_context(|| format!("create {}", out_dir.display()))?;
+    let out = out_dir.join(format!("{}.trace", sanitize(&params.test)));
+    let mut cmd = xctrace_command(&out, &suite.binary_path, &params.test);
+    cmd.current_dir(&suite.cwd);
+    let status = cmd.status().context("run xctrace")?;
+    if !status.success() {
+        bail!("xctrace failed with {:?}", status.code());
+    }
+    println!("[perf trace] open {}", out.display());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn xctrace_command_shape() {
+        let cmd = xctrace_command(
+            Path::new("/out/t.trace"),
+            Path::new("/bin/suite_light-abc"),
+            "offline::gapless",
+        );
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(cmd.get_program().to_string_lossy(), "xcrun");
+        assert_eq!(
+            args,
+            [
+                "xctrace",
+                "record",
+                "--template",
+                "Time Profiler",
+                "--output",
+                "/out/t.trace",
+                "--launch",
+                "--",
+                "/bin/suite_light-abc",
+                "offline::gapless",
+                "--exact",
+                "--nocapture"
+            ]
+        );
+    }
+}

--- a/xtask/src/test.rs
+++ b/xtask/src/test.rs
@@ -80,23 +80,40 @@ pub(crate) fn run(args: &TestArgs) -> Result<()> {
     validate_config(test)?;
 
     let (lane_name, lane) = select_lane(test, &request)?;
-    let mut cmd = Command::new(&lane.program);
-    cmd.args(&lane.prefix_args);
-    let features = features_for(test, lane, &request)?;
-    if !features.is_empty() {
-        cmd.arg(&test.feature_arg)
-            .arg(features.into_iter().collect::<Vec<_>>().join(","));
-    }
-    match passthrough_position(lane)? {
-        PassthroughPosition::BeforeSuffix => {
-            cmd.args(&request.passthrough);
-            cmd.args(&lane.suffix_args);
+    let passthrough = passthrough_position(lane)?;
+    let mut cmd = match passthrough {
+        PassthroughPosition::BeforeSuffix if lane_name == test.default_lane => {
+            let flash = request
+                .flash
+                .unwrap_or_else(|| lane.default_flash.unwrap_or(test.flash.default));
+            let backend = request
+                .net_backend
+                .as_deref()
+                .unwrap_or(&test.default_backend);
+            let (_, cmd) = nextest_lane_command(&project, flash, backend, &request.passthrough)?;
+            cmd
         }
-        PassthroughPosition::AfterSuffix => {
-            cmd.args(&lane.suffix_args);
-            cmd.args(&request.passthrough);
+        passthrough => {
+            let mut cmd = Command::new(&lane.program);
+            cmd.args(&lane.prefix_args);
+            let features = features_for(test, lane, &request)?;
+            if !features.is_empty() {
+                cmd.arg(&test.feature_arg)
+                    .arg(features.into_iter().collect::<Vec<_>>().join(","));
+            }
+            match passthrough {
+                PassthroughPosition::BeforeSuffix => {
+                    cmd.args(&request.passthrough);
+                    cmd.args(&lane.suffix_args);
+                }
+                PassthroughPosition::AfterSuffix => {
+                    cmd.args(&lane.suffix_args);
+                    cmd.args(&request.passthrough);
+                }
+            }
+            cmd
         }
-    }
+    };
 
     let status = cmd
         .status()
@@ -163,18 +180,27 @@ fn features_for(
     lane: &TestLaneConfig,
     request: &TestRequest,
 ) -> Result<BTreeSet<String>> {
-    let mut features = BTreeSet::new();
-    features.extend(lane.default_features.iter().cloned());
     let flash = request
         .flash
         .unwrap_or_else(|| lane.default_flash.unwrap_or(config.flash.default));
+    let backend = request
+        .net_backend
+        .clone()
+        .unwrap_or_else(|| config.default_backend.clone());
+    lane_features(config, lane, flash, &backend)
+}
+
+pub(crate) fn lane_features(
+    config: &TestCommandConfig,
+    lane: &TestLaneConfig,
+    flash: bool,
+    backend_name: &str,
+) -> Result<BTreeSet<String>> {
+    let mut features = BTreeSet::new();
+    features.extend(lane.default_features.iter().cloned());
     if flash {
         features.extend(config.flash.features.iter().cloned());
     }
-    let backend_name = request
-        .net_backend
-        .as_ref()
-        .unwrap_or(&config.default_backend);
     let Some(backend) = config.net_backends.get(backend_name) else {
         let valid = config
             .net_backends
@@ -186,6 +212,30 @@ fn features_for(
     };
     features.extend(backend.features.iter().cloned());
     Ok(features)
+}
+
+pub(crate) fn nextest_lane_command(
+    project: &ProjectConfig,
+    flash: bool,
+    backend: &str,
+    extra: &[String],
+) -> Result<(Vec<String>, Command)> {
+    let test = &project.test;
+    validate_config(test)?;
+    let lane_name = &test.default_lane;
+    let Some(lane) = test.lanes.get(lane_name) else {
+        bail!("test.default_lane `{lane_name}` is not defined in test.lanes");
+    };
+    let features = lane_features(test, lane, flash, backend)?;
+    let mut cmd = Command::new(&lane.program);
+    cmd.args(&lane.prefix_args);
+    if !features.is_empty() {
+        cmd.arg(&test.feature_arg)
+            .arg(features.iter().cloned().collect::<Vec<_>>().join(","));
+    }
+    cmd.args(extra);
+    cmd.args(&lane.suffix_args);
+    Ok((features.into_iter().collect(), cmd))
 }
 
 enum PassthroughPosition {
@@ -206,5 +256,42 @@ fn parse_flash(value: &str) -> Result<bool> {
         "on" | "true" => Ok(true),
         "off" | "false" => Ok(false),
         _ => bail!("unsupported flash mode: {value}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::*;
+
+    fn args_of(cmd: &Command) -> Vec<String> {
+        cmd.get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn lane_features_flash_and_backend() {
+        let project = ProjectConfig::load(Path::new("..")).unwrap();
+        let test = &project.test;
+        let lane = &test.lanes[&test.default_lane];
+        let feats = lane_features(test, lane, true, "apple").unwrap();
+        assert!(feats.contains("flash"));
+        assert!(feats.contains("kithara-integration-tests/apple-net"));
+        let feats = lane_features(test, lane, false, "wreq").unwrap();
+        assert!(feats.is_empty());
+    }
+
+    #[test]
+    fn nextest_lane_command_shape() {
+        let project = ProjectConfig::load(Path::new("..")).unwrap();
+        let extra = vec!["--profile".to_owned(), "perf".to_owned()];
+        let (features, cmd) = nextest_lane_command(&project, true, "wreq", &extra).unwrap();
+        assert_eq!(features, vec!["flash".to_owned()]);
+        let args = args_of(&cmd);
+        assert_eq!(cmd.get_program().to_string_lossy(), "cargo");
+        assert!(args.windows(2).any(|w| w == ["--profile", "perf"]));
+        assert!(args.contains(&"--workspace".to_owned()));
     }
 }


### PR DESCRIPTION
Test-suite work: a green, non-excluding suite; a production seek fix; profiler-driven
optimizations found via a new `xtask perf` measurement pipeline. **No tests are excluded
from the default run** — every win is a real fix or optimization, verified against the full
suite (3288 tests green under contention).

## Measurement pipeline (`cargo xtask perf`)
`matrix` (per-lane JUnit) → `slow` (median ≥1s list) → `profile` (isolated `samply`, symbolicated
via `--unstable-presymbolicate` sidecar) → `report` (gecko on-CPU/off-CPU + wait-class) → `trace`
(xctrace escalation). This is what turned "the suite feels slow" into a ranked, attributed hotspot map
(`sys-01`, 231 symbolicated tests).

## Green suite (hangs + flakes)
- Two deterministic 120s unit-test hangs removed: `kithara-play` unit tests started a real cpal/CoreAudio
  engine — now a test-only Noop backend via a config seam. The suite was RED every run before this.
- Flake fixes: `stress_seek_audio` open-count contract, `abr_mode_switch` blocking read parking the runtime,
  invalid-url DNS fixtures, `shared_download` error propagation, apple short-body fixture threshold.
- Deterministic pacing: seek-middle families use segment gates; deliberate real-time pacing routed through
  the flash virtual clock (wave 1/2).

## Production fix
- `fix(audio)`: post-seek `pcm_rx` drain is now epoch-aware — the old unconditional drain discarded valid
  post-seek chunks under load (seek data-loss). Same patch as #97; whichever merges first, the other no-ops.

## Profiler-driven optimizations (from `sys-01`)
- **RP2** `perf(tests)`: `HlsTestServer::expected_byte_at` was called per byte in verification loops (4.4s pure
  CPU in one stress test). Bulk mismatch scan resolves the source once → `stress_random_seek_read_hls_large`
  7.4s → 1.9s.
- **RP4** `perf(flash)`: the flash virtual-clock pacer polled `try_advance` every 1ms while real I/O was in
  flight — `pace_run` was the #1 on-CPU frame suite-wide (~99s). Replaced with an event-driven
  `park_timeout`-until-next-deadline scheme, woken lock-free via `Thread::unpark`. Flash-only (feature-gated) —
  no production code path changes.
- **RP4-fix** `fix(flash)`: the pacer's own deferred advance re-armed its own park token → busy-spin under
  contention (the `near-zero-wakes` test caught ~1e6 wakes). Guarded so the pacer never unparks itself.
- **RP5** `perf(test-utils)`: probe capture allocated a `String` per field name (`&'static str` from tracing) on
  every captured event; keys are now stored by reference.

## Honest scope
- The pacer win concentrates in **sparse-deadline / long-real-wait** tests (timeout/DRM/network) where the poll
  was the cost — there it collapses toward zero (e.g. `test_large_timeout` 3978ms → 9ms on-CPU). Deadline-dense
  real-time tests (e.g. `flac_swallow`) keep their genuine per-deadline cost; much of the remaining suite time is
  intrinsic real decode/disk I/O, not recoverable without cutting coverage.
- This is **not** a headline "Nx speedup" — it is a green suite + a prod bug fix + real profiler-driven CPU/
  contention reductions + the tooling to keep measuring. A precise full-suite before/after can be produced with
  `xtask perf` on request.

Draft until reviewed.
