### PR TITLE
fix(decode): eliminate splice click on HLS ABR variant switch

### DIFF
--- a/crates/kithara-audio/src/pipeline/source.rs
+++ b/crates/kithara-audio/src/pipeline/source.rs
@@ -3489,6 +3489,533 @@ mod rebuilding_decoder_tests {
 }
 
 #[cfg(test)]
+mod splice_continuity_tests {
+    use std::{
+        num::NonZeroUsize,
+        ops::Range,
+        path::Path,
+        sync::{
+            Arc,
+            atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
+        },
+    };
+
+    use kithara_decode::{DecoderConfig, DecoderFactory as DecodeFactory};
+    use kithara_platform::{sync::Mutex, tokio::runtime::Handle as RuntimeHandle};
+    use kithara_storage::WaitOutcome;
+    use kithara_stream::{
+        Activity, AudioCodec, ByteMap, ChunkPosition, ContainerFormat, MediaInfo, PlayheadRead,
+        PlayheadState, PlayheadWrite, ReadOutcome, SeekState, SegmentDescriptor, Source,
+        SourceError, SourceSeekAnchor, StreamError, StreamResult, VariantControl,
+    };
+    use kithara_test_utils::kithara;
+
+    use super::*;
+
+    struct Consts;
+
+    impl Consts {
+        const CHANNELS: usize = 2;
+        const SAMPLE_RATE: u32 = 44_100;
+        const SEGMENT_DURATION_SECS: u64 = 6;
+        const SPLICE_SEGMENT: u32 = 3;
+        const TOTAL_SEGMENTS: usize = 7;
+        const CAPTURE_END_SEGMENT: u64 = 6;
+        const SLQ_VARIANT: usize = 0;
+        const SMQ_VARIANT: usize = 1;
+    }
+
+    struct VariantLayout {
+        blob: Vec<u8>,
+        init_range: Range<u64>,
+        segments: Vec<SegmentDescriptor>,
+    }
+
+    struct SpliceState {
+        active: AtomicUsize,
+        media_info: Mutex<Option<MediaInfo>>,
+        pending_variant_change: AtomicBool,
+        target_variant: Mutex<Option<usize>>,
+        variants: Vec<VariantLayout>,
+        warmup_landing: Mutex<Option<SegmentDescriptor>>,
+    }
+
+    impl SpliceState {
+        fn new(variants: Vec<VariantLayout>) -> Self {
+            Self {
+                active: AtomicUsize::new(Consts::SLQ_VARIANT),
+                media_info: Mutex::new(Some(media_info(Consts::SLQ_VARIANT))),
+                pending_variant_change: AtomicBool::new(false),
+                target_variant: Mutex::new(None),
+                variants,
+                warmup_landing: Mutex::new(None),
+            }
+        }
+
+        fn active_index(&self) -> usize {
+            self.active
+                .load(Ordering::Acquire)
+                .min(self.variants.len().saturating_sub(1))
+        }
+
+        fn active_layout(&self) -> &VariantLayout {
+            &self.variants[self.active_index()]
+        }
+
+        fn switch_to(&self, variant: usize) {
+            self.active.store(variant, Ordering::Release);
+            *self.media_info.lock() = Some(media_info(variant));
+            *self.target_variant.lock() = Some(variant);
+            self.pending_variant_change.store(true, Ordering::Release);
+        }
+
+        fn warmup_landing(&self) -> Option<SegmentDescriptor> {
+            self.warmup_landing.lock().clone()
+        }
+    }
+
+    impl VariantControl for SpliceState {
+        fn clear_variant_fence(&self) {
+            self.pending_variant_change.store(false, Ordering::Release);
+            *self.target_variant.lock() = None;
+        }
+
+        fn format_change_segment_range(&self) -> StreamResult<Range<u64>> {
+            let range = self.active_layout().init_range.clone();
+            if range.is_empty() {
+                Err(StreamError::Source(SourceError::FormatChangeNotApplicable))
+            } else {
+                Ok(range)
+            }
+        }
+
+        fn has_variant_change_pending(&self) -> bool {
+            self.pending_variant_change.load(Ordering::Acquire)
+        }
+
+        fn variant_change_target(&self) -> Option<usize> {
+            *self.target_variant.lock()
+        }
+    }
+
+    impl ByteMap for SpliceState {
+        fn anchor_at_time(&self, position: Duration) -> StreamResult<Option<SourceSeekAnchor>> {
+            Ok(self.segment_at_time(position).map(|segment| {
+                SourceSeekAnchor::builder()
+                    .segment_start(segment.decode_time)
+                    .segment_end(segment.decode_time.saturating_add(segment.duration))
+                    .segment_index(segment.segment_index)
+                    .variant_index(segment.variant_index)
+                    .byte_offset(segment.byte_range.start)
+                    .build()
+            }))
+        }
+
+        fn init_segment_range(&self) -> Range<u64> {
+            self.active_layout().init_range.clone()
+        }
+
+        fn len(&self) -> Option<u64> {
+            Some(u64::try_from(self.active_layout().blob.len()).expect("blob length fits u64"))
+        }
+
+        fn segment_after_byte(&self, byte_offset: u64) -> Option<SegmentDescriptor> {
+            self.active_layout()
+                .segments
+                .iter()
+                .find(|segment| segment.byte_range.start >= byte_offset)
+                .cloned()
+        }
+
+        fn segment_at_byte(&self, byte_offset: u64) -> Option<SegmentDescriptor> {
+            self.active_layout()
+                .segments
+                .iter()
+                .find(|segment| segment.byte_range.contains(&byte_offset))
+                .cloned()
+        }
+
+        fn segment_at_index(&self, segment_index: u32) -> Option<SegmentDescriptor> {
+            self.active_layout()
+                .segments
+                .get(usize::try_from(segment_index).ok()?)
+                .cloned()
+        }
+
+        fn segment_at_time(&self, t: Duration) -> Option<SegmentDescriptor> {
+            let found = self
+                .active_layout()
+                .segments
+                .iter()
+                .find(|segment| t < segment.decode_time.saturating_add(segment.duration))
+                .or_else(|| self.active_layout().segments.last())
+                .cloned();
+            if self.active_index() == Consts::SMQ_VARIANT
+                && t < Duration::from_secs(120)
+                && let Some(segment) = found.as_ref()
+            {
+                *self.warmup_landing.lock() = Some(segment.clone());
+            }
+            found
+        }
+
+        fn segment_count(&self) -> Option<u32> {
+            u32::try_from(self.active_layout().segments.len()).ok()
+        }
+    }
+
+    struct SpliceSource {
+        playhead: Arc<PlayheadState>,
+        position: Arc<AtomicU64>,
+        seek: Arc<SeekState>,
+        state: Arc<SpliceState>,
+    }
+
+    impl SpliceSource {
+        fn new(state: Arc<SpliceState>) -> Self {
+            Self {
+                playhead: Arc::new(PlayheadState::new()),
+                position: Arc::new(AtomicU64::new(0)),
+                seek: Arc::new(SeekState::new()),
+                state,
+            }
+        }
+    }
+
+    impl Source for SpliceSource {
+        fn activity(&self) -> Arc<dyn Activity> {
+            Arc::clone(&self.seek) as Arc<dyn Activity>
+        }
+
+        fn advance(&self, n: u64) {
+            self.position.fetch_add(n, Ordering::AcqRel);
+        }
+
+        fn byte_map(&self) -> Option<Arc<dyn ByteMap>> {
+            Some(Arc::clone(&self.state) as Arc<dyn ByteMap>)
+        }
+
+        fn len(&self) -> Option<u64> {
+            Some(
+                u64::try_from(self.state.active_layout().blob.len()).expect("blob length fits u64"),
+            )
+        }
+
+        fn media_info(&self) -> Option<MediaInfo> {
+            self.state.media_info.lock().clone()
+        }
+
+        fn phase_at(&self, _range: Range<u64>) -> SourcePhase {
+            SourcePhase::Ready
+        }
+
+        fn playhead_read(&self) -> Arc<dyn PlayheadRead> {
+            Arc::clone(&self.playhead) as Arc<dyn PlayheadRead>
+        }
+
+        fn playhead_write(&self) -> Arc<dyn PlayheadWrite> {
+            Arc::clone(&self.playhead) as Arc<dyn PlayheadWrite>
+        }
+
+        fn position(&self) -> u64 {
+            self.position.load(Ordering::Acquire)
+        }
+
+        fn read_at(&mut self, offset: u64, buf: &mut [u8]) -> StreamResult<ReadOutcome> {
+            let blob = &self.state.active_layout().blob;
+            let start = usize::try_from(offset).unwrap_or(usize::MAX);
+            if start >= blob.len() {
+                return Ok(ReadOutcome::Eof);
+            }
+            let n = (blob.len() - start).min(buf.len());
+            buf[..n].copy_from_slice(&blob[start..start + n]);
+            Ok(ReadOutcome::Bytes(
+                NonZeroUsize::new(n).expect("non-empty read must produce nonzero bytes"),
+            ))
+        }
+
+        fn seek_control(&self) -> Arc<dyn SeekControl> {
+            Arc::clone(&self.seek) as Arc<dyn SeekControl>
+        }
+
+        fn seek_observe(&self) -> Arc<dyn SeekObserve> {
+            Arc::clone(&self.seek) as Arc<dyn SeekObserve>
+        }
+
+        fn set_position(&self, pos: u64) {
+            self.position.store(pos, Ordering::Release);
+        }
+
+        fn variant_control(&self) -> Option<Arc<dyn VariantControl>> {
+            Some(Arc::clone(&self.state) as Arc<dyn VariantControl>)
+        }
+
+        fn wait_range(
+            &mut self,
+            _range: Range<u64>,
+            _timeout: Option<Duration>,
+        ) -> StreamResult<WaitOutcome> {
+            Ok(WaitOutcome::Ready)
+        }
+    }
+
+    struct SpliceConfig {
+        state: Arc<SpliceState>,
+    }
+
+    impl Default for SpliceConfig {
+        fn default() -> Self {
+            Self {
+                state: Arc::new(SpliceState::new(vec![
+                    build_variant_layout("slq", Consts::SLQ_VARIANT),
+                    build_variant_layout("smq", Consts::SMQ_VARIANT),
+                ])),
+            }
+        }
+    }
+
+    struct SpliceStream;
+
+    impl StreamType for SpliceStream {
+        type Config = SpliceConfig;
+        type Events = ();
+        type Source = SpliceSource;
+
+        async fn create(config: Self::Config) -> Result<Self::Source, SourceError> {
+            Ok(SpliceSource::new(config.state))
+        }
+    }
+
+    struct TestWake;
+
+    impl WorkerWake for TestWake {
+        fn wake(&self) {}
+    }
+
+    fn asset_bytes(name: &str) -> Vec<u8> {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../assets/hls")
+            .join(name);
+        std::fs::read(&path).unwrap_or_else(|err| panic!("read {path:?}: {err}"))
+    }
+
+    fn build_variant_layout(label: &str, variant_index: usize) -> VariantLayout {
+        let init = asset_bytes(&format!("init-{label}-a1.mp4"));
+        let init_len = u64::try_from(init.len()).expect("init length fits u64");
+        let mut blob = init;
+        let mut byte_cursor = init_len;
+        let mut segments = Vec::new();
+        for segment_number in 1..=Consts::TOTAL_SEGMENTS {
+            let bytes = asset_bytes(&format!("segment-{segment_number}-{label}-a1.m4s"));
+            let start = byte_cursor;
+            let end = start + u64::try_from(bytes.len()).expect("segment length fits u64");
+            let segment_index = u32::try_from(segment_number - 1).expect("segment index fits u32");
+            segments.push(SegmentDescriptor::new(
+                start..end,
+                Duration::from_secs(u64::from(segment_index) * Consts::SEGMENT_DURATION_SECS),
+                Duration::from_secs(Consts::SEGMENT_DURATION_SECS),
+                segment_index,
+                variant_index,
+            ));
+            blob.extend_from_slice(&bytes);
+            byte_cursor = end;
+        }
+        VariantLayout {
+            blob,
+            init_range: 0..init_len,
+            segments,
+        }
+    }
+
+    fn media_info(variant: usize) -> MediaInfo {
+        let mut info = MediaInfo::new(Some(AudioCodec::AacLc), Some(ContainerFormat::Fmp4));
+        info.variant_index = Some(u32::try_from(variant).expect("variant fits u32"));
+        info
+    }
+
+    fn decoder_backend() -> kithara_decode::DecoderBackend {
+        #[cfg(all(feature = "apple", any(target_os = "macos", target_os = "ios")))]
+        {
+            kithara_decode::DecoderBackend::Apple
+        }
+        #[cfg(not(all(feature = "apple", any(target_os = "macos", target_os = "ios"))))]
+        {
+            kithara_decode::DecoderBackend::Symphonia
+        }
+    }
+
+    fn decoder_config<T: StreamType>(
+        stream: &SharedStream<T>,
+        backend: kithara_decode::DecoderBackend,
+        byte_len: Arc<AtomicU64>,
+    ) -> DecoderConfig {
+        byte_len.store(stream.len().unwrap_or(0), Ordering::Release);
+        DecoderConfig::builder()
+            .backend(backend)
+            .byte_len_handle(byte_len)
+            .maybe_byte_map(stream.byte_map())
+            .gapless(false)
+            .build()
+    }
+
+    async fn splice_source(state: Arc<SpliceState>) -> StreamAudioSource<SpliceStream> {
+        let stream = Stream::<SpliceStream>::new(SpliceConfig {
+            state: Arc::clone(&state),
+        })
+        .await
+        .expect("create in-memory splice stream");
+        let shared_stream = SharedStream::new(stream);
+        let backend = decoder_backend();
+        let initial_byte_len = Arc::new(AtomicU64::new(0));
+        let initial_decoder = DecodeFactory::create_from_media_info(
+            shared_stream.clone(),
+            &media_info(Consts::SLQ_VARIANT),
+            decoder_config(&shared_stream, backend, Arc::clone(&initial_byte_len)),
+        )
+        .expect("create initial slq fMP4 decoder");
+        let factory_byte_len = Arc::new(AtomicU64::new(0));
+        let decoder_factory: DecoderFactory<SpliceStream> =
+            Arc::new(move |stream, info, base_offset| {
+                let byte_len = stream
+                    .len()
+                    .map_or(0, |len| len.saturating_sub(base_offset));
+                factory_byte_len.store(byte_len, Ordering::Release);
+                let config = DecoderConfig::builder()
+                    .backend(backend)
+                    .byte_len_handle(Arc::clone(&factory_byte_len))
+                    .maybe_byte_map(stream.byte_map())
+                    .gapless(false)
+                    .build();
+                let input = OffsetReader::new(stream, base_offset);
+                let decoder = DecodeFactory::create_from_media_info(input, &info, config)?;
+                decoder.update_byte_len(byte_len);
+                Ok(decoder)
+            });
+        StreamAudioSource::new(
+            shared_stream,
+            DecodeInit {
+                decoder: initial_decoder,
+                decoder_factory,
+                gapless_mode: GaplessMode::Disabled,
+                media_info: Some(media_info(Consts::SLQ_VARIANT)),
+            },
+            Arc::new(AtomicU64::new(0)),
+            Vec::new(),
+            RuntimeHandle::try_current().expect("test requires tokio runtime"),
+            Arc::new(TestWake),
+        )
+    }
+
+    fn run_pending_rebuild_inline(source: &mut StreamAudioSource<SpliceStream>) {
+        if let Some(job) = source.pending_rebuild_submit.take() {
+            job.run();
+        }
+    }
+
+    fn append_left_channel(left: &mut Vec<f32>, chunk: &PcmChunk) {
+        let channels = usize::from(chunk.meta.spec.channels);
+        assert_eq!(channels, Consts::CHANNELS, "AAC fixture should be stereo");
+        for frame in 0..chunk.frames() {
+            left.push(chunk.samples[frame * channels]);
+        }
+    }
+
+    fn peak_first_diff(left: &[f32], center: usize, half: usize) -> f32 {
+        assert!(
+            (1..left.len()).contains(&center),
+            "first-difference center must be in 1..{}, got {center}",
+            left.len(),
+        );
+        let start = center.saturating_sub(half).max(1);
+        let end = center.saturating_add(half).min(left.len() - 1);
+        let mut peak = 0.0_f32;
+        for i in start..=end {
+            let diff = (left[i] - left[i - 1]).abs();
+            peak = peak.max(diff);
+        }
+        peak
+    }
+
+    // splice-continuity contract: RED = audible click on variant switch
+    // (see .docs/plans/2026-07-03-resampler-native-src-design.md, S-Click)
+    #[kithara::test(tokio)]
+    async fn hls_aac_lc_abr_variant_switch_splice_continuity_metric() {
+        let state = Arc::new(SpliceState::new(vec![
+            build_variant_layout("slq", Consts::SLQ_VARIANT),
+            build_variant_layout("smq", Consts::SMQ_VARIANT),
+        ]));
+        let mut source = splice_source(Arc::clone(&state)).await;
+        let splice_time =
+            Duration::from_secs(u64::from(Consts::SPLICE_SEGMENT) * Consts::SEGMENT_DURATION_SECS);
+        let capture_frames = usize::try_from(
+            Consts::CAPTURE_END_SEGMENT
+                .saturating_mul(Consts::SEGMENT_DURATION_SECS)
+                .saturating_mul(u64::from(Consts::SAMPLE_RATE)),
+        )
+        .expect("capture frame count fits usize");
+        let mut left = Vec::with_capacity(capture_frames);
+        let mut switched = false;
+        let mut splice_frame = None;
+
+        while left.len() < capture_frames {
+            run_pending_rebuild_inline(&mut source);
+            match source.step_track() {
+                TrackStep::Produced(fetch) => {
+                    let chunk = fetch.into_inner();
+                    append_left_channel(&mut left, &chunk);
+                    source.playhead.advance(&ChunkPosition::from(&chunk.meta));
+                    if !switched
+                        && chunk.meta.segment_index == Some(Consts::SPLICE_SEGMENT - 1)
+                        && chunk.meta.end_timestamp >= splice_time
+                    {
+                        state.switch_to(Consts::SMQ_VARIANT);
+                        switched = true;
+                        splice_frame = Some(left.len());
+                    }
+                }
+                TrackStep::StateChanged | TrackStep::Blocked(_) => {}
+                TrackStep::Eof => break,
+                TrackStep::Failed => panic!("splice source failed before metric collection"),
+            }
+        }
+
+        assert!(switched, "test must trigger the slq -> smq splice");
+        let splice_frame = splice_frame.expect("splice frame should be captured");
+        if let Some(landing) = state.warmup_landing() {
+            println!(
+                "SPLICE_WARMUP variant={} segment={}",
+                landing.variant_index, landing.segment_index
+            );
+        }
+        let switch_peak = peak_first_diff(&left, splice_frame, 64);
+        let mut control_peak = 0.0_f32;
+        let mut control_count = 0usize;
+        for k in 1..Consts::TOTAL_SEGMENTS {
+            let boundary = k
+                .saturating_mul(Consts::SEGMENT_DURATION_SECS as usize)
+                .saturating_mul(Consts::SAMPLE_RATE as usize);
+            if boundary >= left.len() || boundary.abs_diff(splice_frame) <= 4096 {
+                continue;
+            }
+            control_peak = control_peak.max(peak_first_diff(&left, boundary, 64));
+            control_count += 1;
+        }
+        assert!(
+            control_count >= 2,
+            "splice continuity metric needs at least two same-variant control boundaries, got {control_count}",
+        );
+        let ratio = switch_peak / control_peak.max(f32::EPSILON);
+        println!(
+            "SPLICE_CONTINUITY switch_peak={switch_peak:.6} control_peak={control_peak:.6} ratio={ratio:.3}"
+        );
+        assert!(
+            ratio < 3.0,
+            "variant-switch stitch discontinuity {switch_peak:.6} is {ratio:.1}x the worst same-variant segment boundary {control_peak:.6} — audible click at the splice",
+        );
+    }
+}
+
+#[cfg(test)]
 mod playing_flag_tests {
     use std::sync::Arc;
 

--- a/crates/kithara-audio/src/pipeline/source.rs
+++ b/crates/kithara-audio/src/pipeline/source.rs
@@ -4013,6 +4013,100 @@ mod splice_continuity_tests {
             "variant-switch stitch discontinuity {switch_peak:.6} is {ratio:.1}x the worst same-variant segment boundary {control_peak:.6} — audible click at the splice",
         );
     }
