### PR TITLE
fix(hls,assets): close the produce-core RT violations the rtsan-hls lane exposes

### DIFF
--- a/.config/just/test.just
+++ b/.config/just/test.just
@@ -151,7 +151,7 @@ rtsan-async FILTER="no_block":
     RUSTFLAGS="-Zsanitizer=realtime --cfg rtsan" \
     RUSTDOCFLAGS="-Zsanitizer=realtime --cfg rtsan" \
         cargo "+$toolchain" test -p kithara-integration-tests --test suite_light \
-        --features kithara/no-block,kithara-test-utils/no-block --target "$target" -- --nocapture {{ FILTER }}
+        --features no-block --target "$target" -- --nocapture {{ FILTER }}
 
 # `rt_metrics` drives `process()` directly: decode error, underrun, eviction,
 # and the on-core seek re-base.

--- a/crates/kithara-assets/CONTEXT.md
+++ b/crates/kithara-assets/CONTEXT.md
@@ -151,12 +151,14 @@ aggregate `AvailabilityIndex` keyed by the `asset_root` and relative path alread
 - **Updated** by a `ScopedAvailabilityObserver` attached to every resource opened through the base
   stores: `write_at` fires `on_write(range)`, a successful `commit(Some(len))` fires
   `on_commit(len)`, and opening a pre-existing committed file seeds `0..final_len`.
-- **Queried** aggregate-only. The three probes answer from the aggregate alone — no store lock, no
-  filesystem call — which is what makes them legal inside `rtsan_forbid_blocking` regions (the
-  produce core probes readiness through `contains_range`). Hydration at store build plus the
-  observers keep the aggregate complete; a resource the aggregate does not know is absent and gets
-  refetched, the same verdict the acquire path reaches through `is_confirmed`. `resource_state` is
-  the control-side inspection API: it consults the handle cache and the filesystem and may block.
+- **Queried** aggregate-only. The three probes answer from the aggregate alone — no handle-cache
+  mutex, no filesystem call; the aggregate's own cost is a sharded map lookup plus a short
+  per-entry mutex (and a `RangeSet` clone for `available_ranges`). That is what lets the produce
+  core probe readiness through `contains_range` inside its `rtsan_forbid_blocking` region.
+  Hydration at store build plus the observers keep the aggregate complete; a resource the
+  aggregate does not know is absent and gets refetched, the same verdict the acquire path reaches
+  through `is_confirmed`. `resource_state` is the control-side inspection API: it consults the
+  handle cache and the filesystem and may block.
 - **Persisted** in two tiers (below), and it is the **authority on what survives a restart**. A
   segment's file becomes visible at `rename`, but the barrier that puts its blocks on the medium is
   paid later, by the manifest flush, which forces every queued file down *before* naming it. So a

--- a/crates/kithara-assets/CONTEXT.md
+++ b/crates/kithara-assets/CONTEXT.md
@@ -151,8 +151,12 @@ aggregate `AvailabilityIndex` keyed by the `asset_root` and relative path alread
 - **Updated** by a `ScopedAvailabilityObserver` attached to every resource opened through the base
   stores: `write_at` fires `on_write(range)`, a successful `commit(Some(len))` fires
   `on_commit(len)`, and opening a pre-existing committed file seeds `0..final_len`.
-- **Queried** aggregate-first, with a single cold-miss fallback to `resource_state` so pre-existing
-  committed files are discoverable before the observer fires.
+- **Queried** aggregate-only. The three probes answer from the aggregate alone — no store lock, no
+  filesystem call — which is what makes them legal inside `rtsan_forbid_blocking` regions (the
+  produce core probes readiness through `contains_range`). Hydration at store build plus the
+  observers keep the aggregate complete; a resource the aggregate does not know is absent and gets
+  refetched, the same verdict the acquire path reaches through `is_confirmed`. `resource_state` is
+  the control-side inspection API: it consults the handle cache and the filesystem and may block.
 - **Persisted** in two tiers (below), and it is the **authority on what survives a restart**. A
   segment's file becomes visible at `rename`, but the barrier that puts its blocks on the medium is
   paid later, by the manifest flush, which forces every queued file down *before* naming it. So a

--- a/crates/kithara-assets/CONTEXT.md
+++ b/crates/kithara-assets/CONTEXT.md
@@ -151,14 +151,9 @@ aggregate `AvailabilityIndex` keyed by the `asset_root` and relative path alread
 - **Updated** by a `ScopedAvailabilityObserver` attached to every resource opened through the base
   stores: `write_at` fires `on_write(range)`, a successful `commit(Some(len))` fires
   `on_commit(len)`, and opening a pre-existing committed file seeds `0..final_len`.
-- **Queried** aggregate-only. The three probes answer from the aggregate alone — no handle-cache
-  mutex, no filesystem call; the aggregate's own cost is a sharded map lookup plus a short
-  per-entry mutex (and a `RangeSet` clone for `available_ranges`). That is what lets the produce
-  core probe readiness through `contains_range` inside its `rtsan_forbid_blocking` region.
-  Hydration at store build plus the observers keep the aggregate complete; a resource the
-  aggregate does not know is absent and gets refetched, the same verdict the acquire path reaches
-  through `is_confirmed`. `resource_state` is the control-side inspection API: it consults the
-  handle cache and the filesystem and may block.
+- **Queried** aggregate-only: no handle-cache mutex, no filesystem call. A resource the aggregate
+  does not know is absent and gets refetched — the same verdict `is_confirmed` gives the acquire
+  path. `resource_state` is the control-side inspection API and may block.
 - **Persisted** in two tiers (below), and it is the **authority on what survives a restart**. A
   segment's file becomes visible at `rename`, but the barrier that puts its blocks on the medium is
   paid later, by the manifest flush, which forces every queued file down *before* naming it. So a

