### PR TITLE
fix(app): match the deck EQ layout to the knobs the studio draws

### DIFF
--- a/crates/kithara-app/app.yaml
+++ b/crates/kithara-app/app.yaml
@@ -13,7 +13,6 @@
 
 playback:
   crossfade_seconds: 5.0
-  eq_band_count: 10
 
 network:
   should_accept_invalid_certs: true

--- a/crates/kithara-app/build.rs
+++ b/crates/kithara-app/build.rs
@@ -29,7 +29,6 @@ struct AppConfig {
 #[derive(Deserialize)]
 struct Playback {
     crossfade_seconds: f32,
-    eq_band_count: usize,
 }
 
 #[derive(Deserialize)]
@@ -188,12 +187,6 @@ fn emit_scalars(code: &mut String, app: &AppConfig) {
         code,
         "pub const BAKED_CROSSFADE_SECONDS: f32 = {:?};",
         app.playback.crossfade_seconds
-    )
-    .expect("write to String never fails");
-    writeln!(
-        code,
-        "pub const BAKED_EQ_BAND_COUNT: usize = {};",
-        app.playback.eq_band_count
     )
     .expect("write to String never fails");
     writeln!(

--- a/crates/kithara-app/src/config.rs
+++ b/crates/kithara-app/src/config.rs
@@ -58,9 +58,6 @@ pub struct AppConfig {
     /// Crossfade duration in seconds.
     #[builder(default = baked::BAKED_CROSSFADE_SECONDS)]
     pub crossfade_seconds: f32,
-    /// Number of EQ bands for the UI.
-    #[builder(default = baked::BAKED_EQ_BAND_COUNT)]
-    pub eq_band_count: usize,
     /// Source beat-analysis tunables.
     #[builder(default)]
     pub beat_analysis: BeatAnalysisConfig<PlaybackResamplerBackend>,
@@ -87,7 +84,6 @@ impl fmt::Debug for AppConfig {
                 &self.should_accept_invalid_certs,
             )
             .field("crossfade_seconds", &self.crossfade_seconds)
-            .field("eq_band_count", &self.eq_band_count)
             .field("beat_analysis", &self.beat_analysis)
             .field("size_probe_method", &self.size_probe_method)
             .finish_non_exhaustive()

--- a/crates/kithara-app/src/deck.rs
+++ b/crates/kithara-app/src/deck.rs
@@ -7,6 +7,9 @@ use kithara_queue::{Queue, QueueConfig};
 
 use crate::{config::AppConfig, mix::MixState};
 
+/// The DJ isolator every deck runs, and the knobs the studio draws for it.
+pub const EQ_BANDS: [&str; 3] = ["low", "mid", "high"];
+
 /// App-local deck identity; never crosses into a shared playback crate.
 ///
 /// Stable for the deck's lifetime: decks come and go at runtime, so an id is
@@ -33,7 +36,7 @@ impl Deck {
             PlayerConfig::builder()
                 .cancel(config.shutdown.child())
                 .crossfade_duration(config.crossfade_seconds)
-                .eq_layout(generate_log_spaced_bands(config.eq_band_count))
+                .eq_layout(generate_log_spaced_bands(EQ_BANDS.len()))
                 .byte_pool(config.byte_pool.clone())
                 .pcm_pool(config.pcm_pool.clone())
                 .session(session.dispatcher())

--- a/crates/kithara-app/src/gui/studio_reads/deck.rs
+++ b/crates/kithara-app/src/gui/studio_reads/deck.rs
@@ -3,6 +3,7 @@ use num_traits::cast::AsPrimitive;
 
 use super::value::Value;
 use crate::{
+    deck::EQ_BANDS,
     gui::{
         deck::{DeckView, TEMPO_RANGE, TimestretchState},
         studio_ui::{
@@ -166,12 +167,7 @@ struct EqNode<'a> {
 
 impl<'a> Node<'a> for EqNode<'a> {
     fn child(&self, segment: &str, _scope: Scope<'_>) -> Option<Box<dyn Node<'a> + 'a>> {
-        let band = match segment {
-            "low" => 0,
-            "mid" => 1,
-            "high" => 2,
-            _ => return None,
-        };
+        let band = EQ_BANDS.iter().position(|knob| *knob == segment)?;
         let value = eq_value(self.ui.eq_bands.get(band))?;
         Some(Box::new(Value(value)))
     }

--- a/crates/kithara-app/src/gui/studio_ui/events.rs
+++ b/crates/kithara-app/src/gui/studio_ui/events.rs
@@ -7,7 +7,7 @@ use super::{
     scope::deck_index,
 };
 use crate::{
-    deck::DeckId,
+    deck::{DeckId, EQ_BANDS},
     gui::{
         app::Kithara,
         deck::{DeckMsg, TEMPO_STEP},
@@ -131,9 +131,7 @@ fn strip_control(state: &Kithara, control: &str, action: &ControlAction) -> Opti
         ("volume", ControlAction::SetScalar(trim)) => {
             Message::Mix(MixMsg::Trim(id, trim.clamp(0.0, 1.0).as_()))
         }
-        ("low", ControlAction::SetScalar(value)) => Message::Deck(id, eq_msg(0, *value)),
-        ("mid", ControlAction::SetScalar(value)) => Message::Deck(id, eq_msg(1, *value)),
-        ("high", ControlAction::SetScalar(value)) => Message::Deck(id, eq_msg(2, *value)),
+        (_, ControlAction::SetScalar(value)) => Message::Deck(id, eq_msg(eq_band(name)?, *value)),
         _ => return None,
     };
     Some(msg)
@@ -159,6 +157,10 @@ fn library_control(state: &mut Kithara, control: &str, action: &ControlAction) -
 
 fn deck_id(state: &Kithara, index: usize) -> Option<DeckId> {
     state.session.decks().get(index).map(|deck| deck.id)
+}
+
+fn eq_band(knob: &str) -> Option<usize> {
+    EQ_BANDS.iter().position(|name| *name == knob)
 }
 
 fn eq_msg(band: usize, normalized: f64) -> DeckMsg {

--- a/crates/kithara-app/src/gui/studio_ui/tests.rs
+++ b/crates/kithara-app/src/gui/studio_ui/tests.rs
@@ -6,6 +6,7 @@ use kithara_ui::{
 };
 
 use super::{cache::DeckLayout, compile::compile_studio};
+use crate::deck::EQ_BANDS;
 
 const LAYOUTS: [DeckLayout; 2] = [DeckLayout::Single, DeckLayout::Dual];
 
@@ -217,7 +218,7 @@ fn every_channel_strip_carries_the_supported_control_set() {
     let ui = compile_studio(DeckLayout::Dual).unwrap();
     let paths = control_paths(&ui);
     for letter in ["a", "b"] {
-        for name in ["low", "mid", "high", "volume"] {
+        for name in EQ_BANDS.into_iter().chain(["volume"]) {
             let want = format!("mixer/{letter}/{name}");
             assert!(paths.contains(&want.as_str()), "missing control `{want}`");
         }


### PR DESCRIPTION
## Summary
Turning all three deck EQ knobs to the bottom left the deck playing. The deck ran a
10-band EQ built from `eq_band_count: 10` in `app.yaml`, while the studio surfaces
exactly three knobs hard-wired to bands 0, 1 and 2, so bands 3..9 were unreachable and
stayed at 0 dB. Killing the three reachable bands high-passed the deck at roughly
300 Hz rather than silencing it: measured through `EqEffect`, 40 Hz landed at -106 dB,
250 Hz at -10.5 dB, and everything from 800 Hz up passed at unity. The kick fundamental
went away while its body and click stayed, which is what the knocking sounds like. The
previous GUI drew one fader per band, so all-down reached every band and hit the
`silence_active` fast path; the three-knob studio introduced in #121 did not.

The knob table is now the single source of truth. `EQ_BANDS` lists the isolator bands by
the control id the studio draws for each one, the deck builds its layout from its length,
and both the write path and the read binding resolve a knob to a band through it, instead
of each keeping its own copy of the mapping. `eq_band_count` is gone from `app.yaml`, the
bake in `build.rs` and `AppConfig` - the band count is no longer a free parameter that can
drift away from the UI that has to reach it.

## Behavior / scope
- contract or behavior: a deck runs a three-band DJ isolator (crossovers at roughly 250 Hz
  and 4.3 kHz) instead of a 10-band EQ; all three knobs at the bottom silence the deck.
- affected area: `kithara-app` only - deck construction and the studio's EQ bindings.

## Validation
- `cargo test -p kithara-app --features gui --lib` (72 passed)
- `cargo clippy -p kithara-app --features gui --all-targets -- -D warnings` (clean)
- `cargo fmt -p kithara-app -- --check`
- `cargo check -p kithara-app --no-default-features --features tui,client-reqwest,tls-rustls`
- `cargo check --workspace --all-targets`
- `just test` on an earlier revision of this branch: 4202/4204, the two failures were the
  HLS stress tests `vod_manual_switch_affects_future_segments` and
  `live_ephemeral_small_cache_seek_stress_hls_sw`, both unrelated to EQ and both passing in
  isolation.
- `just lint fast` stops at its `ast-grep` step because the binary is not installed on this
  machine; every step before it passed.
- The desktop GUI was built and launched (`cargo run -p kithara-app -- --mode gui`).

## Surface impact
- Public API: changed: `kithara-app` exposes `deck::EQ_BANDS`; `AppConfig::eq_band_count`
  and the baked `BAKED_EQ_BAND_COUNT` are removed.
- Platform/runtime: changed: native app. The `playback.eq_band_count` key is dropped from
  `app.yaml`; the config schema does not deny unknown fields, so an existing local
  `app.yaml` that still carries the key is ignored rather than rejected.
- Perf-sensitive paths: changed: the deck's EQ now runs 3 bands instead of 10, so the
  crossover chain in the audio callback is shorter.

## Risks / follow-ups
- `EQ_MIN_DB` in `gui/studio_ui/endpoints.rs` still duplicates `MIN_GAIN_DB` from
  `kithara-audio`, which is not exported from that crate. If the kill threshold in the
  audio crate ever moves below -24 dB, the knobs stop reaching it. Exporting the constant
  would remove the duplicate.
- `kithara-ffi` keeps its own `eq_band_count: 10` default for the iOS/web surfaces; those
  surfaces draw their own EQ and are untouched here.
