### PR TITLE
fix(queue): isolate loader lanes to fix playlist stall

### DIFF
--- a/crates/kithara-net/src/backend/apple/session.rs
+++ b/crates/kithara-net/src/backend/apple/session.rs
@@ -7,7 +7,6 @@ use kithara_bufpool::BytePool;
 use kithara_platform::{
     CancelToken,
     sync::{Mutex, OnceLock},
-    time::Duration,
     tokio::sync::oneshot,
 };
 use objc2::{rc::Retained, runtime::ProtocolObject};
@@ -38,7 +37,6 @@ type DataStart = (
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct SharedSessionKey {
-    total_timeout: Option<Duration>,
     is_insecure: bool,
     max_connections_per_host: usize,
 }
@@ -173,7 +171,6 @@ impl AppleSession {
 impl From<&NetOptions> for SharedSessionKey {
     fn from(options: &NetOptions) -> Self {
         Self {
-            total_timeout: options.total_timeout,
             max_connections_per_host: options.pool_max_idle_per_host,
             is_insecure: options.is_insecure,
         }
@@ -184,9 +181,6 @@ impl SharedSession {
     fn new(key: SharedSessionKey) -> Self {
         let delegate = AppleSessionDelegate::new(key.is_insecure);
         let configuration = NSURLSessionConfiguration::ephemeralSessionConfiguration();
-        if let Some(total_timeout) = key.total_timeout {
-            configuration.setTimeoutIntervalForResource(total_timeout.as_secs_f64());
-        }
         if let Ok(max_connections) = NSInteger::try_from(key.max_connections_per_host)
             && max_connections > 0
         {

--- a/crates/kithara-net/src/backend/apple/tests.rs
+++ b/crates/kithara-net/src/backend/apple/tests.rs
@@ -90,7 +90,6 @@ fn fast_options(max_retries: u32) -> NetOptions {
             max_delay: Duration::from_millis(10),
         })
         .inactivity_timeout(Duration::from_millis(30))
-        .total_timeout(Duration::from_secs(5))
         .build()
 }
 
@@ -102,7 +101,6 @@ fn stream_options(inactivity_ms: u64) -> NetOptions {
             max_delay: Duration::from_millis(10),
         })
         .inactivity_timeout(Duration::from_millis(inactivity_ms))
-        .total_timeout(Duration::from_secs(5))
         .build()
 }
 

--- a/crates/kithara-net/src/client.rs
+++ b/crates/kithara-net/src/client.rs
@@ -146,11 +146,6 @@ impl RawHttp {
         accept_partial: bool,
     ) -> Result<Response, NetError> {
         let req = Self::apply_headers(req, headers);
-        let req = if let Some(total) = self.options.total_timeout {
-            req.timeout(total)
-        } else {
-            req
-        };
         let resp = self.send_idle_bounded(req).await?;
         let status = resp.status();
 
@@ -394,11 +389,6 @@ impl Net for RawHttp {
     async fn head(&self, url: Url, headers: Option<Headers>) -> Result<Headers, NetError> {
         let req = self.head_request(url.clone());
         let req = Self::apply_headers(req, headers);
-        let req = if let Some(total) = self.options.total_timeout {
-            req.timeout(total)
-        } else {
-            req
-        };
         let resp = self.send_idle_bounded(req).await?;
 
         let status = resp.status();

--- a/crates/kithara-net/src/types.rs
+++ b/crates/kithara-net/src/types.rs
@@ -171,15 +171,6 @@ pub struct NetOptions {
     /// Shared byte buffer pool used by backends that must copy platform-owned
     /// response buffers before handing bytes to Rust consumers.
     pub byte_pool: Option<BytePool>,
-    /// Hard cap on total request lifetime. Maps to
-    /// [`reqwest::RequestBuilder::timeout`]. `None` lets streaming
-    /// downloads run indefinitely as long as `inactivity_timeout` is
-    /// satisfied — required for the player to honour "wait for the
-    /// segment, regardless of connection speed". Default `Some(2 min)`
-    /// keeps a safety net against pathological cases (server stuck in
-    /// mid-body without ever closing) while not racing realistic
-    /// slow-network seeks.
-    pub total_timeout: Option<Duration>,
     #[builder(default)]
     pub retry_policy: RetryPolicy,
     /// Accept invalid TLS certificates (self-signed, expired, wrong hostname).
@@ -205,9 +196,7 @@ pub struct NetOptions {
 
 impl Default for NetOptions {
     fn default() -> Self {
-        Self::builder()
-            .total_timeout(Duration::from_secs(120))
-            .build()
+        Self::builder().build()
     }
 }
 
@@ -216,7 +205,6 @@ impl FromWithParams<Self, Option<BytePool>> for NetOptions {
         Self::builder()
             .compression(options.compression)
             .inactivity_timeout(options.inactivity_timeout)
-            .maybe_total_timeout(options.total_timeout)
             .retry_policy(options.retry_policy)
             .is_insecure(options.is_insecure)
             .pool_max_idle_per_host(options.pool_max_idle_per_host)

--- a/crates/kithara-queue/CONTEXT.md
+++ b/crates/kithara-queue/CONTEXT.md
@@ -93,10 +93,9 @@ gated.
 ## Loading Lifecycle
 
 Each `append` allocates a monotonic [`TrackId`] and a queue entry with
-status `Pending`, then spawns a background task:
+status `Pending`, then spawns a background load attempt:
 
-1. Acquire a semaphore permit (up to
-   `QueueConfig::max_concurrent_loads`).
+1. Acquire a permit in the attempt's lane (see "Load Lanes" below).
 2. Publish `TrackStatusChanged { Loading }`.
 3. Build the `ResourceConfig` (either from `TrackSource::Uri` templates
    or the caller-supplied `Config`) and call `Resource::new`.
@@ -114,6 +113,24 @@ status `Pending`, then spawns a background task:
 After `select_item` succeeds the engine has consumed `items[index]`, so
 the Queue immediately transitions the entry to `TrackStatus::Consumed`.
 Re-selecting a `Consumed` track respawns the load.
+
+## Load Lanes
+
+The loader runs two isolated permit lanes so a prefetch parked on a dead
+host cannot starve a selection: **Prefetch** (append-time, capped by
+`QueueConfig::max_concurrent_loads`) and **Interactive** (`select`, one
+permit). Max in-flight is `max_concurrent_loads + 1`.
+
+Each `TrackRecord` owns its track's status, source, and at most one live
+attempt (`AttemptGuard`), all under the one `Tracks` lock. The guard
+cancels the attempt's per-track `CancelToken` on drop, so removing the
+record (`remove` / `clear`) or flipping the status to `Cancelled` aborts
+the load with no separate call. `select` on a track still waiting for a
+prefetch permit promotes it into the interactive lane (the parked
+attempt is replaced and abandons on wake via a generation check); an
+attempt already downloading is left alone. A cancelled attempt returns
+`QueueError::Cancelled` and leaves `TrackStatus` to the superseding
+path. Byte-level dedupe of same-URL downloads is the `AssetStore`'s job.
 
 The production append/insert path does not start initial playback on its own:
 the caller drives the first `select` / `play` explicitly so playback order is

--- a/crates/kithara-queue/src/attempts.rs
+++ b/crates/kithara-queue/src/attempts.rs
@@ -1,0 +1,79 @@
+use kithara_events::TrackId;
+use kithara_platform::CancelToken;
+
+/// Which loader lane a load attempt occupies.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum LoadClass {
+    /// User-facing selection: one dedicated permit, isolated from
+    /// prefetch so a hung background lane cannot starve selection.
+    Interactive,
+    /// Append-time background prefetch, capped by
+    /// [`QueueConfig::max_concurrent_loads`](crate::QueueConfig::max_concurrent_loads).
+    Prefetch,
+}
+
+/// Claim ticket held by a spawned attempt task. Lifecycle reports are
+/// generation-checked, so a replaced ticket silently loses its claim.
+pub(crate) struct Ticket {
+    pub(crate) id: TrackId,
+    pub(crate) generation: u64,
+}
+
+/// A track's live load attempt. Dropping the guard armed cancels the
+/// attempt's per-track token, so removing a track aborts the load without an explicit call.
+pub(crate) struct AttemptGuard {
+    pub(crate) generation: u64,
+    pub(crate) waiting: bool,
+    /// `None` = disarmed: the token now belongs to the built `Resource`.
+    cancel: Option<CancelToken>,
+}
+
+impl AttemptGuard {
+    pub(crate) fn new(generation: u64, cancel: CancelToken) -> Self {
+        Self {
+            generation,
+            waiting: true,
+            cancel: Some(cancel),
+        }
+    }
+
+    pub(crate) fn is_cancelled(&self) -> bool {
+        self.cancel.as_ref().is_none_or(CancelToken::is_cancelled)
+    }
+
+    /// Give the token up to its next owner; dropping then cancels nothing.
+    pub(crate) fn disarm(&mut self) {
+        self.cancel = None;
+    }
+}
+
+impl Drop for AttemptGuard {
+    fn drop(&mut self) {
+        if let Some(cancel) = self.cancel.take() {
+            cancel.cancel();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use kithara_test_utils::kithara;
+
+    use super::*;
+
+    #[kithara::test]
+    fn drop_cancels_armed_guard() {
+        let token = CancelToken::never().child();
+        drop(AttemptGuard::new(0, token.clone()));
+        assert!(token.is_cancelled());
+    }
+
+    #[kithara::test]
+    fn drop_after_disarm_cancels_nothing() {
+        let token = CancelToken::never().child();
+        let mut guard = AttemptGuard::new(0, token.clone());
+        guard.disarm();
+        drop(guard);
+        assert!(!token.is_cancelled());
+    }
+}

--- a/crates/kithara-queue/src/config.rs
+++ b/crates/kithara-queue/src/config.rs
@@ -36,7 +36,7 @@ pub(crate) const DEFAULT_PREFETCH_DURATION: f32 = 3.5;
 #[builder(state_mod(vis = "pub"))]
 #[non_exhaustive]
 pub struct QueueConfig {
-    /// Max concurrent `Loader` in-flight loads. Default: 3.
+    /// Max concurrent background prefetch loads. Default: 3.
     #[builder(default = DEFAULT_MAX_CONCURRENT_LOADS)]
     pub max_concurrent_loads: NonZeroUsize,
 

--- a/crates/kithara-queue/src/error.rs
+++ b/crates/kithara-queue/src/error.rs
@@ -17,6 +17,10 @@ pub enum QueueError {
     #[error("track not ready: {0:?}")]
     NotReady(TrackId),
 
+    /// Load attempt aborted: superseded by a newer selection or torn down with its track.
+    #[error("load cancelled: {0:?}")]
+    Cancelled(TrackId),
+
     /// Error bubbled up from `kithara-play`.
     #[error(transparent)]
     Play(#[from] PlayError),

--- a/crates/kithara-queue/src/lib.rs
+++ b/crates/kithara-queue/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! See `CONTEXT.md` for the public API contract and migration notes.
 
+mod attempts;
 mod config;
 mod error;
 mod loader;

--- a/crates/kithara-queue/src/loader.rs
+++ b/crates/kithara-queue/src/loader.rs
@@ -2,34 +2,30 @@ use std::{num::NonZeroUsize, sync::Arc};
 
 use kithara_events::{DownloaderEvent, Event, EventBus, TrackId, TrackStatus};
 use kithara_platform::{
-    tokio,
+    CancelToken, tokio,
     tokio::{
         sync::Semaphore,
         task::{JoinHandle, spawn},
     },
 };
 use kithara_play::{PlayerImpl, Resource, ResourceConfig};
-use tracing::{debug, warn};
 
 use crate::{
+    attempts::{LoadClass, Ticket},
     error::QueueError,
     track::{TrackSource, Tracks},
 };
 
-/// Async track loader: parallelism-capped `ResourceConfig` -> `Resource`.
-///
-/// Owns the semaphore that limits concurrent `Resource::new` invocations and
-/// subscribes to the per-resource [`EventBus`](kithara_events::EventBus) to
-/// surface `LoadSlow` as [`QueueEvent::TrackStatusChanged`] with
-/// [`TrackStatus::Slow`]. On failure emits `Failed(reason)`; successful
-/// resources are returned to [`Queue`](crate::Queue) for `replace_item` +
-/// `Loaded` emission.
+/// Async track loader: `ResourceConfig` -> `Resource`, run in two
+/// isolated permit lanes with one abortable attempt per track.
 pub(crate) struct Loader {
     player: Arc<PlayerImpl>,
-    semaphore: Arc<Semaphore>,
-    /// Same `Arc<Tracks>` as `Queue::tracks`. All status transitions go
-    /// through [`Tracks::set_status`] so polled and event-stream views
-    /// never drift.
+    /// Background prefetch lane (`max_concurrent_loads` permits).
+    prefetch_lane: Arc<Semaphore>,
+    /// User-selection lane: one dedicated permit, isolated from prefetch.
+    interactive_lane: Arc<Semaphore>,
+    /// Same `Arc<Tracks>` as `Queue::tracks`: owns per-track status and the live attempt,
+    /// so both change under one lock.
     tracks: Arc<Tracks>,
 }
 
@@ -42,7 +38,8 @@ impl Loader {
         Self {
             player,
             tracks,
-            semaphore: Arc::new(Semaphore::new(max_concurrent_loads.get())),
+            prefetch_lane: Arc::new(Semaphore::new(max_concurrent_loads.get())),
+            interactive_lane: Arc::new(Semaphore::new(1)),
         }
     }
 
@@ -65,15 +62,9 @@ impl Loader {
         Ok(self.player.prepare_config(config))
     }
 
-    /// Load a [`Resource`] for the given track. Caller is responsible for
-    /// applying it via `PlayerImpl::replace_item` and emitting
-    /// [`TrackStatus::Loaded`].
-    pub(crate) async fn load(
-        &self,
-        id: TrackId,
-        source: TrackSource,
-    ) -> Result<Resource, QueueError> {
-        let config = self.build_config(source)?;
+    /// Load a [`Resource`] from a prepared config. Caller is responsible
+    /// for applying it via `PlayerImpl::replace_item` and emitting [`TrackStatus::Loaded`].
+    async fn load(&self, id: TrackId, config: ResourceConfig) -> Result<Resource, QueueError> {
         let slow_watcher =
             Self::watch_for_slow_status(id, config.bus.clone(), Arc::clone(&self.tracks));
         let resource_fut = async {
@@ -89,35 +80,105 @@ impl Loader {
         }
     }
 
-    /// Spawn an async load. Acquires a semaphore permit for the duration of
-    /// the load. Emits `Loading` on start, `Failed(reason)` on error. On
-    /// success, the [`Resource`] is returned through the `JoinHandle`.
+    /// Spawn a fresh async load in the given lane. `None` when a live
+    /// attempt already exists - one track never occupies two permits.
     pub(crate) fn spawn_load(
         self: &Arc<Self>,
         id: TrackId,
         source: TrackSource,
+        class: LoadClass,
+    ) -> Option<JoinHandle<Result<Resource, QueueError>>> {
+        let (config, cancel) = match self.attempt_config(id, source) {
+            Ok(pair) => pair,
+            Err(err) => return Some(self.spawn_config_failure(id, err)),
+        };
+        let ticket = self.tracks.begin_attempt(id, cancel.clone())?;
+        Some(self.spawn_attempt(ticket, config, cancel, class))
+    }
+
+    /// Move a track's pending load into the interactive lane.
+    pub(crate) fn promote_load(
+        self: &Arc<Self>,
+        id: TrackId,
+        source: TrackSource,
+    ) -> Option<JoinHandle<Result<Resource, QueueError>>> {
+        let (config, cancel) = match self.attempt_config(id, source) {
+            Ok(pair) => pair,
+            Err(err) => return Some(self.spawn_config_failure(id, err)),
+        };
+        let ticket = self.tracks.promote_attempt(id, cancel.clone())?;
+        Some(self.spawn_attempt(ticket, config, cancel, LoadClass::Interactive))
+    }
+
+    fn attempt_config(
+        &self,
+        id: TrackId,
+        source: TrackSource,
+    ) -> Result<(ResourceConfig, CancelToken), QueueError> {
+        let config = self.build_config(source)?;
+        let Some(cancel) = config.cancel.clone() else {
+            return Err(QueueError::Resource(format!(
+                "track {id:?}: resource config missing per-track cancel"
+            )));
+        };
+        Ok((config, cancel))
+    }
+
+    fn spawn_attempt(
+        self: &Arc<Self>,
+        ticket: Ticket,
+        config: ResourceConfig,
+        cancel: CancelToken,
+        class: LoadClass,
     ) -> JoinHandle<Result<Resource, QueueError>> {
         let this = Arc::clone(self);
         spawn(async move {
-            let permit = Arc::clone(&this.semaphore)
-                .acquire_owned()
-                .await
-                .map_err(|e| QueueError::Resource(format!("semaphore closed: {e}")))?;
+            let id = ticket.id;
+            let lane = match class {
+                LoadClass::Interactive => &this.interactive_lane,
+                LoadClass::Prefetch => &this.prefetch_lane,
+            };
+            let permit = tokio::select! {
+                biased;
+                _ = cancel.cancelled() => {
+                    this.tracks.finish_attempt(&ticket, None);
+                    return Err(QueueError::Cancelled(id));
+                }
+                permit = Arc::clone(lane).acquire_owned() => permit
+                    .map_err(|e| QueueError::Resource(format!("semaphore closed: {e}")))?,
+            };
+            if !this.tracks.mark_loading(&ticket) {
+                drop(permit);
+                return Err(QueueError::Cancelled(id));
+            }
 
-            this.tracks.set_status(id, TrackStatus::Loading);
-
-            let result = this.load(id, source).await;
+            let result = tokio::select! {
+                biased;
+                _ = cancel.cancelled() => Err(QueueError::Cancelled(id)),
+                result = this.load(id, config) => result,
+            };
             drop(permit);
 
-            match &result {
-                Ok(_) => debug!(id = id.as_u64(), "track load ok"),
-                Err(e) => {
-                    warn!(id = id.as_u64(), error = %e, "track load failed");
-                    this.tracks
-                        .set_status(id, TrackStatus::Failed(format!("{e}")));
-                }
-            }
+            let failure = match &result {
+                Ok(_) | Err(QueueError::Cancelled(_)) => None,
+                Err(e) => Some(format!("{e}")),
+            };
+            this.tracks.finish_attempt(&ticket, failure);
             result
+        })
+    }
+
+    /// Wrap a synchronous config failure (e.g. invalid URI) in a resolved
+    /// handle so callers keep one completion path. No lane, no permit.
+    fn spawn_config_failure(
+        &self,
+        id: TrackId,
+        err: QueueError,
+    ) -> JoinHandle<Result<Resource, QueueError>> {
+        let tracks = Arc::clone(&self.tracks);
+        spawn(async move {
+            tracks.set_status(id, TrackStatus::Failed(format!("{err}")));
+            Err(err)
         })
     }
 
@@ -156,7 +217,7 @@ mod tests {
     use kithara_test_utils::kithara;
 
     use super::*;
-    use crate::track::TrackEntry;
+    use crate::track::TrackRecord;
 
     /// Builder for test [`Loader`] fixtures. Defaults cover most tests;
     /// override via setters when a specific concurrency cap matters.
@@ -230,20 +291,8 @@ mod tests {
         assert!(matches!(err, QueueError::InvalidUrl(_)));
     }
 
-    #[kithara::test(tokio)]
-    async fn load_invalid_uri_returns_invalid_url_error() {
-        let loader = LoaderFixtureSpec::default().build().loader;
-        let Err(err) = loader
-            .load(TrackId(0), TrackSource::Uri("not-a-url".into()))
-            .await
-        else {
-            panic!("should reject relative path");
-        };
-        assert!(matches!(err, QueueError::InvalidUrl(_)));
-    }
-
     #[kithara::test(tokio, multi_thread)]
-    async fn semaphore_caps_concurrent_loads() {
+    async fn prefetch_lane_caps_concurrent_loads() {
         let cap = NonZeroUsize::new(2).expect("BUG: 2 > 0 is mathematically guaranteed");
         let loader = LoaderFixtureSpec::default().with_cap(cap).build().loader;
 
@@ -252,7 +301,7 @@ mod tests {
 
         let mut handles = Vec::new();
         for _ in 0..6 {
-            let sem = Arc::clone(&loader.semaphore);
+            let sem = Arc::clone(&loader.prefetch_lane);
             let in_flight = Arc::clone(&in_flight);
             let max_seen = Arc::clone(&max_seen);
             handles.push(spawn(async move {
@@ -279,27 +328,33 @@ mod tests {
     #[kithara::test(tokio, multi_thread)]
     async fn spawn_load_bad_url_emits_failed_status() {
         let fx = LoaderFixtureSpec::default().build();
-        fx.tracks.lock().push(TrackEntry {
-            id: TrackId(42),
-            url: None,
-            name: String::new(),
-            status: TrackStatus::Pending,
-        });
+        fx.tracks.lock().push(TrackRecord::new(
+            TrackId(42),
+            String::new(),
+            TrackSource::Uri("not-a-url".into()),
+        ));
         let mut rx = fx.bus.subscribe();
         let loader = fx.loader;
 
-        let handle = loader.spawn_load(TrackId(42), TrackSource::Uri("not-a-url".into()));
+        let handle = loader
+            .spawn_load(
+                TrackId(42),
+                TrackSource::Uri("not-a-url".into()),
+                LoadClass::Prefetch,
+            )
+            .expect("config failure still yields a completion handle");
         let result = handle.await.expect("BUG: spawned task panicked");
         assert!(matches!(result, Err(QueueError::InvalidUrl(_))));
 
-        let mut saw_loading = false;
+        // Invalid config fails synchronously without ever loading: the
+        // track goes straight to Failed, no fictional Loading first.
         let mut saw_failed = false;
         for _ in 0..8 {
             match time::timeout(Duration::from_millis(200), rx.recv()).await {
                 Ok(Ok(Event::Queue(QueueEvent::TrackStatusChanged {
                     id: TrackId(42),
                     status: TrackStatus::Loading,
-                }))) => saw_loading = true,
+                }))) => panic!("invalid config must not emit Loading"),
                 Ok(Ok(Event::Queue(QueueEvent::TrackStatusChanged {
                     id: TrackId(42),
                     status: TrackStatus::Failed(_),
@@ -308,7 +363,6 @@ mod tests {
                 Ok(Err(_)) | Err(_) => break,
             }
         }
-        assert!(saw_loading, "Loading status event missing");
         assert!(saw_failed, "Failed status event missing");
     }
 }

--- a/crates/kithara-queue/src/queue/access.rs
+++ b/crates/kithara-queue/src/queue/access.rs
@@ -1,11 +1,9 @@
-use std::sync::PoisonError;
-
 use kithara_events::{EventReceiver, TrackId};
 
 use super::Queue;
 use crate::{
     navigation::RepeatMode,
-    track::{TrackEntry, TrackSource},
+    track::{TrackEntry, TrackRecord, TrackSource},
 };
 
 impl Queue {
@@ -20,7 +18,7 @@ impl Queue {
     #[must_use]
     pub fn current(&self) -> Option<TrackEntry> {
         let idx = self.lock_navigation().current_index()?;
-        self.lock_tracks().get(idx).cloned()
+        self.lock_tracks().get(idx).map(TrackRecord::entry)
     }
 
     /// ABR handle of the currently playing adaptive item, if any.
@@ -93,23 +91,22 @@ impl Queue {
     /// Lookup a track entry by id.
     #[must_use]
     pub fn track(&self, id: TrackId) -> Option<TrackEntry> {
-        self.lock_tracks().iter().find(|e| e.id == id).cloned()
+        self.lock_tracks()
+            .iter()
+            .find(|r| r.id == id)
+            .map(TrackRecord::entry)
     }
 
     /// The original [`TrackSource`] for `id`, if still queued. Lets callers
     /// rebuild a resource by track identity rather than by queue position.
     #[must_use]
     pub fn track_source(&self, id: TrackId) -> Option<TrackSource> {
-        self.sources
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .get(&id)
-            .cloned()
+        self.tracks.source(id)
     }
 
     /// Snapshot of all track entries, in queue order.
     #[must_use]
     pub fn tracks(&self) -> Vec<TrackEntry> {
-        self.lock_tracks().clone()
+        self.lock_tracks().iter().map(TrackRecord::entry).collect()
     }
 }

--- a/crates/kithara-queue/src/queue/lifecycle.rs
+++ b/crates/kithara-queue/src/queue/lifecycle.rs
@@ -1,14 +1,18 @@
+#[cfg(any(test, feature = "probe"))]
 use std::sync::PoisonError;
 
-use kithara_events::{QueueEvent, TrackId, TrackStatus};
+#[cfg(any(test, feature = "probe"))]
+use kithara_events::TrackStatus;
+use kithara_events::{QueueEvent, TrackId};
 
 use super::{
     Queue,
     types::{Placement, Transition, extract_track_name},
 };
 use crate::{
+    attempts::LoadClass,
     error::QueueError,
-    track::{TrackEntry, TrackSource},
+    track::{TrackRecord, TrackSource},
 };
 
 impl Queue {
@@ -29,18 +33,15 @@ impl Queue {
         self.insert_entry(id, source.into(), Placement::Append)
     }
 
-    /// Remove all tracks from the queue.
+    /// Remove all tracks from the queue. Dropping the records aborts
+    /// their in-flight loads.
     pub fn clear(&self) {
         let ids: Vec<TrackId> = {
             let mut guard = self.lock_tracks_mut();
-            let ids = guard.iter().map(|e| e.id).collect();
+            let ids = guard.iter().map(|r| r.id).collect();
             guard.clear();
             ids
         };
-        self.sources
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .clear();
         self.player.remove_all_items();
         for id in ids {
             self.bus.publish(QueueEvent::TrackRemoved { id });
@@ -85,7 +86,7 @@ impl Queue {
 
     /// Shared insertion path for [`Self::append`] and [`Self::insert`].
     ///
-    /// Builds the [`TrackEntry`] with `id`, places it per `placement`,
+    /// Builds the [`TrackRecord`] with `id`, places it per `placement`,
     /// then mirrors the track into the player, bus, and background
     /// loader. Position resolution — including fallible `after_id`
     /// lookup — happens in the caller, so this helper is infallible.
@@ -95,33 +96,24 @@ impl Queue {
         source: TrackSource,
         placement: Placement,
     ) -> TrackId {
-        let entry = TrackEntry {
-            id,
-            name: extract_track_name(&source),
-            url: source.uri().map(str::to_string),
-            status: TrackStatus::Pending,
-        };
+        let record = TrackRecord::new(id, extract_track_name(&source), source.clone());
 
         let index = {
             let mut guard = self.lock_tracks_mut();
             match placement {
                 Placement::Append => {
-                    guard.push(entry);
+                    guard.push(record);
                     guard.len() - 1
                 }
                 Placement::At(pos) => {
-                    guard.insert(pos, entry);
+                    guard.insert(pos, record);
                     pos
                 }
             }
         };
-        self.sources
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .insert(id, source.clone());
         self.player.reserve_slots(self.len());
         self.bus.publish(QueueEvent::TrackAdded { id, index });
-        self.spawn_apply_after_load(id, source);
+        self.spawn_apply_after_load(id, source, LoadClass::Prefetch);
         id
     }
 
@@ -170,21 +162,12 @@ impl Queue {
     pub fn register_for_test(&self) -> TrackId {
         let id = TrackId::allocate();
         let url = format!("test://memory/{}", id.as_u64());
-        let entry = TrackEntry {
-            id,
-            name: format!("test-{}", id.as_u64()),
-            url: Some(url.clone()),
-            status: TrackStatus::Pending,
-        };
+        let record = TrackRecord::new(id, format!("test-{}", id.as_u64()), TrackSource::Uri(url));
         let index = {
             let mut guard = self.lock_tracks_mut();
-            guard.push(entry);
+            guard.push(record);
             guard.len() - 1
         };
-        self.sources
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .insert(id, TrackSource::Uri(url));
         self.player.reserve_slots(self.len());
         if self.should_autoplay {
             let _ = self.autoplay_target.arm_if_disarmed(id);
@@ -227,10 +210,6 @@ impl Queue {
             guard.remove(pos);
             pos
         };
-        self.sources
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .remove(&id);
         let _ = self.player.remove_at(index);
         self.bus.publish(QueueEvent::TrackRemoved { id });
 

--- a/crates/kithara-queue/src/queue/playback.rs
+++ b/crates/kithara-queue/src/queue/playback.rs
@@ -338,13 +338,12 @@ impl Queue {
     }
 
     fn track_id_for_src(&self, src: &str) -> Option<TrackId> {
-        let sources = self.sources.lock().unwrap_or_else(PoisonError::into_inner);
-        sources.iter().find_map(|(id, source)| {
-            let matches = match source {
+        self.lock_tracks().iter().find_map(|record| {
+            let matches = match &record.source {
                 TrackSource::Uri(uri) => uri == src,
                 TrackSource::Config(config) => config.src.to_string() == src,
             };
-            matches.then_some(*id)
+            matches.then_some(record.id)
         })
     }
 

--- a/crates/kithara-queue/src/queue/selection.rs
+++ b/crates/kithara-queue/src/queue/selection.rs
@@ -2,7 +2,7 @@ use std::sync::{Arc, PoisonError};
 
 use kithara_events::{QueueEvent, TrackId, TrackStatus};
 use kithara_platform::tokio::task;
-use kithara_play::SelectTransition;
+use kithara_play::{Resource, SelectTransition};
 use tracing::{debug, warn};
 
 use super::{
@@ -10,6 +10,7 @@ use super::{
     types::{PendingSelect, SelectPhase, Transition},
 };
 use crate::{
+    attempts::LoadClass,
     error::QueueError,
     navigation::RepeatMode,
     track::{TrackEntry, TrackSource},
@@ -94,15 +95,15 @@ impl Queue {
         }
         let tracks = self.lock_tracks();
         indices.into_iter().find_map(|idx| {
-            let entry = tracks.get(idx)?;
-            if matches!(entry.status, TrackStatus::Cancelled) {
+            let record = tracks.get(idx)?;
+            if matches!(record.status, TrackStatus::Cancelled) {
                 debug!(
-                    id = entry.id.as_u64(),
+                    id = record.id.as_u64(),
                     "advance_to_next: skipping cancelled track"
                 );
                 None
             } else {
-                Some(entry.clone())
+                Some(record.entry())
             }
         })
     }
@@ -193,30 +194,48 @@ impl Queue {
             }
             TrackStatus::Pending | TrackStatus::Loading | TrackStatus::Slow => {
                 self.override_pending_select(PendingSelect { id, transition });
+                self.promote_pending_load(id);
                 Ok(())
             }
             TrackStatus::Cancelled | TrackStatus::Consumed | TrackStatus::Failed(_) => {
                 if let Some(result) = self.try_replant_test_resource(id, index, transition) {
                     return result;
                 }
-                let source = self
-                    .sources
-                    .lock()
-                    .unwrap_or_else(PoisonError::into_inner)
-                    .get(&id)
-                    .cloned()
-                    .ok_or(QueueError::NotReady(id))?;
+                let source = self.tracks.source(id).ok_or(QueueError::NotReady(id))?;
                 self.override_pending_select(PendingSelect { id, transition });
                 self.set_status(id, TrackStatus::Pending);
-                self.spawn_apply_after_load(id, source);
+                self.spawn_apply_after_load(id, source, LoadClass::Interactive);
                 Ok(())
             }
             _ => Err(QueueError::NotReady(id)),
         }
     }
 
-    pub(super) fn spawn_apply_after_load(&self, id: TrackId, source: TrackSource) {
-        let handle = self.loader.spawn_load(id, source);
+    pub(super) fn spawn_apply_after_load(
+        &self,
+        id: TrackId,
+        source: TrackSource,
+        class: LoadClass,
+    ) {
+        let handle = self.loader.spawn_load(id, source, class);
+        self.watch_apply(id, handle);
+    }
+
+    fn promote_pending_load(&self, id: TrackId) {
+        if let Some(source) = self.tracks.source(id) {
+            let handle = self.loader.promote_load(id, source);
+            self.watch_apply(id, handle);
+        }
+    }
+
+    fn watch_apply(
+        &self,
+        id: TrackId,
+        handle: Option<task::JoinHandle<Result<Resource, QueueError>>>,
+    ) {
+        let Some(handle) = handle else {
+            return;
+        };
         let player = Arc::clone(&self.player);
         let tracks = Arc::clone(&self.tracks);
         let pending_select = Arc::clone(&self.pending_select);
@@ -233,11 +252,9 @@ impl Queue {
                 }
             };
 
-            // Serialise the apply against a concurrent `select` (see
-            // `select_apply`): the cancelled re-check below and the
-            // `select_item` must be atomic w.r.t. a superseding select that
-            // marks this track `Cancelled`. The whole block is synchronous —
-            // the guard is never held across an `.await`.
+            // Held across the whole synchronous block (never across .await):
+            // the Cancelled re-check and select_item must be atomic w.r.t. a
+            // superseding select.
             let _apply = select_apply.lock().unwrap_or_else(PoisonError::into_inner);
 
             let was_cancelled = tracks

--- a/crates/kithara-queue/src/queue/state.rs
+++ b/crates/kithara-queue/src/queue/state.rs
@@ -1,7 +1,6 @@
-use std::{
-    collections::HashMap,
-    sync::{Arc, Mutex, PoisonError},
-};
+#[cfg(any(test, feature = "probe"))]
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, PoisonError};
 
 use kithara_events::{EventBus, EventReceiver, TrackId};
 use kithara_platform::{CancelScope, CancelToken};
@@ -14,16 +13,12 @@ use crate::{
     config::QueueConfig,
     loader::Loader,
     navigation::NavigationState,
-    track::{TrackEntry, TrackSource, Tracks},
+    track::{TrackRecord, Tracks},
 };
 
-/// Track-id keyed cache of original `TrackSource`s. Aliased so the
-/// field declaration stays free of the structural
-/// `Arc<Mutex<HashMap<…>>>` god-map pattern (see `arch.no-arc-mutex-godmap`).
-pub(super) type TrackSources = HashMap<TrackId, TrackSource>;
-
-/// Test-only respawn resource cache, same aliasing rationale as
-/// [`TrackSources`].
+/// Test-only respawn resource cache. Aliased so the field declaration
+/// stays free of the structural `Arc<Mutex<HashMap<…>>>` god-map
+/// pattern (see `arch.no-arc-mutex-godmap`).
 #[cfg(any(test, feature = "probe"))]
 pub(super) type TestResources = HashMap<TrackId, kithara_play::Resource>;
 
@@ -82,12 +77,6 @@ pub struct Queue {
     /// "Selection serialization".
     pub(super) select_apply: Arc<Mutex<()>>,
     pub(super) player: Arc<PlayerImpl>,
-    /// Kept alongside `tracks` so a `Consumed` track can be re-spawned
-    /// on re-selection (user tapping a previously-played track). The
-    /// original `TrackSource::Config` — including DRM keys and custom
-    /// net/headers — is preserved; a bare URL wouldn't be enough to
-    /// reconstruct a DRM-protected source.
-    pub(super) sources: Arc<Mutex<TrackSources>>,
     /// Test-only respawn resource cache. Populated by
     /// [`Queue::supply_test_resource_for_respawn`] and consumed by
     /// `select` when a `Consumed` / `Cancelled` / `Failed` track is
@@ -95,8 +84,9 @@ pub struct Queue {
     /// without a real loader.
     #[cfg(any(test, feature = "probe"))]
     pub(super) test_resources: Arc<Mutex<TestResources>>,
-    /// Sole owner of the `Vec<TrackEntry>`. Shared with [`Loader`]
-    /// through `Arc<Tracks>`; every status transition goes through
+    /// Sole owner of the `Vec<TrackRecord>` (status, source, and live
+    /// load attempt per track). Shared with [`Loader`] through
+    /// `Arc<Tracks>`; every status transition goes through
     /// [`Tracks::set_status`](crate::track::Tracks::set_status) so polling
     /// and the event stream stay in sync.
     pub(super) tracks: Arc<Tracks>,
@@ -166,7 +156,6 @@ impl Queue {
             navigation: Arc::new(Mutex::new(NavigationState::new())),
             pending_select: Arc::new(Mutex::new(SelectPhase::Idle)),
             select_apply: Arc::new(Mutex::new(())),
-            sources: Arc::new(Mutex::new(HashMap::new())),
             #[cfg(any(test, feature = "probe"))]
             test_resources: Arc::new(Mutex::new(HashMap::new())),
             player_rx: Mutex::new(player_rx),
@@ -207,11 +196,11 @@ impl Queue {
             .unwrap_or_else(PoisonError::into_inner)
     }
 
-    pub(super) fn lock_tracks(&self) -> std::sync::MutexGuard<'_, Vec<TrackEntry>> {
+    pub(super) fn lock_tracks(&self) -> std::sync::MutexGuard<'_, Vec<TrackRecord>> {
         self.tracks.lock()
     }
 
-    pub(super) fn lock_tracks_mut(&self) -> std::sync::MutexGuard<'_, Vec<TrackEntry>> {
+    pub(super) fn lock_tracks_mut(&self) -> std::sync::MutexGuard<'_, Vec<TrackRecord>> {
         self.tracks.lock()
     }
 

--- a/crates/kithara-queue/src/track.rs
+++ b/crates/kithara-queue/src/track.rs
@@ -1,7 +1,13 @@
-use std::sync::{Mutex, PoisonError};
+use std::sync::{
+    Mutex, PoisonError,
+    atomic::{AtomicU64, Ordering},
+};
 
 use kithara_events::{EventBus, QueueEvent, TrackId, TrackStatus};
+use kithara_platform::CancelToken;
 use kithara_play::ResourceConfig;
+
+use crate::attempts::{AttemptGuard, Ticket};
 
 /// Snapshot of a track entry in the queue.
 #[derive(Debug, Clone)]
@@ -79,17 +85,50 @@ impl From<Box<ResourceConfig>> for TrackSource {
     }
 }
 
+/// Single owner of everything the queue knows about one track. Dropping the record aborts its
+/// attempt via [`AttemptGuard`].
+pub(crate) struct TrackRecord {
+    pub(crate) id: TrackId,
+    pub(crate) name: String,
+    pub(crate) url: Option<String>,
+    pub(crate) status: TrackStatus,
+    pub(crate) source: TrackSource,
+    pub(crate) attempt: Option<AttemptGuard>,
+}
+
+impl TrackRecord {
+    pub(crate) fn new(id: TrackId, name: String, source: TrackSource) -> Self {
+        Self {
+            id,
+            name,
+            url: source.uri().map(str::to_string),
+            status: TrackStatus::Pending,
+            source,
+            attempt: None,
+        }
+    }
+
+    pub(crate) fn entry(&self) -> TrackEntry {
+        TrackEntry {
+            id: self.id,
+            name: self.name.clone(),
+            url: self.url.clone(),
+            status: self.status.clone(),
+        }
+    }
+}
+
 /// Authoritative store for the queue's track list.
 ///
-/// Single owner of `Vec<TrackEntry>`; shared between [`Queue`](crate::Queue)
+/// Single owner of `Vec<TrackRecord>`; shared between [`Queue`](crate::Queue)
 /// and [`Loader`](crate::loader::Loader) via `Arc<Tracks>`. Every status
-/// transition — `Loading` / `Slow` / `Failed` / `Loaded` / `Consumed`
-/// / `Pending` respawn — MUST go through [`Tracks::set_status`] so that
-/// the polled view (`tracks[i].status`) and the reactive
+/// transition MUST go through [`Tracks::set_status`] (or the attempt ops
+/// below) so the polled view and the reactive
 /// [`QueueEvent::TrackStatusChanged`] stream never drift.
 pub(crate) struct Tracks {
     bus: EventBus,
-    inner: Mutex<Vec<TrackEntry>>,
+    inner: Mutex<Vec<TrackRecord>>,
+    next_generation: AtomicU64,
 }
 
 impl Tracks {
@@ -97,27 +136,153 @@ impl Tracks {
         Self {
             bus,
             inner: Mutex::new(Vec::new()),
+            next_generation: AtomicU64::new(0),
         }
     }
 
-    /// Lock the underlying `Vec<TrackEntry>` for direct read/write.
+    /// Lock the underlying `Vec<TrackRecord>` for direct read/write.
     /// Callers that only need to flip status should prefer
     /// [`Self::set_status`].
-    pub(crate) fn lock(&self) -> std::sync::MutexGuard<'_, Vec<TrackEntry>> {
+    pub(crate) fn lock(&self) -> std::sync::MutexGuard<'_, Vec<TrackRecord>> {
         self.inner.lock().unwrap_or_else(PoisonError::into_inner)
     }
 
-    /// Atomically mutate `entry.status` and publish
-    /// [`QueueEvent::TrackStatusChanged`]. No-op when `id` is not
-    /// present (caller most likely raced with `Queue::remove`).
+    /// Atomically mutate `record.status` and publish
+    /// [`QueueEvent::TrackStatusChanged`]. `Cancelled` also aborts the
+    /// track's live attempt — a cancelled track never keeps loading.
+    /// No-op when `id` is not present (caller raced `Queue::remove`).
     pub(crate) fn set_status(&self, id: TrackId, status: TrackStatus) {
         let mut guard = self.lock();
-        if let Some(entry) = guard.iter_mut().find(|e| e.id == id) {
-            entry.status = status.clone();
-            drop(guard);
-            self.bus
-                .publish(QueueEvent::TrackStatusChanged { id, status });
+        let Some(record) = guard.iter_mut().find(|r| r.id == id) else {
+            return;
+        };
+        record.status = status.clone();
+        let aborted = matches!(status, TrackStatus::Cancelled)
+            .then(|| record.attempt.take())
+            .flatten();
+        drop(guard);
+        drop(aborted);
+        self.bus
+            .publish(QueueEvent::TrackStatusChanged { id, status });
+    }
+
+    /// Original source for `id`, if still queued.
+    pub(crate) fn source(&self, id: TrackId) -> Option<TrackSource> {
+        self.lock()
+            .iter()
+            .find(|r| r.id == id)
+            .map(|r| r.source.clone())
+    }
+
+    /// Register a fresh attempt. Dedupes against a live attempt; replaces
+    /// one that is already cancelled but still unwinding.
+    pub(crate) fn begin_attempt(&self, id: TrackId, cancel: CancelToken) -> Option<Ticket> {
+        let mut guard = self.lock();
+        let ticket = match guard.iter_mut().find(|r| r.id == id) {
+            Some(record)
+                if record
+                    .attempt
+                    .as_ref()
+                    .is_none_or(AttemptGuard::is_cancelled) =>
+            {
+                Some(install(record, &self.next_generation, cancel))
+            }
+            _ => None,
+        };
+        drop(guard);
+        ticket
+    }
+
+    /// Move a track's pending load into the interactive lane: replace a
+    /// still-waiting (or cancelled-but-unwinding) attempt. An attempt
+    /// already holding a permit is kept - its download is progressing.
+    /// Vacant means the attempt just finished; the completion path owns
+    /// what happens next, so no new attempt starts.
+    pub(crate) fn promote_attempt(&self, id: TrackId, cancel: CancelToken) -> Option<Ticket> {
+        let mut guard = self.lock();
+        let ticket = match guard.iter_mut().find(|r| r.id == id) {
+            Some(record)
+                if record
+                    .attempt
+                    .as_ref()
+                    .is_some_and(|a| a.waiting || a.is_cancelled()) =>
+            {
+                Some(install(record, &self.next_generation, cancel))
+            }
+            _ => None,
+        };
+        drop(guard);
+        ticket
+    }
+
+    /// Attempt won its lane permit: flip the track to `Loading`. `false`
+    /// means the ticket was replaced or cancelled while waiting - the
+    /// caller must release the permit and bail out without loading.
+    pub(crate) fn mark_loading(&self, ticket: &Ticket) -> bool {
+        let mut guard = self.lock();
+        let claimed = guard
+            .iter_mut()
+            .find(|r| r.id == ticket.id)
+            .is_some_and(|r| {
+                let Some(attempt) = r.attempt.as_mut() else {
+                    return false;
+                };
+                if attempt.generation != ticket.generation || attempt.is_cancelled() {
+                    return false;
+                }
+                attempt.waiting = false;
+                r.status = TrackStatus::Loading;
+                true
+            });
+        drop(guard);
+        if claimed {
+            self.bus.publish(QueueEvent::TrackStatusChanged {
+                id: ticket.id,
+                status: TrackStatus::Loading,
+            });
         }
+        claimed
+    }
+
+    /// Attempt finished. Disarms and removes the guard this ticket owns
+    /// (the token now belongs to the built `Resource`, or died with the
+    /// dropped load future); `failure` flips the track to `Failed`.
+    /// A stale ticket changes nothing.
+    pub(crate) fn finish_attempt(&self, ticket: &Ticket, failure: Option<String>) {
+        let mut guard = self.lock();
+        let Some(record) = guard.iter_mut().find(|r| r.id == ticket.id) else {
+            return;
+        };
+        if record
+            .attempt
+            .as_ref()
+            .is_none_or(|a| a.generation != ticket.generation)
+        {
+            return;
+        }
+        if let Some(mut attempt) = record.attempt.take() {
+            attempt.disarm();
+        }
+        let Some(reason) = failure else {
+            return;
+        };
+        record.status = TrackStatus::Failed(reason.clone());
+        drop(guard);
+        self.bus.publish(QueueEvent::TrackStatusChanged {
+            id: ticket.id,
+            status: TrackStatus::Failed(reason),
+        });
+    }
+}
+
+fn install(record: &mut TrackRecord, generations: &AtomicU64, cancel: CancelToken) -> Ticket {
+    let generation = generations.fetch_add(1, Ordering::Relaxed);
+    // Replacing the guard drops the old one armed, cancelling the
+    // superseded attempt.
+    record.attempt = Some(AttemptGuard::new(generation, cancel));
+    Ticket {
+        id: record.id,
+        generation,
     }
 }
 
@@ -145,5 +310,117 @@ mod tests {
         let src: TrackSource = cfg.into();
         assert!(matches!(src, TrackSource::Config(_)));
         assert_eq!(src.uri(), None);
+    }
+
+    fn tracks_with(id: TrackId) -> Tracks {
+        let tracks = Tracks::new(EventBus::default());
+        tracks.lock().push(TrackRecord::new(
+            id,
+            String::new(),
+            "https://x/a.mp3".into(),
+        ));
+        tracks
+    }
+
+    fn token() -> CancelToken {
+        CancelToken::never().child()
+    }
+
+    #[kithara::test]
+    fn begin_dedupes_live_attempt() {
+        let tracks = tracks_with(TrackId(1));
+        assert!(tracks.begin_attempt(TrackId(1), token()).is_some());
+        assert!(tracks.begin_attempt(TrackId(1), token()).is_none());
+    }
+
+    #[kithara::test]
+    fn begin_replaces_cancelled_unwinding_attempt() {
+        let tracks = tracks_with(TrackId(1));
+        let first_cancel = token();
+        let first = tracks
+            .begin_attempt(TrackId(1), first_cancel.clone())
+            .expect("BUG: vacant record must accept an attempt");
+        tracks.set_status(TrackId(1), TrackStatus::Cancelled);
+        assert!(first_cancel.is_cancelled(), "Cancelled must abort the load");
+        let second = tracks
+            .begin_attempt(TrackId(1), token())
+            .expect("cancelled attempt must be replaceable");
+        assert!(!tracks.mark_loading(&first), "replaced ticket loses claim");
+        assert!(tracks.mark_loading(&second));
+    }
+
+    #[kithara::test]
+    fn promote_replaces_waiting_and_cancels_it() {
+        let tracks = tracks_with(TrackId(1));
+        let parked_cancel = token();
+        let parked = tracks
+            .begin_attempt(TrackId(1), parked_cancel.clone())
+            .expect("BUG: vacant record must accept an attempt");
+        let promoted = tracks
+            .promote_attempt(TrackId(1), token())
+            .expect("waiting attempt must be promotable");
+        assert!(parked_cancel.is_cancelled(), "parked attempt must abort");
+        assert!(!tracks.mark_loading(&parked));
+        assert!(tracks.mark_loading(&promoted));
+    }
+
+    #[kithara::test]
+    fn promote_keeps_attempt_holding_permit() {
+        let tracks = tracks_with(TrackId(1));
+        let loading = tracks
+            .begin_attempt(TrackId(1), token())
+            .expect("BUG: vacant record must accept an attempt");
+        assert!(tracks.mark_loading(&loading));
+        assert!(
+            tracks.promote_attempt(TrackId(1), token()).is_none(),
+            "an attempt past the permit gate keeps its download"
+        );
+    }
+
+    #[kithara::test]
+    fn promote_vacant_is_noop() {
+        let tracks = tracks_with(TrackId(1));
+        assert!(tracks.promote_attempt(TrackId(1), token()).is_none());
+    }
+
+    #[kithara::test]
+    fn finish_disarms_and_ignores_stale_ticket() {
+        let tracks = tracks_with(TrackId(1));
+        let first_cancel = token();
+        let old = tracks
+            .begin_attempt(TrackId(1), first_cancel.clone())
+            .expect("BUG: vacant record must accept an attempt");
+        let new = tracks
+            .promote_attempt(TrackId(1), token())
+            .expect("waiting attempt must be promotable");
+        tracks.finish_attempt(&old, None);
+        assert!(tracks.mark_loading(&new), "stale finish must not evict");
+        tracks.finish_attempt(&new, None);
+        assert!(
+            tracks.begin_attempt(TrackId(1), token()).is_some(),
+            "finished attempt must leave the record vacant"
+        );
+    }
+
+    #[kithara::test]
+    fn removing_record_cancels_attempt() {
+        let tracks = tracks_with(TrackId(1));
+        let cancel = token();
+        let _ticket = tracks
+            .begin_attempt(TrackId(1), cancel.clone())
+            .expect("BUG: vacant record must accept an attempt");
+        tracks.lock().clear();
+        assert!(cancel.is_cancelled(), "dropping the record aborts the load");
+    }
+
+    #[kithara::test]
+    fn finish_with_failure_sets_failed_once() {
+        let tracks = tracks_with(TrackId(1));
+        let ticket = tracks
+            .begin_attempt(TrackId(1), token())
+            .expect("BUG: vacant record must accept an attempt");
+        tracks.finish_attempt(&ticket, Some("boom".into()));
+        let status = tracks.lock()[0].status.clone();
+        assert!(matches!(status, TrackStatus::Failed(_)));
     }
 }

--- a/crates/kithara-storage/src/backend/resource/wait.rs
+++ b/crates/kithara-storage/src/backend/resource/wait.rs
@@ -11,11 +11,11 @@ use crate::{
     resource::{WaitOutcome, range_covered_by},
 };
 
-/// Watchdog timeout for the network-bound `wait_range_inner`: must exceed
-/// the `kithara-net` `total_timeout` (default 120s) so a stalled upstream is
-/// failed by the network layer (this wait then returns `Failed`) before the
-/// deadlock-watchdog fires. Only a wait that never returns after the fetch
-/// resolved is a real deadlock.
+/// Watchdog timeout for the network-bound `wait_range_inner`: sized well
+/// above the `kithara-net` `inactivity_timeout` (plus retry backoff) so a
+/// stalled upstream is failed by the network layer (this wait then returns
+/// `Failed`) before the deadlock-watchdog fires. Only a wait that never
+/// returns after the fetch resolved is a real deadlock.
 const WAIT_HANG_TIMEOUT: Duration = Duration::from_secs(180);
 
 impl<D: DriverIo> ResourceCore<D> {

--- a/crates/kithara-stream/src/dl/tests.rs
+++ b/crates/kithara-stream/src/dl/tests.rs
@@ -171,7 +171,6 @@ async fn peer_handle_execute_returns_error_on_unreachable() {
     const CANCEL_GUARD_SECS: u64 = 2;
     let net = NetOptions::builder()
         .inactivity_timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
-        .total_timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
         .build();
     let dl = Downloader::new(
         DownloaderConfig::for_client(HttpClient::new(net, CancelToken::never())).build(),

--- a/tests/tests/kithara_file/early_stream_close.rs
+++ b/tests/tests/kithara_file/early_stream_close.rs
@@ -98,7 +98,6 @@ async fn file_stream_closes_early_seek_still_works() {
         DownloaderConfig::for_client(HttpClient::new(
             NetOptions::builder()
                 .inactivity_timeout(Duration::from_secs(1))
-                .total_timeout(Duration::from_secs(1))
                 .build(),
             CancelToken::never(),
         ))

--- a/tests/tests/kithara_file/resume_stall_budget.rs
+++ b/tests/tests/kithara_file/resume_stall_budget.rs
@@ -1,0 +1,170 @@
+#![cfg(not(target_arch = "wasm32"))]
+#![forbid(unsafe_code)]
+
+//! A file gap-resume loop that makes zero progress must surface a terminal
+//! `FileEvent::Error` within a bounded number of re-fetches. Models a host
+//! that serves the head of a file and then blackholes every follow-up.
+
+use std::{
+    io,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
+
+use axum::{
+    Router,
+    body::Body,
+    extract::State,
+    http::{HeaderMap, StatusCode, header},
+    response::Response,
+    routing::get,
+};
+use bytes::Bytes;
+use futures::stream;
+use kithara::{
+    assets::StoreOptions,
+    events::{Event, EventBus, FileEvent},
+    file::{File, FileConfig, FileSrc},
+    net::{HttpClient, NetOptions, RetryPolicy},
+    platform::{
+        CancelToken,
+        time::{self, Duration},
+    },
+    stream::{
+        Stream,
+        dl::{Downloader, DownloaderConfig},
+    },
+};
+use kithara_integration_tests::{TestHttpServer, TestTempDir, kithara};
+
+struct Consts;
+impl Consts {
+    /// Advertised full length; the stall leaves a large permanent gap.
+    const TOTAL: usize = 1_024_000;
+    /// Bytes the server actually delivers before going dark.
+    const HEAD: usize = 64 * 1024;
+    /// Short idle timeout so each dead fetch cycles quickly.
+    const INACTIVITY: Duration = Duration::from_millis(300);
+    /// Wall-clock ceiling for the terminal error. Generous against the
+    /// per-cycle cost (idle timeout + one retry) so a pass is a real
+    /// budget, not a lucky race.
+    const ERROR_DEADLINE: Duration = Duration::from_secs(20);
+}
+
+#[derive(Clone)]
+struct StallState {
+    data: Arc<Vec<u8>>,
+    gets: Arc<AtomicUsize>,
+}
+
+fn range_start(headers: &HeaderMap) -> usize {
+    headers
+        .get(header::RANGE)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("bytes="))
+        .and_then(|v| v.split('-').next())
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(0)
+}
+
+async fn serve_head_then_stall(State(state): State<StallState>, headers: HeaderMap) -> Response {
+    state.gets.fetch_add(1, Ordering::SeqCst);
+    let total = state.data.len();
+    let start = range_start(&headers).min(total);
+    let head_end = Consts::HEAD.clamp(start, total);
+    let head = Bytes::copy_from_slice(&state.data[start..head_end]);
+
+    let body = Body::from_stream(stream::unfold(Some(head), |chunk| async move {
+        match chunk {
+            Some(bytes) if !bytes.is_empty() => Some((Ok::<_, io::Error>(bytes), None)),
+            _ => std::future::pending().await,
+        }
+    }));
+
+    let mut builder = Response::builder()
+        .header(header::ACCEPT_RANGES, "bytes")
+        .header(header::CONTENT_TYPE, "audio/mpeg")
+        .header(header::CONTENT_LENGTH, (total - start).to_string());
+    builder = if start > 0 {
+        builder.status(StatusCode::PARTIAL_CONTENT).header(
+            header::CONTENT_RANGE,
+            format!("bytes {start}-{}/{total}", total - 1),
+        )
+    } else {
+        builder.status(StatusCode::OK)
+    };
+    builder.body(body).expect("stall response")
+}
+
+#[kithara::test(tokio, multi_thread, timeout(Duration::from_secs(45)))]
+async fn zero_progress_resume_loop_fails_terminally() {
+    let data: Vec<u8> = (0..Consts::TOTAL).map(|i| (i % 256) as u8).collect();
+    let gets = Arc::new(AtomicUsize::new(0));
+    let app = Router::new()
+        .route("/audio.mp3", get(serve_head_then_stall))
+        .with_state(StallState {
+            data: Arc::new(data),
+            gets: Arc::clone(&gets),
+        });
+    let server = TestHttpServer::new(app).await;
+    let url = server.url("/audio.mp3");
+
+    let temp = TestTempDir::new();
+    let cancel = CancelToken::never();
+    let downloader = Downloader::new(
+        DownloaderConfig::for_client(HttpClient::new(
+            NetOptions::builder()
+                .inactivity_timeout(Consts::INACTIVITY)
+                .retry_policy(RetryPolicy::new(
+                    1,
+                    Duration::from_millis(50),
+                    Duration::from_millis(100),
+                ))
+                .build(),
+            CancelToken::never(),
+        ))
+        .cancel(cancel.clone())
+        .build(),
+    );
+
+    // Subscribe BEFORE the stream starts so the terminal publish is not raced.
+    let bus = EventBus::new(64);
+    let mut rx = bus.subscribe();
+
+    let config = FileConfig::for_src(FileSrc::Remote(url))
+        .events(bus)
+        .store(StoreOptions::new(temp.path()))
+        .cancel(cancel)
+        .look_ahead_bytes(Consts::TOTAL as u64)
+        .downloader(downloader)
+        .build();
+    let _stream = Stream::<File>::new(config)
+        .await
+        .expect("stream opens on the reachable head");
+
+    let terminal = time::timeout(Consts::ERROR_DEADLINE, async {
+        loop {
+            match rx.recv().await {
+                Ok(Event::File(FileEvent::Error { .. })) => return true,
+                Ok(_) => {}
+                Err(_) => return false,
+            }
+        }
+    })
+    .await;
+
+    assert!(
+        matches!(terminal, Ok(true)),
+        "zero-progress gap-resume must fail terminally within {:?} \
+         (server saw {} fetches and the loop was still spinning)",
+        Consts::ERROR_DEADLINE,
+        gets.load(Ordering::SeqCst),
+    );
+    assert!(
+        gets.load(Ordering::SeqCst) >= 2,
+        "expected at least one zero-progress resume fetch, got {}",
+        gets.load(Ordering::SeqCst),
+    );
+}

--- a/tests/tests/kithara_net/http_client.rs
+++ b/tests/tests/kithara_net/http_client.rs
@@ -777,7 +777,6 @@ async fn test_net_builder_creates_functional_client() {
 async fn test_net_builder_with_custom_options() {
     let opts = NetOptions::builder()
         .inactivity_timeout(Duration::from_millis(100))
-        .total_timeout(Duration::from_millis(100))
         .retry_policy(RetryPolicy::new(
             2,
             Duration::from_millis(50),

--- a/tests/tests/kithara_play/resource_regressions.rs
+++ b/tests/tests/kithara_play/resource_regressions.rs
@@ -1371,7 +1371,6 @@ async fn live_remote_resource_decodes_with_duration(
     let store = store_options(&temp_dir, true);
     let net = NetOptions::builder()
         .inactivity_timeout(Duration::from_secs(25))
-        .total_timeout(Duration::from_secs(25))
         .build();
     let downloader = Downloader::new(
         DownloaderConfig::builder()

--- a/tests/tests/kithara_queue/loader_lanes.rs
+++ b/tests/tests/kithara_queue/loader_lanes.rs
@@ -1,0 +1,274 @@
+//! Per-track load-attempt contracts around user selection: promotion of
+//! a parked `Pending` track past a hung background lane, single download
+//! session per track, and lane release on a superseded selection.
+
+#![cfg(not(target_arch = "wasm32"))]
+#![forbid(unsafe_code)]
+
+use std::{num::NonZeroUsize, sync::Arc};
+
+use kithara::{
+    assets::StoreOptions,
+    events::{TrackId, TrackStatus},
+    net::{HttpClient, NetOptions},
+    platform::{
+        CancelToken,
+        time::{Duration, Instant, sleep},
+        tokio,
+    },
+    play::{PlayerConfig, PlayerImpl, ResourceConfig},
+    queue::{Queue, QueueConfig, TrackSource, Transition},
+    stream::dl::{Downloader, DownloaderConfig},
+};
+use kithara_integration_tests::{
+    BehaviorHandle, Content, Delivery, FixtureBehavior, TestServerHelper, TestTempDir,
+    audio_fixture::EmbeddedAudio,
+    kithara,
+    offline::OfflineSession,
+    temp_dir,
+    waits::{wait_for_loader_done, wait_for_position_at_least},
+};
+use url::Url;
+
+struct Consts;
+impl Consts {
+    /// Background lane width. One permit, so a single hung prefetch
+    /// saturates it.
+    const BG_CAP: usize = 1;
+    /// Above the probe buffer (1 `KiB`) so the probe waits for bytes, not EOF.
+    const HUNG_BODY_LEN: usize = 64 * 1024;
+    const HUNG_THROTTLE_CHUNK: usize = 1;
+    /// Past the test window and the 30s net `inactivity_timeout`, so the
+    /// load stays parked instead of failing.
+    const HUNG_THROTTLE_DELAY_MS: u64 = 600_000;
+    const GATE_DEADLINE: Duration = Duration::from_secs(15);
+    /// Short enough that a miss means starvation, not a slow load.
+    const FAST_DEADLINE: Duration = Duration::from_secs(8);
+    const PLAY_DEADLINE: Duration = Duration::from_secs(10);
+    const POLL_INTERVAL: Duration = Duration::from_millis(50);
+    /// Audible-progress threshold proving the selection actually plays.
+    const PLAY_POSITION_SECS: f64 = 0.3;
+}
+
+/// A throttled body that never delivers a byte in the test window, so the
+/// probe parks inside `Resource::new` and the load keeps its permit.
+fn register_hung(helper: &TestServerHelper) -> BehaviorHandle {
+    helper.register_behavior(FixtureBehavior {
+        content: Content::StaticBytes {
+            bytes: Arc::new(vec![0u8; Consts::HUNG_BODY_LEN]),
+            content_type: Some("audio/mpeg"),
+        },
+        delivery: Delivery::Throttle {
+            chunk: Consts::HUNG_THROTTLE_CHUNK,
+            delay_ms: Consts::HUNG_THROTTLE_DELAY_MS,
+        },
+    })
+}
+
+/// A reachable, decodable MP3 whose per-request hits the test can count.
+fn register_fast_mp3(helper: &TestServerHelper) -> BehaviorHandle {
+    helper.register_behavior(FixtureBehavior {
+        content: Content::StaticBytes {
+            bytes: Arc::new(EmbeddedAudio::TEST_MP3_BYTES.to_vec()),
+            content_type: Some("audio/mpeg"),
+        },
+        delivery: Delivery::Range,
+    })
+}
+
+fn fast_url(handle: &BehaviorHandle) -> Url {
+    handle.child_url("track.mp3")
+}
+
+fn build_queue_with_tick(
+    temp_dir: &TestTempDir,
+    cap: usize,
+) -> (
+    Arc<Queue>,
+    Downloader,
+    StoreOptions,
+    tokio::task::JoinHandle<()>,
+) {
+    let player = Arc::new(PlayerImpl::new(
+        PlayerConfig::builder()
+            .session(OfflineSession::arc_auto())
+            .build(),
+    ));
+    let cap = NonZeroUsize::new(cap).expect("BUG: cap must be > 0");
+    let queue = Arc::new(Queue::new(
+        QueueConfig::builder()
+            .max_concurrent_loads(cap)
+            .build()
+            .with_player(player),
+    ));
+    let queue_for_tick = Arc::clone(&queue);
+    let tick_handle = tokio::task::spawn(async move {
+        loop {
+            sleep(Duration::from_millis(50)).await;
+            if queue_for_tick.tick().is_err() {
+                break;
+            }
+        }
+    });
+    let downloader = Downloader::new(
+        DownloaderConfig::for_client(HttpClient::new(NetOptions::default(), CancelToken::never()))
+            .build(),
+    );
+    let store = StoreOptions::new(temp_dir.path());
+    (queue, downloader, store, tick_handle)
+}
+
+fn mk_cfg(url: &Url, downloader: &Downloader, store: &StoreOptions) -> ResourceConfig {
+    ResourceConfig::for_src(url.as_str())
+        .expect("valid fixture URL")
+        .downloader(downloader.clone())
+        .store(store.clone())
+        .build()
+}
+
+fn status_of(queue: &Queue, id: TrackId) -> Option<TrackStatus> {
+    queue.track(id).map(|e| e.status)
+}
+
+async fn wait_for_status_matching(
+    queue: &Queue,
+    id: TrackId,
+    deadline: Duration,
+    what: &str,
+    pred: impl Fn(&TrackStatus) -> bool,
+) -> Result<(), String> {
+    let start = Instant::now();
+    loop {
+        if status_of(queue, id).as_ref().is_some_and(&pred) {
+            return Ok(());
+        }
+        if start.elapsed() >= deadline {
+            return Err(format!(
+                "track {id:?} never became {what} within {deadline:?} (last={:?})",
+                status_of(queue, id)
+            ));
+        }
+        sleep(Consts::POLL_INTERVAL).await;
+    }
+}
+
+/// A `Pending` track parked behind a saturated background lane must be
+/// promoted by `select` and play, without a duplicate download session
+/// from the abandoned parked attempt.
+#[kithara::test(tokio, multi_thread, timeout(Duration::from_secs(60)))]
+async fn select_pending_track_parked_behind_hung_load_promotes() {
+    let helper = TestServerHelper::new().await;
+    let hung = register_hung(&helper);
+    let fast = register_fast_mp3(&helper);
+
+    let temp = temp_dir();
+    let (queue, downloader, store, tick_handle) = build_queue_with_tick(&temp, Consts::BG_CAP);
+
+    let hung_id = queue.append(TrackSource::Config(Box::new(mk_cfg(
+        &hung.url(),
+        &downloader,
+        &store,
+    ))));
+    wait_for_status_matching(&queue, hung_id, Consts::GATE_DEADLINE, "Loading", |s| {
+        matches!(s, TrackStatus::Loading)
+    })
+    .await
+    .unwrap_or_else(|e| panic!("hung track gate: {e}"));
+
+    // Parked: the background lane is saturated by the hung load.
+    let fast_id = queue.append(TrackSource::Config(Box::new(mk_cfg(
+        &fast_url(&fast),
+        &downloader,
+        &store,
+    ))));
+
+    queue
+        .select(fast_id, Transition::None)
+        .expect("select fast");
+
+    let load_result = wait_for_loader_done(&queue, fast_id, Consts::FAST_DEADLINE).await;
+    assert_hung_still_loading(&queue, hung_id);
+    load_result.unwrap_or_else(|e| {
+        panic!("selected Pending track stayed parked behind the hung background load: {e}")
+    });
+
+    wait_for_position_at_least(&queue, Consts::PLAY_POSITION_SECS, Consts::PLAY_DEADLINE)
+        .await
+        .unwrap_or_else(|e| panic!("promoted selection must play: {e}"));
+
+    assert_eq!(
+        fast.request_count(),
+        1,
+        "promotion must not spawn a second download session for the same track"
+    );
+
+    tick_handle.abort();
+}
+
+/// A follow-up selection is not blocked by a superseded hung one, and
+/// the superseded track ends `Cancelled`.
+#[kithara::test(tokio, multi_thread, timeout(Duration::from_secs(60)))]
+async fn superseded_hung_selection_frees_lane_for_next_select() {
+    let helper = TestServerHelper::new().await;
+    let hung = register_hung(&helper);
+    let fast = register_fast_mp3(&helper);
+
+    let temp = temp_dir();
+    let (queue, downloader, store, tick_handle) = build_queue_with_tick(&temp, Consts::BG_CAP);
+
+    let hung_id = queue.append(TrackSource::Config(Box::new(mk_cfg(
+        &hung.url(),
+        &downloader,
+        &store,
+    ))));
+    wait_for_status_matching(&queue, hung_id, Consts::GATE_DEADLINE, "Loading", |s| {
+        matches!(s, TrackStatus::Loading)
+    })
+    .await
+    .unwrap_or_else(|e| panic!("hung track gate: {e}"));
+
+    let fast_id = queue.append(TrackSource::Config(Box::new(mk_cfg(
+        &fast_url(&fast),
+        &downloader,
+        &store,
+    ))));
+
+    // The user clicks the stuck track, then gives up and clicks another.
+    queue
+        .select(hung_id, Transition::None)
+        .expect("select hung");
+    queue
+        .select(fast_id, Transition::None)
+        .expect("select fast");
+
+    wait_for_loader_done(&queue, fast_id, Consts::FAST_DEADLINE)
+        .await
+        .unwrap_or_else(|e| {
+            panic!("selection after a superseded hung selection must still load: {e}")
+        });
+    wait_for_position_at_least(&queue, Consts::PLAY_POSITION_SECS, Consts::PLAY_DEADLINE)
+        .await
+        .unwrap_or_else(|e| panic!("follow-up selection must play: {e}"));
+
+    // "select on a Loading track keeps its single attempt" is pinned
+    // deterministically by `Tracks` unit tests; a request count here
+    // would flake on legitimate stall-resume refetches of the hung URL.
+    assert!(
+        matches!(status_of(&queue, hung_id), Some(TrackStatus::Cancelled)),
+        "superseded selection must be Cancelled (last={:?})",
+        status_of(&queue, hung_id)
+    );
+
+    tick_handle.abort();
+}
+
+/// Setup invariant: the hung track must still be mid-load when the fast
+/// track resolves, otherwise the scenario did not actually exercise lane
+/// isolation.
+fn assert_hung_still_loading(queue: &Queue, hung_id: TrackId) {
+    assert!(
+        matches!(status_of(queue, hung_id), Some(TrackStatus::Loading)),
+        "setup invariant broken: hung track should still be Loading (last={:?})",
+        status_of(queue, hung_id)
+    );
+}

--- a/tests/tests/kithara_queue/loader_starvation.rs
+++ b/tests/tests/kithara_queue/loader_starvation.rs
@@ -143,7 +143,6 @@ async fn wait_until_loading(queue: &Queue, id: TrackId, deadline: Duration) -> R
 }
 
 #[kithara::test(tokio, multi_thread, timeout(Duration::from_secs(60)))]
-#[ignore = "repro for the still-open queue permit-starvation bug (hung loads hold all loader permits, starving a user-selected track); added in PR #72 without an accompanying scheduling fix — unignore when the loader-permit fairness fix lands. Run with --run-ignored."]
 async fn hung_loads_must_not_starve_user_selected_track() {
     let helper = TestServerHelper::new().await;
     let hung_urls: Vec<Url> = (0..Consts::HUNG_TRACKS)

--- a/tests/tests/kithara_queue/mod.rs
+++ b/tests/tests/kithara_queue/mod.rs
@@ -13,6 +13,7 @@ mod flac_swallow_fixture;
 mod hls_seek_cancels_stale_fetches;
 mod hls_seek_near_end_stress;
 mod hls_variant_playlists_concurrent;
+mod loader_lanes;
 mod loader_starvation;
 mod local_track_plays;
 mod rapid_scrub_decode_failure;

--- a/tests/tests/suite_light.rs
+++ b/tests/tests/suite_light.rs
@@ -52,6 +52,8 @@ mod kithara_file {
     mod file_source;
     mod html_error_cleanup;
     #[cfg(not(target_arch = "wasm32"))]
+    mod resume_stall_budget;
+    #[cfg(not(target_arch = "wasm32"))]
     mod shared_download;
     #[cfg(not(target_arch = "wasm32"))]
     mod waveform_shared_download;


### PR DESCRIPTION
## Problem

Running the standard playlist left the player unresponsive to Play / track switching. Append-time loads shared one 3-permit loader semaphore; unreachable hosts held every permit for minutes, and a user `select` (stashed as a pending select with no priority and no cancellation) did nothing.

## Changes

Three self-contained commits:

- **`feat(queue)`: isolate loader lanes and unify per-track ownership** — split the loader into two isolated permit lanes (background prefetch + a dedicated 1-permit interactive lane), so hung prefetch can never starve a user selection. Per-track state (status, source, live attempt) is folded into a single `TrackRecord` under one lock; `AttemptGuard` cancels the per-track token on drop, so `remove`/`clear` and a `Cancelled` transition abort the load with no separate call. The parallel `sources` map and standalone `AttemptRegistry` are gone.
- **`refactor(net)`: remove total_timeout** — the whole-request cap gave little over `inactivity_timeout` (which already guards connect/headers/body on both backends) and was counterproductive on streaming bodies, where a fired cap just re-sliced a large file into 120s Range-resume chunks. Removed the field, builder knob, both reqwest `req.timeout()` applications, the apple `setTimeoutIntervalForResource`, and all call sites.
- **`test(file)`: pin bounded zero-progress gap-resume** — regression pin that a stalled gap-resume fails terminally within a bounded number of re-fetches instead of looping forever.

## Testing

- New behaviour tests: `loader_starvation` (un-ignored), `loader_lanes` (promotion past a hung lane + Cancelled on supersession, asserted on real playback), plus `Tracks` unit tests covering the attempt state machine (dedupe / promote / drop-cancels-load).
- Full `cargo xtask test`: **3348 passed, 143 skipped**.

Not fixed here (out of scope, environment): unreachable staging hosts, expired DRM tokens, unfollowed 301s.
