### PR TITLE
fix(ci): name the Linux image once, and let a test keep it that way

### DIFF
--- a/.gitlab/ci/common.yml
+++ b/.gitlab/ci/common.yml
@@ -22,7 +22,7 @@
 
 .linux-job:
   extends: .unix-job
-  image: kithara-ci:linux-20260729
+  image: kithara-ci:linux-20260806d
   tags:
     - kithara-linux
 

--- a/xtask/src/ci/run.rs
+++ b/xtask/src/ci/run.rs
@@ -229,6 +229,31 @@ mod tests {
         lanes
     }
 
+    /// The image a Linux job starts in is named twice: in the reviewed pins,
+    /// which every machine builds and provisions from, and in the pipeline that
+    /// runs the job. Nothing but this test connects them, and a machine that
+    /// has built one tag cannot serve a pipeline asking for the other — which
+    /// is how a host ended up with an image its own provisioning refused.
+    #[test]
+    fn the_linux_pipeline_starts_the_image_the_pins_name() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("xtask has a workspace root");
+        let pins = crate::ci::config::CiPins::load(&root.join(crate::ci::config::PINS_PATH))
+            .expect("the reviewed pins load");
+        let common = fs::read_to_string(root.join(".gitlab/ci/common.yml"))
+            .expect("the shared pipeline definition is readable");
+        let declared = common
+            .lines()
+            .find_map(|line| line.trim().strip_prefix("image: "))
+            .expect("the Linux job names an image");
+
+        assert_eq!(
+            declared, pins.linux_image,
+            "the pipeline and the pins name different images"
+        );
+    }
+
     #[test]
     fn ci_lane_is_typed_and_uses_modular_names() {
         assert!(Cli::try_parse_from(["xtask", "ci", "run", "apple-lint"]).is_ok());


### PR DESCRIPTION
## Summary

The tag of the Linux CI image was written in two places: `.config/ci-pins.toml`,
which every machine builds and provisions from, and `.gitlab/ci/common.yml`,
which starts the job. Moving the pins for one machine left the other holding an
image nothing asked for and asking for an image it had never built. Worse, its
own provisioning command validates the pinned image before it will write
anything, so the machine could not be brought back in step by the tool that
exists to do exactly that — only by hand.

The pipeline now names what the pins name, and a test connects the two the same
way one already connects the lane enum to its job names: nothing else does, and
the disagreement is invisible until a runner is minutes into a build.

## Behavior / scope

- `.gitlab/ci/common.yml` starts the pinned image rather than a tag of its own.
- A new test reads the reviewed pins and the shared pipeline definition and
  fails when they disagree.
- No lane, no job and no runner definition changes.

## Validation

- `cargo test -p xtask --bins` — 153 passed, including the new test.
- Checked that the new test fails on the disagreement it is meant to catch: it
  is what the aligned tag was written against.
- Not exercised here: the machine that still has to build the pinned image.
  See the follow-up below.

## Surface impact

- Public API: none.
- Platform/runtime: changed: the Linux CI image a GitLab job starts in.
- Perf-sensitive paths: none.

## Risks / follow-ups

- A machine holding only the previous tag will not serve the Linux lane until
  it builds the pinned one (`ci host build-linux-image`). That is the cost of
  the two names having drifted, not of naming them once.
- The same class of gap remains one level up: a host profile renamed in the
  code strands a machine whose provisioning ran before the rename, and the
  repair is manual. Worth deciding whether `ci host install-services` should
  carry an explicit one-time migration.