+
+    #[kithara::test(tokio)]
+    async fn hls_aac_lc_same_variant_recreate_continuity_metric() {
+        let state = Arc::new(SpliceState::new(vec![build_variant_layout(
+            "slq",
+            Consts::SLQ_VARIANT,
+        )]));
+        let mut source = splice_source(Arc::clone(&state)).await;
+        let recreate_after =
+            Duration::from_secs(u64::from(Consts::SPLICE_SEGMENT) * Consts::SEGMENT_DURATION_SECS);
+        let capture_frames = usize::try_from(
+            Consts::CAPTURE_END_SEGMENT
+                .saturating_mul(Consts::SEGMENT_DURATION_SECS)
+                .saturating_mul(u64::from(Consts::SAMPLE_RATE)),
+        )
+        .expect("capture frame count fits usize");
+        let mut left = Vec::with_capacity(capture_frames);
+        let mut recreated = false;
+        let mut recreate_frame = None;
+
+        while left.len() < capture_frames {
+            run_pending_rebuild_inline(&mut source);
+            match source.step_track() {
+                TrackStep::Produced(fetch) => {
+                    let chunk = fetch.into_inner();
+                    append_left_channel(&mut left, &chunk);
+                    source.playhead.advance(&ChunkPosition::from(&chunk.meta));
+                    if !recreated
+                        && chunk.meta.segment_index == Some(Consts::SPLICE_SEGMENT - 1)
+                        && chunk.meta.end_timestamp >= recreate_after
+                    {
+                        let active = state.active_index();
+                        assert_eq!(
+                            active,
+                            Consts::SLQ_VARIANT,
+                            "same-variant recreate test must stay on the SLQ variant",
+                        );
+                        source.start_recreating_decoder(RecreateState {
+                            cause: RecreateCause::VariantSwitch,
+                            media_info: media_info(active),
+                            next: RecreateNext::ApplySeek(SeekRequest {
+                                seek: SeekContext {
+                                    epoch: source.epoch.load(Ordering::Acquire),
+                                    target: chunk.meta.end_timestamp,
+                                },
+                                emit_request: false,
+                            }),
+                            offset: state.active_layout().init_range.start,
+                        });
+                        recreated = true;
+                        recreate_frame = Some(left.len());
+                    }
+                }
+                TrackStep::StateChanged | TrackStep::Blocked(_) => {}
+                TrackStep::Eof => break,
+                TrackStep::Failed => {
+                    panic!("same-variant recreate source failed before metric collection");
+                }
+            }
+        }
+
+        assert!(recreated, "test must trigger the same-variant recreate");
+        assert_eq!(
+            state.active_index(),
+            Consts::SLQ_VARIANT,
+            "same-variant recreate must not change the active variant",
+        );
+        let recreate_frame = recreate_frame.expect("recreate frame should be captured");
+        let recreate_peak = peak_first_diff(&left, recreate_frame, 64);
+        let mut control_peak = 0.0_f32;
+        let mut control_count = 0usize;
+        for k in 1..Consts::TOTAL_SEGMENTS {
+            let boundary = k
+                .saturating_mul(Consts::SEGMENT_DURATION_SECS as usize)
+                .saturating_mul(Consts::SAMPLE_RATE as usize);
+            if boundary >= left.len() || boundary.abs_diff(recreate_frame) <= 4096 {
+                continue;
+            }
+            control_peak = control_peak.max(peak_first_diff(&left, boundary, 64));
+            control_count += 1;
+        }
+        assert!(
+            control_count >= 2,
+            "recreate continuity metric needs at least two same-content control boundaries, got {control_count}",
+        );
+        let ratio = recreate_peak / control_peak.max(f32::EPSILON);
+        println!(
+            "RECREATE_CONTINUITY recreate_peak={recreate_peak:.6} control_peak={control_peak:.6} ratio={ratio:.3}"
+        );
+        assert!(
+            ratio < 3.0,
+            "same-variant recreate discontinuity {recreate_peak:.6} is {ratio:.1}x the worst same-content segment boundary {control_peak:.6}",
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/kithara-decode/src/composed.rs
+++ b/crates/kithara-decode/src/composed.rs
@@ -685,8 +685,18 @@ mod seek_trim_tests {
     use super::{test_counting_codec::CountingCodec, *};
     use crate::{
         demuxer::{DemuxOutcome, DemuxSeekOutcome, Frame, TrackInfo},
+        duration_for_frames,
         traits::Decoder,
     };
+
+    struct Consts;
+
+    impl Consts {
+        const CHANNELS: u16 = 2;
+        const PACKET_COUNT: u64 = 6;
+        const PACKET_FRAMES: u32 = 1024;
+        const SAMPLE_RATE: u32 = 44_100;
+    }
 
     struct ThreeFrameDemuxer {
         track: TrackInfo,
@@ -705,6 +715,12 @@ mod seek_trim_tests {
         held: Vec<u8>,
         frames: Vec<BoundaryFrame>,
         idx: usize,
+    }
+
+    #[derive(Clone, Copy)]
+    enum SeekTrimLayout {
+        RegularPackets,
+        RoundedPastTarget,
     }
 
     impl Demuxer for ThreeFrameDemuxer {
@@ -792,6 +808,42 @@ mod seek_trim_tests {
         }
     }
 
+    fn packet_duration() -> Duration {
+        duration_for_frames(Consts::SAMPLE_RATE, u64::from(Consts::PACKET_FRAMES))
+    }
+
+    fn regular_seek_frames() -> Vec<BoundaryFrame> {
+        (0..Consts::PACKET_COUNT)
+            .map(|packet_idx| BoundaryFrame {
+                pts: duration_for_frames(
+                    Consts::SAMPLE_RATE,
+                    packet_idx.saturating_mul(u64::from(Consts::PACKET_FRAMES)),
+                ),
+                duration: packet_duration(),
+            })
+            .collect()
+    }
+
+    fn rounded_past_target_frames(target: Duration) -> Vec<BoundaryFrame> {
+        vec![
+            BoundaryFrame {
+                pts: Duration::ZERO,
+                duration: target.saturating_add(Duration::from_nanos(1)),
+            },
+            BoundaryFrame {
+                pts: target,
+                duration: packet_duration(),
+            },
+        ]
+    }
+
+    fn seek_frames_for(target: Duration, layout: SeekTrimLayout) -> Vec<BoundaryFrame> {
+        match layout {
+            SeekTrimLayout::RegularPackets => regular_seek_frames(),
+            SeekTrimLayout::RoundedPastTarget => rounded_past_target_frames(target),
+        }
+    }
+
     #[kithara::test]
     fn pre_target_frames_are_decoded_and_dropped_by_pending_seek_target() {
         const FRAME_FRAMES: u32 = 882;
@@ -866,6 +918,71 @@ mod seek_trim_tests {
         );
         assert_eq!(chunk.meta.frame_offset, u64::from(PACKET_FRAMES));
         assert_eq!(chunk.meta.timestamp, target);
+    }
+
+    #[kithara::test]
+    #[case::packet_boundary(
+        duration_for_frames(Consts::SAMPLE_RATE, u64::from(Consts::PACKET_FRAMES)),
+        SeekTrimLayout::RegularPackets
+    )]
+    #[case::mid_packet(
+        duration_for_frames(Consts::SAMPLE_RATE, u64::from(Consts::PACKET_FRAMES) + 512),
+        SeekTrimLayout::RegularPackets
+    )]
+    #[case::rounding_hair_past_boundary(
+        duration_for_frames(Consts::SAMPLE_RATE, u64::from(Consts::PACKET_FRAMES))
+            .saturating_add(Duration::from_nanos(1)),
+        SeekTrimLayout::RoundedPastTarget
+    )]
+    #[case::multiple_fully_pre_target_packets(
+        duration_for_frames(Consts::SAMPLE_RATE, u64::from(Consts::PACKET_FRAMES) * 3 + 512),
+        SeekTrimLayout::RegularPackets
+    )]
+    fn seek_trim_lands_first_chunk_on_exact_target_frame(
+        #[case] target: Duration,
+        #[case] layout: SeekTrimLayout,
+    ) {
+        let codec = CountingCodec::new(
+            PcmSpec::new(
+                Consts::CHANNELS,
+                NonZeroU32::new(Consts::SAMPLE_RATE).expect("test rate"),
+            ),
+            Consts::PACKET_FRAMES,
+        );
+        let demuxer = BoundaryFrameDemuxer {
+            track: empty_track(),
+            held: Vec::new(),
+            frames: seek_frames_for(target, layout),
+            idx: 0,
+        };
+        let mut decoder = ComposedDecoder::new(demuxer, codec, DecoderRuntime::for_test());
+
+        let _ = decoder.seek(target).expect("BUG: seek");
+        let outcome = decoder.next_chunk().expect("BUG: next_chunk");
+        let DecoderChunkOutcome::Chunk(chunk) = outcome else {
+            panic!("expected Chunk, got {outcome:?}");
+        };
+        let expected_frame = frame_offset_for(target, Consts::SAMPLE_RATE);
+        let packet_offset = expected_frame % u64::from(Consts::PACKET_FRAMES);
+        let expected_frames = if packet_offset == 0 {
+            Consts::PACKET_FRAMES
+        } else {
+            Consts::PACKET_FRAMES - u32::try_from(packet_offset).expect("packet offset fits in u32")
+        };
+
+        assert_eq!(chunk.meta.frame_offset, expected_frame);
+        assert_eq!(chunk.meta.timestamp, target);
+        assert_eq!(
+            frame_offset_for(chunk.meta.timestamp, Consts::SAMPLE_RATE),
+            expected_frame
+        );
+        assert!(
+            chunk.meta.timestamp >= target,
+            "first chunk timestamp {:?} before seek target {:?}",
+            chunk.meta.timestamp,
+            target
+        );
+        assert_eq!(chunk.meta.frames, expected_frames);
     }
 }
 

