### PR TITLE
fix(app): an EQ band is flat when its knob points straight up

### DIFF
--- a/crates/kithara-app/src/gui/studio_reads/deck.rs
+++ b/crates/kithara-app/src/gui/studio_reads/deck.rs
@@ -8,7 +8,7 @@ use crate::{
         deck::{DeckView, TEMPO_RANGE, TimestretchState},
         studio_ui::{
             cache::{DeckCache, analysis_bpm},
-            endpoints::{EQ_MAX_DB, EQ_MIN_DB},
+            endpoints::knob_from_db,
             scope::deck_index,
         },
         view::playhead,
@@ -277,7 +277,5 @@ fn title(ui: &UiState) -> Option<&str> {
 }
 
 fn eq_value(db: Option<&f32>) -> Option<ReadValue<'static>> {
-    let db = *db?;
-    let normalized = (db - EQ_MIN_DB) / (EQ_MAX_DB - EQ_MIN_DB);
-    Some(ReadValue::Scalar(f64::from(normalized.clamp(0.0, 1.0))))
+    Some(ReadValue::Scalar(f64::from(knob_from_db(*db?))))
 }

--- a/crates/kithara-app/src/gui/studio_ui/endpoints.rs
+++ b/crates/kithara-app/src/gui/studio_ui/endpoints.rs
@@ -4,19 +4,15 @@ use kithara_ui::{
 };
 
 /// EQ knob travel in dB: knob `0.0` is `EQ_MIN_DB`, knob `0.5` is unity, knob
-/// `1.0` is `EQ_MAX_DB`. Each half of the travel spans its own side of unity,
-/// so the cut half resolves coarser per degree than the boost half.
+/// `1.0` is `EQ_MAX_DB`.
 pub(in crate::gui) const EQ_MIN_DB: f32 = -24.0;
 pub(in crate::gui) const EQ_MAX_DB: f32 = 6.0;
 
-/// Band gain the knob at `knob` asks for. Canonical owner of the EQ travel;
-/// [`knob_from_db`] is its inverse.
 pub(in crate::gui) fn db_from_knob(knob: f32) -> f32 {
     let offset = knob.clamp(0.0, 1.0) - 0.5;
     2.0 * offset * half_span(offset)
 }
 
