### PR TITLE
fix(decode): find the MP3 Xing tag behind an oversized ID3v2 tag

### DIFF
--- a/crates/kithara-decode/src/gapless/mp3.rs
+++ b/crates/kithara-decode/src/gapless/mp3.rs
@@ -136,7 +136,7 @@ fn find_frame_start(data: &[u8]) -> Option<usize> {
     None
 }
 
-fn skip_id3v2(data: &[u8]) -> usize {
+pub(super) fn skip_id3v2(data: &[u8]) -> usize {
     if data.len() < 10 || &data[..3] != b"ID3" {
         return 0;
     }
@@ -236,6 +236,19 @@ mod tests {
         buf[lame_off + 22] = ((trim >> 8) & 0xFF) as u8;
         buf[lame_off + 23] = (trim & 0xFF) as u8;
         buf
+    }
+
+    #[test]
+    fn finds_the_frame_when_the_id3_tag_fits_the_buffer() {
+        let mut data = vec![0u8; 10 + 64];
+        data[..3].copy_from_slice(b"ID3");
+        data[3] = 3;
+        data[9] = 64;
+        data.extend_from_slice(&build_mpeg1_stereo_xing(576, 960));
+
+        let lame = read_lame_trim(&data).expect("BUG: LAME behind an ID3v2 tag");
+
+        assert_eq!(lame.enc_delay, 576);
     }
 
     #[test]

--- a/crates/kithara-decode/src/gapless/probe.rs
+++ b/crates/kithara-decode/src/gapless/probe.rs
@@ -97,7 +97,10 @@ pub(crate) fn probe_codec_gapless(
 fn read_mp3_probe_prefix(source: &mut dyn DecoderInput) -> Vec<u8> {
     let buffer = read_probe_window(source);
     let audio_start = skip_id3v2(&buffer);
-    if audio_start == 0 || audio_start < buffer.len() {
+    // A short window means the source ran out of ready bytes, not that the tag
+    // is long, and seeking past the download frontier reads back as EOF. Only a
+    // full window proves the tag really outgrows it.
+    if buffer.len() < Consts::WINDOW_BYTES || audio_start < Consts::WINDOW_BYTES {
         return buffer;
     }
 
@@ -107,9 +110,16 @@ fn read_mp3_probe_prefix(source: &mut dyn DecoderInput) -> Vec<u8> {
         .map_or(buffer, |_| read_probe_window(source))
 }
 
-fn read_probe_window(source: &mut dyn DecoderInput) -> Vec<u8> {
-    const WINDOW_BYTES: usize = 16 * 1024;
+struct Consts;
+
+impl Consts {
     const CHUNK_BYTES: usize = 1024;
+    const WINDOW_BYTES: usize = 16 * 1024;
+}
+
+fn read_probe_window(source: &mut dyn DecoderInput) -> Vec<u8> {
+    const WINDOW_BYTES: usize = Consts::WINDOW_BYTES;
+    const CHUNK_BYTES: usize = Consts::CHUNK_BYTES;
 
     let mut buffer = Vec::with_capacity(WINDOW_BYTES);
     let mut scratch = [0u8; CHUNK_BYTES];
@@ -155,6 +165,18 @@ mod tests {
 
         assert_eq!(buffer.first().copied(), Some(0xFF));
         assert_eq!(buffer.get(1).copied(), Some(0xFB));
+    }
+
+    #[test]
+    fn probe_window_stays_put_when_the_source_ends_inside_the_tag() {
+        let mut data = mp3_behind_id3(32 * 1024);
+        data.truncate(4 * 1024);
+        let mut source = Cursor::new(data);
+
+        let buffer = read_mp3_probe_prefix(&mut source);
+
+        assert_eq!(buffer.first().copied(), Some(b'I'));
+        assert_eq!(buffer.len(), 4 * 1024);
     }
 
     #[test]

--- a/crates/kithara-decode/src/gapless/probe.rs
+++ b/crates/kithara-decode/src/gapless/probe.rs
@@ -6,7 +6,11 @@ use kithara_stream::AudioCodec;
 
 #[cfg(all(feature = "apple", any(target_os = "macos", target_os = "ios")))]
 use super::mp3::read_xing_duration;
-use super::{GaplessInfo, mp3::read_lame_trim, mp4::probe_mp4_gapless_dyn};
+use super::{
+    GaplessInfo,
+    mp3::{read_lame_trim, skip_id3v2},
+    mp4::probe_mp4_gapless_dyn,
+};
 use crate::traits::{DecoderInput, InputReadOutcome};
 
 #[cfg(all(feature = "apple", any(target_os = "macos", target_os = "ios")))]
@@ -86,7 +90,24 @@ pub(crate) fn probe_codec_gapless(
     }
 }
 
+/// Xing/Info and LAME live in the first audio frame, which an `ID3v2` tag can
+/// push past the probe window: cover art alone reaches hundreds of kilobytes.
+/// The tag declares its own length, so skip to the first audio byte and read
+/// the window there instead of widening it.
 fn read_mp3_probe_prefix(source: &mut dyn DecoderInput) -> Vec<u8> {
+    let buffer = read_probe_window(source);
+    let audio_start = skip_id3v2(&buffer);
+    if audio_start == 0 || audio_start < buffer.len() {
+        return buffer;
+    }
+
+    u64::try_from(audio_start)
+        .ok()
+        .filter(|offset| source.seek(SeekFrom::Start(*offset)).is_ok())
+        .map_or(buffer, |_| read_probe_window(source))
+}
+
+fn read_probe_window(source: &mut dyn DecoderInput) -> Vec<u8> {
     const WINDOW_BYTES: usize = 16 * 1024;
     const CHUNK_BYTES: usize = 1024;
 
@@ -103,4 +124,47 @@ fn read_mp3_probe_prefix(source: &mut dyn DecoderInput) -> Vec<u8> {
         }
     }
     buffer
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::*;
+
+    /// An `ID3v2` tag of `payload_len` bytes followed by one MPEG sync word,
+    /// so a probe that stops inside the tag yields no frame at all.
+    fn mp3_behind_id3(payload_len: usize) -> Vec<u8> {
+        let mut data = vec![0u8; 10 + payload_len];
+        data[..3].copy_from_slice(b"ID3");
+        data[3] = 3;
+        let len = u32::try_from(payload_len).expect("test tag fits u32");
+        data[6] = ((len >> 21) & 0x7f) as u8;
+        data[7] = ((len >> 14) & 0x7f) as u8;
+        data[8] = ((len >> 7) & 0x7f) as u8;
+        data[9] = (len & 0x7f) as u8;
+        data.extend_from_slice(&[0xFF, 0xFB, 0x90, 0x00]);
+        data
+    }
+
+    #[test]
+    fn probe_window_starts_at_the_audio_behind_an_oversized_id3_tag() {
+        let mut source = Cursor::new(mp3_behind_id3(32 * 1024));
+
+        let buffer = read_mp3_probe_prefix(&mut source);
+
+        assert_eq!(buffer.first().copied(), Some(0xFF));
+        assert_eq!(buffer.get(1).copied(), Some(0xFB));
+    }
+
+    #[test]
+    fn probe_window_keeps_a_tag_that_fits_it() {
+        let tag_bytes = 10 + 1024;
+        let mut source = Cursor::new(mp3_behind_id3(1024));
+
+        let buffer = read_mp3_probe_prefix(&mut source);
+
+        assert_eq!(buffer.first().copied(), Some(b'I'));
+        assert_eq!(buffer.get(tag_bytes).copied(), Some(0xFF));
+    }
 }


### PR DESCRIPTION
## Summary
Some tracks played with no progress bar and no way to seek. The cause was not
the network or the file: the reported track was a well-formed MPEG-1 Layer III
320 kbps stream with a valid `Info`+LAME header, served with `content-length`
and `accept-ranges: bytes`. What made it different was a 471 KiB `ID3v2` tag —
cover art — that pushes the first audio frame far into the file.

The gapless probe read a fixed 16 KiB window from byte 0. With a tag that
large, the window holds nothing but tag bytes: `find_frame_start` skips ahead by
the declared tag length, lands past the end of the buffer, and both
`read_xing_duration` and `read_lame_trim` return `None`. On Apple this is fatal
for the duration, because MP3 deliberately opens through `open_streaming` — a
complete open would make `AudioFileServices` scan the whole file to build a
packet table — so `total_packets` is `None` and `TrackInfo.duration` rests
entirely on the Xing hint. No duration means no progress to render and nothing
to seek through; the LAME gapless trim was silently lost as well.

The probe now uses what the tag itself declares: if the window came back full
and the tag ends beyond it, seek to the first audio byte and read the window
there. The window is not widened, so no extra bytes are fetched for ordinary
files. The second commit narrows that condition after the suite caught a
regression of the first cut: on a streaming source a short window means the
bytes have not arrived yet, not that the tag is long, and seeking to the
declared tag end landed past the download frontier, where the follow-up read
reads back as EOF.

## Behavior / scope
- contract or behavior: MP3 startup metadata (Xing/Info duration hint and LAME
  gapless trim) is now found regardless of `ID3v2` tag size. Files whose tag
  fits the probe window, and sources that stop mid-tag, keep their previous
  behavior byte for byte.
- affected area: `kithara-decode` gapless probe (`gapless/probe.rs`,
  `gapless/mp3.rs`). The Apple demuxer, the streaming open, and every other
  codec path are untouched.

## Validation
- `just test all` — 4207 tests run: 4207 passed, 146 skipped
- `cargo test -p kithara-decode --lib gapless::` — 44 passed
- verified the regression test fails without the fix: reverting the skip makes
  `probe_window_starts_at_the_audio_behind_an_oversized_id3_tag` fail while the
  other probe tests stay green
- an earlier run of the suite failed `live_ephemeral_small_cache_seek_stress_drm_hw`
  (HLS/FLAC, HangDetector on `recv_outcome_blocking`); it passed in the runs
  before and after, and it does not reach this MP3-only code path
- not run: on-device playback of the reporting track was exercised manually
  through the iOS host app, not by an automated test

## Surface impact
- Public API: none
- Platform/runtime: none — no platform-specific code changed; the MP3 duration
  hint simply becomes available on Apple where it previously went missing
- Perf-sensitive paths: changed: startup probe for MP3 only. Files with a small
  tag read exactly as before; a file whose tag exceeds 16 KiB now performs one
  extra seek plus one window read instead of returning nothing useful.

## Risks / follow-ups
- The probe still gives up when a source stops inside an oversized tag, so a
  track that starts playing before the tag is fully downloaded keeps its
  duration until the next probe. Widening that would require the probe to wait
  on the source, which the startup path deliberately avoids.