--- a/crates/kithara-assets/src/index/availability/disk.rs
+++ b/crates/kithara-assets/src/index/availability/disk.rs
@@ -172,7 +172,7 @@ fn write_aggregate(
                         // The crash-recovery snapshot is a COMMITTED-only
                         // contract: an uncommitted partial write (whose `.tmp`
                         // was never renamed) must be invisible after a rebuild,
-                        // exactly as the slow path reports it Missing. Persisting
+                        // matching the aggregate probes' verdict. Persisting
                         // its in-flight ranges would let a flush that races the
                         // writer's cleanup resurrect a partial segment on the
                         // next open — corrupting availability and a real crash

--- a/crates/kithara-assets/src/store/handle.rs
+++ b/crates/kithara-assets/src/store/handle.rs
@@ -133,29 +133,10 @@ impl AssetStore {
     }
 
     /// Return a snapshot of byte ranges known to be available for the
-    /// given resource.
-    ///
-    /// Fast path: aggregate lookup. Slow path: if the aggregate is
-    /// empty for this key and `resource_state` reports
-    /// `Committed { final_len: Some(len) }`, return `0..len` without
-    /// seeding the aggregate (the observer does the actual seeding on
-    /// open).
+    /// given resource, answered from the availability aggregate.
     #[must_use]
     pub fn available_ranges(&self, key: &ResourceKey) -> RangeSet<u64> {
-        let ranges = self.availability().available_ranges(key);
-        if !ranges.is_empty() {
-            return ranges;
-        }
-        if let Ok(AssetResourceState::Committed {
-            final_len: Some(len),
-        }) = self.resource_state(key)
-            && len > 0
-        {
-            let mut set = RangeSet::default();
-            set.insert(0..len);
-            return set;
-        }
-        ranges
+        self.availability().available_ranges(key)
     }
 
     /// Persist the in-memory byte-availability aggregate snapshot to
@@ -183,24 +164,14 @@ impl AssetStore {
     /// Return `true` when every byte in `range` is already present for
     /// the resource, or when the range is empty.
     ///
-    /// Fast path checks the aggregate; slow path falls back to
-    /// `resource_state` so pre-existing committed files on disk are
-    /// discoverable even before the observer wires in.
+    /// Answers from the availability aggregate alone, which keeps the
+    /// probe free of store locks and filesystem calls — it runs inside
+    /// `rtsan_forbid_blocking` regions. Hydration at store build and the
+    /// write/commit observers keep the aggregate complete; a resource the
+    /// aggregate does not know is absent and gets refetched.
     #[must_use]
     pub fn contains_range(&self, key: &ResourceKey, range: Range<u64>) -> bool {
-        if range.start >= range.end {
-            return true;
-        }
-        if self.availability().contains_range(key, range.clone()) {
-            return true;
-        }
-        if let Ok(AssetResourceState::Committed {
-            final_len: Some(len),
-        }) = self.resource_state(key)
-        {
-            return range.end <= len;
-        }
-        false
+        self.availability().contains_range(key, range)
     }
 
     /// Delete the entire asset directory.
@@ -223,19 +194,11 @@ impl AssetStore {
         }
     }
 
-    /// Return the committed final length of the resource, if known.
+    /// Return the committed final length of the resource, if known to
+    /// the availability aggregate.
     #[must_use]
     pub fn final_len(&self, key: &ResourceKey) -> Option<u64> {
-        if let Some(len) = self.availability().final_len(key) {
-            return Some(len);
-        }
-        if let Ok(AssetResourceState::Committed {
-            final_len: Some(len),
-        }) = self.resource_state(key)
-        {
-            return Some(len);
-        }
-        None
+        self.availability().final_len(key)
     }
 
     /// Return whether both handles refer to the same store instance.

--- a/crates/kithara-assets/src/store/handle.rs
+++ b/crates/kithara-assets/src/store/handle.rs
@@ -132,8 +132,7 @@ impl AssetStore {
         }
     }
 
