### PR TITLE
ci(gitlab): let a branch push reach the Apple host

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,12 @@ workflow:
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    # A branch with an open merge request is already covered by the
+    # merge-request pipeline. A second pipeline on the same commit would take
+    # the one Apple host twice to report the same thing.
+    - if: $CI_PIPELINE_SOURCE == "push" && $CI_OPEN_MERGE_REQUESTS
+      when: never
+    - if: $CI_PIPELINE_SOURCE == "push"
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_PIPELINE_SOURCE == "web" && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $KITHARA_RELEASE_VERSION =~ /^\d+\.\d+\.\d+(-[0-9A-Za-z.]+)?$/
     - if: $CI_PIPELINE_SOURCE == "api" && $KITHARA_QUARANTINE_SHA
@@ -28,6 +34,29 @@ dispatch:merge-request:
     KITHARA_PIPELINE_KIND: merge-request
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+
+# Work in progress reaching the Apple host on its own, before anyone opens a
+# merge request. It answers a question rather than guarding anything, so it
+# takes neither the verdict nor the queue from the pipelines that do: the
+# trigger is allowed to fail, and it holds a resource group of its own, so a
+# push can never make `dispatch:main` or a merge request wait behind an hour of
+# somebody's branch. Measurement stays honest regardless — the suites, the
+# simulator run and every perf lane share `kithara-suite` across pipelines, so
+# one of them still holds the machine at a time.
+dispatch:branch:
+  stage: dispatch
+  resource_group: kithara-mac-mini-branch
+  allow_failure: true
+  interruptible: true
+  trigger:
+    include:
+      - local: .gitlab/ci/pipeline.yml
+    strategy: depend
+  variables:
+    KITHARA_CACHE_TRUST: review
+    KITHARA_PIPELINE_KIND: branch
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH != $CI_DEFAULT_BRANCH
 
 dispatch:main:
   extends: .serialized

--- a/.gitlab/ci/apple.yml
+++ b/.gitlab/ci/apple.yml
@@ -6,7 +6,9 @@
   timeout: 60 minutes
 
 apple:lint:
-  extends: .apple-job
+  extends:
+    - .apple-job
+    - .rules-verify-and-branch
   needs: []
   script:
     - just ci run apple-lint
@@ -28,6 +30,7 @@ apple:test:
   extends:
     - .apple-job
     - .measured
+    - .rules-verify-and-branch
   needs:
     - apple:lint
   script:
@@ -43,7 +46,7 @@ apple:test:
 apple:test-flash-off:
   extends:
     - .macos-job
-    - .rules-integration
+    - .rules-integration-and-branch
     - .measured
   stage: apple
   timeout: 60 minutes
@@ -60,7 +63,9 @@ apple:test-flash-off:
       - target/nextest/ci/junit.xml
 
 apple:xcframework:
-  extends: .apple-job
+  extends:
+    - .apple-job
+    - .rules-verify-and-branch
   needs:
     - apple:lint
   script:
@@ -93,7 +98,7 @@ apple:ios:
 apple:ios-test:
   extends:
     - .macos-job
-    - .rules-integration
+    - .rules-integration-and-branch
     - .measured
   stage: apple
   timeout: 60 minutes
@@ -102,6 +107,28 @@ apple:ios-test:
       artifacts: true
   script:
     - just ci run apple-ios-test
+
+# The resampler axis: the same end-to-end playback through three source-rate
+# conversion shapes, which is what a change to decode, blending or output can
+# break without a single unit test noticing.
+apple:e2e:
+  extends:
+    - .macos-job
+    - .rules-branch-or-nightly
+    - .measured
+  stage: apple
+  timeout: 90 minutes
+  needs:
+    - apple:lint
+  script:
+    - just ci run apple-e2e
+  artifacts:
+    when: always
+    expire_in: 30 days
+    reports:
+      junit: target/nextest/ci/junit.xml
+    paths:
+      - target/nextest/ci/junit.xml
 
 apple:safari:
   extends:

