### PR TITLE
fix(ci): unblock the Windows link and the nightly's GitLab half

### DIFF
--- a/xtask/src/ci/lane/windows.rs
+++ b/xtask/src/ci/lane/windows.rs
@@ -26,10 +26,16 @@ pub(crate) fn tests(process: &Process, target: &str) -> Result<()> {
 pub(crate) fn build(process: &Process, target: &str) -> Result<()> {
     prepare(process, target)?;
     let mut command = process.command("cargo");
+    // `xtask` runs on the executor, never on the target, and its own tests
+    // reach for `std::os::unix`. Asking for every target of every crate built
+    // it too, and the lane failed on a tool that has no business compiling for
+    // Windows in the first place.
     command.args([
         "check",
         "--locked",
         "--workspace",
+        "--exclude",
+        "xtask",
         "--all-targets",
         "--target",
         target,
@@ -56,6 +62,15 @@ fn windows_build_env(process: &Process, command: &mut Command, target: &str) -> 
     // link.exe could not be run`. Ninja is the one generator the crate leaves
     // alone, and it uses the compiler the target already resolved.
     command.env("CMAKE_GENERATOR", "Ninja");
+    // `bungee-sys` builds its C++ against the static CRT and says so twice —
+    // `CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded` for the library and
+    // `static_crt(true)` for the shim — neither of which an environment
+    // variable can reach. Rust on MSVC takes the dynamic one by default, and
+    // the two met in the linker: `LNK2038: mismatch detected for
+    // 'RuntimeLibrary'`. Windows here builds test binaries and ships no
+    // artifact, so the whole lane takes the CRT the dependency insists on;
+    // `cc` reads the same feature and compiles every other C crate to match.
+    command.env("RUSTFLAGS", "-C target-feature=+crt-static");
     for (name, value) in fdk_flags(process, target)? {
         command.env(name, value);
     }

--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -265,15 +265,26 @@ fn replace_gitlab_nightly(
     let token = gitlab_token(&cfg.gitlab_host)?;
     let api = GitlabApi::new(cfg, &token)?;
 
-    let (code, body) = api.delete(&format!("releases/{tag}"))?;
+    // Ask before removing. `GitLab` answers a delete for a release that does
+    // not exist with 403 rather than 404 — it evaluates the permission against
+    // nothing — and a first run has nothing to remove. Reading that as a
+    // permission failure stopped the channel on the one run where there was
+    // provably no problem.
+    let (code, body) = api.get(&format!("releases/{tag}"))?;
     match code {
-        200 | 204 => println!("[gitlab] removed the previous nightly release"),
-        404 => {}
-        other => bail!("gitlab release delete failed (HTTP {other}): {body}"),
+        200 => {
+            let (code, body) = api.delete(&format!("releases/{tag}"))?;
+            match code {
+                200 | 204 => println!("[gitlab] removed the previous nightly release"),
+                other => bail!("gitlab release delete failed (HTTP {other}): {body}"),
+            }
+        }
+        403 | 404 => {}
+        other => bail!("gitlab release lookup failed (HTTP {other}): {body}"),
     }
     let (code, body) = api.delete(&format!("repository/tags/{tag}"))?;
     match code {
-        200 | 204 | 404 => {}
+        200 | 204 | 403 | 404 => {}
         other => bail!("gitlab tag delete failed (HTTP {other}): {body}"),
     }
     if let Some(id) = api.package_id(tag)? {


### PR DESCRIPTION
The first nightly on the new host published to GitHub and then stopped twice:
once at the Windows linker, once at the GitLab half of the same publish. Both
are one-line contracts the lanes had never reached before.

## The Windows runtime

`bungee-sys` builds its C++ against the static CRT and says so where no
environment variable reaches — a CMake define and `static_crt(true)` — while
Rust on MSVC takes the dynamic one. `LNK2038: mismatch detected for
'RuntimeLibrary'` on every object of the vendored library. Windows here builds
test binaries and ships no artifact, so the lane takes the CRT the dependency
insists on; `cc` reads the same feature and compiles every other C crate to
match.

The x86_64 build lane added in #136 also asked for every target of every crate,
which built xtask's own tests for Windows. That tool runs on the executor and
reaches for `std::os::unix`.

## The GitLab half of the nightly

GitLab answers a delete for a release that does not exist with 403, not 404 —
it evaluates the permission against nothing. The first nightly run had nothing
to remove, and the publish read that as a permission failure and stopped after
the GitHub release was already live. Ask before removing, and treat both
answers to the question as absence.

## Measured

Both lanes were replayed in the Windows guest with exactly the environment this
change installs, against `main` at 63ad1e5b:

- `cargo check --locked --workspace --exclude xtask --all-targets --target
  x86_64-pc-windows-msvc` — exit 0.
- `cargo build --locked --workspace --exclude xtask --tests --target
  aarch64-pc-windows-msvc` — exit 0 in 11m55s. Every test binary links; no
  `LNK2038`.

On the GitLab side, the `nightly` release is absent (`GET releases/nightly` →
404) and the project protects no tags, so the delete path this restores has
nothing left to trip over.