-    /// Return a snapshot of byte ranges known to be available for the
-    /// given resource, answered from the availability aggregate.
+    /// Byte ranges known to the availability aggregate for this resource.
     #[must_use]
     pub fn available_ranges(&self, key: &ResourceKey) -> RangeSet<u64> {
         self.availability().available_ranges(key)
@@ -162,12 +161,8 @@ impl AssetStore {
     }
 
     /// Return `true` when every byte in `range` is already present for
-    /// the resource, or when the range is empty.
-    ///
-    /// Answers from the availability aggregate alone — no handle-cache
-    /// mutex, no filesystem call. Hydration at store build and the
-    /// write/commit observers keep the aggregate complete; a resource the
-    /// aggregate does not know is absent and gets refetched.
+    /// the resource, or when the range is empty. Aggregate-only: no
+    /// locks, no filesystem.
     #[must_use]
     pub fn contains_range(&self, key: &ResourceKey, range: Range<u64>) -> bool {
         self.availability().contains_range(key, range)
@@ -193,8 +188,7 @@ impl AssetStore {
         }
     }
 
-    /// Return the committed final length of the resource, if known to
-    /// the availability aggregate.
+    /// Committed final length per the availability aggregate, if known.
     #[must_use]
     pub fn final_len(&self, key: &ResourceKey) -> Option<u64> {
         self.availability().final_len(key)

--- a/crates/kithara-assets/src/store/handle.rs
+++ b/crates/kithara-assets/src/store/handle.rs
@@ -164,9 +164,8 @@ impl AssetStore {
     /// Return `true` when every byte in `range` is already present for
     /// the resource, or when the range is empty.
     ///
-    /// Answers from the availability aggregate alone, which keeps the
-    /// probe free of store locks and filesystem calls — it runs inside
-    /// `rtsan_forbid_blocking` regions. Hydration at store build and the
+    /// Answers from the availability aggregate alone — no handle-cache
+    /// mutex, no filesystem call. Hydration at store build and the
     /// write/commit observers keep the aggregate complete; a resource the
     /// aggregate does not know is absent and gets refetched.
     #[must_use]

--- a/crates/kithara-assets/tests/crash_recovery.rs
+++ b/crates/kithara-assets/tests/crash_recovery.rs
@@ -131,8 +131,15 @@ fn garbage_lru_bin_is_treated_as_empty() {
     assert!(scope.store().contains_range(&key, 0..12));
 }
 
+/// The availability manifest is the sole authority on which bytes are
+/// present: the segment file becomes visible at `rename`, while its
+/// durability barrier is paid later by the manifest flush, so a file that
+/// the manifest does not vouch for may carry the right name and length
+/// over unwritten blocks. A corrupt manifest therefore costs a refetch,
+/// never a wrong read — and the probes answer from the aggregate alone,
+/// which keeps them free of locks and filesystem calls on the produce core.
 #[kithara::test(native, timeout(Duration::from_secs(5)))]
-fn garbage_availability_bin_is_treated_as_empty() {
+fn garbage_availability_bin_costs_a_refetch() {
     let dir = tempdir().unwrap();
     seed_clean_state_then(dir.path(), |root, _, _| {
         fs::write(availability_bin(root), b"corrupted-bytes-here").unwrap();
@@ -148,10 +155,17 @@ fn garbage_availability_bin_is_treated_as_empty() {
     let key = scope.key(&resource(Consts::KEY_NAME)).unwrap();
     assert_eq!(
         scope.store().final_len(&key),
-        Some(12),
-        "slow-path must recover committed segments when availability.bin is unreadable"
+        None,
+        "an unvouched file is a torn write; the probes must not resurrect it"
     );
-    assert!(scope.store().contains_range(&key, 0..12));
+    assert!(!scope.store().contains_range(&key, 0..12));
+    assert!(scope.store().available_ranges(&key).is_empty());
+
+    let acq = store.acquire_resource(&key, None).unwrap();
+    assert!(
+        matches!(acq, AcquisitionResult::Pending(_)),
+        "the acquire path reaches the same verdict and refetches"
+    );
 }
 
 #[kithara::test(native, timeout(Duration::from_secs(5)))]
@@ -443,7 +457,7 @@ fn red_canonical_path_must_have_exact_bytes_after_commit_no_initial_mmap_padding
 }
 
 #[kithara::test(native, timeout(Duration::from_secs(5)))]
-fn doubly_corrupted_indexes_do_not_panic_and_slow_path_serves_data() {
+fn doubly_corrupted_indexes_do_not_panic_and_the_store_refetches() {
     let dir = tempdir().unwrap();
     seed_clean_state_then(dir.path(), |root, _, _| {
         fs::write(pins_bin(root), b"").unwrap();
@@ -461,10 +475,12 @@ fn doubly_corrupted_indexes_do_not_panic_and_slow_path_serves_data() {
 
     assert_eq!(
         scope.store().final_len(&key),
-        Some(12),
-        "every index corrupt → slow-path still works"
+        None,
+        "every index corrupt → the unvouched segment is refetched, never trusted"
     );
-    assert!(scope.store().contains_range(&key, 0..12));
+    assert!(!scope.store().contains_range(&key, 0..12));
+    let acq = store.acquire_resource(&key, None).unwrap();
+    assert!(matches!(acq, AcquisitionResult::Pending(_)));
 
     store
         .checkpoint()

--- a/crates/kithara-assets/tests/crash_recovery.rs
+++ b/crates/kithara-assets/tests/crash_recovery.rs
@@ -131,13 +131,6 @@ fn garbage_lru_bin_is_treated_as_empty() {
     assert!(scope.store().contains_range(&key, 0..12));
 }
 
-/// The availability manifest is the sole authority on which bytes are
-/// present: the segment file becomes visible at `rename`, while its
-/// durability barrier is paid later by the manifest flush, so a file that
-/// the manifest does not vouch for may carry the right name and length
-/// over unwritten blocks. A corrupt manifest therefore costs a refetch,
-/// never a wrong read — and the probes answer from the aggregate alone,
-/// which keeps them free of locks and filesystem calls on the produce core.
 #[kithara::test(native, timeout(Duration::from_secs(5)))]
 fn garbage_availability_bin_costs_a_refetch() {
     let dir = tempdir().unwrap();
@@ -476,7 +469,7 @@ fn doubly_corrupted_indexes_do_not_panic_and_the_store_refetches() {
     assert_eq!(
         scope.store().final_len(&key),
         None,
-        "every index corrupt → the unvouched segment is refetched, never trusted"
+        "every index corrupt -> the unvouched segment is refetched"
     );
     assert!(!scope.store().contains_range(&key, 0..12));
     let acq = store.acquire_resource(&key, None).unwrap();

--- a/crates/kithara-hls/src/handle/resource.rs
+++ b/crates/kithara-hls/src/handle/resource.rs
@@ -1,8 +1,7 @@
 use std::{io::ErrorKind, ops::Range};
 
 use kithara_assets::{
-    AssetResourceState, AssetScope, AssetsError, AssetsResult, ReadSide, ResourceAcquisition,
-    ResourceKey,
+    AssetScope, AssetsError, AssetsResult, ReadSide, ResourceAcquisition, ResourceKey,
 };
 use kithara_stream::{StreamError, StreamResult};
 use url::Url;
@@ -37,13 +36,12 @@ impl<'a> ResourceHandle<'a> {
         }
     }
 
-    /// Committed on-disk length when the resource is `Committed` with a known
-    /// `final_len` — the skip-fetch guard's size source.
+    /// Committed length per the availability manifest — the skip-fetch
+    /// guard's size source. The manifest is the sole byte authority: a file
+    /// it does not vouch for reads as absent here, the guard dispatches the
+    /// fetch, and the acquire path deletes the torn leftover and refetches.
     pub(crate) fn committed_len(&self) -> Option<u64> {
-        match self.scope.store().resource_state(self.key) {
-            Ok(AssetResourceState::Committed { final_len }) => final_len,
-            _ => None,
-        }
+        self.scope.store().final_len(self.key)
     }
 
     /// Whether every byte in `range` is already present on disk for this
@@ -68,5 +66,74 @@ impl<'a> ResourceHandle<'a> {
             .read_at(range.start, dst)
             .map_err(|e| StreamError::Source(HlsError::from(e).into()))?;
         Ok(Some(n))
+    }
+}
+
+#[cfg(test)]
+#[cfg(not(target_arch = "wasm32"))]
+mod tests {
+    use std::fs;
+
+    use kithara_assets::{
+        AcquisitionResult, AssetResource, AssetSource, AssetStore, StorageBackend, WriteSide,
+    };
+    use kithara_test_utils::kithara;
+
+    use super::*;
+
+    fn segment_fixture(dir: &std::path::Path) -> (AssetScope, ResourceKey, Url) {
+        let store = AssetStore::builder()
+            .backend(StorageBackend::Disk { root: dir.into() })
+            .build();
+        let url = Url::parse("https://example.com/media/seg0.m4s").expect("segment url");
+        let scope = store
+            .scope::<crate::Hls>(&AssetSource::Remote {
+                url: Url::parse("https://example.com/master.m3u8").expect("master url"),
+                discriminator: None,
+            })
+            .expect("scope");
+        let key = scope.key(&AssetResource::Url(url.clone())).expect("key");
+        (scope, key, url)
+    }
+
+    /// The skip-fetch guard and the readiness gate must consult the same
+    /// byte authority — the availability manifest. A segment file the
+    /// manifest does not vouch for is a torn write: the guard reports no
+    /// committed length, the fetch is dispatched, and the acquire path
+    /// replaces the leftover. A metadata-based answer here marks the slot
+    /// `Loaded` while the readiness gate keeps answering "absent", and
+    /// playback wedges on a warm cache with no manifest.
+    #[kithara::test]
+    fn committed_len_answers_from_the_availability_manifest() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (scope, key, url) = segment_fixture(dir.path());
+
+        let path = dir
+            .path()
+            .join(scope.asset_root())
+            .join(key.rel_path().expect("relative key"));
+        fs::create_dir_all(path.parent().expect("parent")).expect("mkdir");
+        fs::write(&path, b"unvouched-bytes").expect("write");
+
+        let handle = ResourceHandle::new(&scope, &key, &url);
+        assert_eq!(
+            handle.committed_len(),
+            None,
+            "a file the manifest does not vouch for must be refetched, never sized"
+        );
+
+        let AcquisitionResult::Pending(writer) =
+            scope.store().acquire_resource(&key, None).expect("acquire")
+        else {
+            panic!("unvouched file must reacquire as Pending");
+        };
+        writer.write_at(0, b"committed-bytes").expect("write_at");
+        drop(writer.commit(Some(15)).expect("commit"));
+
+        assert_eq!(
+            handle.committed_len(),
+            Some(15),
+            "a commit through the store vouches the bytes and sizes the guard"
+        );
     }
 }

--- a/crates/kithara-hls/src/handle/resource.rs
+++ b/crates/kithara-hls/src/handle/resource.rs
@@ -36,10 +36,8 @@ impl<'a> ResourceHandle<'a> {
         }
     }
 
-    /// Committed length per the availability manifest — the skip-fetch
-    /// guard's size source. The manifest is the sole byte authority: a file
-    /// it does not vouch for reads as absent here, the guard dispatches the
-    /// fetch, and the acquire path deletes the torn leftover and refetches.
+    /// Committed length per the availability manifest - the skip-fetch
+    /// guard's size source.
     pub(crate) fn committed_len(&self) -> Option<u64> {
         self.scope.store().final_len(self.key)
     }
@@ -96,13 +94,6 @@ mod tests {
         (scope, key, url)
     }
 
-    /// The skip-fetch guard and the readiness gate must consult the same
-    /// byte authority — the availability manifest. A segment file the
-    /// manifest does not vouch for is a torn write: the guard reports no
-    /// committed length, the fetch is dispatched, and the acquire path
-    /// replaces the leftover. A metadata-based answer here marks the slot
-    /// `Loaded` while the readiness gate keeps answering "absent", and
-    /// playback wedges on a warm cache with no manifest.
     #[kithara::test]
     fn committed_len_answers_from_the_availability_manifest() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -119,7 +110,7 @@ mod tests {
         assert_eq!(
             handle.committed_len(),
             None,
-            "a file the manifest does not vouch for must be refetched, never sized"
+            "an unvouched file must be refetched, never sized"
         );
 
         let AcquisitionResult::Pending(writer) =
@@ -130,10 +121,6 @@ mod tests {
         writer.write_at(0, b"committed-bytes").expect("write_at");
         drop(writer.commit(Some(15)).expect("commit"));
 
-        assert_eq!(
-            handle.committed_len(),
-            Some(15),
-            "a commit through the store vouches the bytes and sizes the guard"
-        );
+        assert_eq!(handle.committed_len(), Some(15));
     }
 }

--- a/crates/kithara-hls/src/variant/flow/seek.rs
+++ b/crates/kithara-hls/src/variant/flow/seek.rs
@@ -26,11 +26,9 @@ impl HlsVariant {
             .store(Self::NO_SEEK_TAIL, Ordering::Release);
     }
 
-    /// Resolve a time-target seek to its byte anchor on the produce core:
-    /// lock-free layout reads plus atomic anchor stores. The fetch plan is
-    /// owned by the download peer, which re-aims the queue when it observes
-    /// the epoch bump (`seek_epoch_reset` -> `rebuild_at_time`); that rebuild
-    /// replaces the previous plan wholesale (`queue.clear()`).
+    /// Resolve a time seek to its byte anchor on the produce core: lock-free
+    /// layout reads plus atomic anchor stores. The fetch plan belongs to the
+    /// download peer (`seek_epoch_reset` -> `rebuild_at_time`).
     pub(crate) fn prepare_seek_time_anchor(
         &self,
         position: Duration,

--- a/crates/kithara-hls/src/variant/flow/seek.rs
+++ b/crates/kithara-hls/src/variant/flow/seek.rs
@@ -26,6 +26,11 @@ impl HlsVariant {
             .store(Self::NO_SEEK_TAIL, Ordering::Release);
     }
 
+    /// Resolve a time-target seek to its byte anchor on the produce core:
+    /// lock-free layout reads plus atomic anchor stores. The fetch plan is
+    /// owned by the download peer, which re-aims the queue when it observes
+    /// the epoch bump (`seek_epoch_reset`); stale entries of the previous
+    /// epoch are dropped by the dispatcher's epoch tag.
     pub(crate) fn prepare_seek_time_anchor(
         &self,
         position: Duration,
@@ -68,9 +73,6 @@ impl HlsVariant {
         self.set_prefetch_anchor(prefetch_anchor);
         self.set_seek_alias(byte_offset, seg_idx_u32);
         self.set_segment_aware_seek_tail(fetch_start);
-        if !self.queue_matches_plan(fetch_start) {
-            self.rebuild_queue(fetch_start, None);
-        }
         self.set_exact_seek_demand(byte_offset, seg_idx_u32);
         Ok(Some(anchor))
     }

--- a/crates/kithara-hls/src/variant/flow/seek.rs
+++ b/crates/kithara-hls/src/variant/flow/seek.rs
@@ -29,8 +29,8 @@ impl HlsVariant {
     /// Resolve a time-target seek to its byte anchor on the produce core:
     /// lock-free layout reads plus atomic anchor stores. The fetch plan is
     /// owned by the download peer, which re-aims the queue when it observes
-    /// the epoch bump (`seek_epoch_reset`); stale entries of the previous
-    /// epoch are dropped by the dispatcher's epoch tag.
+    /// the epoch bump (`seek_epoch_reset` -> `rebuild_at_time`); that rebuild
+    /// replaces the previous plan wholesale (`queue.clear()`).
     pub(crate) fn prepare_seek_time_anchor(
         &self,
         position: Duration,

--- a/crates/kithara-hls/src/variant/map/offsets.rs
+++ b/crates/kithara-hls/src/variant/map/offsets.rs
@@ -199,13 +199,13 @@ pub(super) struct Layout {
     /// Serializes off-RT writers so a concurrent load-clone-mutate-store pair
     /// cannot lose an update (the old `RwLock` serialized writes; `ArcSwap`
     /// alone does not). Never taken on the produce-core read path.
-    write_lock: Mutex<()>,
-    /// Frames displaced by a swap, alive until a later mutation sees them
-    /// quiesced (`strong_count == 1`). Keeps reclamation on the writer
-    /// thread: a produce-core guard racing the swap can resolve to the
-    /// displaced frame, and this floor makes its drop a pure decrement.
-    /// Touched only under `write_lock`.
-    retired: Mutex<Vec<Arc<Frame>>>,
+    ///
+    /// Its payload is the retire list: frames displaced by a swap, alive
+    /// until a later mutation sees them quiesced (`strong_count == 1`).
+    /// Keeps reclamation on the writer thread — a produce-core guard racing
+    /// the swap can resolve to the displaced frame, and this floor makes its
+    /// drop a pure decrement.
+    write_lock: Mutex<Vec<Arc<Frame>>>,
 }
 
 impl Layout {
@@ -222,11 +222,10 @@ impl Layout {
         let snapshot = frame.snapshot(segments, init_size);
         Self {
             frame: ArcSwap::from(Arc::new(frame)),
-            write_lock: Mutex::new(()),
+            write_lock: Mutex::new(Vec::new()),
             total: AtomicU64::new(snapshot.total),
             sizes_complete: AtomicBool::new(snapshot.sizes_complete),
             publication_seq: AtomicU64::new(0),
-            retired: Mutex::new(Vec::new()),
         }
     }
 
@@ -255,14 +254,14 @@ impl Layout {
         store: impl FnOnce() -> u64,
         before_publish: impl FnOnce(),
     ) {
-        let _w = self.write_lock.lock();
+        let mut retired = self.write_lock.lock();
         self.begin_publication();
         let init_size = store();
         before_publish();
         let mut frame = (**self.frame.load()).clone();
         frame.recompute(init_size, segments);
         let snapshot = frame.snapshot(segments, init_size);
-        self.retire_current();
+        Self::retire_current(&mut retired, &self.frame);
         self.frame.store(Arc::new(frame));
         self.republish(snapshot);
         self.finish_publication();
@@ -311,23 +310,23 @@ impl Layout {
     /// and republishes the atomics. Concurrent writers cannot lose an update
     /// because each runs the whole cycle under `write_lock`.
     fn mutate_frame(&self, segments: &[Segment], init_size: u64, f: impl FnOnce(&mut Frame)) {
-        let _w = self.write_lock.lock();
+        let mut retired = self.write_lock.lock();
         self.begin_publication();
         let mut frame = (**self.frame.load()).clone();
         f(&mut frame);
         let snapshot = frame.snapshot(segments, init_size);
-        self.retire_current();
+        Self::retire_current(&mut retired, &self.frame);
         self.frame.store(Arc::new(frame));
         self.republish(snapshot);
         self.finish_publication();
     }
 
-    /// Under `write_lock`: reclaim quiesced retirees, then move the live
-    /// frame into the retire list ahead of the swap.
-    fn retire_current(&self) {
-        let mut retired = self.retired.lock();
+    /// Reclaim quiesced retirees, then move the live frame into the retire
+    /// list ahead of the swap. Takes the write-lock payload, so a caller
+    /// holds the lock by construction.
+    fn retire_current(retired: &mut Vec<Arc<Frame>>, frame: &ArcSwap<Frame>) {
         retired.retain(|frame| Arc::strong_count(frame) > 1);
-        retired.push(self.frame.load_full());
+        retired.push(frame.load_full());
     }
 
     pub(super) fn natural_offset(&self, idx: usize) -> Option<u64> {
@@ -433,6 +432,17 @@ mod tests {
             displaced.upgrade().is_none(),
             "the next mutation reclaims quiesced frames on the writer thread"
         );
+    }
+
+    /// `mutate_frame` (reset / activation mutators) routes through the same
+    /// retire step as `apply_commit`.
+    #[kithara::test]
+    fn mutate_frame_retires_the_displaced_frame() {
+        let layout = Layout::new(0, &[]);
+        let displaced: Weak<Frame> = Arc::downgrade(&layout.frame.load_full());
+
+        layout.mutate_frame(&[], 0, |_| {});
+        assert!(displaced.upgrade().is_some());
     }
 
     #[kithara::test]

--- a/crates/kithara-hls/src/variant/map/offsets.rs
+++ b/crates/kithara-hls/src/variant/map/offsets.rs
@@ -196,15 +196,10 @@ pub(super) struct Layout {
     /// old frame.
     publication_seq: AtomicU64,
     total: AtomicU64,
-    /// Serializes off-RT writers so a concurrent load-clone-mutate-store pair
-    /// cannot lose an update (the old `RwLock` serialized writes; `ArcSwap`
-    /// alone does not). Never taken on the produce-core read path.
-    ///
-    /// Its payload is the retire list: frames displaced by a swap, alive
-    /// until a later mutation sees them quiesced (`strong_count == 1`).
-    /// Keeps reclamation on the writer thread — a produce-core guard racing
-    /// the swap can resolve to the displaced frame, and this floor makes its
-    /// drop a pure decrement.
+    /// Serializes off-RT writers; never taken on the produce-core read
+    /// path. Payload: frames displaced by a swap, held until quiesced
+    /// (`strong_count == 1`) so reclamation stays on the writer and a
+    /// reader guard drop is a pure decrement.
     write_lock: Mutex<Vec<Arc<Frame>>>,
 }
 
@@ -321,9 +316,7 @@ impl Layout {
         self.finish_publication();
     }
 
-    /// Reclaim quiesced retirees, then move the live frame into the retire
-    /// list ahead of the swap. Takes the write-lock payload, so a caller
-    /// holds the lock by construction.
+    /// Reclaim quiesced retirees, then park the live frame ahead of the swap.
     fn retire_current(retired: &mut Vec<Arc<Frame>>, frame: &ArcSwap<Frame>) {
         retired.retain(|frame| Arc::strong_count(frame) > 1);
         retired.push(frame.load_full());
@@ -411,10 +404,6 @@ mod tests {
 
     use super::*;
 
-    /// A produce-core reader racing a frame swap can end up holding the last
-    /// reference to the displaced frame, and dropping it would `free` inside
-    /// the forbid region. The writer therefore keeps every displaced frame
-    /// alive until a later mutation proves it quiesced.
     #[kithara::test]
     fn displaced_frame_is_freed_by_the_writer() {
         let layout = Layout::new(0, &[]);
@@ -423,19 +412,16 @@ mod tests {
         layout.apply_commit(&[], || 0);
         assert!(
             displaced.upgrade().is_some(),
-            "the displaced frame must stay alive: a racing reader guard may still \
-             resolve to it, and its drop must never be the one that frees"
+            "a racing reader guard may still resolve to the displaced frame"
         );
 
         layout.apply_commit(&[], || 0);
         assert!(
             displaced.upgrade().is_none(),
-            "the next mutation reclaims quiesced frames on the writer thread"
+            "the next mutation reclaims quiesced frames"
         );
     }
 
-    /// `mutate_frame` (reset / activation mutators) routes through the same
-    /// retire step as `apply_commit`.
     #[kithara::test]
     fn mutate_frame_retires_the_displaced_frame() {
         let layout = Layout::new(0, &[]);
@@ -455,14 +441,11 @@ mod tests {
         layout.apply_commit(&[], || 0);
         assert!(
             displaced.upgrade().is_some(),
-            "a frame with an outstanding reader reference must survive reclamation"
+            "an outstanding reader blocks reclamation"
         );
 
         drop(reader);
         layout.apply_commit(&[], || 0);
-        assert!(
-            displaced.upgrade().is_none(),
-            "once the reader is gone the writer reclaims the frame"
-        );
+        assert!(displaced.upgrade().is_none());
     }
 }

--- a/crates/kithara-hls/src/variant/map/offsets.rs
+++ b/crates/kithara-hls/src/variant/map/offsets.rs
@@ -200,6 +200,12 @@ pub(super) struct Layout {
     /// cannot lose an update (the old `RwLock` serialized writes; `ArcSwap`
     /// alone does not). Never taken on the produce-core read path.
     write_lock: Mutex<()>,
+    /// Frames displaced by a swap, alive until a later mutation sees them
+    /// quiesced (`strong_count == 1`). Keeps reclamation on the writer
+    /// thread: a produce-core guard racing the swap can resolve to the
+    /// displaced frame, and this floor makes its drop a pure decrement.
+    /// Touched only under `write_lock`.
+    retired: Mutex<Vec<Arc<Frame>>>,
 }
 
 impl Layout {
@@ -220,6 +226,7 @@ impl Layout {
             total: AtomicU64::new(snapshot.total),
             sizes_complete: AtomicBool::new(snapshot.sizes_complete),
             publication_seq: AtomicU64::new(0),
+            retired: Mutex::new(Vec::new()),
         }
     }
 
@@ -255,6 +262,7 @@ impl Layout {
         let mut frame = (**self.frame.load()).clone();
         frame.recompute(init_size, segments);
         let snapshot = frame.snapshot(segments, init_size);
+        self.retire_current();
         self.frame.store(Arc::new(frame));
         self.republish(snapshot);
         self.finish_publication();
@@ -308,9 +316,18 @@ impl Layout {
         let mut frame = (**self.frame.load()).clone();
         f(&mut frame);
         let snapshot = frame.snapshot(segments, init_size);
+        self.retire_current();
         self.frame.store(Arc::new(frame));
         self.republish(snapshot);
         self.finish_publication();
+    }
+
+    /// Under `write_lock`: reclaim quiesced retirees, then move the live
+    /// frame into the retire list ahead of the swap.
+    fn retire_current(&self) {
+        let mut retired = self.retired.lock();
+        retired.retain(|frame| Arc::strong_count(frame) > 1);
+        retired.push(self.frame.load_full());
     }
 
     pub(super) fn natural_offset(&self, idx: usize) -> Option<u64> {
@@ -386,5 +403,56 @@ impl Layout {
             #[field]
             pub(super) fn served_from(&self) -> u32;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use kithara_platform::sync::Weak;
+
+    use super::*;
+
+    /// A produce-core reader racing a frame swap can end up holding the last
+    /// reference to the displaced frame, and dropping it would `free` inside
+    /// the forbid region. The writer therefore keeps every displaced frame
+    /// alive until a later mutation proves it quiesced.
+    #[kithara::test]
+    fn displaced_frame_is_freed_by_the_writer() {
+        let layout = Layout::new(0, &[]);
+        let displaced: Weak<Frame> = Arc::downgrade(&layout.frame.load_full());
+
+        layout.apply_commit(&[], || 0);
+        assert!(
+            displaced.upgrade().is_some(),
+            "the displaced frame must stay alive: a racing reader guard may still \
+             resolve to it, and its drop must never be the one that frees"
+        );
+
+        layout.apply_commit(&[], || 0);
+        assert!(
+            displaced.upgrade().is_none(),
+            "the next mutation reclaims quiesced frames on the writer thread"
+        );
+    }
+
+    #[kithara::test]
+    fn outstanding_reader_blocks_reclamation() {
+        let layout = Layout::new(0, &[]);
+        let reader: Arc<Frame> = layout.frame.load_full();
+        let displaced = Arc::downgrade(&reader);
+
+        layout.apply_commit(&[], || 0);
+        layout.apply_commit(&[], || 0);
+        assert!(
+            displaced.upgrade().is_some(),
+            "a frame with an outstanding reader reference must survive reclamation"
+        );
+
+        drop(reader);
+        layout.apply_commit(&[], || 0);
+        assert!(
+            displaced.upgrade().is_none(),
+            "once the reader is gone the writer reclaims the frame"
+        );
     }
 }

--- a/crates/kithara-hls/src/variant/tests.rs
+++ b/crates/kithara-hls/src/variant/tests.rs
@@ -904,12 +904,16 @@ fn segment_aware_seek_time_anchor_fetches_preroll_segment() {
         anchor.byte_offset, 200,
         "decoder anchor remains the target segment boundary"
     );
-    assert_eq!(
-        queue_seg_indices(&v),
-        vec![1, 2, 3, 4],
-        "fetch queue includes the segment a codec warmup backoff may read"
+    assert!(
+        queue_seg_indices(&v).is_empty(),
+        "anchor resolution runs on the produce core and leaves the fetch \
+         plan to the download peer (seek_epoch_reset -> rebuild_at_time)"
     );
-    assert_eq!(v.prefetch_anchor(), 100);
+    assert_eq!(
+        v.prefetch_anchor(),
+        100,
+        "the lock-free prefetch anchor still aims at the preroll segment"
+    );
 }
 
 #[kithara::test]

--- a/crates/kithara-hls/src/variant/tests.rs
+++ b/crates/kithara-hls/src/variant/tests.rs
@@ -910,14 +910,9 @@ fn segment_aware_seek_time_anchor_leaves_the_fetch_plan_to_the_peer() {
     assert_eq!(
         queue_seg_indices(&v),
         plan_before,
-        "anchor resolution runs on the produce core and leaves the fetch \
-         plan to the download peer (seek_epoch_reset -> rebuild_at_time)"
+        "the fetch plan is the peer's; anchor resolution must not touch it"
     );
-    assert_eq!(
-        v.prefetch_anchor(),
-        100,
-        "the lock-free prefetch anchor still aims at the preroll segment"
-    );
+    assert_eq!(v.prefetch_anchor(), 100);
 }
 
 #[kithara::test]

--- a/crates/kithara-hls/src/variant/tests.rs
+++ b/crates/kithara-hls/src/variant/tests.rs
@@ -883,7 +883,7 @@ fn segment_aware_rebuild_at_time_prefetches_seek_preroll_segment() {
 }
 
 #[kithara::test]
-fn segment_aware_seek_time_anchor_fetches_preroll_segment() {
+fn segment_aware_seek_time_anchor_leaves_the_fetch_plan_to_the_peer() {
     let ctx = test_ctx(3);
     let v = VariantParts {
         init: None,
@@ -893,6 +893,9 @@ fn segment_aware_seek_time_anchor_fetches_preroll_segment() {
         container: Some(ContainerFormat::Fmp4),
     }
     .into_variant(0, &ctx);
+
+    v.rebuild(&ctx, 0);
+    let plan_before = queue_seg_indices(&v);
 
     let anchor = v
         .prepare_seek_time_anchor(Duration::from_secs(4))
@@ -904,8 +907,9 @@ fn segment_aware_seek_time_anchor_fetches_preroll_segment() {
         anchor.byte_offset, 200,
         "decoder anchor remains the target segment boundary"
     );
-    assert!(
-        queue_seg_indices(&v).is_empty(),
+    assert_eq!(
+        queue_seg_indices(&v),
+        plan_before,
         "anchor resolution runs on the produce core and leaves the fetch \
          plan to the download peer (seek_epoch_reset -> rebuild_at_time)"
     );


### PR DESCRIPTION
# fix(hls,assets): close the produce-core RT violations the rtsan-hls lane exposes

## Summary

Three violations of the `rtsan_forbid_blocking` contract on the shared decode
worker's produce core, closed one per commit, each proven by a changed rtsan
abort stack under CPU load — plus a broken detector lane and a review-found
regression, closed the same way. The lane is contention-gated: on a quiet
machine it is green even with all three defects present, so every claim below
was measured under controlled CPU overload (8 busy cores of 10), five runs
per arm.

The chain as it actually unfolded on this base — the task packet named the LRU
mutex as the sole remaining violation, but under load two more surfaced around
it, and the first abort was not the documented one:

1. **Frame reclamation landed on the reader** (`c7f11e64`, kithara-hls). Every
   loaded baseline run aborted on `free` inside the forbid region:
   `Layout::natural_offset → drop(arc_swap::Guard<Arc<Frame>>) → drop_slow`.
   arc-swap hands reclamation to whichever side drops last, so a produce-core
   guard racing the writer's swap frees the displaced `Frame` (and its offsets
   `Vec`) on the core. No load order avoids that; reclamation had to move.
   The writer now parks the displaced frame in a retire list (the write lock's
   payload) and reclaims quiesced retirees (`strong_count == 1`) at the next
   mutation. The reader path is untouched; a guard drop is a pure refcount
   decrement. Red-first tests pin retention, quiesce, and the `mutate_frame`
   route.

2. **The availability probes fell back into the LRU mutex** (`ad9047c8`,
   kithara-assets — the violation the packet documents). With (1) closed, the
   lane aborts exactly on the packet's stack: `segment_contains →
   contains_range → resource_state → CachedAssets::cached_state →
   Mutex<LruCache>::lock_slow`. The aggregate miss that triggers the fallback
   is the *normal* state of a segment still downloading, so the produce core
   took that mutex on every readiness probe — and on disk the same fallback
   continued into `fs::metadata`. `contains_range` / `available_ranges` /
   `final_len` now answer from the `AvailabilityIndex` alone; hydration at
   store build plus the write/commit observers keep it complete, and an
   unknown resource is refetched — the verdict `is_confirmed` already gives
   the acquire path. The metadata fallback also contradicted the durability
   contract (a file the manifest does not vouch for can carry the right name
   and length over unwritten blocks), so the two crash-recovery tests that
   codified it now pin the refetch contract instead. `resource_state` stays
   the blocking control-side inspection API.

3. **Applying a seek rebuilt the fetch queue on the core** (`bbb6739a`,
   kithara-hls). With (2) closed, the lane aborts on
   `prepare_seek_time_anchor → rebuild_queue →
   Mutex<VecDeque<PlannedFetch>>::lock_slow` — two locks plus a VecDeque
   clear+extend inside the forbid region, bypassing `PlanCtx`, the token every
   other queue mutation carries. The plan has one owner: the download peer
   already re-aims the queue when it observes the epoch bump
   (`seek_epoch_reset → rebuild_at_time`, including the codec-preroll start
   segment), and that rebuild replaces the previous plan wholesale. The
   inline rebuild is deleted; anchor resolution keeps only its lock-free half
   (layout reads, atomic prefetch/alias/tail/demand stores).

4. **The rtsan-async lane compiled zero of its tests** (`f44fb489`). The
   recipe enabled `no-block` on the dependencies but not on
   kithara-integration-tests itself, and suite_light gates `mod no_block` on
   the package's own feature — a green run on an empty filter, on this base
   and on the packet's. `--features no-block` (the package feature forwards
   to both) brings its three poll-blocking detector tests back.

5. **Review found (2) had split the byte authority** (`b30fdcc3`,
   kithara-hls). The readiness gate asks the manifest, but the dispatcher's
   skip-fetch guard still sized segments from `resource_state`'s bare
   `fs::metadata`: on a warm cache with no manifest it would mark the slot
   `Loaded` and skip the fetch while the readiness gate answered "absent"
   forever — a wedge, with the delete-and-refetch acquire path
   short-circuited past. `committed_len` now reads the manifest's
   `final_len`; a red-first test pins the single-authority contract at the
   seam that diverged. `1877568a` carries the remaining review hygiene
   (retire list as the lock payload, doc corrections, a queue assertion that
   actually distinguishes the two plan owners); `35f764b1` trims the
   comments this branch added down to contract size.

## Behavior / scope

- contract or behavior: the produce core no longer frees layout frames, no
  longer takes the asset handle-cache mutex or touches the filesystem from
  the availability probes, and no longer mutates the fetch plan while
  applying a seek. `AssetStore`'s availability aggregate is the single byte
  authority end to end: probes, the HLS skip-fetch guard, and the acquire
  path all reach the same verdict, and a committed file the manifest does
  not vouch for reads as absent and is refetched (previously the probes and
  the guard resurrected it from `fs::metadata`). Post-seek queue re-aim is
  solely the download peer's epoch-observation path.
- affected area: `kithara-hls` `variant/map/offsets.rs`, `variant/flow/seek.rs`,
  `handle/resource.rs`; `kithara-assets` `store/handle.rs`, `CONTEXT.md`,
  crash-recovery tests; `.config/just/test.just`.

## Validation

Base for every "before" number: `d5485309` (product tree; branch base
`72d02cd2` differs only in CI/xtask). Loaded runs are `just test rtsan-hls`
with 8 `yes` processes alongside on a 10-core machine, five runs per arm.

- rtsan-hls, loaded:
  - base: **5/5 abort**, all on the `free(Frame)` stack (identical frames);
  - after (1): 3 green, **2 abort on a different stack** — the packet's LRU
    mutex (`cached_state`), i.e. the chain advanced;
  - after (2): 3 green, **1 abort on a different stack** — the seek-path
    queue mutex (`rebuild_queue`), plus 1 oracle assert flake (below);
  - after (3): 4 green + 1 oracle assert flake, zero rtsan aborts;
  - final tree (all six commits): **5/5 green**.
- rtsan-hls, quiet: 5/5 green (also green on the quiet base — the lane is
  contention-gated, which is why every arm ran under load).
- `just test rtsan-file`: 41 passed, 1 failed — the failure is
  `phase_continuity_file_apple_fused_src_44k_to_host_48k`, the known non-RT
  fused-SRC assert (packet Non-goals; reproduces on clean upstream); zero
  rtsan interceptions in the log, so the lane is RT-clean.
- `just test rtsan`: green, 8 tests.
- `just test rtsan-async`: was silently empty (see commit 4); after the
  recipe fix, 3/3 green.
- `just test` (full flash lane): final tree **4661/4661**. Two earlier runs
  mid-branch: 4658/4659 each, one failure per run, different names each
  time, both from the #137 flake profile
  (`abr_mode_switch::multi_track_shared_abr_with_cache`, then
  `player_worker_hls_then_mp3_reopen_keeps_backward_seek_ephemeral_apple` —
  the latter named verbatim in #137's flake list); both isolated-green
  (5/5 and 3/3) on the same tree.
- `just lint fast`: 0 regressions, 0 new across both gates (final tree).
- `just fmt` per commit.
- Perf, quiet machine, `just test run`:
  - `stress_seek_audio` (`--flash=on`, 7 tests): base summaries 1.960 /
    2.066 / 2.010 s → after 2.054 / 2.062 / 2.093 s — inside the base's own
    spread;
  - `live_ephemeral_revisit_sequence_regression` (4 tests): base 5×4/4
    green, 0.863–0.896 s → after 5×4/4 green, 0.863–0.868 s. (The #137
    held-reader lease this test killed measured 3/5 red; this branch leaves
    it clean.)
- Reviewed by the rust-architecture-guardian agent; its blocking finding is
  commit `b30fdcc3`, its notes are `1877568a`, and it verified the retire
  scheme against arc-swap 1.9.1 internals (writer's `wait_for_readers` pays
  outstanding debts into real strong counts before `store` returns, so the
  `strong_count == 1` quiesce check is sound).

## Surface impact

- Public API: `AssetStore::{contains_range, available_ranges, final_len}`
  keep their signatures; their answers are now aggregate-only (see Behavior).
- Platform/runtime: none
- Perf-sensitive paths: changed — the produce-core probe and seek-apply paths
  lose a mutex, a filesystem stat, and a queue rebuild; the dispatcher loses
  an fs stat per sized segment; the layout write path gains a retire-list
  push/prune under its existing lock. Numbers above.

## Risks / follow-ups

- **The next structural link is the same queue mutex from the probe side.**
  `fetch_is_planned` / `segment_has_demand` / `init_has_demand`
  (`variant/io/read.rs`, `read_data.rs`) lock `flow.queue` inside the phase
  probes to classify `Waiting` vs `WaitingDemand`. Ten loaded runs never
  tripped it (the planner side is quiet post-fix), but the lock is on the
  forbid path. Fix shape if it surfaces: a lock-free plan view (the seqlock
  pattern `flow/seqlock.rs` already uses for the seek alias) published by
  the queue's owners.
- The availability aggregate's own per-entry mutex (`index/availability/
  core.rs`) is short but real, and writers hold it across a `RangeSet`
  insert; pre-existing, documented in CONTEXT.md, never tripped in any run.
- The phase-continuity oracle flakes under deliberate 8-core overload
  (`hls.rs:241`, ~1 run in 5 mid-branch, different test variants each time,
  present before and after these fixes; quiet runs 5/5 green, and the final
  loaded series was 5/5 green). Same class as the #137 load-flake finding —
  an oracle that measures the host under extreme contention.
- Tried and rejected here: nothing beyond the packet's own list — the two
  #137 conclusions (pins flush cannot be deferred; HLS-side reader lease
  measured worse than base) were treated as constraints, and neither
  mechanism was touched.