--- a/.gitlab/ci/common.yml
+++ b/.gitlab/ci/common.yml
@@ -65,6 +65,33 @@
     - if: $KITHARA_PIPELINE_KIND == "main"
     - if: $KITHARA_PIPELINE_KIND == "nightly"
 
+# A branch push runs the iOS-facing subset, not everything: the platform under
+# focus, on the host that is that platform. The branch kind is therefore added
+# to the jobs that subset names rather than to the shared sets above, which the
+# Linux, Android and web lanes also extend. Cancellation comes from the parent
+# `dispatch:branch`, which is interruptible and takes the child pipeline with
+# it, so these keep the interruptibility their own kind asks for.
+.rules-verify-and-branch:
+  interruptible: true
+  rules:
+    - if: $KITHARA_PIPELINE_KIND == "branch"
+    - !reference [.rules-verify, rules]
+
+.rules-integration-and-branch:
+  interruptible: false
+  rules:
+    - if: $KITHARA_PIPELINE_KIND == "branch"
+    - !reference [.rules-integration, rules]
+
+# Long lanes a branch asks for on purpose. Keeping them off `main` leaves the
+# merge queue as short as it is today; the nightly channel is where they guard
+# the default branch.
+.rules-branch-or-nightly:
+  interruptible: false
+  rules:
+    - if: $KITHARA_PIPELINE_KIND == "branch"
+    - if: $KITHARA_PIPELINE_KIND == "nightly"
+
 .rules-nightly:
   interruptible: false
   rules:

--- a/xtask/src/ci/lane/apple.rs
+++ b/xtask/src/ci/lane/apple.rs
@@ -64,7 +64,13 @@ pub(crate) fn test(process: &Process, config: &CiConfig, kind: PipelineKind) -> 
             &["test", "run", "--profile", "ci"],
             "Apple merge-request tests",
         ),
