### PR TITLE
test: stop an unrelated dependency bump from emptying the fixture cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4686,6 +4686,7 @@ dependencies = [
  "thirtyfour",
  "thiserror 2.0.18",
  "tokio-stream",
+ "toml 1.1.2+spec-1.1.0",
  "tower",
  "tower-http 0.7.0",
  "tracing",

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -8,6 +8,12 @@ publish = false
 autotests = false
 build = "build.rs"
 
+[build-dependencies]
+# Reads the resolved encoder versions out of the workspace lockfile; see
+# `build.rs`. Hashing the whole lockfile invalidated the fixture cache on every
+# unrelated dependency bump.
+toml = { workspace = true }
+
 [package.metadata.cargo-machete]
 ignored = ["serial_test"]
 

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -1,12 +1,13 @@
 //! Emits `KITHARA_FIXTURE_BUILD`: a fingerprint of the fixture-encoding code and
-//! its dependency lockfile, baked into every test binary of this package.
+//! the encoder versions the lockfile resolved, baked into every test binary of
+//! this package.
 //!
 //! The L2 fixture cache (see `src/fixture_cache.rs`) namespaces its default
 //! directory by this value, so:
 //! - all test binaries of one build (`suite_stress`, `suite_heavy`, …) share the
 //!   same cache dir — an AAC fixture encoded by one binary is reused by every
 //!   other binary and by repeated runs of the same build;
-//! - a change to the encoder, the fixture server, or any dependency version
+//! - a change to the encoding code or to an encoder crate's resolved version
 //!   yields a fresh namespace, so a stale cache can never serve outdated bytes.
 
 use std::{
@@ -15,6 +16,8 @@ use std::{
     hash::{Hash, Hasher},
     path::Path,
 };
+
+use toml::{Table, Value};
 
 /// Hash every `.rs` file under `dir` (path + contents) and register each for
 /// change-tracking so the fingerprint refreshes whenever encoding code changes.
@@ -37,6 +40,58 @@ fn hash_rs_tree(dir: &Path, hasher: &mut DefaultHasher) {
     }
 }
 
+/// The crates whose resolved build determines an encoded byte. Read from the
+/// lockfile by name, so a version bump to any of them still lands in a fresh
+/// namespace.
+const ENCODERS: &[&str] = &["fdk-aac", "fdk-aac-sys", "ffmpeg-next", "ffmpeg-sys-next"];
+
+const LOCKFILE: &str = "../Cargo.lock";
+
+/// Hash what the lockfile resolved for [`ENCODERS`], rather than the lockfile.
+///
+/// The whole file was hashed here before, on the reasoning that a dependency
+/// version determines the encoded bytes. Only these ones do: bumping an XML
+/// parser cannot change an AAC frame, but hashing the file said it could, so
+/// every unrelated dependency bump moved the namespace and left the suite with
+/// an empty cache — and a cold cache means per-test ffmpeg re-encodes, which
+/// blow the budgets of tests that assert against a deadline. That is the same
+/// failure the `src/native` narrowing above was written to stop; the lockfile
+/// was the remaining wide input.
+fn hash_encoder_versions(hasher: &mut DefaultHasher) {
+    println!("cargo:rerun-if-changed={LOCKFILE}");
+    let text = fs::read_to_string(LOCKFILE).expect("the workspace lockfile must be readable");
+    let lock: Table = text.parse().expect("the workspace lockfile must be TOML");
+    let packages = lock
+        .get("package")
+        .and_then(Value::as_array)
+        .expect("the workspace lockfile must list packages");
+
+    let mut resolved: Vec<String> = packages
+        .iter()
+        .filter_map(|package| {
+            let name = package.get("name").and_then(Value::as_str)?;
+            ENCODERS.contains(&name).then(|| {
+                let field = |key| package.get(key).and_then(Value::as_str).unwrap_or_default();
+                // The checksum pins the exact bytes the version resolves to,
+                // which a re-release under one version number would not.
+                format!("{name} {} {}", field("version"), field("checksum"))
+            })
+        })
+        .collect();
+    resolved.sort();
+
+    // A crate leaving the lock under a name listed here would silently stop
+    // being tracked, and an untracked encoder change is a cache serving bytes
+    // it should not. Fail the build instead.
+    assert_eq!(
+        resolved.len(),
+        ENCODERS.len(),
+        "{LOCKFILE} resolved {resolved:?} for {ENCODERS:?}; update ENCODERS to \
+         match the crates that encode fixtures"
+    );
+    resolved.hash(hasher);
+}
+
 fn main() {
     let mut hasher = DefaultHasher::new();
 
@@ -50,19 +105,18 @@ fn main() {
         println!("cargo:rerun-if-changed={dir}");
         hash_rs_tree(Path::new(dir), &mut hasher);
     }
-    // The encode glue, the PCM signal generator, and the dependency lockfile
-    // (ffmpeg-sys / encoder crate versions) also determine the encoded bytes.
+    // The encode glue and the PCM signal generator also determine the bytes.
     for file in [
         "src/native/hls_stream.rs",
         "src/native/routes/signal.rs",
         "src/signal_pcm.rs",
-        "../Cargo.lock",
     ] {
         if let Ok(bytes) = fs::read(file) {
             bytes.hash(&mut hasher);
         }
         println!("cargo:rerun-if-changed={file}");
     }
+    hash_encoder_versions(&mut hasher);
     println!("cargo:rerun-if-changed=build.rs");
 
     println!(


### PR DESCRIPTION
`KITHARA_FIXTURE_BUILD` namespaces the L2 cache of encoded fixtures, and it hashed the whole workspace lockfile. Only four crates in there can change an encoded byte — `fdk-aac`, `fdk-aac-sys`, `ffmpeg-next`, `ffmpeg-sys-next`. The rest cannot, and saying they can cost a full re-encode of every fixture on every dependency bump.

A cold cache is not merely slow. Tests that assert against their own deadline encode inside it: `track_replay_after_switch` has a 20 s budget, and on a loaded runner a cold encode does not fit, so the suite reported a product hang that was an empty directory.

## Evidence

Bumping quick-xml and swapping `serde_yml` for `serde_yaml_ng` — neither of which can reach an AAC frame — turned two CI runs red:

| | main | after the lock bump |
|---|---|---|
| `..._plain` | PASS 0.376 s | FAIL 20.614 s |
| `..._aes128` | PASS 0.379 s | FAIL 20.618 s |
| `Qavg:` lines in the job log | 2 | 4 |

`Qavg:` is printed once per ffmpeg AAC encode session. The two extra ones carry an identical value and sit inside the captured stderr of exactly those two tests: they encoded their fixture from scratch, and on main they did not. A third run on the same commit went green with `Qavg` back to 2, once the cache had refilled.

`tests/build.rs` already documents this failure mode in a comment — hashing all of `src/native` "forced a cold cache (and per-test ffmpeg re-encodes blowing test budgets) on every test-server edit". The lockfile was the remaining wide input.

## The fix

The fingerprint now reads the versions and checksums the lockfile resolved for the encoders, which is what the comment beside it already claimed to capture. Those four entries are byte-identical across the two lock revisions that caused this, so the same bumps would have left the namespace alone.

A name listed in `ENCODERS` that no longer appears in the lock fails the build: an encoder that silently stopped being tracked is a cache serving bytes it should not.

This changes the fingerprint itself, so the first run after it lands is cold once more. After that a dependency bump costs nothing.