-/// Knob position that reads back the band gain `db`.
 pub(in crate::gui) fn knob_from_db(db: f32) -> f32 {
     let db = db.clamp(EQ_MIN_DB, EQ_MAX_DB);
     0.5 + db / (2.0 * half_span(db))

--- a/crates/kithara-app/src/gui/studio_ui/endpoints.rs
+++ b/crates/kithara-app/src/gui/studio_ui/endpoints.rs
@@ -3,9 +3,28 @@ use kithara_ui::{
     registry::{EndpointCategory, EndpointDesc, EndpointRegistry, ValueKind},
 };
 
-/// EQ knob travel in dB: knob `0.0` is `EQ_MIN_DB`, knob `1.0` is `EQ_MAX_DB`.
+/// EQ knob travel in dB: knob `0.0` is `EQ_MIN_DB`, knob `0.5` is unity, knob
+/// `1.0` is `EQ_MAX_DB`. Each half of the travel spans its own side of unity,
+/// so the cut half resolves coarser per degree than the boost half.
 pub(in crate::gui) const EQ_MIN_DB: f32 = -24.0;
 pub(in crate::gui) const EQ_MAX_DB: f32 = 6.0;
+
+/// Band gain the knob at `knob` asks for. Canonical owner of the EQ travel;
+/// [`knob_from_db`] is its inverse.
+pub(in crate::gui) fn db_from_knob(knob: f32) -> f32 {
+    let offset = knob.clamp(0.0, 1.0) - 0.5;
+    2.0 * offset * half_span(offset)
+}
+
+/// Knob position that reads back the band gain `db`.
+pub(in crate::gui) fn knob_from_db(db: f32) -> f32 {
+    let db = db.clamp(EQ_MIN_DB, EQ_MAX_DB);
+    0.5 + db / (2.0 * half_span(db))
+}
+
+fn half_span(side: f32) -> f32 {
+    if side < 0.0 { -EQ_MIN_DB } else { EQ_MAX_DB }
+}
 
 struct Endpoint {
     scopes: &'static [&'static str],
@@ -324,5 +343,34 @@ impl EndpointRegistry for StudioRegistry {
             .iter()
             .find(|entry| entry.endpoint.category == category && entry.endpoint.id == id.0)
             .map(|entry| &entry.desc)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use kithara_test_utils::kithara;
+
+    use super::*;
+
+    const STEPS: usize = 256;
+
+    #[kithara::test]
+    fn unity_gain_sits_at_the_middle_of_the_knob_travel() {
+        assert_eq!(knob_from_db(0.0), 0.5);
+        assert_eq!(db_from_knob(0.5), 0.0);
+        assert_eq!(db_from_knob(0.0), EQ_MIN_DB);
+        assert_eq!(db_from_knob(1.0), EQ_MAX_DB);
+    }
+
+    #[kithara::test]
+    fn reading_back_a_written_gain_lands_on_the_same_knob_position() {
+        for step in 0..=STEPS {
+            let knob = step as f32 / STEPS as f32;
+            let round_trip = knob_from_db(db_from_knob(knob));
+            assert!(
+                (round_trip - knob).abs() < 1e-6,
+                "knob {knob} came back as {round_trip}"
+            );
+        }
     }
 }

--- a/crates/kithara-app/src/gui/studio_ui/events.rs
+++ b/crates/kithara-app/src/gui/studio_ui/events.rs
@@ -3,7 +3,7 @@ use num_traits::cast::AsPrimitive;
 
 use super::{
     cache::{DeckLayout, StudioCache},
-    endpoints::{EQ_MAX_DB, EQ_MIN_DB},
+    endpoints::db_from_knob,
     scope::{deck_index, eq_band},
 };
 use crate::{
@@ -214,9 +214,8 @@ fn deck_id(state: &Kithara, index: usize) -> Option<DeckId> {
     state.session.decks().get(index).map(|deck| deck.id)
 }
 
-fn eq_msg(band: usize, normalized: f64) -> DeckMsg {
-    let normalized: f32 = normalized.clamp(0.0, 1.0).as_();
-    DeckMsg::EqBandChanged(band, normalized.mul_add(EQ_MAX_DB - EQ_MIN_DB, EQ_MIN_DB))
+fn eq_msg(band: usize, knob: f64) -> DeckMsg {
+    DeckMsg::EqBandChanged(band, db_from_knob(knob.as_()))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What

An EQ knob at rest pointed sideways instead of straight up, and a double-click
on it made the deck quieter. Both come from one mapping: the knob travel was
linear across the `-24..+6 dB` band range, so unity gain landed at `0.8` of the
travel while three separate places already treat `0.5` as neutral — the dial's
double-click reset, the arc-fill origin in the skin, and the eye.

The travel is now piecewise: each half spans its own side of unity.

## Highlights

- A freshly loaded deck shows its bands flat — pointer up, arc empty — instead of lifted by a third of the travel.
- A double-click on a band returns it to `0 dB` rather than parking it at `-9 dB` while the dial claims neutral.
- Full travel still reaches the same ends: `-24 dB` cut, `+6 dB` boost. The cut half is coarser per degree than the boost half, which is where a DJ EQ wants its resolution anyway.
- The mapping and its inverse now live next to the range they describe, sharing one half-span, so a read cannot drift from the write that produced it. The two hand-written inverse expressions in `studio_reads` and `studio_ui` are gone.

## Validation

- `just test` — 4463 passed, 146 skipped.
- `just lint fast` — 0 regressions, 0 new.
- Two tests on the travel: unity sits mid-travel with both ends intact, and a written gain reads back to the same knob position across the range.
- Checked by hand in the desktop app: the knobs behave as described above.