-        PipelineKind::Main | PipelineKind::Nightly | PipelineKind::Release => process.run(
+        // A branch push asks the same question the default branch asks, before
+        // anyone opens a merge request: what a reviewer would have to fix
+        // anyway is cheaper to learn now.
+        PipelineKind::Branch
+        | PipelineKind::Main
+        | PipelineKind::Nightly
+        | PipelineKind::Release => process.run(
             "just",
             &[
                 "test",
@@ -94,6 +100,23 @@ pub(crate) fn test_flash_off(process: &Process, config: &CiConfig) -> Result<()>
         "ci",
     ]);
     process.run_command(&mut command, "Apple flash-off gate")
+}
+
+/// End-to-end playback across the resampler axis. Each lane pins one
+/// source-rate conversion shape, and a change to decode, blending or output can
+/// break one of them while every unit test still passes — so the three run
+/// together or the axis is not covered. They share a target directory: the
+/// lanes differ by feature, and the executor keeps the tree warm between them.
+pub(crate) fn e2e(process: &Process, config: &CiConfig) -> Result<()> {
+    preflight(process, config)?;
+    for lane in ["--lane=e2e", "--lane=e2e-fused", "--lane=e2e-glide"] {
+        process.run(
+            "just",
+            &["test", "run", lane, "--profile", "ci"],
+            "Apple end-to-end suite",
+        )?;
+    }
+    Ok(())
 }
 
 pub(crate) fn xcframework(process: &Process, config: &CiConfig) -> Result<()> {

--- a/xtask/src/ci/run.rs
+++ b/xtask/src/ci/run.rs
@@ -19,6 +19,7 @@ pub(crate) enum Lane {
     AppleMsrv,
     AppleTest,
     AppleTestFlashOff,
+    AppleE2e,
     AppleXcframework,
     AppleSwiftTest,
     AppleIos,
@@ -70,6 +71,7 @@ impl Lane {
             | Self::AppleMsrv
             | Self::AppleTest
             | Self::AppleTestFlashOff
+            | Self::AppleE2e
             | Self::AppleXcframework
             | Self::AppleSwiftTest
             | Self::AppleIos
@@ -105,6 +107,7 @@ impl Lane {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
 pub(crate) enum PipelineKind {
+    Branch,
     MergeRequest,
     Quarantine,
     Main,
@@ -160,6 +163,7 @@ pub(crate) fn run(args: &RunArgs, ctx: &Ctx) -> Result<()> {
         Lane::AppleMsrv => lane::apple::msrv(&process, &ci_config),
         Lane::AppleTest => lane::apple::test(&process, &ci_config, args.kind),
         Lane::AppleTestFlashOff => lane::apple::test_flash_off(&process, &ci_config),
+        Lane::AppleE2e => lane::apple::e2e(&process, &ci_config),
         Lane::AppleXcframework => lane::apple::xcframework(&process, &ci_config),
         Lane::AppleSwiftTest => lane::apple::swift_test(&process, &ci_config, &swiftpm_cache),
         Lane::AppleIos => lane::apple::ios(&process, &ci_config),


### PR DESCRIPTION
## Summary

A push to a branch started no GitLab pipeline. The workflow admitted merge
requests, the default branch, schedules, releases and the quarantine API
trigger — so the Mac mini, the one machine that *is* the platform currently
under focus, stayed out of reach until someone opened a merge request. That is
exactly when the answer stops being cheap.

A branch push now dispatches its own pipeline running the iOS-facing subset:
full lint, both clock gates, the simulator suite, and a new resampler-axis
end-to-end job.

It answers a question rather than guarding anything, and the change is built so
it cannot become a gate. The trigger is `allow_failure: true`, so a branch never
decides a verdict, and it holds a resource group of its own, so it can never
make `dispatch:main` or a merge request queue behind an hour of work in
progress. Measurement stays honest regardless: the suites, the simulator run and
every perf lane already share `kithara-suite` across pipelines, so one of them
still holds the machine at a time.

## Behavior / scope

- `dispatch:branch` — new, for `push` on a non-default branch. Own resource
  group, allowed to fail, interruptible (a newer push cancels it through the
  parent, which takes the child pipeline with it).
- A branch with an open merge request keeps one pipeline, not two.
- `PipelineKind::Branch` runs the same suite the default branch runs
  (`--flash=on --no-block=on`), because what a reviewer would have to fix anyway
  is cheaper to learn before the merge request exists.
- Jobs on a branch push: `apple:lint`, `apple:test`, `apple:test-flash-off`,
  `apple:xcframework`, `apple:ios-test`, `apple:e2e`. The branch kind is added
  to those jobs rather than to `.rules-verify` / `.rules-integration`, which the
  Linux, Android and web lanes also extend.
- `apple:e2e` is new: the three end-to-end lanes each pin one source-rate
  conversion shape, and a change to decode, blending or output can break one of
  them while every unit test passes. It runs on branch pushes and nightly, not
  on `main` — the merge queue stays as short as it is today.
- `!reference` is used to compose the rule sets rather than duplicating them;
  it is GitLab's documented mechanism and this is its first use here.

## Risks or follow-ups

- The Apple host is serialized by `kithara-suite`, so branch pushes lengthen the
  queue for other *measured* jobs even though they never block a pipeline. If
  that becomes noticeable, the subset is the knob.
- Nothing verifies the trigger rules except GitLab itself; they take effect only
  once this is on the default branch.

## Validation

- `just fmt` — clean.
- `just lint fast` — exit 0, **0 regressions / 0 new** (25 deny / 1013 warn, the
  existing baseline).
- `cargo test -p xtask ci::` — 52 passed. This includes
  `the_pipeline_schedules_every_lane_and_only_real_lanes`, which is what proves
  `apple-e2e` exists as both a pipeline job and a typed lane.
- YAML parses for all three changed files.
- The full suite was not run: this changes CI configuration and one xtask lane,
  no product code.
