### PR TITLE
fix(apple): unblock xcframework build (pin uniffi 0.31.2 + simulator bindgen triple)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,11 +297,11 @@ dependencies = [
 
 [[package]]
 name = "askama"
-version = "0.16.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf825125edd887a019d0a3a837dcc5499a68b0d034cc3eb594070c3e18addc"
+checksum = "f75363874b771be265f4ffe307ca705ef6f3baa19011c149da8674a87f1b75c4"
 dependencies = [
- "askama_macros",
+ "askama_derive",
  "itoa",
  "percent-encoding",
  "serde",
@@ -310,13 +310,12 @@ dependencies = [
 
 [[package]]
 name = "askama_derive"
-version = "0.16.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1c7065972a130eafa84215f21352ae15b4a7393da48c1f5e103904490736738"
+checksum = "129397200fe83088e8a68407a8e2b1f826cf0086b21ccdb866a722c8bcd3a94f"
 dependencies = [
  "askama_parser",
  "basic-toml",
- "glob",
  "memchr",
  "proc-macro2",
  "quote",
@@ -327,25 +326,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "askama_macros"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e23b1d2c4bd39a41971f6124cef4cc6fd0540913ecb90919b69ab3bbe44ae1a"
-dependencies = [
- "askama_derive",
-]
-
-[[package]]
 name = "askama_parser"
-version = "0.16.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7db09fde9143e7ac4513358fb32ee32847125b63b18ea715afd487956da715da"
+checksum = "d6ab5630b3d5eaf232620167977f95eb51f3432fc76852328774afbd242d4358"
 dependencies = [
- "rustc-hash 2.1.2",
+ "memchr",
  "serde",
  "serde_derive",
- "unicode-ident",
- "winnow 1.0.3",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -765,7 +754,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-time",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1230,6 +1219,15 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
@@ -1240,12 +1238,26 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+dependencies = [
+ "camino",
+ "cargo-platform 0.1.9",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "cargo_metadata"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
 dependencies = [
  "camino",
- "cargo-platform",
+ "cargo-platform 0.3.3",
  "semver",
  "serde",
  "serde_json",
@@ -2378,7 +2390,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2570,7 +2582,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3062,9 +3074,9 @@ dependencies = [
 
 [[package]]
 name = "fs-err"
-version = "3.3.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
 dependencies = [
  "autocfg",
 ]
@@ -3769,7 +3781,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -4173,7 +4185,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4557,7 +4569,7 @@ name = "kithara-devtools"
 version = "0.0.1-alpha4"
 dependencies = [
  "anyhow",
- "cargo_metadata",
+ "cargo_metadata 0.23.1",
  "clap",
  "glob",
  "kithara-workspace-hack",
@@ -5750,7 +5762,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6936,7 +6948,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6974,7 +6986,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -7736,7 +7748,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7793,7 +7805,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.8",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8889,7 +8901,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9791,13 +9803,13 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "uniffi"
-version = "0.32.0"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a782a48d72cfd7a2d65cfc7c691dbf5375c43104b3c195f7eccc716dcc3540c8"
+checksum = "46eefd5468602930da46b1f49d3448c6dfc2e81295f93120f23f8174fd70267f"
 dependencies = [
  "anyhow",
  "camino",
- "cargo_metadata",
+ "cargo_metadata 0.19.2",
  "clap",
  "uniffi_bindgen",
  "uniffi_core",
@@ -9807,14 +9819,14 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.32.0"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533b0312c73e3b54eb78a4b257ceae390962dd4767995778309a74644643f9ac"
+checksum = "c4a0c9b375d32e1365cdb2bdd7cb495eecf6fac851ddbad077412b4ee1888514"
 dependencies = [
  "anyhow",
  "askama",
  "camino",
- "cargo_metadata",
+ "cargo_metadata 0.19.2",
  "fs-err",
  "glob",
  "goblin 0.8.2",
@@ -9824,7 +9836,7 @@ dependencies = [
  "serde",
  "tempfile",
  "textwrap",
- "toml 1.1.2+spec-1.1.0",
+ "toml 0.8.23",
  "uniffi_internal_macros",
  "uniffi_meta",
  "uniffi_pipeline",
@@ -9833,9 +9845,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.32.0"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e32e261c5b0dfaba6488f536e71957dddd6b1a498ac7eb791bee56b60a086be"
+checksum = "eec017b112701681f6fbbe5d92014b5c468eb0b177a94389de03ceec40665095"
 dependencies = [
  "anyhow",
  "bytes",
@@ -9845,9 +9857,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_internal_macros"
-version = "0.32.0"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84ae78069a5e6772ef694fd5bdb628532c88d2c2f0e7142bf6a384636eadb1af"
+checksum = "4641669b48fefbc5e80ff08c5004d9c7617fb91232131a6734ab6712779cb04c"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -9858,9 +9870,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.32.0"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330be6770532e86320df31f54c70bb0be67588594e8e77fa56e9083a3fed5d0d"
+checksum = "eeb8617ee814de22caf7417bf514715ba0b3f46bd9d5a5d794413fd8282cb737"
 dependencies = [
  "camino",
  "fs-err",
@@ -9869,15 +9881,15 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.118",
- "toml 1.1.2+spec-1.1.0",
+ "toml 0.8.23",
  "uniffi_meta",
 ]
 
 [[package]]
 name = "uniffi_meta"
-version = "0.32.0"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78de021f5547e56ab16c665a49d67d4fd3d31e77422f7739a2e9359d328cd9e7"
+checksum = "58d5b94fc92803d21b2928bd15c6f06e57609b95caf98ea561c99cda1b6d2a25"
 dependencies = [
  "anyhow",
  "siphasher",
@@ -9887,9 +9899,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_pipeline"
-version = "0.32.0"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8201bb1907ed8a42d80e11cbc25c8a033e7a31c3cff1d911f56eedb81d4948"
+checksum = "032739b3ec725576914c15899dedaf080163ced86b6934566c20ec2b20ce90ca"
 dependencies = [
  "anyhow",
  "heck",
@@ -9900,9 +9912,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.32.0"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e57996bc58009cc29bf04845d627ae313c2547b87171c1c349d6c51a1656c0"
+checksum = "fc0a1d0a0252ce1af9e8ce78ba67ac0d8937fb2bedaf10cbddd43d3614d06ec6"
 dependencies = [
  "anyhow",
  "textwrap",
@@ -10769,7 +10781,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11480,7 +11492,7 @@ name = "xtask"
 version = "0.0.1-alpha4"
 dependencies = [
  "anyhow",
- "cargo_metadata",
+ "cargo_metadata 0.23.1",
  "clap",
  "glob",
  "kithara-devtools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -351,7 +351,7 @@ tracing-android = "0.2.0"
 tracing-log = "0.2"
 tracing-subscriber = { version = "0.3.23", default-features = false, features = ["fmt", "registry"] }
 tracing-wasm = "0.2"
-uniffi = { version = "0.32.0", default-features = false }
+uniffi = { version = "0.31.2", default-features = false }
 unimock = { version = "0.6", features = ["std"] }
 url = "2.5.8"
 usdt = { version = "0.6", default-features = false, features = ["asm"] }

--- a/xtask/src/apple.rs
+++ b/xtask/src/apple.rs
@@ -441,6 +441,7 @@ fn run_build(profile: crate::BuildProfile, target: Option<&str>) -> Result<()> {
     ]);
     cmd.current_dir(&crate_dir);
     cmd.env("IPHONEOS_DEPLOYMENT_TARGET", "16.0");
+    set_simulator_bindgen_args(&mut cmd)?;
 
     let status = cmd.status().context("failed to run cargo swift package")?;
     if !status.success() {
@@ -495,6 +496,29 @@ fn run_build(profile: crate::BuildProfile, target: Option<&str>) -> Result<()> {
         guard.restore()?;
     }
 
+    Ok(())
+}
+
+/// `signalsmith-stretch` runs `bindgen`, which derives clang's target from
+/// cargo's `TARGET`. For simulator slices that yields `arm64-apple-ios-sim`,
+/// but libclang wants `-simulator`; pin valid simulator triples and sysroot.
+fn set_simulator_bindgen_args(cmd: &mut Command) -> Result<()> {
+    let sim_sdk = sdk_path("iphonesimulator")?;
+    let sim_sdk = sim_sdk
+        .to_str()
+        .context("iphonesimulator SDK path is not UTF-8")?;
+    for (key, triple) in [
+        (
+            "BINDGEN_EXTRA_CLANG_ARGS_aarch64_apple_ios_sim",
+            "arm64-apple-ios-simulator",
+        ),
+        (
+            "BINDGEN_EXTRA_CLANG_ARGS_x86_64_apple_ios",
+            "x86_64-apple-ios-simulator",
+        ),
+    ] {
+        cmd.env(key, format!("--target={triple} -isysroot {sim_sdk}"));
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Description

`just apple xcframework` / `apple release` are currently broken on `main` by **two independent blockers**:

**1. UniFFI binding generation (uniffi 0.32 vs cargo-swift)**

The apple build goes through `cargo swift package`, which generates the UniFFI Swift bindings with its **bundled** `uniffi_bindgen`. `cargo-swift` 0.11.0 and the latest 0.11.1 both link `uniffi_bindgen = "=0.31.x"` (verified against the crates.io deps API). #95 bumped the workspace `uniffi` 0.31.2 → 0.32.0, and the 0.31 reader cannot parse 0.32 metadata:

```
Could not generate UniFFI bindings ...
extracting metadata for '_UNIFFI_META_KITHARA_FFI_CONSTRUCTOR_AUDIOPLAYERITEM_NEW':
Invalid string data: invalid utf-8 sequence of 1 bytes from index 671
```

This fails **before any slice compiles**. (Proof it's a reader-version skew, not corrupt data: the workspace's own `uniffi-bindgen` 0.32 reads the exact same library cleanly. Android is unaffected — it generates bindings via the workspace `uniffi-bindgen` binary, which is version-matched.)

Fix: pin `uniffi` back to 0.31.2 (its pre-#95 version). #95 touched only Cargo files and nothing consumes 0.32-only APIs, so the downgrade is code-safe. This is a holding pin until `cargo-swift` ships a 0.32 reader (or the apple build is rerouted through the workspace `uniffi-bindgen` like android).

**2. Simulator bindgen triple (signalsmith-stretch)**

Past the binding step, the simulator slice fails to compile: `signalsmith-stretch`'s `build.rs` runs `bindgen`, which derives clang's target from cargo's `TARGET`. For `aarch64-apple-ios-sim` that yields the invalid triple `arm64-apple-ios-sim` — libclang rejects it (`version 'sim' ... is invalid`; it wants `-simulator`, not `-sim`).

```
signalsmith-stretch-0.1.3/build.rs:23: Unable to generate bindings:
ClangDiagnostic("error: version 'sim' in target triple 'arm64-apple-ios-sim' is invalid")
```

Fix: in `xtask/src/apple.rs`, set `BINDGEN_EXTRA_CLANG_ARGS_<target>` for the simulator targets so bindgen's clang gets a valid `-simulator` triple plus the simulator sysroot; the appended `--target` overrides the auto-derived one. The device slice keeps its already-valid auto-derived triple, untouched. The deployment target (16.0) is unchanged and no slice is disabled.

## Type of Change

- [x] Bug fix

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes (`just lint-fast`: 0 regressions, 0 new)
- [ ] Tests added/updated — n/a (build-tooling + dependency pin; no runtime code changed)
- [x] No `unwrap()`/`expect()` in production code
- [ ] Documentation updated — n/a

## Verification

- Full `just apple xcframework` builds green on this branch — all slices (device iOS `ios-arm64`, simulator `ios-arm64-simulator`, macOS `macos-arm64_x86_64`) — and `cargo xtask apple audit` passes: **0 banned decoder symbols, AppleCodec linked in all 3 slices**.
- `just lint-fast` (fmt + `clippy --workspace -D warnings` + ast-grep + arch): 0 regressions, 0 new.
- `cargo hakari verify` — workspace-hack consistent.
- Runtime `just test` on the identical two-change set: no regressions — the only failures are the pre-existing invalid-domain-timeout flake family (net/HLS error-handling tests hitting a deliberately non-existent domain), unrelated to a build-tooling + dependency-pin change.