--- a/crates/kithara-decode/src/composed.rs
+++ b/crates/kithara-decode/src/composed.rs
@@ -193,7 +193,13 @@ impl<D: Demuxer, C: FrameCodec> ComposedDecoder<D, C> {
                         frames_to_trim(frame_pts, target, live_spec.sample_rate.get())
                             .min(u64::from(frames));
                     let trim_frames = u32::try_from(trim_frames_u64).unwrap_or(frames);
-                    if trim_frames > 0 && trim_frames < frames {
+                    // Duration rounding can leave `frame_end > target` even when
+                    // this packet is fully pre-target in sample space.
+                    if trim_frames >= frames {
+                        drop(buf);
+                        continue;
+                    }
+                    if trim_frames > 0 {
                         let channels = usize::from(live_spec.channels);
                         let trim_samples = usize::try_from(trim_frames)
                             .unwrap_or(0)
@@ -688,6 +694,19 @@ mod seek_trim_tests {
         idx: usize,
     }
 
+    #[derive(Clone, Copy)]
+    struct BoundaryFrame {
+        pts: Duration,
+        duration: Duration,
+    }
+
+    struct BoundaryFrameDemuxer {
+        track: TrackInfo,
+        held: Vec<u8>,
+        frames: Vec<BoundaryFrame>,
+        idx: usize,
+    }
+
     impl Demuxer for ThreeFrameDemuxer {
         fn duration(&self) -> Option<Duration> {
             Some(Duration::from_millis(60))
@@ -725,6 +744,43 @@ mod seek_trim_tests {
         }
     }
 
+    impl Demuxer for BoundaryFrameDemuxer {
+        fn duration(&self) -> Option<Duration> {
+            None
+        }
+
+        fn next_frame(&mut self) -> DecodeResult<DemuxOutcome<'_>> {
+            let Some(frame) = self.frames.get(self.idx).copied() else {
+                return Ok(DemuxOutcome::Eof);
+            };
+            self.idx += 1;
+            self.held = vec![0u8; 4];
+            Ok(DemuxOutcome::Frame(Frame {
+                pts: frame.pts,
+                duration: frame.duration,
+                data: &self.held,
+                packet_desc: &[],
+            }))
+        }
+
+        fn seek(
+            &mut self,
+            _pos: Duration,
+            _priming: crate::codec::CodecPriming,
+        ) -> DecodeResult<DemuxSeekOutcome> {
+            self.idx = 0;
+            Ok(DemuxSeekOutcome::Landed {
+                landed_at: Duration::ZERO,
+                landed_byte: Some(0),
+                preroll: crate::demuxer::PrerollHint::NotNeeded,
+            })
+        }
+
+        fn track_info(&self) -> &TrackInfo {
+            &self.track
+        }
+    }
+
     fn empty_track() -> TrackInfo {
         TrackInfo {
             codec: AudioCodec::AacLc,
@@ -738,9 +794,11 @@ mod seek_trim_tests {
 
     #[kithara::test]
     fn pre_target_frames_are_decoded_and_dropped_by_pending_seek_target() {
+        const FRAME_FRAMES: u32 = 882;
+
         let codec = CountingCodec::new(
             PcmSpec::new(2, NonZeroU32::new(44_100).expect("test rate")),
-            1,
+            FRAME_FRAMES,
         );
         let calls = Arc::clone(&codec.decode_calls);
         let demuxer = ThreeFrameDemuxer {
@@ -764,6 +822,50 @@ mod seek_trim_tests {
             2,
             "decode_frame must be called for pre-target frames so MDCT advances"
         );
+    }
+
+    #[kithara::test]
+    fn fully_trimmed_seek_packet_is_dropped_before_target_chunk() {
+        const SAMPLE_RATE: u32 = 44_100;
+        const PACKET_FRAMES: u32 = 1024;
+
+        let target = crate::duration_for_frames(SAMPLE_RATE, u64::from(PACKET_FRAMES));
+        let rounded_past_target = target.saturating_add(Duration::from_nanos(1));
+        let codec = CountingCodec::new(
+            PcmSpec::new(2, NonZeroU32::new(SAMPLE_RATE).expect("test rate")),
+            PACKET_FRAMES,
+        );
+        let calls = Arc::clone(&codec.decode_calls);
+        let demuxer = BoundaryFrameDemuxer {
+            track: empty_track(),
+            held: Vec::new(),
+            idx: 0,
+            frames: vec![
+                BoundaryFrame {
+                    pts: Duration::ZERO,
+                    duration: rounded_past_target,
+                },
+                BoundaryFrame {
+                    pts: target,
+                    duration: rounded_past_target,
+                },
+            ],
+        };
+        let mut decoder = ComposedDecoder::new(demuxer, codec, DecoderRuntime::for_test());
+
+        let _ = decoder.seek(target).expect("BUG: seek");
+        let outcome = decoder.next_chunk().expect("BUG: next_chunk");
+        let DecoderChunkOutcome::Chunk(chunk) = outcome else {
+            panic!("expected Chunk, got {outcome:?}");
+        };
+
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            2,
+            "the fully pre-target packet must be decode-discarded before emitting"
+        );
+        assert_eq!(chunk.meta.frame_offset, u64::from(PACKET_FRAMES));
+        assert_eq!(chunk.meta.timestamp, target);
     }
 }
 

--- a/tests/tests/kithara_play/gapless_offline_e2e.rs
+++ b/tests/tests/kithara_play/gapless_offline_e2e.rs
@@ -215,6 +215,73 @@ async fn two_tracks_gapless_no_click_with_silence_trim_zero_crossfade(temp_dir: 
     timeout(Duration::from_secs(30)),
     env(KITHARA_HANG_TIMEOUT_SECS = "1")
 )]
+async fn two_tracks_gapless_stitch_continuity_metric(temp_dir: TestTempDir) {
+    let server = TestServerHelper::new().await;
+    let stitch_frame = crate::gapless_common::generated_aac_elst_visible_frames();
+    let harness = OfflinePlayerHarness::with_sample_rate(
+        PlayerConfig::builder()
+            .crossfade_duration(0.0)
+            .gapless_mode(silence_trim_with_trailing())
+            .build(),
+        GAPLESS_SAMPLE_RATE,
+    );
+
+    let first = create_resource(
+        harness.player(),
+        &server,
+        temp_dir.path(),
+        "continuity-1",
+        Some(AAC_GAPLESS_ENCODER_DELAY),
+        Some(AAC_GAPLESS_TRAILING_DELAY),
+        0,
+    )
+    .await;
+    let second = create_resource(
+        harness.player(),
+        &server,
+        temp_dir.path(),
+        "continuity-2",
+        Some(AAC_GAPLESS_ENCODER_DELAY),
+        Some(AAC_GAPLESS_TRAILING_DELAY),
+        u64::try_from(stitch_frame).expect("stitch frame fits u64"),
+    )
+    .await;
+
+    load_tagged_queue(&harness, [first, second]);
+
+    let (rendered, events) = render_until_item_end(&harness, "continuity-2").await;
+    let left = deinterleave_left(&rendered, usize::from(GAPLESS_CHANNELS));
+
+    assert!(
+        left.len() > stitch_frame + ContinuityMetric::HALF_WINDOW_FRAMES,
+        "rendered PCM must cover the stitch window; left_frames={}, stitch_frame={stitch_frame}, events={events:?}",
+        left.len()
+    );
+    assert_prefetch_before_first_end(&events, "continuity-1");
+
+    let switch_peak = peak_first_diff(&left, stitch_frame, ContinuityMetric::HALF_WINDOW_FRAMES);
+    let (control_peak, control_count) = gapless_control_peak(&left, stitch_frame);
+    assert!(
+        control_count >= ContinuityMetric::MIN_CONTROL_WINDOWS,
+        "gapless continuity metric needs at least {} same-track control windows, got {control_count}",
+        ContinuityMetric::MIN_CONTROL_WINDOWS,
+    );
+    let ratio = switch_peak / control_peak.max(f32::EPSILON);
+    println!(
+        "GAPLESS_CONTINUITY switch_peak={switch_peak:.6} control_peak={control_peak:.6} ratio={ratio:.3}"
+    );
+    assert!(
+        ratio < ContinuityMetric::MAX_RATIO,
+        "gapless stitch discontinuity {switch_peak:.6} is {ratio:.1}x the worst same-track control window {control_peak:.6}",
+    );
+}
+
+#[kithara::test(
+    native,
+    tokio,
+    timeout(Duration::from_secs(30)),
+    env(KITHARA_HANG_TIMEOUT_SECS = "1")
+)]
 async fn disabled_gapless_mode_keeps_full_decoded_length(temp_dir: TestTempDir) {
     let server = TestServerHelper::new().await;
     let harness = OfflinePlayerHarness::with_sample_rate(
@@ -655,6 +722,15 @@ struct TimedPlayerEvent {
     event: PlayerEvent,
 }
 
+struct ContinuityMetric;
+
+impl ContinuityMetric {
+    const CONTROL_STRIDE_FRAMES: usize = GAPLESS_SAMPLE_RATE as usize / 4;
+    const HALF_WINDOW_FRAMES: usize = 64;
+    const MAX_RATIO: f32 = 3.0;
+    const MIN_CONTROL_WINDOWS: usize = 2;
+}
+
 fn timed_event_frame_end<P>(events: &[TimedPlayerEvent], predicate: P) -> Option<usize>
 where
     P: Fn(&PlayerEvent) -> bool,
@@ -663,6 +739,64 @@ where
         .iter()
         .find(|timed| predicate(&timed.event))
         .map(|timed| timed.frame_end)
+}
+
+fn assert_prefetch_before_first_end(events: &[TimedPlayerEvent], first_item_id: &str) {
+    let prefetch = events
+        .iter()
+        .position(|timed| matches!(&timed.event, PlayerEvent::PrefetchRequested))
+        .expect("PrefetchRequested must fire so the test exercises arm_next");
+    let first_end = events
+        .iter()
+        .position(|timed| {
+            matches!(
+                &timed.event,
+                PlayerEvent::ItemDidPlayToEnd { item_id: Some(id), .. }
+                    if id.as_ref() == first_item_id
+            )
+        })
+        .expect("first item must emit ItemDidPlayToEnd");
+    assert!(
+        prefetch < first_end,
+        "PrefetchRequested must precede the first ItemDidPlayToEnd; events={events:?}"
+    );
+}
+
+fn peak_first_diff(left: &[f32], center: usize, half: usize) -> f32 {
+    assert!(
+        (1..left.len()).contains(&center),
+        "first-difference center must be in 1..{}, got {center}",
+        left.len(),
+    );
+    let start = center.saturating_sub(half).max(1);
+    let end = center.saturating_add(half).min(left.len() - 1);
+    let mut peak = 0.0_f32;
+    for i in start..=end {
+        peak = peak.max((left[i] - left[i - 1]).abs());
+    }
+    peak
+}
+
+fn gapless_control_peak(left: &[f32], stitch_frame: usize) -> (f32, usize) {
+    let mut peak = 0.0_f32;
+    let mut count = 0usize;
+    for center in [
+        stitch_frame.saturating_sub(ContinuityMetric::CONTROL_STRIDE_FRAMES),
+        stitch_frame.saturating_add(ContinuityMetric::CONTROL_STRIDE_FRAMES),
+    ] {
+        if center <= ContinuityMetric::HALF_WINDOW_FRAMES
+            || center + ContinuityMetric::HALF_WINDOW_FRAMES >= left.len()
+        {
+            continue;
+        }
+        peak = peak.max(peak_first_diff(
+            left,
+            center,
+            ContinuityMetric::HALF_WINDOW_FRAMES,
+        ));
+        count += 1;
+    }
+    (peak, count)
 }
 
 /// Index just past the last sample whose absolute amplitude is at or above


### PR DESCRIPTION
## Summary

Fixes the audible click on HLS ABR variant switches: `ComposedDecoder`'s seek trim
leaked a decoded packet that lay fully before the seek target, splicing stale PCM
into the post-switch stream. The packet is now dropped when `trim_frames >= frames`,
keeping `pending_seek_target` armed until a packet actually covers the target.

## Commits

- `fix(decode)`: drop fully-pre-target packet on seek trim — the root fix, plus an
  offline splice-continuity regression test driving the real `FormatBoundary` path.
- `test(audio)`: PCM-continuity regression guards for the three sibling paths —
  frame-exact seek landing, same-variant decoder recreate, and two-track gapless
  stitch. All three were already green; only the variant-switch path was defective.
- `fix(xtask)`: `publish_order_is_resolved` pinned the publishable-crate count at 20;
  merge-skew between #99 (`kithara-devtools`) and #100 (`kithara-stretch`) left the
  pin stale on `main` (21 crates), so the suite fails on a clean `main` checkout.
  The test now derives the expected set from `cargo metadata` with the same publish
  filter `resolve_publish_order()` uses — no more pinned count.

## Validation

- `just clippy` — clean.
- Full `just test` on the rebased branch: 3321 tests, 3320 passed; the single
  failure was the stale publish-order pin fixed by the last commit (fails on clean
  `main` too). Focused rerun after the fix: all `xtask` publish tests green.
- The known pre-existing `stress_seek` / `phase_continuity` baseline flakes passed
  in this run; they are tracked separately.
