### PR TITLE
perf(assets,storage): cut the per-read and per-segment disk cost of HLS playback

### DIFF
--- a/crates/kithara-assets/CONTEXT.md
+++ b/crates/kithara-assets/CONTEXT.md
@@ -153,9 +153,13 @@ aggregate `AvailabilityIndex` keyed by the `asset_root` and relative path alread
   `on_commit(len)`, and opening a pre-existing committed file seeds `0..final_len`.
 - **Queried** aggregate-first, with a single cold-miss fallback to `resource_state` so pre-existing
   committed files are discoverable before the observer fires.
-- **Persisted** in two tiers (below); a missing, stale, or corrupt `availability.bin` is never a
-  correctness dependency — it loads as an empty seed and the slow path re-derives from committed
-  files.
+- **Persisted** in two tiers (below), and it is the **authority on what survives a restart**. A
+  segment's file becomes visible at `rename`, but the barrier that puts its blocks on the medium is
+  paid later, by the manifest flush, which forces every queued file down *before* naming it. So a
+  file alone proves nothing — after a power cut it can carry the right name and length over
+  unwritten blocks. `DiskAssetStore` therefore treats an existing file as ready only when
+  `availability` knows its final length; anything else is a torn write and is refetched. A missing
+  or corrupt `availability.bin` costs a refetch, never a wrong read.
 
 The persisted snapshot is a **committed-only** contract — an uncommitted partial write is never
 serialised, so a flush racing a writer's cleanup cannot resurrect a partial segment whose `.tmp`
