### PR TITLE
fix(ci): trust the platform certificate store for GitLab

### DIFF
--- a/ci/bridge/config.example.toml
+++ b/ci/bridge/config.example.toml
@@ -3,7 +3,6 @@ github_app_id = 1
 github_installation_id = 1
 github_private_key = "/path/to/github-app.pem"
 github_repo = "zvuk/kithara"
-gitlab_ca_file = "/path/to/gitlab-ca.crt"
 gitlab_project_id = 1
 gitlab_project_path = "group/kithara"
 gitlab_token_file = "/path/to/gitlab-token"

--- a/docs/guides/ci-host.md
+++ b/docs/guides/ci-host.md
@@ -76,8 +76,15 @@ Create four project runner authentication tokens in corporate GitLab:
 Each token file must contain one `glrt-...` token and have mode `0600`. Also
 create `~/.config/kithara-ci/cilicon-ssh.password` with the SSH password of the
 pinned Cilicon image and mode `0600`; this value is written only to the local
-`cilicon.yml`. Install the corporate CA as
-`~/.config/kithara-ci/gitlab-ca.crt`, then run:
+`cilicon.yml`.
+
+GitLab is reached over its public certificate chain, so runners, Cilicon
+guests, and the bridge all validate `gitlab_url` against the platform trust
+store. No private CA is installed or configured anywhere. A host that cannot
+build that chain is a network fault to fix upstream, never a certificate to
+add here and never a reason to relax TLS verification.
+
+Then run:
 
 ```text
 /Volumes/KitharaCI/services/bin/kithara-ci ci host configure-runners
@@ -112,7 +119,7 @@ Android, and web checks.
 Copy `ci/bridge/config.example.toml` to
 `/Volumes/KitharaCI/services/bridge/config.toml`. The config, GitHub App key,
 and GitLab token must belong to UID 504 (`kithara-sync`) and have mode `0600`.
-The GitLab CA may be read-only. Validate without network mutation:
+Validate without network mutation:
 
 ```text
 /Volumes/KitharaCI/services/bin/kithara-ci ci bridge validate --config /Volumes/KitharaCI/services/bridge/config.toml

--- a/xtask/src/ci/bridge/api.rs
+++ b/xtask/src/ci/bridge/api.rs
@@ -11,7 +11,7 @@ use base64::{
     engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
 };
 use reqwest::{
-    Certificate, Method, Url,
+    Method, Url,
     blocking::{Client, RequestBuilder},
 };
 use serde_json::{Value, json};
@@ -28,14 +28,10 @@ struct Api {
 }
 
 impl Api {
-    fn new(ca_pem: Option<&[u8]>) -> Result<Self> {
-        let mut builder = Client::builder()
+    fn new() -> Result<Self> {
+        let builder = Client::builder()
             .timeout(Duration::from_secs(60))
             .user_agent("kithara-git-bridge/1");
-        if let Some(pem) = ca_pem {
-            let certificate = Certificate::from_pem(pem).context("parsing configured GitLab CA")?;
-            builder = builder.add_root_certificate(certificate);
-        }
         Ok(Self {
             client: builder.build().context("building bridge HTTP client")?,
         })
@@ -89,7 +85,7 @@ impl Github {
     pub(super) fn new(config: &BridgeConfig) -> Result<Self> {
         Ok(Self {
             config: config.clone(),
-            api: Api::new(None)?,
+            api: Api::new()?,
         })
     }
 
@@ -239,11 +235,9 @@ impl Gitlab {
         if token.is_empty() {
             bail!("GitLab token file is empty");
         }
-        let ca = fs::read(&config.gitlab_ca_file)
-            .with_context(|| format!("reading GitLab CA {}", config.gitlab_ca_file.display()))?;
         Ok(Self {
             config: config.clone(),
-            api: Api::new(Some(&ca))?,
+            api: Api::new()?,
             token,
         })
     }

--- a/xtask/src/ci/bridge/command.rs
+++ b/xtask/src/ci/bridge/command.rs
@@ -48,7 +48,6 @@ pub(super) struct BridgeConfig {
     pub(super) gitlab_project_path: String,
     pub(super) gitlab_username: String,
     pub(super) gitlab_token_file: PathBuf,
-    pub(super) gitlab_ca_file: PathBuf,
     pub(super) branch: String,
     pub(super) state_dir: PathBuf,
     #[serde(default = "default_pipeline_timeout_seconds")]
@@ -83,7 +82,6 @@ impl BridgeConfig {
         for (label, path) in [
             ("GitHub App private key", &self.github_private_key),
             ("GitLab token", &self.gitlab_token_file),
-            ("GitLab CA", &self.gitlab_ca_file),
         ] {
             if !regular_file(path) {
                 bail!("{label} not found: {}", path.display());
@@ -161,7 +159,26 @@ fn default_pipeline_poll_seconds() -> u64 {
 mod tests {
     use clap::Parser;
 
+    use super::BridgeConfig;
     use crate::Cli;
+
+    fn example() -> String {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .join("ci/bridge/config.example.toml");
+        std::fs::read_to_string(path).unwrap()
+    }
+
+    #[test]
+    fn bridge_config_trusts_the_platform_store_only() {
+        toml::from_str::<BridgeConfig>(&example()).unwrap();
+        let with_ca = format!("{}gitlab_ca_file = \"/path/to/ca.crt\"\n", example());
+        assert!(
+            toml::from_str::<BridgeConfig>(&with_ca).is_err(),
+            "bridge config must reject a private CA instead of silently ignoring it"
+        );
+    }
 
     #[test]
     fn bridge_requires_an_explicit_operation() {

--- a/xtask/src/ci/bridge/git.rs
+++ b/xtask/src/ci/bridge/git.rs
@@ -50,7 +50,6 @@ impl GitRepo {
                 ),
             ],
             Some(github.git_header()?),
-            None,
         )?;
 
         let gitlab_url = format!(
@@ -70,7 +69,6 @@ impl GitRepo {
                 ),
             ],
             Some(gitlab.git_header()),
-            Some(&self.config.gitlab_ca_file),
         )?;
         Ok(())
     }
@@ -118,7 +116,6 @@ impl GitRepo {
         self.run(
             &["push", &url, &format!("{sha}:refs/heads/{destination}")],
             Some(gitlab.git_header()),
-            Some(&self.config.gitlab_ca_file),
         )?;
         Ok(())
     }
@@ -132,17 +129,11 @@ impl GitRepo {
                 &format!("{sha}:refs/heads/{}", self.config.branch),
             ],
             Some(github.git_header()?),
-            None,
         )?;
         Ok(())
     }
 
-    fn run(
-        &self,
-        args: &[&str],
-        header: Option<String>,
-        ca_file: Option<&Path>,
-    ) -> Result<Vec<u8>> {
+    fn run(&self, args: &[&str], header: Option<String>) -> Result<Vec<u8>> {
         let mut command = Command::new("git");
         command.current_dir(&self.root).args(args);
         if let Some(header) = header {
@@ -150,9 +141,6 @@ impl GitRepo {
                 .env("GIT_CONFIG_COUNT", "1")
                 .env("GIT_CONFIG_KEY_0", "http.extraHeader")
                 .env("GIT_CONFIG_VALUE_0", header);
-        }
-        if let Some(ca_file) = ca_file {
-            command.env("GIT_SSL_CAINFO", ca_file);
         }
         let output = command
             .output()

--- a/xtask/src/ci/config/host.rs
+++ b/xtask/src/ci/config/host.rs
@@ -139,12 +139,6 @@ impl CiHost {
         self.gitlab_url.as_str().trim_end_matches('/').to_string()
     }
 
-    pub(crate) fn gitlab_host(&self) -> Result<&str> {
-        self.gitlab_url
-            .host_str()
-            .context("gitlab_url has no hostname")
-    }
-
     pub(crate) fn brew_tool(&self, name: &str) -> PathBuf {
         self.brew_root.join("bin").join(name)
     }

--- a/xtask/src/ci/host/runner_guest.rs
+++ b/xtask/src/ci/host/runner_guest.rs
@@ -55,21 +55,6 @@ impl RunnerManager<'_> {
             ],
             "install guest host profile",
         )?;
-        sudo(
-            &["install", "-d", "-m", "0755", "/etc/gitlab-runner/certs"],
-            "create guest runner CA directory",
-        )?;
-        let ca_name = format!("{}.crt", self.config.host.gitlab_host()?);
-        sudo(
-            &[
-                "install",
-                "-m",
-                "0644",
-                path_text(&shared.join("kithara-certs").join(&ca_name))?,
-                path_text(&Path::new("/etc/gitlab-runner/certs").join(&ca_name))?,
-            ],
-            "install guest runner CA",
-        )?;
         let xcode =
             self.process
                 .capture("/usr/bin/xcodebuild", &["-version"], "guest Xcode version")?;

--- a/xtask/src/ci/host/runners.rs
+++ b/xtask/src/ci/host/runners.rs
@@ -29,12 +29,8 @@ impl<'a> RunnerManager<'a> {
         let home = self.ci_home();
         let config_root = home.join(".config/kithara-ci");
         let runner_root = home.join(".gitlab-runner");
-        let ca = config_root.join("gitlab-ca.crt");
         let image_digest_path = config_root.join("linux-image.digest");
         let cilicon_password_path = config_root.join("cilicon-ssh.password");
-        if !ca.is_file() {
-            bail!("missing corporate GitLab CA: {}", ca.display());
-        }
         let expected_linux = read_trimmed(&image_digest_path)?;
         let actual_linux = self.linux_image_digest(&home)?;
         if expected_linux != actual_linux {
@@ -45,9 +41,7 @@ impl<'a> RunnerManager<'a> {
         for path in [
             &config_root,
             &runner_root,
-            &runner_root.join("certs"),
             &self.config.host.host_root.join("cache/gitlab-runner"),
-            &self.config.host.host_root.join("toolchains/shared-certs"),
             &self.config.host.host_root.join("toolchains/shared-bin"),
             &self.config.host.host_root.join("vm/cilicon-clone"),
             &self.config.host.host_root.join("workspaces/gitlab"),
@@ -56,18 +50,6 @@ impl<'a> RunnerManager<'a> {
             fs::create_dir_all(path)
                 .with_context(|| format!("creating runner directory {}", path.display()))?;
         }
-        let ca_name = format!("{}.crt", self.config.host.gitlab_host()?);
-        fs::copy(&ca, runner_root.join("certs").join(&ca_name))
-            .context("installing GitLab runner CA")?;
-        fs::copy(
-            &ca,
-            self.config
-                .host
-                .host_root
-                .join("toolchains/shared-certs")
-                .join(&ca_name),
-        )
-        .context("installing shared GitLab CA")?;
         self.copy_shared_tool("xcodegen")?;
         let current = std::env::current_exe().context("resolving CI executable")?;
         fs::copy(
@@ -92,7 +74,7 @@ impl<'a> RunnerManager<'a> {
 
         write_secure(
             &runner_root.join("config.toml"),
-            &self.runner_config(&home, &runner_root, &tokens)?,
+            &self.runner_config(&home, &tokens),
         )?;
         write_secure(
             &home.join("cilicon.yml"),
@@ -164,29 +146,23 @@ impl<'a> RunnerManager<'a> {
         Ok(())
     }
 
-    fn runner_config(&self, home: &Path, runner_root: &Path, tokens: &Tokens) -> Result<String> {
+    fn runner_config(&self, home: &Path, tokens: &Tokens) -> String {
         let root = self.config.host.host_root.display();
         let url = self.config.host.gitlab_origin();
         let cache = self.config.host.cache_root_linux.display();
         let lane_config = LANE_CONFIG_PATH;
-        let ca = runner_root
-            .join("certs")
-            .join(format!("{}.crt", self.config.host.gitlab_host()?));
-        Ok(format!(
+        format!(
             "concurrent = 1\ncheck_interval = 3\nshutdown_timeout = 30\n\n\
-             [[runners]]\n  name = \"kithara-mac-mini-linux\"\n  url = \"{url}\"\n  token = \"{}\"\n  tls-ca-file = \"{}\"\n  executor = \"docker\"\n  builds_dir = \"{root}/workspaces/gitlab\"\n  output_limit = 16384\n  environment = [\"KITHARA_CI_CACHE_ROOT={cache}\", \"KITHARA_CI_HOST_CONFIG={lane_config}\", \"RUSTUP_HOME=/usr/local/rustup\"]\n\
+             [[runners]]\n  name = \"kithara-mac-mini-linux\"\n  url = \"{url}\"\n  token = \"{}\"\n  executor = \"docker\"\n  builds_dir = \"{root}/workspaces/gitlab\"\n  output_limit = 16384\n  environment = [\"KITHARA_CI_CACHE_ROOT={cache}\", \"KITHARA_CI_HOST_CONFIG={lane_config}\", \"RUSTUP_HOME=/usr/local/rustup\"]\n\
              [runners.docker]\n    host = \"{}\"\n    image = \"{}\"\n    pull_policy = \"if-not-present\"\n    allowed_pull_policies = [\"if-not-present\"]\n    allowed_images = [\"kithara-ci:*\"]\n    cpus = \"5\"\n    memory = \"5g\"\n    privileged = false\n    disable_cache = true\n    shm_size = 1073741824\n    volumes = [\"{root}/cache:{cache}:rw\", \"{root}/cache/gitlab-runner:/cache:rw\", \"{root}/services/host.toml:{lane_config}:ro\"]\n\n\
-             [[runners]]\n  name = \"kithara-mac-mini-android\"\n  url = \"{url}\"\n  token = \"{}\"\n  tls-ca-file = \"{}\"\n  executor = \"shell\"\n  shell = \"bash\"\n  builds_dir = \"{root}/workspaces/gitlab\"\n  output_limit = 16384\n  environment = [\"KITHARA_CI_HOST_CONFIG={lane_config}\"]\n\n\
-             [[runners]]\n  name = \"kithara-mac-mini-release\"\n  url = \"{url}\"\n  token = \"{}\"\n  tls-ca-file = \"{}\"\n  executor = \"shell\"\n  shell = \"bash\"\n  builds_dir = \"{root}/workspaces/gitlab\"\n  output_limit = 16384\n  environment = [\"KITHARA_CI_HOST_CONFIG={lane_config}\"]\n",
+             [[runners]]\n  name = \"kithara-mac-mini-android\"\n  url = \"{url}\"\n  token = \"{}\"\n  executor = \"shell\"\n  shell = \"bash\"\n  builds_dir = \"{root}/workspaces/gitlab\"\n  output_limit = 16384\n  environment = [\"KITHARA_CI_HOST_CONFIG={lane_config}\"]\n\n\
+             [[runners]]\n  name = \"kithara-mac-mini-release\"\n  url = \"{url}\"\n  token = \"{}\"\n  executor = \"shell\"\n  shell = \"bash\"\n  builds_dir = \"{root}/workspaces/gitlab\"\n  output_limit = 16384\n  environment = [\"KITHARA_CI_HOST_CONFIG={lane_config}\"]\n",
             tokens.linux,
-            ca.display(),
             docker_host(home),
             self.config.pins.linux_image,
             tokens.android,
-            ca.display(),
             tokens.release,
-            ca.display(),
-        ))
+        )
     }
 
     fn cilicon_config(&self, home: &Path, tokens: &Tokens, ssh_password: &str) -> Result<String> {
@@ -237,11 +213,6 @@ impl<'a> RunnerManager<'a> {
                 DirectoryMount {
                     host_path: root.join("toolchains/shared-bin"),
                     guest_folder: "kithara-tools",
-                    read_only: true,
-                },
-                DirectoryMount {
-                    host_path: root.join("toolchains/shared-certs"),
-                    guest_folder: "kithara-certs",
                     read_only: true,
                 },
             ],
@@ -438,7 +409,7 @@ struct CiliconConfig<'a> {
     console_devices: [&'a str; 1],
     ssh_credentials: SshCredentials<'a>,
     hardware: Hardware,
-    directory_mounts: [DirectoryMount<'a>; 5],
+    directory_mounts: [DirectoryMount<'a>; 4],
     pre_run: &'a str,
     provisioner: Provisioner<'a>,
 }
@@ -584,7 +555,6 @@ mod tests {
             .host_root
             .join("home")
             .join(&config.host.ci_user);
-        let runner_root = home.join(".gitlab-runner");
         let tokens = Tokens {
             macos: "glrt-macos".into(),
             linux: "glrt-linux".into(),
@@ -592,10 +562,7 @@ mod tests {
             release: "glrt-release".into(),
         };
 
-        toml::from_str::<toml::Value>(
-            &manager.runner_config(&home, &runner_root, &tokens).unwrap(),
-        )
-        .unwrap();
+        toml::from_str::<toml::Value>(&manager.runner_config(&home, &tokens)).unwrap();
         let cilicon = manager
             .cilicon_config(&home, &tokens, "fixture-password")
             .unwrap();
@@ -604,6 +571,50 @@ mod tests {
         assert!(cilicon.contains("downloadURL:"));
         assert!(cilicon.contains("preRun:"));
         assert!(!cilicon.contains("password: admin"));
+    }
+
+    #[test]
+    fn generated_configs_trust_the_platform_store_only() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .to_path_buf();
+        let config = fixture();
+        let process = Process::new(&root, BTreeMap::new());
+        let manager = RunnerManager::new(&config, &process);
+        let home = config
+            .host
+            .host_root
+            .join("home")
+            .join(&config.host.ci_user);
+        let tokens = Tokens {
+            macos: "glrt-macos".into(),
+            linux: "glrt-linux".into(),
+            android: "glrt-android".into(),
+            release: "glrt-release".into(),
+        };
+
+        let runner = manager.runner_config(&home, &tokens);
+        let cilicon = manager
+            .cilicon_config(&home, &tokens, "fixture-password")
+            .unwrap();
+        for rendered in [&runner, &cilicon] {
+            for forbidden in [
+                "tls-ca-file",
+                "tls_ca_file",
+                "ca.crt",
+                "kithara-certs",
+                "shared-certs",
+                "tls-skip-verify",
+                "insecure",
+            ] {
+                assert!(
+                    !rendered.contains(forbidden),
+                    "rendered CI configuration must not carry {forbidden}"
+                );
+            }
+        }
+        assert!(runner.contains(&config.host.gitlab_origin()));
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary
`xtask ci host configure-runners` could never complete on the dedicated Mac mini. Its very first check looked for a private corporate CA at `~/.config/kithara-ci/gitlab-ca.crt` and bailed before reading anything else, so runner registration never ran and all four project runners stayed `never_contacted`.

That check no longer describes reality. SSL inspection between the CI host and `gitlab.zvq.me` has been removed (NET-2297 / ITSA-3121): the origin now serves its own public chain — leaf `CN=*.zvq.me` (O=ZVUK) issued by `GlobalSign RSA OV SSL CA 2018` under `GlobalSign Root CA - R3`. Verified from the CI host itself: `openssl s_client` reports `Verify return code: 0 (ok)` against the stock `/etc/ssl/cert.pem` bundle, `curl` reports `SSL certificate verify ok` with `ssl_verify_result=0`, `git ls-remote https://gitlab.zvq.me/disrupt/kithara.git` succeeds, and the System keychain holds no corporate root and no trust-setting overrides. Nothing private is needed to build that chain.

Rather than make the CA optional and keep a branch for a network shape that no longer exists, this removes the private-CA path outright. Runners, Cilicon guests, and the bridge all validate `gitlab_url` against the platform trust store. A host that cannot build the chain is now a network fault to fix upstream, not a certificate to smuggle in — and TLS verification is never relaxed to compensate.

## Behavior / scope
- contract or behavior: CI components validate GitLab against the platform trust store only. Removed the `gitlab-ca.crt` probe and its `bail!`, the copies into the runner and shared cert roots, `tls-ca-file` from the three generated runner entries, the `kithara-certs` Cilicon mount, the guest CA install, and `gitlab_ca_file` from the bridge config. `BridgeConfig` keeps `deny_unknown_fields`, so a stale `gitlab_ca_file` key is now a hard parse error instead of a silently ignored one.
- affected area: `xtask ci host` (runner and guest provisioning), `xtask ci bridge`, `docs/guides/ci-host.md`, `ci/bridge/config.example.toml`.
- dead code removed with the path: the `ca_pem` parameter of `Api::new`, the `ca_file` parameter of `Git::run`, and `CiHost::gitlab_host`, which only ever named the CA file. `runner_config` became infallible and no longer returns `Result`.

## Validation
- `cargo check --locked -p xtask`
- `cargo clippy --locked -p xtask --all-targets` — no issues
- `cargo test --locked -p xtask ci::` — 31 passed
- `just fmt`
- pre-commit `lint-fast` — passed
- negative control: temporarily reintroducing `tls-ca-file` into the generated runner config makes `generated_configs_trust_the_platform_store_only` fail with `rendered CI configuration must not carry tls-ca-file`, confirming the guard is not vacuously green.
- not run: full `just test` and `just ci gate`; no runner was registered from this branch, because that needs the host-side install and this change has not landed on GitLab `main` yet.

## Surface impact
- Public API: none
- Platform/runtime: changed: tooling surface (`xtask ci host`, `xtask ci bridge`)
- Perf-sensitive paths: none

## Risks / follow-ups
- If SSL inspection is ever reintroduced for the CI host, this path has to be rebuilt rather than re-enabled by configuration. That is deliberate: the repo does not keep dormant branches for network shapes that are not in use.
- Two new tests pin the contract: `generated_configs_trust_the_platform_store_only` asserts no rendered runner or Cilicon config carries `tls-ca-file`, `kithara-certs`, `shared-certs`, or any `insecure` / `tls-skip-verify` knob; `bridge_config_trusts_the_platform_store_only` asserts the shipped example parses and that adding `gitlab_ca_file` is rejected.
- This unblocks `configure-runners` but does not by itself bring runners online: the host still needs the privileged `bootstrap`/`finish` steps and a `kithara-ci` GUI session before registration can run.