@@ -176,8 +180,14 @@ All three write through `Atomic<R>` and register with a shared `FlushHub` (`Flus
 50 ms debounce, 100 ms poll, forced flush every 256 signals). Two tiers:
 
 - **Non-durable** best-effort: the background worker atomically renames without `sync_data`.
-  Availability uses this tier because it is rewritten on every write/commit; it buys cross-instance
-  visibility and fast crash-recovery hydration.
+  Availability uses this tier for the snapshot itself because it is rewritten on every
+  write/commit. The files it vouches for are a different matter: each availability flush first
+  `sync_data`s the segment files committed since the last one, and only then writes the snapshot.
+  That ordering is what lets a segment commit skip its own barrier (`Barrier::Deferred`) — the cost
+  is paid once per flush instead of once per segment, off the download path. Reversing it would let
+  the manifest vouch for bytes that never landed.
+- `AssetStore` checkpoints itself when its last handle drops. Every index holds the flush hub
+  alive, so waiting for the hub's own teardown would find the sources already gone.
 - **Durable** authoritative: `AssetStore::checkpoint()` → `FlushHub::flush_now` → `flush_durable`
   (`sync_data` before rename) over every source. It also re-flushes sources the worker last wrote
   non-durably even when their `dirty` flag is clear, so a checkpoint never leaves a stale worker

--- a/crates/kithara-assets/CONTEXT.md
+++ b/crates/kithara-assets/CONTEXT.md
@@ -80,8 +80,9 @@ Outermost to innermost:
 
 A decorator becomes a transparent pass-through for an absolute `ResourceKey` and whenever its
 capability bit is absent. Handles opened through `LeaseAssets` pin their `asset_root` for the
-handle's lifetime via an RAII guard inside `LeaseWriter` / `LeaseReader`; the 0→1 and 1→0
-transitions flush `_index/pins.bin`. Abandoning a `LeaseWriter` without committing removes the
+handle's lifetime via an RAII guard inside `LeaseWriter` / `LeaseReader`; a writer's pin is durable
+and its 0→1 / 1→0 transitions flush `_index/pins.bin`, a reader's pin is process-local and stays in
+memory. Abandoning a `LeaseWriter` without committing removes the
 partial resource; an explicit `fail(reason)` keeps it observable through `resource_state` instead.
 `retain()` on a cached handle pins it in the LRU cache until `CachedReader::release` for the same
 key; retained entries are exempt from both capacity and byte-bound eviction.
@@ -187,9 +188,13 @@ All three write through `Atomic<R>` and register with a shared `FlushHub` (`Flus
 
 ### Pins index
 
-- `PinsIndex` encapsulates its `Arc`, so `Clone` is a refcount bump. Each `asset_root` is
-  refcounted; the on-disk set changes and flushes only on 0→1 and 1→0 transitions, intermediate
-  steps stay in memory.
+- `PinsIndex` encapsulates its `Arc`, so `Clone` is a refcount bump. Each `asset_root` carries two
+  refcounts, split by `PinDurability`. Both bar eviction identically — `snapshot` covers them
+  together — and they differ only in reach: a `Durable` pin (an unfinished write) is persisted, a
+  `Local` one (a reader holding committed bytes) is not. Only the durable count's 0→1 and 1→0
+  transitions flush `_index/pins.bin`; everything else stays in memory, which is what keeps the
+  decoder read loop off the disk. A `Local` pin is deliberately invisible to the next process: a pin
+  that cannot outlive its holder would hydrate as a phantom that nothing ever releases.
 - Persistence is lazy — the file materialises on the first flush — while an existing file from a
   previous run is opened and hydrated eagerly in `with_persist_at` (native only). On wasm32 the
   index is always ephemeral.

--- a/crates/kithara-assets/src/backend/disk.rs
+++ b/crates/kithara-assets/src/backend/disk.rs
@@ -17,7 +17,7 @@ use super::AssetDeleter;
 use crate::{
     decorator::{Assets, Capabilities},
     error::{AssetsError, AssetsResult},
-    index::AvailabilityIndex,
+    index::{AvailabilityIndex, PinDurability},
     layout::{ResourceKey, ResourceKeyKind},
     resource::{AcquisitionResult, AssetResourceState, BaseReader, BaseWriter, RequestIdentity},
 };
@@ -76,7 +76,10 @@ impl AssetDeleter for DiskAssetDeleter {
     fn delete_asset(&self, asset_root: &str) -> AssetsResult<()> {
         delete_asset_dir(&self.root_dir, asset_root).map_err(AssetsError::from)?;
         self.availability.clear_root(asset_root);
-        let pins_result = self.pins.remove(asset_root).map(|_| ());
+        let pins_result = self
+            .pins
+            .remove(asset_root, PinDurability::Durable)
+            .map(|_| ());
         let lru_result = self.lru.remove(asset_root);
         pins_result.and(lru_result)
     }
@@ -486,7 +489,7 @@ mod tests {
         availability.record_commit(&key, 4);
 
         let pins = PinsIndex::ephemeral();
-        pins.add(asset_root).unwrap();
+        pins.add(asset_root, PinDurability::Durable).unwrap();
         let lru = LruIndex::ephemeral();
         lru.touch(asset_root, Some(4)).unwrap();
 

--- a/crates/kithara-assets/src/backend/disk.rs
+++ b/crates/kithara-assets/src/backend/disk.rs
@@ -169,6 +169,15 @@ impl DiskAssetStore {
         key: &ResourceKey,
         path: PathBuf,
     ) -> AssetsResult<AtomicChunked<MmapDriver>> {
+        /// Bytes reserved for a fresh segment's temp file. A segment arrives
+        /// in many small chunks, and every time the writes outgrow the
+        /// mapping the driver re-maps the file — the single most expensive
+        /// step of a segment commit. One reservation that covers a typical
+        /// segment removes those re-maps; anything larger still grows, and
+        /// the surplus is trimmed back to `final_len` on commit, so this
+        /// costs a sparse extent and nothing else.
+        const SEGMENT_RESERVATION: u64 = 1024 * 1024;
+
         let observer = self.scoped_observer(key);
         let cancel = self.cancel.clone();
         let chunked = AtomicChunked::open(path, move |target, intent| {
@@ -180,6 +189,7 @@ impl DiskAssetStore {
                 cancel.clone(),
                 MmapOptions::for_path(target.to_path_buf())
                     .mode(mode)
+                    .maybe_initial_len((intent == OpenIntent::Fresh).then_some(SEGMENT_RESERVATION))
                     .build(),
                 Some(Arc::clone(&observer) as Arc<dyn AvailabilityObserver>),
             )
@@ -399,7 +409,7 @@ mod tests {
     use super::*;
     use crate::{
         index::{EvictConfig, LruIndex, PinsIndex},
-        resource::ReadSide,
+        resource::{ReadSide, WriteSide},
     };
 
     #[kithara::test]
@@ -456,6 +466,66 @@ mod tests {
         let mut buf = [0u8; 15];
         let n = res.read_at(0, &mut buf).unwrap();
         assert_eq!(&buf[..n], b"fake audio data");
+    }
+
+    /// A media segment arrives in many small chunks. If the backing file
+    /// starts small and doubles, every crossing re-maps it — the dominant
+    /// cost of a segment commit. Writing a typical segment must leave the
+    /// file's size untouched.
+    #[kithara::test]
+    fn writing_a_segment_does_not_resize_its_backing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = DiskAssetStore::new(
+            dir.path().to_path_buf(),
+            CancelToken::never(),
+            &crate::BytePool::default(),
+        );
+        let key = ResourceKey::relative("asset", "segments/0001.bin");
+        let AcquisitionResult::Pending(writer) = store.acquire_resource(&key, None).unwrap() else {
+            panic!("a fresh segment key must acquire a writer");
+        };
+        let tmp = dir
+            .path()
+            .join("asset")
+            .join("segments")
+            .join("0001.bin.tmp");
+        let reserved = fs::metadata(&tmp).unwrap().len();
+
+        let chunk = vec![0xABu8; 16 * 1024];
+        for i in 0..12u64 {
+            writer.write_at(i * chunk.len() as u64, &chunk).unwrap();
+        }
+
+        assert_eq!(
+            fs::metadata(&tmp).unwrap().len(),
+            reserved,
+            "a segment-sized write must fit the reservation instead of re-mapping the file"
+        );
+    }
+
+    #[kithara::test]
+    fn a_committed_segment_keeps_only_its_own_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = DiskAssetStore::new(
+            dir.path().to_path_buf(),
+            CancelToken::never(),
+            &crate::BytePool::default(),
+        );
+        let key = ResourceKey::relative("asset", "segments/0001.bin");
+        let AcquisitionResult::Pending(writer) = store.acquire_resource(&key, None).unwrap() else {
+            panic!("a fresh segment key must acquire a writer");
+        };
+        let payload = vec![0xCDu8; 100_000];
+        writer.write_at(0, &payload).unwrap();
+
+        drop(writer.commit(Some(payload.len() as u64)).unwrap());
+
+        let canonical = dir.path().join("asset").join("segments").join("0001.bin");
+        assert_eq!(
+            fs::metadata(&canonical).unwrap().len(),
+            payload.len() as u64,
+            "the reservation must be trimmed back to the committed length"
+        );
     }
 
     #[kithara::test]

--- a/crates/kithara-assets/src/backend/disk.rs
+++ b/crates/kithara-assets/src/backend/disk.rs
@@ -159,8 +159,9 @@ impl DiskAssetStore {
     }
 
     /// Open a fresh segment as an `AtomicChunked<MmapResource>`. The
-    /// inner mmap is bound to `<path>.tmp`; on `commit()` the tmp
-    /// file is `sync_data`'d and renamed atomically to `path`. The
+    /// inner mmap is bound to `<path>.tmp`; on `commit()` the tmp file is
+    /// renamed atomically to `path`, and the durability barrier is deferred
+    /// to the manifest flush rather than paid on the download path. The
     /// availability observer is attached to the inner mmap so
     /// `record_write` / `record_commit` fire as bytes arrive — same
     /// contract as the non-atomic path.
@@ -178,9 +179,9 @@ impl DiskAssetStore {
         /// costs a sparse extent and nothing else.
         const SEGMENT_RESERVATION: u64 = 1024 * 1024;
 
-        let observer = self.scoped_observer(key);
+        let observer = self.segment_observer(key, path.clone());
         let cancel = self.cancel.clone();
-        let chunked = AtomicChunked::open(path, move |target, intent| {
+        let chunked = AtomicChunked::open_deferred(path, move |target, intent| {
             let mode = match intent {
                 OpenIntent::Fresh => OpenMode::ReadWrite,
                 OpenIntent::Reopen => OpenMode::ReadOnly,
@@ -233,6 +234,16 @@ impl DiskAssetStore {
         self.root_dir.join("_index").join("pins.bin")
     }
 
+    /// Whether `key`'s bytes are known durable. The file existing is not
+    /// enough: it becomes visible at `rename`, while the barrier that puts
+    /// its blocks on the medium lands later, so an unconfirmed file may be
+    /// the right length over unwritten blocks. The availability manifest is
+    /// written only after that barrier, and is therefore the authority.
+    fn is_confirmed(&self, key: &ResourceKey, path: &Path) -> bool {
+        self.availability.final_len(key).is_some()
+            && path.metadata().is_ok_and(|meta| meta.len() > 0)
+    }
+
     fn resource_path(&self, key: &ResourceKey) -> AssetsResult<PathBuf> {
         match key.kind() {
             ResourceKeyKind::Relative {
@@ -255,6 +266,16 @@ impl DiskAssetStore {
 
     fn scoped_observer(&self, key: &ResourceKey) -> Arc<dyn AvailabilityObserver> {
         crate::index::ScopedAvailabilityObserver::new(key.clone(), self.availability.clone())
+    }
+
+    /// Observer for a segment: its commit hands the file to the manifest's
+    /// durability barrier instead of paying one inline.
+    fn segment_observer(&self, key: &ResourceKey, path: PathBuf) -> Arc<dyn AvailabilityObserver> {
+        crate::index::ScopedAvailabilityObserver::for_file(
+            key.clone(),
+            self.availability.clone(),
+            path,
+        )
     }
 
     /// Like [`DiskAssetStore::new`] but shares the given aggregate
@@ -305,13 +326,19 @@ impl Assets for DiskAssetStore {
         }
 
         let path = self.resource_path(key)?;
-        if path.exists() && path.metadata().is_ok_and(|m| m.len() > 0) {
+        if self.is_confirmed(key, &path) {
             let storage =
                 StorageResource::from(self.open_storage_resource(key, path, OpenMode::Auto)?);
             if matches!(storage.status(), ResourceStatus::Committed { .. }) {
                 return Ok(AcquisitionResult::Ready(BaseReader::new(storage)));
             }
             return Ok(AcquisitionResult::Pending(BaseWriter::new(storage)));
+        }
+        // Unconfirmed leftovers are indistinguishable from a torn write, so
+        // they are refetched rather than trusted. Clear the path so the fresh
+        // acquisition can claim its temp file.
+        if path.exists() {
+            let _ = fs::remove_file(&path);
         }
         let chunked = self.open_atomic_chunked_resource(key, path)?;
         Ok(AcquisitionResult::Pending(BaseWriter::new(
@@ -466,6 +493,31 @@ mod tests {
         let mut buf = [0u8; 15];
         let n = res.read_at(0, &mut buf).unwrap();
         assert_eq!(&buf[..n], b"fake audio data");
+    }
+
+    /// Bytes reach the disk before the barrier that makes them durable, so a
+    /// file on its own proves nothing: after a power cut it can carry the
+    /// right name and length over unwritten blocks. Only the availability
+    /// manifest, written after that barrier, says a resource is readable.
+    #[kithara::test]
+    fn an_unconfirmed_file_is_not_served_as_ready() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = DiskAssetStore::new(
+            dir.path().to_path_buf(),
+            CancelToken::never(),
+            &crate::BytePool::default(),
+        );
+        let key = ResourceKey::relative("asset", "segments/0001.bin");
+        let path = dir.path().join("asset").join("segments").join("0001.bin");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, vec![0xEEu8; 4096]).unwrap();
+
+        let acquired = store.acquire_resource(&key, None).unwrap();
+
+        assert!(
+            !acquired.is_ready(),
+            "a file the manifest never confirmed must not be handed out as committed"
+        );
     }
 
     /// A media segment arrives in many small chunks. If the backing file

--- a/crates/kithara-assets/src/backend/memory.rs
+++ b/crates/kithara-assets/src/backend/memory.rs
@@ -17,7 +17,7 @@ use super::AssetDeleter;
 use crate::{
     decorator::{Assets, Capabilities},
     error::{AssetsError, AssetsResult},
-    index::{AvailabilityIndex, ScopedAvailabilityObserver},
+    index::{AvailabilityIndex, PinDurability, ScopedAvailabilityObserver},
     layout::ResourceKey,
     resource::{AcquisitionResult, AssetResourceState, BaseReader, BaseWriter, RequestIdentity},
 };
@@ -91,7 +91,10 @@ impl AssetDeleter for MemAssetDeleter {
         self.active_resources
             .retain(|k, _| k.key.asset_root() != Some(asset_root));
         self.availability.clear_root(asset_root);
-        let pins_result = self.pins.remove(asset_root).map(|_| ());
+        let pins_result = self
+            .pins
+            .remove(asset_root, PinDurability::Durable)
+            .map(|_| ());
         let lru_result = self.lru.remove(asset_root);
         pins_result.and(lru_result)
     }

--- a/crates/kithara-assets/src/decorator/lease/layer.rs
+++ b/crates/kithara-assets/src/decorator/lease/layer.rs
@@ -19,7 +19,7 @@ use super::{
 use crate::{
     decorator::{Assets, ByteRecorder, CachedAssets, Capabilities, ProcessCtx},
     error::AssetsResult,
-    index::PinsIndex,
+    index::{PinDurability, PinsIndex},
     layout::ResourceKey,
     resource::{AcquisitionResult, AssetResourceState, ReadSide, RequestIdentity},
 };
@@ -83,8 +83,9 @@ where
     event_bus: LeaseEvents,
     byte_recorder: Option<Arc<dyn ByteRecorder>>,
     /// Shared pins index — same instance held by `EvictAssets` and
-    /// `DiskAssetDeleter`. Mutations (`add` / `remove`) flush
-    /// immediately via the index's internal best-effort persistence.
+    /// `DiskAssetDeleter`. A writer's pin is durable and flushes on its
+    /// 0→1 / 1→0 transitions; a reader's pin is process-local and stays
+    /// in memory, so the decoder read loop never reaches disk.
     pins: PinsIndex,
 }
 
@@ -151,8 +152,8 @@ where
         }
     }
 
-    fn pin(&self, asset_root: &str) -> AssetsResult<LeaseGuard> {
-        self.pins.add(asset_root)?;
+    fn pin(&self, asset_root: &str, durability: PinDurability) -> AssetsResult<LeaseGuard> {
+        self.pins.add(asset_root, durability)?;
 
         let pins = self.pins.clone();
         let ar = asset_root.to_string();
@@ -163,7 +164,7 @@ where
                 return;
             }
             tracing::trace!(asset_root = %ar, "LeaseGuard::drop - removing pin");
-            if let Err(e) = pins.remove(&ar) {
+            if let Err(e) = pins.remove(&ar, durability) {
                 tracing::warn!(
                     asset_root = %ar,
                     error = %e,
@@ -255,14 +256,18 @@ where
 {
     /// Resolve the pin guard + removal channel + byte recorder for `key`.
     /// Absolute keys (and the bypass capability) yield a no-op lease.
-    fn lease_for(&self, key: &ResourceKey) -> AssetsResult<LeaseBindings> {
+    fn lease_for(
+        &self,
+        key: &ResourceKey,
+        durability: PinDurability,
+    ) -> AssetsResult<LeaseBindings> {
         let pin = (self.is_active() && !key.is_absolute())
             .then(|| key.asset_root())
             .flatten();
         let Some(asset_root) = pin else {
             return Ok((LeaseGuard::inactive(), None, None));
         };
-        let lease = self.pin(asset_root)?;
+        let lease = self.pin(asset_root, durability)?;
         let remove: RemoveFn = {
             let inner = Arc::clone(&self.inner);
             Arc::new(move |key: &ResourceKey| {
@@ -278,7 +283,7 @@ where
         inner: A::ReadyRes,
     ) -> AssetsResult<LeaseReader<A::ReadyRes, LeaseGuard>> {
         let live = self.open_live_resource(key, inner.status());
-        let (lease, remove, byte_recorder) = self.lease_for(key)?;
+        let (lease, remove, byte_recorder) = self.lease_for(key, PinDurability::Local)?;
         Ok(LeaseReader::new(
             inner,
             lease,
@@ -296,7 +301,7 @@ where
         inner: A::ActiveRes,
     ) -> AssetsResult<LeaseWriter<A::ActiveRes, LeaseGuard>> {
         let live = self.open_live_resource(key, ResourceStatus::Active);
-        let (lease, remove, byte_recorder) = self.lease_for(key)?;
+        let (lease, remove, byte_recorder) = self.lease_for(key, PinDurability::Durable)?;
         Ok(LeaseWriter::new(
             inner,
             lease,
@@ -325,7 +330,7 @@ mod tests {
     use kithara_test_utils::kithara;
 
     use super::*;
-    use crate::{backend::DiskAssetStore, layout::ResourceKey};
+    use crate::{backend::DiskAssetStore, layout::ResourceKey, resource::WriteSide};
 
     const ROOT: &str = "test_asset";
 
@@ -359,6 +364,53 @@ mod tests {
         let idx =
             PinsIndex::with_persist_at(path, CancelToken::never(), &crate::BytePool::default());
         idx.snapshot()
+    }
+
+    /// Write `payload` under `key` and commit it, leaving no live handle.
+    fn commit_resource(lease: &LeaseAssets<DiskAssetStore>, key: &ResourceKey, payload: &[u8]) {
+        let AcquisitionResult::Pending(writer) = lease.acquire_resource(key, None).unwrap() else {
+            panic!("a fresh key must acquire a writer");
+        };
+        writer.write_at(0, payload).unwrap();
+        let len = u64::try_from(payload.len()).unwrap();
+        drop(writer.commit(Some(len)).unwrap());
+    }
+
+    #[kithara::test(timeout(Duration::from_secs(5)))]
+    fn reading_a_committed_resource_does_not_write_the_pins_index() {
+        let dir = tempfile::tempdir().unwrap();
+        let lease = make_lease(dir.path());
+        let key = ResourceKey::relative(ROOT, "audio.mp3");
+        commit_resource(&lease, &key, b"data");
+
+        let path = dir.path().join("_index").join("pins.bin");
+        fs::remove_file(&path).unwrap();
+
+        for _ in 0..16 {
+            let reader = lease.open_resource(&key, None).unwrap();
+            let mut buf = [0u8; 4];
+            reader.read_at(0, &mut buf).unwrap();
+        }
+
+        assert!(
+            !path.exists(),
+            "reads of a committed resource must not reach the pins index on disk"
+        );
+    }
+
+    #[kithara::test(timeout(Duration::from_secs(5)))]
+    fn reader_lease_still_guards_the_asset_against_eviction() {
+        let dir = tempfile::tempdir().unwrap();
+        let lease = make_lease(dir.path());
+        let key = ResourceKey::relative(ROOT, "audio.mp3");
+        commit_resource(&lease, &key, b"data");
+
+        let _reader = lease.open_resource(&key, None).unwrap();
+
+        assert!(
+            lease.pins.snapshot().contains(ROOT),
+            "a live reader must keep its asset root pinned in memory"
+        );
     }
 
     #[kithara::test(timeout(Duration::from_secs(5)))]

--- a/crates/kithara-assets/src/index/availability/core.rs
+++ b/crates/kithara-assets/src/index/availability/core.rs
@@ -4,13 +4,14 @@
 use std::sync::Weak;
 use std::{
     ops::Range,
+    path::PathBuf,
     sync::{
         OnceLock,
         atomic::{AtomicBool, Ordering},
     },
 };
 
-use dashmap::DashMap;
+use dashmap::{DashMap, DashSet};
 use kithara_platform::sync::{Arc, Mutex};
 use kithara_storage::AvailabilityObserver;
 use rangemap::RangeSet;
@@ -79,6 +80,10 @@ pub(super) struct InnerIndex {
     /// just marks `dirty` so the next call to
     /// [`AvailabilityIndex::flush`] writes the snapshot.
     pub(super) hub: OnceLock<Arc<FlushHub>>,
+    /// Committed files still awaiting their durability barrier. The flush
+    /// forces these down before writing the snapshot, so a resource is
+    /// never named in the manifest ahead of its own bytes.
+    pub(super) pending_durability: DashSet<PathBuf>,
     /// Disk-backed persist target. Set once via
     /// `AvailabilityIndex::enable_persistence`; later flushes reuse
     /// the cached `Atomic<MmapDriver>` handle. Native only.
@@ -96,6 +101,7 @@ impl AvailabilityIndex {
                 persist: OnceLock::new(),
                 hub: OnceLock::new(),
                 dirty: AtomicBool::new(false),
+                pending_durability: DashSet::new(),
             }),
         }
     }
@@ -210,6 +216,13 @@ impl AvailabilityIndex {
         }
     }
 
+    /// Enqueue a committed file for the durability barrier. The manifest
+    /// flush pays one barrier per queued file and only then names them, so
+    /// the download path never waits on the medium itself.
+    pub(crate) fn record_pending_durability(&self, path: PathBuf) {
+        self.inner.pending_durability.insert(path);
+    }
+
     pub(crate) fn record_commit(&self, key: &ResourceKey, final_len: u64) {
         let (root, path) = Self::resolve_refs(key);
         let arc = self.insert_or_get_entry(root, path);
@@ -296,16 +309,36 @@ impl std::fmt::Debug for AvailabilityIndex {
 pub(crate) struct ScopedAvailabilityObserver {
     index: AvailabilityIndex,
     key: ResourceKey,
+    /// Backing file, when the resource has one whose durability the index
+    /// must force before naming it in the manifest.
+    path: Option<PathBuf>,
 }
 
 impl ScopedAvailabilityObserver {
     pub(crate) fn new(key: ResourceKey, index: AvailabilityIndex) -> Arc<Self> {
-        Arc::new(Self { index, key })
+        Arc::new(Self {
+            index,
+            key,
+            path: None,
+        })
+    }
+
+    /// Observer for a file-backed resource: its commit enqueues the file for
+    /// the durability barrier the manifest flush pays on everyone's behalf.
+    pub(crate) fn for_file(key: ResourceKey, index: AvailabilityIndex, path: PathBuf) -> Arc<Self> {
+        Arc::new(Self {
+            index,
+            key,
+            path: Some(path),
+        })
     }
 }
 
 impl AvailabilityObserver for ScopedAvailabilityObserver {
     fn on_commit(&self, final_len: u64) {
+        if let Some(path) = self.path.as_ref() {
+            self.index.record_pending_durability(path.clone());
+        }
         self.index.record_commit(&self.key, final_len);
     }
 

--- a/crates/kithara-assets/src/index/availability/disk.rs
+++ b/crates/kithara-assets/src/index/availability/disk.rs
@@ -1,6 +1,6 @@
 #![forbid(unsafe_code)]
 
-use std::{collections::BTreeMap, path::PathBuf, sync::OnceLock};
+use std::{collections::BTreeMap, fs, path::PathBuf, sync::OnceLock};
 
 use dashmap::DashMap;
 use kithara_platform::{
@@ -122,9 +122,34 @@ impl InnerIndex {
         let Some(p) = self.persist.get() else {
             return Ok(());
         };
+        // Order is the whole point: force the committed files onto the medium
+        // first, then name them. Reversed, a crash could leave the manifest
+        // vouching for bytes that never landed.
+        self.barrier_pending_files();
         let atomic = init_atomic(&p.res, &p.path, &p.cancel)?;
         write_aggregate(self, atomic, durable)?;
         Ok(())
+    }
+
+    /// `sync_data` every committed file queued since the last flush. A file
+    /// that vanished (evicted, or its asset deleted) simply drops out — the
+    /// manifest entry goes with it.
+    fn barrier_pending_files(&self) {
+        let queued: Vec<PathBuf> = self
+            .pending_durability
+            .iter()
+            .map(|entry| entry.key().clone())
+            .collect();
+        for path in queued {
+            self.pending_durability.remove(&path);
+            let synced = fs::OpenOptions::new()
+                .write(true)
+                .open(&path)
+                .and_then(|file| file.sync_data());
+            if let Err(error) = synced {
+                tracing::debug!(?path, %error, "availability: durability barrier skipped");
+            }
+        }
     }
 }
 

--- a/crates/kithara-assets/src/index/mod.rs
+++ b/crates/kithara-assets/src/index/mod.rs
@@ -13,5 +13,5 @@ pub use demand::{DemandLease, ProducerHandle};
 pub(crate) use lru::{EvictConfig, LruIndex};
 pub use persistence::schema;
 pub(crate) use persistence::{FlushHub, FlushPolicy};
-pub use pins::PinsIndex;
+pub use pins::{PinDurability, PinsIndex};
 pub(crate) use transaction::ResourceTransactionIndex;

--- a/crates/kithara-assets/src/index/pins/core.rs
+++ b/crates/kithara-assets/src/index/pins/core.rs
@@ -2,7 +2,6 @@
 
 use std::{
     collections::HashSet,
-    num::NonZeroU32,
     sync::{OnceLock, Weak, atomic::AtomicBool},
 };
 
@@ -14,10 +13,71 @@ use crate::{
     index::persistence::{FlushHub, Flushable, flush_sync},
 };
 
+/// How long a pin has to outlive its holder.
+///
+/// Both kinds bar eviction identically while they are held; they differ
+/// only in whether the pin reaches `_index/pins.bin`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PinDurability {
+    /// Outlives the process: an unfinished write whose bytes a later run
+    /// must not evict before the download completes. Persisted.
+    Durable,
+    /// Bounded by the process: a reader holding committed bytes open.
+    /// In-memory only — a pin that cannot survive a restart has nothing
+    /// to say to the next one.
+    Local,
+}
+
+/// Per-root pin refcounts, split by what each pin has to outlive.
+///
+/// Fields are open to `disk`, which picks the persisted subset by `durable`
+/// and seeds hydrated roots.
+#[derive(Clone, Copy, Debug, Default)]
+pub(super) struct PinCounts {
+    pub(super) durable: u32,
+    pub(super) local: u32,
+}
+
+impl PinCounts {
+    fn is_pinned(self) -> bool {
+        self.durable > 0 || self.local > 0
+    }
+
+    /// Add one pin; `true` when the durable count went 0→1.
+    fn pin(&mut self, durability: PinDurability) -> bool {
+        match durability {
+            PinDurability::Durable => {
+                self.durable = self.durable.saturating_add(1);
+                self.durable == 1
+            }
+            PinDurability::Local => {
+                self.local = self.local.saturating_add(1);
+                false
+            }
+        }
+    }
+
+    /// Drop one pin; `true` when the durable count went 1→0.
+    fn unpin(&mut self, durability: PinDurability) -> bool {
+        match durability {
+            PinDurability::Durable => {
+                let held = self.durable;
+                self.durable = held.saturating_sub(1);
+                held == 1
+            }
+            PinDurability::Local => {
+                self.local = self.local.saturating_sub(1);
+                false
+            }
+        }
+    }
+}
+
 /// In-memory + best-effort disk-backed index of pinned `asset_root`s.
 ///
-/// Refcounted per root, lazily persisted, flushed only on 0→1 / 1→0
-/// transitions. See the crate `CONTEXT.md` "Pins index" for the contract.
+/// Refcounted per root, lazily persisted. Only durable pins reach disk,
+/// and only on their 0→1 / 1→0 transitions. See the crate `CONTEXT.md`
+/// "Pins index" for the contract.
 #[derive(Clone)]
 pub struct PinsIndex {
     pub(super) inner: Arc<PinsInner>,
@@ -35,7 +95,7 @@ impl std::fmt::Debug for PinsIndex {
 
 pub(super) struct PinsInner {
     pub(super) dirty: AtomicBool,
-    pub(super) pins: DashMap<String, NonZeroU32>,
+    pub(super) pins: DashMap<String, PinCounts>,
     /// Set by [`FlushHub::register`]. While `None`, mutators flush
     /// synchronously through [`Flushable::flush`] directly — matches
     /// the historical inline-flush path for ad-hoc tests that never
@@ -49,31 +109,30 @@ impl PinsIndex {
     /// Pin an `asset_root`. Returns `true` on the 0→1 transition (newly pinned),
     /// `false` when an existing pin's refcount was incremented.
     ///
-    /// Disk-backed instances flush the snapshot synchronously on the 0→1
-    /// transition only; intermediate refcount increments stay in-memory.
-    /// An `Err` here means the pin is **not** durable. Ephemeral instances
-    /// cannot fail.
+    /// Disk-backed instances flush the snapshot synchronously when the
+    /// **durable** count goes 0→1; every other increment, and every
+    /// [`PinDurability::Local`] pin, stays in memory. An `Err` here means the
+    /// pin is **not** durable. Ephemeral instances cannot fail.
     ///
     /// # Errors
     ///
     /// Propagates the underlying [`AssetsError`](crate::error::AssetsError)
     /// when the on-disk flush fails (mmap open, atomic swap, rkyv serialise).
-    pub fn add(&self, asset_root: &str) -> AssetsResult<bool> {
-        let transitioned = match self.inner.pins.entry(asset_root.to_string()) {
-            Entry::Occupied(mut e) => {
-                let count = e.get_mut();
-                *count = count.saturating_add(1);
-                false
-            }
-            Entry::Vacant(e) => {
-                e.insert(NonZeroU32::MIN);
-                true
-            }
-        };
-        if transitioned {
+    pub fn add(&self, asset_root: &str, durability: PinDurability) -> AssetsResult<bool> {
+        let (newly_pinned, persisted_set_changed) =
+            match self.inner.pins.entry(asset_root.to_string()) {
+                Entry::Occupied(mut e) => (false, e.get_mut().pin(durability)),
+                Entry::Vacant(e) => {
+                    let mut counts = PinCounts::default();
+                    let changed = counts.pin(durability);
+                    e.insert(counts);
+                    (true, changed)
+                }
+            };
+        if persisted_set_changed {
             flush_sync(&*self.inner)?;
         }
-        Ok(transitioned)
+        Ok(newly_pinned)
     }
 
     /// Bind this index to a [`FlushHub`] for coordinated flushing.
@@ -126,18 +185,19 @@ impl PinsIndex {
     /// removed), `false` when the refcount was decremented but the asset
     /// is still pinned by other holders or was not pinned at all.
     ///
-    /// Same durability contract as [`Self::add`]: flush only fires on
-    /// 1→0 transitions.
+    /// Same durability contract as [`Self::add`]: the flush fires when the
+    /// durable count goes 1→0, not when the last reader lets go.
     ///
     /// # Errors
     ///
     /// Propagates the underlying [`AssetsError`](crate::error::AssetsError)
     /// when the on-disk flush fails.
-    pub fn remove(&self, asset_root: &str) -> AssetsResult<bool> {
-        let transitioned =
+    pub fn remove(&self, asset_root: &str, durability: PinDurability) -> AssetsResult<bool> {
+        let mut persisted_set_changed = false;
+        let fully_unpinned =
             if let Entry::Occupied(mut e) = self.inner.pins.entry(asset_root.to_string()) {
-                if let Some(decremented) = NonZeroU32::new(e.get().get() - 1) {
-                    *e.get_mut() = decremented;
+                persisted_set_changed = e.get_mut().unpin(durability);
+                if e.get().is_pinned() {
                     false
                 } else {
                     e.remove();
@@ -146,13 +206,15 @@ impl PinsIndex {
             } else {
                 false
             };
-        if transitioned {
+        if persisted_set_changed {
             flush_sync(&*self.inner)?;
         }
-        Ok(transitioned)
+        Ok(fully_unpinned)
     }
 
-    /// Snapshot of currently pinned `asset_root`s (keys only — refcount stays internal).
+    /// Snapshot of currently pinned `asset_root`s (keys only — refcounts stay
+    /// internal). Covers both durabilities: eviction must respect a reader's
+    /// pin exactly as it respects a writer's.
     #[must_use]
     pub fn snapshot(&self) -> HashSet<String> {
         self.inner.pins.iter().map(|r| r.key().clone()).collect()
@@ -164,7 +226,7 @@ impl Flushable for PinsInner {
         &self.dirty
     }
 
-    /// Serialise the current pinned set to `_index/pins.bin`. Refcount
+    /// Serialise the durable pinned set to `_index/pins.bin`. Refcount
     /// is collapsed to mere set-membership on disk — the persisted
     /// format only records keys.
     fn flush(&self) -> AssetsResult<()> {
@@ -214,95 +276,162 @@ mod tests {
         );
     }
 
+    fn disk_index(path: &std::path::Path) -> PinsIndex {
+        PinsIndex::with_persist_at(
+            path.to_path_buf(),
+            CancelToken::never(),
+            &BytePool::default(),
+        )
+    }
+
     #[kithara::test(timeout(Duration::from_secs(1)))]
-    fn add_and_remove_persist_immediately() {
+    fn durable_pin_persists_immediately() {
         let temp_dir = tempdir().unwrap();
         let path = temp_dir.path().join("pins.bin");
-        let idx =
-            PinsIndex::with_persist_at(path.clone(), CancelToken::never(), &BytePool::default());
+        let idx = disk_index(&path);
 
-        assert!(idx.add("asset_a").unwrap(), "first pin reports 0→1");
-        assert!(path.exists(), "first add must materialise pins.bin");
-        assert!(idx.add("asset_b").unwrap(), "fresh root reports 0→1");
-        assert!(
-            !idx.add("asset_a").unwrap(),
-            "second add of same root reports refcount-only update"
-        );
-        assert!(idx.contains("asset_a"));
-        assert_eq!(idx.snapshot().len(), 2);
+        idx.add("asset_a", PinDurability::Durable).unwrap();
+
+        assert!(path.exists(), "a durable pin must materialise pins.bin");
+    }
+
+    #[kithara::test(timeout(Duration::from_secs(1)))]
+    fn durable_unpin_persists_immediately() {
+        let temp_dir = tempdir().unwrap();
+        let path = temp_dir.path().join("pins.bin");
+        let idx = disk_index(&path);
+        idx.add("asset_a", PinDurability::Durable).unwrap();
+
+        idx.remove("asset_a", PinDurability::Durable).unwrap();
 
         assert!(
-            !idx.remove("asset_a").unwrap(),
-            "decrement-only remove must not signal a 1→0 transition"
+            !disk_index(&path).contains("asset_a"),
+            "dropping the last durable pin must reach disk at once"
         );
+    }
+
+    #[kithara::test(timeout(Duration::from_secs(1)))]
+    fn local_pin_stays_off_disk() {
+        let temp_dir = tempdir().unwrap();
+        let path = temp_dir.path().join("pins.bin");
+        let idx = disk_index(&path);
+
+        idx.add("asset_a", PinDurability::Local).unwrap();
+
+        assert!(
+            !path.exists(),
+            "a pin that cannot outlive the process must not be written"
+        );
+    }
+
+    #[kithara::test(timeout(Duration::from_secs(1)))]
+    fn local_pin_bars_eviction_like_any_other() {
+        let temp_dir = tempdir().unwrap();
+        let path = temp_dir.path().join("pins.bin");
+        let idx = disk_index(&path);
+
+        idx.add("asset_a", PinDurability::Local).unwrap();
+
+        assert!(
+            idx.snapshot().contains("asset_a"),
+            "eviction reads the in-memory set, which covers local pins"
+        );
+    }
+
+    #[kithara::test(timeout(Duration::from_secs(1)))]
+    fn a_local_pin_alongside_a_durable_one_leaves_the_file_alone() {
+        let temp_dir = tempdir().unwrap();
+        let path = temp_dir.path().join("pins.bin");
+        let idx = disk_index(&path);
+        idx.add("asset_a", PinDurability::Durable).unwrap();
+        let written = fs::read(&path).unwrap();
+
+        idx.add("asset_a", PinDurability::Local).unwrap();
+        idx.remove("asset_a", PinDurability::Local).unwrap();
+
+        assert_eq!(
+            fs::read(&path).unwrap(),
+            written,
+            "local pin churn must not rewrite the durable set"
+        );
+    }
+
+    #[kithara::test(timeout(Duration::from_secs(1)))]
+    fn a_live_local_pin_survives_the_durable_one() {
+        let temp_dir = tempdir().unwrap();
+        let path = temp_dir.path().join("pins.bin");
+        let idx = disk_index(&path);
+        idx.add("asset_a", PinDurability::Durable).unwrap();
+        idx.add("asset_a", PinDurability::Local).unwrap();
+
+        idx.remove("asset_a", PinDurability::Durable).unwrap();
+
         assert!(
             idx.contains("asset_a"),
-            "still pinned by remaining refcount"
+            "the reader still holds the asset even once the writer is done"
         );
-        assert!(idx.remove("asset_a").unwrap());
-        assert!(!idx.contains("asset_a"));
-        assert!(!idx.remove("asset_a").unwrap());
-        assert!(idx.contains("asset_b"));
     }
 
     #[kithara::test(timeout(Duration::from_secs(1)))]
     fn refcount_coalesces_repeated_pins() {
         let temp_dir = tempdir().unwrap();
         let path = temp_dir.path().join("pins.bin");
-        let idx =
-            PinsIndex::with_persist_at(path.clone(), CancelToken::never(), &BytePool::default());
+        let idx = disk_index(&path);
 
-        let transitions_in = (0..5).filter(|_| idx.add("hot_asset").unwrap()).count();
+        let transitions_in = (0..5)
+            .filter(|_| idx.add("hot_asset", PinDurability::Durable).unwrap())
+            .count();
         assert_eq!(transitions_in, 1, "only the 0→1 transition counts");
-        assert!(idx.contains("hot_asset"));
 
-        let transitions_out = (0..4).filter(|_| idx.remove("hot_asset").unwrap()).count();
+        let transitions_out = (0..4)
+            .filter(|_| idx.remove("hot_asset", PinDurability::Durable).unwrap())
+            .count();
         assert_eq!(transitions_out, 0, "intermediate decrements stay in-memory");
-        assert!(idx.contains("hot_asset"), "refcount=1 keeps the pin alive");
-
-        assert!(idx.remove("hot_asset").unwrap());
-        assert!(!idx.contains("hot_asset"));
     }
 
     #[kithara::test(timeout(Duration::from_secs(1)))]
     fn concurrent_leases_keep_pin_alive() {
         let temp_dir = tempdir().unwrap();
         let path = temp_dir.path().join("pins.bin");
-        let idx = PinsIndex::with_persist_at(path, CancelToken::never(), &BytePool::default());
+        let idx = disk_index(&path);
 
-        idx.add("playlist").unwrap();
-        idx.add("playlist").unwrap();
+        idx.add("playlist", PinDurability::Durable).unwrap();
+        idx.add("playlist", PinDurability::Durable).unwrap();
 
-        assert!(!idx.remove("playlist").unwrap());
+        assert!(!idx.remove("playlist", PinDurability::Durable).unwrap());
         assert!(idx.contains("playlist"));
 
-        assert!(idx.remove("playlist").unwrap());
+        assert!(idx.remove("playlist", PinDurability::Durable).unwrap());
         assert!(!idx.contains("playlist"));
     }
 
     #[kithara::test(timeout(Duration::from_secs(1)))]
-    fn persistence_across_instances() {
+    fn durable_pins_persist_across_instances() {
         let temp_dir = tempdir().unwrap();
         let path = temp_dir.path().join("shared.bin");
+        disk_index(&path)
+            .add("persistent_asset", PinDurability::Durable)
+            .unwrap();
 
-        {
-            let idx = PinsIndex::with_persist_at(
-                path.clone(),
-                CancelToken::never(),
-                &BytePool::default(),
-            );
-            idx.add("persistent_asset").unwrap();
-        }
+        let reopened = disk_index(&path);
 
-        {
-            let idx = PinsIndex::with_persist_at(
-                path.clone(),
-                CancelToken::never(),
-                &BytePool::default(),
-            );
-            assert!(idx.contains("persistent_asset"));
-            assert_eq!(idx.snapshot().len(), 1);
-        }
+        assert!(reopened.contains("persistent_asset"));
+    }
+
+    #[kithara::test(timeout(Duration::from_secs(1)))]
+    fn local_pins_do_not_cross_instances() {
+        let temp_dir = tempdir().unwrap();
+        let path = temp_dir.path().join("shared.bin");
+        disk_index(&path)
+            .add("reader_only", PinDurability::Local)
+            .unwrap();
+
+        let reopened = disk_index(&path);
+
+        assert!(
+            !reopened.contains("reader_only"),
+            "a process-local pin must not be resurrected as a phantom"
+        );
     }
 
     #[kithara::test(timeout(Duration::from_secs(1)))]
@@ -318,7 +447,7 @@ mod tests {
     #[kithara::test(timeout(Duration::from_secs(1)))]
     fn ephemeral_index_does_not_persist() {
         let idx = PinsIndex::ephemeral();
-        assert!(idx.add("asset").unwrap());
+        assert!(idx.add("asset", PinDurability::Durable).unwrap());
         assert!(idx.contains("asset"));
     }
 
@@ -329,10 +458,10 @@ mod tests {
         let idx = PinsIndex::with_persist_at(path, CancelToken::never(), &BytePool::default());
         let idx2 = idx.clone();
 
-        idx.add("from_first").unwrap();
+        idx.add("from_first", PinDurability::Durable).unwrap();
         assert!(idx2.contains("from_first"));
 
-        idx2.remove("from_first").unwrap();
+        idx2.remove("from_first", PinDurability::Durable).unwrap();
         assert!(!idx.contains("from_first"));
     }
 }

--- a/crates/kithara-assets/src/index/pins/disk.rs
+++ b/crates/kithara-assets/src/index/pins/disk.rs
@@ -3,7 +3,6 @@
 use std::{
     collections::BTreeMap,
     fs,
-    num::NonZeroU32,
     path::PathBuf,
     sync::{
         OnceLock,
@@ -16,7 +15,7 @@ use kithara_bufpool::BytePool;
 use kithara_platform::{CancelToken, sync::Arc};
 use kithara_storage::{Atomic, MmapDriver, StorageError};
 
-use super::core::{PinsIndex, PinsInner};
+use super::core::{PinCounts, PinsIndex, PinsInner};
 use crate::{
     error::{AssetsError, AssetsResult},
     index::persistence::{init_atomic, open_existing, schema::PinsIndexFile},
@@ -58,12 +57,21 @@ impl PinsIndex {
 }
 
 impl PinsInner {
+    /// Roots held by at least one durable pin — the set that belongs on disk.
+    fn durable_roots(&self) -> Vec<String> {
+        self.pins
+            .iter()
+            .filter(|r| r.value().durable > 0)
+            .map(|r| r.key().clone())
+            .collect()
+    }
+
     pub(super) fn flush_with_durability(&self, durable: bool) -> AssetsResult<()> {
         let Some(persist) = self.persist.as_ref() else {
             self.dirty.store(false, Ordering::Release);
             return Ok(());
         };
-        let snapshot: Vec<String> = self.pins.iter().map(|r| r.key().clone()).collect();
+        let snapshot = self.durable_roots();
         let atomic = init_atomic(&persist.res, &persist.path, &persist.cancel)?;
         write_pins(atomic, &snapshot, durable)?;
         self.dirty.store(false, Ordering::Release);
@@ -75,7 +83,7 @@ fn hydrate_existing(
     path: &std::path::Path,
     cancel: &CancelToken,
     pool: &BytePool,
-) -> (DashMap<String, NonZeroU32>, Option<Atomic<MmapDriver>>) {
+) -> (DashMap<String, PinCounts>, Option<Atomic<MmapDriver>>) {
     let nonempty = fs::metadata(path).is_ok_and(|m| m.len() > 0);
     if !nonempty {
         return (DashMap::new(), None);
@@ -93,10 +101,19 @@ fn hydrate_existing(
     }
 }
 
+/// Counts for a root read back from `pins.bin`: whoever set that pin is gone,
+/// so the surviving claim is a single durable one.
+fn hydrated_counts() -> PinCounts {
+    PinCounts {
+        durable: 1,
+        local: 0,
+    }
+}
+
 fn read_pins(
     res: &Atomic<MmapDriver>,
     pool: &BytePool,
-) -> AssetsResult<DashMap<String, NonZeroU32>> {
+) -> AssetsResult<DashMap<String, PinCounts>> {
     let mut buf = pool.get();
     let n = res.read_into(&mut buf)?;
 
@@ -119,7 +136,7 @@ fn read_pins(
         .pinned
         .iter()
         .filter(|(_, v)| **v)
-        .map(|(k, _)| (k.as_str().to_string(), NonZeroU32::MIN))
+        .map(|(k, _)| (k.as_str().to_string(), hydrated_counts()))
         .collect();
     Ok(pinned)
 }

--- a/crates/kithara-assets/src/index/pins/mod.rs
+++ b/crates/kithara-assets/src/index/pins/mod.rs
@@ -4,4 +4,4 @@ mod core;
 #[cfg(not(target_arch = "wasm32"))]
 mod disk;
 
-pub use core::PinsIndex;
+pub use core::{PinDurability, PinsIndex};

--- a/crates/kithara-assets/src/store/builder.rs
+++ b/crates/kithara-assets/src/store/builder.rs
@@ -320,7 +320,7 @@ mod tests {
     use super::*;
     use crate::{
         AssetResourceState, AssetWriter, AssetsError, ResourceAcquisition, ResourceKey,
-        decorator::{Assets, Capabilities},
+        decorator::Capabilities,
         resource::{AcquisitionResult, ReadSide, WriteSide},
     };
 

--- a/crates/kithara-assets/src/store/handle.rs
+++ b/crates/kithara-assets/src/store/handle.rs
@@ -161,9 +161,10 @@ impl AssetStore {
     /// Persist the in-memory byte-availability aggregate snapshot to
     /// disk. For an in-memory store this is a no-op.
     ///
-    /// Checkpointing is always explicit — there is no `Drop` hook and
-    /// no background flush timer. Callers decide when a consistent
-    /// aggregate must survive a restart.
+    /// Callers can checkpoint at any point they want a consistent
+    /// aggregate on disk; the store also checkpoints itself when the last
+    /// handle drops, because the manifest is what makes a resource usable
+    /// after a restart.
     ///
     /// # Errors
     ///
@@ -336,6 +337,23 @@ impl AssetStore {
         Fut: Future<Output = T>,
     {
         self.transactions().run(key, operation).await
+    }
+}
+
+/// The manifest decides what survives a restart, so the last handle writes
+/// it before the indexes go away. Waiting for the flush hub's own teardown
+/// is too late: every index holds the hub alive, so by the time the hub
+/// drops there is nothing left to flush.
+impl Drop for AssetStoreInner {
+    fn drop(&mut self) {
+        #[cfg(not(target_arch = "wasm32"))]
+        if let StoreBackendInner::Disk {
+            base: Some(base), ..
+        } = &self.backend
+            && let Err(error) = base.checkpoint()
+        {
+            tracing::warn!(%error, "AssetStore: final checkpoint failed");
+        }
     }
 }
 

--- a/crates/kithara-storage/src/backend/mmap/driver.rs
+++ b/crates/kithara-storage/src/backend/mmap/driver.rs
@@ -72,6 +72,11 @@ pub struct MmapDriver {
     pub(super) mmap: Mutex<MmapState>,
     pub(super) mode: OpenMode,
     pub(super) path: PathBuf,
+    /// Size a fresh mapping starts at, from `MmapOptions::initial_len`. A
+    /// re-download reuses it so the rewrite generation is reserved exactly
+    /// like the first one instead of restarting from the default and
+    /// re-mapping its way back up.
+    pub(super) initial_len: u64,
     /// Lock-free queue for fast-path range notifications.
     pub(super) ready_ranges: SegQueue<Range<u64>>,
 }
@@ -150,6 +155,7 @@ impl Driver for MmapDriver {
             committed,
             mmap: Mutex::new(mmap_state),
             path: opts.path,
+            initial_len: opts.initial_len.unwrap_or(Consts::DEFAULT_INITIAL_SIZE),
             ready_ranges: SegQueue::new(),
         };
 
@@ -369,6 +375,28 @@ mod tests {
         let n = res.read_at(0, &mut buf).unwrap();
         assert_eq!(n, 1024);
         assert!(buf.iter().all(|&b| b == 42));
+    }
+
+    /// A re-download starts a fresh generation in a rewrite temp file. It
+    /// carries the same payload as the first one, so it must start from the
+    /// same reservation — otherwise the rewrite re-maps its way back up from
+    /// the default while the original never had to.
+    #[kithara::test(timeout(Duration::from_secs(1)))]
+    fn rewrite_generation_reuses_the_original_reservation() {
+        let dir = TempDir::new().unwrap();
+        let reservation = 1024 * 1024;
+        let res = create_resource_with_size(&dir, Some(reservation));
+        res.write_at(0, b"first").unwrap();
+        let res = res.commit(Some(5)).unwrap();
+
+        let _writer = res.reactivate().unwrap();
+
+        let rewrite = dir.path().join("test.dat.kithara-rewrite");
+        assert_eq!(
+            fs::metadata(&rewrite).unwrap().len(),
+            reservation,
+            "the rewrite generation must be reserved like the first one"
+        );
     }
 
     #[kithara::test(timeout(Duration::from_secs(1)))]

--- a/crates/kithara-storage/src/backend/mmap/driver.rs
+++ b/crates/kithara-storage/src/backend/mmap/driver.rs
@@ -377,6 +377,22 @@ mod tests {
         assert!(buf.iter().all(|&b| b == 42));
     }
 
+    /// Sealing finalizes the bytes without publishing a snapshot, because the
+    /// caller is about to rename the file and republish it itself. Until that
+    /// happens the live mapping is all a reader has, so it must keep serving.
+    #[kithara::test(timeout(Duration::from_secs(1)))]
+    fn a_sealed_resource_still_serves_its_bytes() {
+        let dir = TempDir::new().unwrap();
+        let res = create_resource_with_size(&dir, Some(64 * 1024));
+        res.write_at(0, b"payload").unwrap();
+
+        res.seal_in_place(Some(7)).unwrap();
+
+        let mut buf = [0u8; 7];
+        res.reader().read_at(0, &mut buf).unwrap();
+        assert_eq!(&buf, b"payload", "a sealed resource must stay readable");
+    }
+
     /// A re-download starts a fresh generation in a rewrite temp file. It
     /// carries the same payload as the first one, so it must start from the
     /// same reservation — otherwise the rewrite re-maps its way back up from

--- a/crates/kithara-storage/src/backend/mmap/io.rs
+++ b/crates/kithara-storage/src/backend/mmap/io.rs
@@ -104,6 +104,32 @@ impl DriverIo for MmapDriver {
         Ok(())
     }
 
+    /// Flush the written pages and stop, keeping the active mapping. The
+    /// caller renames the file and reopens on its canonical path, so the
+    /// snapshot this would have published is dead on arrival — and the live
+    /// mapping is what serves readers until that reopen lands. A zero-length
+    /// or already-published resource has nothing to keep alive and takes the
+    /// ordinary commit path.
+    fn seal(&self, final_len: Option<u64>) -> StorageResult<()> {
+        if final_len == Some(0) {
+            return self.commit(final_len);
+        }
+        let mmap_guard = self.mmap.lock();
+        let MmapState::Active(mmap) = &*mmap_guard else {
+            drop(mmap_guard);
+            return self.commit(final_len);
+        };
+        // Flush the written prefix, not the whole mapping: the reservation
+        // beyond `final_len` is untouched, and syncing it back would cost
+        // more than the re-map this seal exists to avoid.
+        match final_len.filter(|len| *len < mmap.len()) {
+            Some(len) => mmap.flush_range(0, len)?,
+            None => mmap.flush()?,
+        }
+        drop(mmap_guard);
+        Ok(())
+    }
+
     fn committed_len(&self) -> Option<u64> {
         self.committed.load().as_ref().map(|m| m.len())
     }

--- a/crates/kithara-storage/src/backend/mmap/io.rs
+++ b/crates/kithara-storage/src/backend/mmap/io.rs
@@ -137,7 +137,7 @@ impl DriverIo for MmapDriver {
                 let temp = self.rewrite_temp_path();
                 // Drop any stale temp left by a previously-cancelled rewrite.
                 let _ = fs::remove_file(&temp);
-                let rw = MemoryMappedFile::create_rw(&temp, Consts::DEFAULT_INITIAL_SIZE)?;
+                let rw = MemoryMappedFile::create_rw(&temp, self.initial_len)?;
                 *mmap_guard = MmapState::Active(rw);
             }
         }

--- a/crates/kithara-storage/src/backend/resource/handle.rs
+++ b/crates/kithara-storage/src/backend/resource/handle.rs
@@ -177,6 +177,14 @@ impl<D: DriverIo> Resource<Active, D> {
             /// cannot finalize.
             #[call(commit_inner)]
             pub(crate) fn commit_in_place(&self, final_len: Option<u64>) -> StorageResult<()>;
+            /// Commit in place without publishing a snapshot, for a decorator
+            /// that republishes the resource itself right after.
+            ///
+            /// # Errors
+            /// Returns error if the resource is cancelled, failed, or the backend
+            /// cannot flush.
+            #[call(seal_inner)]
+            pub(crate) fn seal_in_place(&self, final_len: Option<u64>) -> StorageResult<()>;
             /// Mark the resource as failed, consuming the writer.
             #[call(fail_inner)]
             pub fn fail(self, reason: String);

--- a/crates/kithara-storage/src/backend/resource/lifecycle.rs
+++ b/crates/kithara-storage/src/backend/resource/lifecycle.rs
@@ -10,11 +10,32 @@ use crate::{
     resource::{ResourceStatus, range_covered_by},
 };
 
+/// Whether finalizing also publishes the driver's committed snapshot.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Publish {
+    Snapshot,
+    Skip,
+}
+
 impl<D: DriverIo> ResourceCore<D> {
     pub(super) fn commit_inner(&self, final_len: Option<u64>) -> StorageResult<()> {
+        self.finish_inner(final_len, Publish::Snapshot)
+    }
+
+    /// Commit without publishing a driver snapshot — see [`DriverIo::seal`].
+    /// Readiness is announced exactly as in [`Self::commit_inner`]: waiters
+    /// must wake whether or not a snapshot was published.
+    pub(super) fn seal_inner(&self, final_len: Option<u64>) -> StorageResult<()> {
+        self.finish_inner(final_len, Publish::Skip)
+    }
+
+    fn finish_inner(&self, final_len: Option<u64>, publish: Publish) -> StorageResult<()> {
         self.check_health()?;
 
-        self.inner.driver.commit(final_len)?;
+        match publish {
+            Publish::Snapshot => self.inner.driver.commit(final_len)?,
+            Publish::Skip => self.inner.driver.seal(final_len)?,
+        }
         self.inner.committed.store(true, Ordering::Release);
 
         {

--- a/crates/kithara-storage/src/backend/traits.rs
+++ b/crates/kithara-storage/src/backend/traits.rs
@@ -29,6 +29,24 @@ pub trait DriverIo: Send + Sync + 'static {
     /// truncation or read-only reopen fails).
     fn commit(&self, final_len: Option<u64>) -> StorageResult<()>;
 
+    /// Finalize the written bytes without publishing a committed snapshot.
+    ///
+    /// For a caller that is about to replace this resource anyway — the
+    /// atomic-chunked commit renames the file and reopens on the canonical
+    /// path — publishing here would map a file that is discarded a moment
+    /// later. Sealing flushes the bytes and leaves the active mapping in
+    /// place, so readers that already hold a view keep serving from it until
+    /// the replacement lands.
+    ///
+    /// Drivers that cannot separate the two fall back to [`Self::commit`].
+    ///
+    /// # Errors
+    ///
+    /// Returns error if the written bytes cannot be flushed.
+    fn seal(&self, final_len: Option<u64>) -> StorageResult<()> {
+        self.commit(final_len)
+    }
+
     /// Length of the published committed snapshot, if any.
     ///
     /// Returns `Some(n)` iff an immutable committed snapshot of length `n`

--- a/crates/kithara-storage/src/decorator/chunked/core.rs
+++ b/crates/kithara-storage/src/decorator/chunked/core.rs
@@ -103,28 +103,40 @@ impl<D: DriverIo> AtomicChunked<D> {
     /// # Errors
     /// Propagates the inner commit error and any filesystem error.
     pub fn commit(&self, final_len: Option<u64>) -> StorageResult<()> {
-        self.inner.load().commit_in_place(final_len)?;
+        let Some(tmp) = self.tmp_path.lock().take() else {
+            return self.inner.load().commit_in_place(final_len);
+        };
 
-        let tmp = self.tmp_path.lock().take();
-        if let Some(tmp) = tmp {
-            let f = OpenOptions::new().write(true).open(&tmp).map_err(|e| {
-                StorageError::Failed(format!("AtomicChunked commit: open tmp {tmp:?}: {e}"))
-            })?;
-            f.sync_data().map_err(|e| {
-                StorageError::Failed(format!("AtomicChunked commit: sync_data {tmp:?}: {e}"))
-            })?;
-            drop(f);
-            fs::rename(&tmp, &self.canonical_path).map_err(|e| {
-                StorageError::Failed(format!(
-                    "AtomicChunked commit: rename {tmp:?} -> {:?}: {e}",
-                    self.canonical_path
-                ))
-            })?;
+        // Sealing skips the driver's snapshot: it would map the temp file
+        // that the rename below retires. One handle then trims the surplus
+        // reservation and forces the bytes down, so the canonical path can
+        // only ever appear fully durable.
+        self.inner.load().seal_in_place(final_len)?;
 
-            if let Some(factory) = self.factory.as_ref() {
-                let new_inner = factory(&self.canonical_path, OpenIntent::Reopen)?;
-                self.inner.store(Arc::new(new_inner));
-            }
+        let f = OpenOptions::new().write(true).open(&tmp).map_err(|e| {
+            StorageError::Failed(format!("AtomicChunked commit: open tmp {tmp:?}: {e}"))
+        })?;
+        if let Some(len) = final_len
+            && f.metadata().is_ok_and(|m| m.len() > len)
+        {
+            f.set_len(len).map_err(|e| {
+                StorageError::Failed(format!("AtomicChunked commit: trim {tmp:?}: {e}"))
+            })?;
+        }
+        f.sync_data().map_err(|e| {
+            StorageError::Failed(format!("AtomicChunked commit: sync_data {tmp:?}: {e}"))
+        })?;
+        drop(f);
+        fs::rename(&tmp, &self.canonical_path).map_err(|e| {
+            StorageError::Failed(format!(
+                "AtomicChunked commit: rename {tmp:?} -> {:?}: {e}",
+                self.canonical_path
+            ))
+        })?;
+
+        if let Some(factory) = self.factory.as_ref() {
+            let new_inner = factory(&self.canonical_path, OpenIntent::Reopen)?;
+            self.inner.store(Arc::new(new_inner));
         }
         Ok(())
     }

--- a/crates/kithara-storage/src/decorator/chunked/core.rs
+++ b/crates/kithara-storage/src/decorator/chunked/core.rs
@@ -24,6 +24,18 @@ pub(super) fn make_tmp_path(canonical: &Path) -> Option<PathBuf> {
     Some(parent.join(format!("{name}.tmp")))
 }
 
+/// When the committed bytes are forced onto the medium.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Barrier {
+    /// `sync_data` before the rename. The canonical path can then only ever
+    /// appear fully durable, at the cost of one medium-speed wait per commit.
+    Inline,
+    /// No barrier here — the owner forces these files down itself and only
+    /// then records them as usable. Until it does, the file on disk proves
+    /// nothing, so the owner must not treat its mere existence as readiness.
+    Deferred,
+}
+
 /// Hint passed to the factory closure to disambiguate the two
 /// lifecycle calls.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -59,11 +71,10 @@ type FactoryFn<D> =
 /// [`ResourceWriter`].
 ///
 /// During the write phase the inner resource is mmapped at
-/// `<canonical>.tmp`. On `commit()` the data is durably flushed
-/// (`sync_data`), the temp file is atomically renamed to
-/// `canonical`, and the inner is reopened on the canonical path —
-/// guaranteeing that any external observer of the canonical path
-/// either sees no file or sees the fully durable committed bytes.
+/// `<canonical>.tmp`. On `commit()` the temp file is atomically renamed to
+/// `canonical` and the inner is reopened there, so an external observer of
+/// the canonical path either sees no file or sees the whole thing. Whether
+/// those bytes are also *durable* by then is [`Barrier`]'s business.
 #[derive(fieldwork::Fieldwork)]
 #[fieldwork(opt_in, get, deref = false)]
 pub struct AtomicChunked<D: DriverIo> {
@@ -77,6 +88,7 @@ pub struct AtomicChunked<D: DriverIo> {
     /// Factory to reopen the inner on the canonical path post-rename.
     /// `None` when the wrapper was constructed in passthrough mode.
     factory: Option<FactoryFn<D>>,
+    barrier: Barrier,
     #[field(get(
         deref = Path,
         doc = "Path the resource will land at on a successful commit."
@@ -123,9 +135,11 @@ impl<D: DriverIo> AtomicChunked<D> {
                 StorageError::Failed(format!("AtomicChunked commit: trim {tmp:?}: {e}"))
             })?;
         }
-        f.sync_data().map_err(|e| {
-            StorageError::Failed(format!("AtomicChunked commit: sync_data {tmp:?}: {e}"))
-        })?;
+        if self.barrier == Barrier::Inline {
+            f.sync_data().map_err(|e| {
+                StorageError::Failed(format!("AtomicChunked commit: sync_data {tmp:?}: {e}"))
+            })?;
+        }
         drop(f);
         fs::rename(&tmp, &self.canonical_path).map_err(|e| {
             StorageError::Failed(format!(
@@ -183,6 +197,30 @@ impl<D: DriverIo> AtomicChunked<D> {
     where
         F: Fn(&Path, OpenIntent) -> StorageResult<ResourceWriter<D>> + Send + Sync + 'static,
     {
+        Self::open_with_barrier(canonical_path, factory, Barrier::Inline)
+    }
+
+    /// Like [`Self::open`], but the caller owns the durability barrier — see
+    /// [`Barrier::Deferred`] for what it takes on by doing so.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`Self::open`].
+    pub fn open_deferred<F>(canonical_path: PathBuf, factory: F) -> StorageResult<Self>
+    where
+        F: Fn(&Path, OpenIntent) -> StorageResult<ResourceWriter<D>> + Send + Sync + 'static,
+    {
+        Self::open_with_barrier(canonical_path, factory, Barrier::Deferred)
+    }
+
+    fn open_with_barrier<F>(
+        canonical_path: PathBuf,
+        factory: F,
+        barrier: Barrier,
+    ) -> StorageResult<Self>
+    where
+        F: Fn(&Path, OpenIntent) -> StorageResult<ResourceWriter<D>> + Send + Sync + 'static,
+    {
         let tmp_path = make_tmp_path(&canonical_path).ok_or_else(|| {
             StorageError::Failed(format!(
                 "AtomicChunked: cannot derive tmp path from {canonical_path:?}"
@@ -206,6 +244,7 @@ impl<D: DriverIo> AtomicChunked<D> {
         }
         let inner = factory(&tmp_path, OpenIntent::Fresh)?;
         Ok(Self {
+            barrier,
             canonical_path,
             inner: ArcSwap::from_pointee(inner),
             tmp_path: Mutex::new(Some(tmp_path)),
@@ -224,6 +263,7 @@ impl<D: DriverIo> AtomicChunked<D> {
             inner: ArcSwap::from_pointee(inner),
             tmp_path: Mutex::default(),
             factory: None,
+            barrier: Barrier::Inline,
         }
     }
 

--- a/crates/kithara-storage/src/decorator/chunked/mod.rs
+++ b/crates/kithara-storage/src/decorator/chunked/mod.rs
@@ -9,4 +9,4 @@ pub(crate) mod core;
 #[cfg(test)]
 mod tests;
 
-pub use core::{AtomicChunked, OpenIntent};
+pub use core::{AtomicChunked, Barrier, OpenIntent};

--- a/crates/kithara-storage/src/decorator/mod.rs
+++ b/crates/kithara-storage/src/decorator/mod.rs
@@ -7,4 +7,4 @@ pub(crate) mod atomic;
 pub(crate) mod chunked;
 
 pub use atomic::Atomic;
-pub use chunked::{AtomicChunked, OpenIntent};
+pub use chunked::{AtomicChunked, Barrier, OpenIntent};

--- a/crates/kithara-storage/src/lib.rs
+++ b/crates/kithara-storage/src/lib.rs
@@ -30,7 +30,7 @@ pub use backend::{
 };
 #[cfg(not(target_arch = "wasm32"))]
 pub use backend::{MmapDriver, MmapOptions, MmapResource};
-pub use decorator::{Atomic, AtomicChunked, OpenIntent};
+pub use decorator::{Atomic, AtomicChunked, Barrier, OpenIntent};
 pub use error::{StorageError, StorageResult};
 pub use resource::{OpenMode, ResourceStatus, WaitOutcome};
 pub use unified::StorageResource;

--- a/tests/src/asset_fixture.rs
+++ b/tests/src/asset_fixture.rs
@@ -3,7 +3,10 @@
 use std::collections::HashSet;
 
 use kithara::{
-    assets::{Assets, AssetsResult, BytePool, index::PinsIndex as InnerPinsIndex},
+    assets::{
+        Assets, AssetsResult, BytePool,
+        index::{PinDurability, PinsIndex as InnerPinsIndex},
+    },
     platform::CancelToken,
 };
 
@@ -52,10 +55,10 @@ impl PinsIndex {
     pub fn store(&self, pins: &HashSet<String>) -> AssetsResult<()> {
         let current = self.inner.snapshot();
         for outdated in current.difference(pins) {
-            self.inner.remove(outdated)?;
+            self.inner.remove(outdated, PinDurability::Durable)?;
         }
         for added in pins.difference(&current) {
-            self.inner.add(added)?;
+            self.inner.add(added, PinDurability::Durable)?;
         }
         self.inner.flush()
     }


### PR DESCRIPTION
## Why

`kithara_hls::stress_seek_audio` timed out roughly every other run on an idle
host. Not load: the disk cases had simply grown into their own budget.

```
stress_seek_audio_hls_wav_symphonia_ephemeral      1.58 s  PASS
stress_seek_audio_hls_wav_symphonia_mmap          30.63 s  FAIL (30 s timeout)
stress_seek_audio_hls_wav_symphonia_full_cache    30.65 s  FAIL
```

Same scenario throughout — the cases differ only in storage backend. The 30 s
ceiling is untouched here; the product is what changed.

## Root cause

`ResourceHandle::read_at` opens the resource on *every* read, and `LeaseAssets`
pins the asset root on every open. Both refcount transitions through zero
rewrote `_index/pins.bin` whole — temp file, write, rename, mmap reopen — and
Symphonia refills its buffer on every read, so a 1000-seek storm paid thousands
of atomic file rewrites.

Profile (`sample`, 2321 samples on `kithara-audio-worker`): `write_pins`
accounts for **1738 of them, ~75 % of the worker**. Leaf syscalls: `open` 1168,
`rename` 568. A memory backend has no persistence, which is the whole 17× gap.

The cache was never the culprit and the numbers say so: `full_cache` (capacity
56 over 48 segments — cannot miss) ran exactly as slow as the capped case.
`CachedAssets` sits *below* `LeaseAssets`, so a cache hit saves the file open
but never the pin.

## What changed

Five commits, each measured and gated separately.

1. **Reader pins stay off disk.** `PinsIndex` keeps two refcounts per root by
   `PinDurability`. Both bar eviction identically; only the durable subset — an
   unfinished write — reaches disk, and only on its own transitions through
   zero. Local pins are never hydrated back: a pin that cannot outlive its
   holder would return as a phantom nothing releases.
2. **Segment files are reserved up front.** They opened at the driver's 64 KB
   default and doubled while writing, re-mapping twice per 200 KB segment. The
   reservation is trimmed to `final_len` on commit, so it costs a sparse extent.
3. **No snapshot the rename retires.** A commit opened the backing file four
   times; `DriverIo::seal` finalizes without publishing, and the trim rides the
   handle already opened for `sync_data`. Two opens remain.
4. **The durability barrier is paid once per flush.** Batching it as such is
   impossible — it is issued per descriptor — so it moves off the download path
   instead: segments open with `Barrier::Deferred` and only rename, while the
   availability flush `sync_data`s the files committed since the last flush and
   *then* writes the snapshot. That order is the guarantee.

Since a file alone no longer proves anything, hydration is inverted with it: an
existing file counts as ready only when the manifest knows its final length.
Anything else is indistinguishable from a torn write and is refetched. Losing
the manifest costs a refetch, never a wrong read — the guarantee this buffer
needs, because a decode error is fatal.

`AssetStore` now also checkpoints itself when its last handle drops. Deferring
to the flush hub's teardown does not work: every index holds the hub alive, so
by then the sources are gone and a segment downloaded just before shutdown
would be refetched.

## Result

| case | before | after |
|---|---|---|
| `wav_symphonia_full_cache` | 9.02 s | **0.77 s** |
| `wav_symphonia_mmap` | 9.39 s | **1.98 s** |
| `wav_apple_mmap` | 5.78 s | 1.98 s |
| `ephemeral` (in-memory) | 0.67 s | 0.51 s |

The disk-vs-memory gap went from ~17× to ~1.5×, and the 30 s budget now has
roughly 40× headroom instead of 1.5 s.

## Verification

`just ci gate` on this base, both lanes: **4624/4624** (flash on) and
**4543/4543** (flash off). Lint `0 deny, 0 regression, 0 new`. Every commit was
gated on its own before the next one started.

## Notes for review

- Isolated microbenchmarks overestimated every item here by ~5×; all numbers
  above come from phase timings of real runs. Worth knowing before trusting a
  similar model next time.
- Two regressions were caught by measuring rather than reading: flushing the
  whole mapping instead of the written prefix (capped-cache 2.28 s → 3.05 s),
  and a final flush placed in the hub's `Drop`, where the sources are already
  dead.
- `crates/kithara-assets/CONTEXT.md` is updated: the manifest is now the
  authority on what survives a restart, replacing "a file on disk is the truth".
