### PR TITLE
ci: the cleanup timer keeps what the fleet runs, not what the checkout pins

### DIFF
--- a/.config/just/ci.just
+++ b/.config/just/ci.just
@@ -65,7 +65,7 @@ full OUTPUT:
 
     run_stage lint    just lint fast
     run_stage test    just test
-    run_stage e2e     just test run --lane=e2e
+    # A Linux container has no output device; the hardware e2e lane runs as `apple:e2e`.
     run_stage mutants just test mutants run-all --output "{{ OUTPUT }}/mutants"
 
     echo "=== ci full $RUN_ID done at $(date -u -Iseconds) ==="

--- a/.config/just/quality.just
+++ b/.config/just/quality.just
@@ -9,6 +9,10 @@ report *ARGS:
 assess *ARGS:
     just _xtask quality assess "$@"
 
+[positional-arguments]
+summary *ARGS:
+    just _xtask quality summary "$@"
+
 unimock-check:
     just _xtask quality unimock-check
 

--- a/.config/just/test.just
+++ b/.config/just/test.just
@@ -13,13 +13,11 @@ all:
     just test
     just test run --lane=doc
 
+# All three lanes require a real output device.
 [positional-arguments]
 e2e-resamplers *ARGS:
     #!/usr/bin/env bash
     set -euo pipefail
-    if (( $# == 0 )); then
-      set -- -E 'test(track_plays_end_to_end_silvercomet)' --test-threads=4
-    fi
     just test run --lane=e2e "$@"
     just test run --lane=e2e-fused "$@"
     just test run --lane=e2e-glide "$@"

--- a/.config/xtask.toml
+++ b/.config/xtask.toml
@@ -300,7 +300,14 @@ prefix_args = [
 default_features = ["integration-regressions"]
 default_flash = true
 
-[test.lanes.selenium]
+# The harness (tests/tests/kithara_ffi_web/selenium.rs) reads
+# KITHARA_SELENIUM_BROWSER to pick a browser and defaults to chrome if unset.
+# Naming the browser in the lane itself, rather than leaving it to whatever
+# the caller happens to export, is what makes `--lane=selenium-firefox` an
+# honest description of what ran. Firefox is the only browser this pins today
+# (geckodriver, below); a `selenium-chrome` lane needs a reviewed chromedriver
+# pin first.
+[test.lanes.selenium-firefox]
 program = "cargo"
 prefix_args = [
   "+nightly",
@@ -481,8 +488,8 @@ hard_invariant = true
 complete_only = true
 
 [[quality.assessment.deep_stages]]
-name = "selenium"
-command = ["just", "test", "run", "--lane=selenium"]
+name = "selenium-firefox"
+command = ["just", "test", "run", "--lane=selenium-firefox"]
 tools = ["selenium-tests"]
 hard_invariant = true
 complete_only = true

--- a/.config/xtask.toml
+++ b/.config/xtask.toml
@@ -196,9 +196,11 @@ default_flash = false
 # on Rubato; inert off Apple), `e2e-glide` the Glide backend (no Rubato in the
 # graph, otherwise the compile-time alias picks Rubato).
 #
-# All three run `suite_e2e`, which reaches nothing outside the runner. The tests
-# that need the zvuk CDN or the corporate VPN live in `suite_network` behind the
-# `network` feature, so no amount of `--run-ignored` can pull them in here.
+# All three need a real output device, so they run on the Apple executor and are
+# absent from the Linux container fleet. `suite_e2e` reaches nothing outside the
+# runner. The tests that need the zvuk CDN or the corporate VPN live in
+# `suite_network` behind the `network` feature, so no amount of `--run-ignored`
+# can pull them in here.
 [test.lanes.e2e]
 program = "cargo"
 prefix_args = [

--- a/.github/workflows/lanes.yml
+++ b/.github/workflows/lanes.yml
@@ -22,34 +22,59 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Which lanes this run is for, decided before any of them start.
+  #
+  # Selecting inside the lane job instead would skip the step and leave the job
+  # green: a run scoped to one lane then reports every other lane as passing,
+  # which is the opposite of what a lane exists to say. A lane that does not run
+  # must produce no job at all.
+  select:
+    name: select lanes
+    if: vars.KITHARA_RUNNER_LABELS != '' && github.actor == github.repository_owner
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      lanes: ${{ steps.pick.outputs.lanes }}
+    steps:
+      - name: Pick the lanes
+        id: pick
+        env:
+          # Absent for `workflow_call`, which always means every lane.
+          REQUESTED: ${{ github.event.inputs.lane }}
+        run: |
+          set -euo pipefail
+          configured='["integration-regressions","network","loom","e2e","e2e-fused","e2e-glide","selenium"]'
+          if [ -z "$REQUESTED" ] || [ "$REQUESTED" = all ]; then
+            echo "lanes=$configured" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # A lane nobody configured would otherwise select nothing and report a
+          # run that tested nothing as green.
+          if ! echo "$configured" | jq -e --arg lane "$REQUESTED" 'index($lane)' >/dev/null; then
+            echo "::error::no lane named '$REQUESTED'; configured lanes are $configured"
+            exit 1
+          fi
+          printf 'lanes=%s\n' "$(jq -cn --arg lane "$REQUESTED" '[$lane]')" >> "$GITHUB_OUTPUT"
+
   lanes:
     name: ${{ matrix.lane }}
-    if: vars.KITHARA_RUNNER_LABELS != '' && github.actor == github.repository_owner
+    needs: select
     runs-on: ${{ fromJSON(vars.KITHARA_RUNNER_LABELS) }}
     timeout-minutes: 180
-    # One red lane must not hide the others: this run exists to enumerate.
-    continue-on-error: true
     strategy:
+      # One red lane must not hide the others: this run exists to enumerate, so
+      # a failure stops neither its siblings nor the report. It does count —
+      # `continue-on-error` here additionally made the run green whatever the
+      # lanes said, so the nightly report had nothing to key on.
       fail-fast: false
       matrix:
-        lane:
-          - integration-regressions
-          - network
-          - loom
-          - e2e
-          - e2e-fused
-          - e2e-glide
-          - selenium
+        lane: ${{ fromJSON(needs.select.outputs.lanes) }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Run the lane
-        if: >-
-          github.event.inputs.lane == ''
-          || github.event.inputs.lane == 'all'
-          || github.event.inputs.lane == matrix.lane
         env:
           LANE: ${{ matrix.lane }}
           # The network lane builds against the production key server. These are

--- a/.github/workflows/lanes.yml
+++ b/.github/workflows/lanes.yml
@@ -43,7 +43,12 @@ jobs:
           REQUESTED: ${{ github.event.inputs.lane }}
         run: |
           set -euo pipefail
-          configured='["integration-regressions","network","loom","e2e","e2e-fused","e2e-glide","selenium-firefox"]'
+          # These runners are containers with no output device, so the three
+          # e2e lanes would fail on the machine rather than on the code.
+          # `apple:e2e` serves them on hardware. A lane this fleet cannot run is
+          # left out entirely, producing no job at all rather than a red one or
+          # a skipped-but-green one.
+          configured='["integration-regressions","network","loom","selenium-firefox"]'
           if [ -z "$REQUESTED" ] || [ "$REQUESTED" = all ]; then
             echo "lanes=$configured" >> "$GITHUB_OUTPUT"
             exit 0

--- a/.github/workflows/lanes.yml
+++ b/.github/workflows/lanes.yml
@@ -43,7 +43,7 @@ jobs:
           REQUESTED: ${{ github.event.inputs.lane }}
         run: |
           set -euo pipefail
-          configured='["integration-regressions","network","loom","e2e","e2e-fused","e2e-glide","selenium"]'
+          configured='["integration-regressions","network","loom","e2e","e2e-fused","e2e-glide","selenium-firefox"]'
           if [ -z "$REQUESTED" ] || [ "$REQUESTED" = all ]; then
             echo "lanes=$configured" >> "$GITHUB_OUTPUT"
             exit 0
@@ -84,4 +84,11 @@ jobs:
           KITHARA_DRM_PROD_KEY: ${{ secrets.KITHARA_DRM_PROD_KEY }}
           KITHARA_DRM_PROD_AUTH_TOKEN: ${{ secrets.KITHARA_DRM_PROD_AUTH_TOKEN }}
           KITHARA_DRM_PROD_SP_ZV_TOKEN: ${{ secrets.KITHARA_DRM_PROD_SP_ZV_TOKEN }}
-        run: CARGO_TARGET_DIR="target-lane-$LANE" just test run "--lane=$LANE"
+        # A selenium-<browser> lane names the browser it exercises; the
+        # harness (tests/tests/kithara_ffi_web/selenium.rs) otherwise defaults
+        # to chrome regardless of what the fleet actually pins.
+        run: |
+          if [[ "$LANE" == selenium-* ]]; then
+            export KITHARA_SELENIUM_BROWSER="${LANE#selenium-}"
+          fi
+          CARGO_TARGET_DIR="target-lane-$LANE" just test run "--lane=$LANE"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -53,6 +53,20 @@ jobs:
             just quality assess
           fi
 
+      # Decision evidence stays visible when assessment execution is partial.
+      - name: Summarize the assessment
+        if: always()
+        env:
+          DEPTH: ${{ inputs.depth || 'shallow' }}
+        run: |
+          summary_args=()
+          if [[ "$DEPTH" == "deep" ]]; then
+            summary_args=(--depth deep)
+          fi
+          if ! just quality summary "${summary_args[@]}" >> "$GITHUB_STEP_SUMMARY"; then
+            echo "::warning::Quality assessment summary could not be rendered; see the error above." >&2
+          fi
+
       - name: Upload the assessment
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -93,8 +107,26 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # `viz` no longer fails over a degraded optional overlay, so the only place
+      # that degradation would otherwise appear is an artifact nobody opens.
       - name: Render the architecture document
-        run: just arch viz
+        run: |
+          mkdir -p target
+          just arch viz 2>&1 | tee target/viz.log
+
+      - name: Report the architecture evidence status
+        if: always()
+        run: |
+          {
+            echo "## Architecture document"
+            echo
+            if [[ -f target/viz.log ]]; then
+              grep -E '^(==>|warning:)' target/viz.log | sed 's/^/- /' \
+                || echo "- The render produced no status line."
+            else
+              echo "- The render step did not run."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Sweep for orphans
         run: just arch orphans

--- a/.github/workflows/verified.yml
+++ b/.github/workflows/verified.yml
@@ -1,0 +1,66 @@
+name: Verified
+
+# `ci.yml` reacts to a push and never to a pull request, because a self-hosted
+# runner executes whatever the checked-out tree says. That leaves a merge
+# proposal with nothing to show, and a repository whose jobs are all gated off
+# produces a run that concludes `skipped` — which reads as "not failing", so a
+# branch nobody verified merges as easily as one that passed a full gate.
+#
+# This job closes that. It runs on a GitHub-hosted runner, never checks out the
+# proposed tree, and executes no repository code: it only asks the API whether a
+# CI run for this commit exists and got as far as running.
+on:
+  pull_request:
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  verified:
+    name: This repository verified this commit
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Find the CI run for this commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # The push run is usually already going when the pull request opens,
+          # so wait for it rather than racing it. A full gate is well inside
+          # this budget; the job timeout above is the real bound.
+          for _ in $(seq 1 80); do
+            conclusion=$(gh api "repos/$REPO/actions/runs?head_sha=$SHA&event=push" \
+              --jq '[.workflow_runs[] | select(.name == "CI")]
+                    | first
+                    | if . == null then "absent"
+                      elif .status != "completed" then "running"
+                      else .conclusion end' 2>/dev/null || echo running)
+            [ "$conclusion" = running ] || break
+            sleep 30
+          done
+
+          case "$conclusion" in
+            success)
+              echo "CI ran on $SHA and passed."
+              ;;
+            skipped)
+              echo "::error::The CI run for $SHA concluded 'skipped': every job was gated off, so this repository verified nothing about this commit. Attach runners here (the KITHARA_RUNNER_LABELS variable names them) — a run that did not happen must not read as one that passed."
+              exit 1
+              ;;
+            absent)
+              echo "::error::No CI run exists for $SHA in $REPO. Push the branch to a copy of this repository that has runners attached, so the commit being merged is the commit that was tested."
+              exit 1
+              ;;
+            running)
+              echo "::error::The CI run for $SHA was still going when this job ran out of time. Re-run this check once it finishes."
+              exit 1
+              ;;
+            *)
+              echo "::error::The CI run for $SHA concluded '$conclusion'."
+              exit 1
+              ;;
+          esac

--- a/.gitlab/ci/lanes.yml
+++ b/.gitlab/ci/lanes.yml
@@ -21,20 +21,8 @@ lanes:integration-regressions:
   script:
     - just ci run linux-integration-regressions
 
-lanes:e2e:
-  extends: .lane-job
-  script:
-    - just ci run linux-e2e
-
-lanes:e2e-fused:
-  extends: .lane-job
-  script:
-    - just ci run linux-e2e-fused
-
-lanes:e2e-glide:
-  extends: .lane-job
-  script:
-    - just ci run linux-e2e-glide
+# Linux CI runs in containers with no output device, so `apple:e2e` serves the
+# hardware-dependent e2e lanes.
 
 lanes:selenium-firefox:
   extends: .lane-job

--- a/.gitlab/ci/lanes.yml
+++ b/.gitlab/ci/lanes.yml
@@ -36,7 +36,7 @@ lanes:e2e-glide:
   script:
     - just ci run linux-e2e-glide
 
-lanes:selenium:
+lanes:selenium-firefox:
   extends: .lane-job
   script:
-    - just ci run linux-selenium
+    - just ci run linux-selenium-firefox

--- a/TESTING.md
+++ b/TESTING.md
@@ -19,7 +19,7 @@ just test run -p kithara-hls   # one package
 just test run --profile ci     # a specific nextest profile
 just test run EXPR             # a nextest filter expression, e.g. test(seek)
 just test run --lane=doc       # doc-tests (nextest does not run them)
-just test run --lane=e2e       # gated by the `e2e` feature (suite_e2e)
+just test run --lane=e2e       # gated by the `e2e` feature (suite_e2e); needs a real output device
 just test run --lane=cached    # opt-in ephemeral L2 fixture cache (profile `cache`)
 ```
 

--- a/crates/kithara-devtools/CONTEXT.md
+++ b/crates/kithara-devtools/CONTEXT.md
@@ -87,7 +87,7 @@ source contour stays in `contours.json`. An endpoint hidden by LOD lifts to its 
 visible owner; equal visible endpoint/kind pairs aggregate while retaining the original
 method pairs, occurrence count, evidence origins, and style in `projection.json`, and
 relation kinds stay distinct. There is no diagram node budget: LOD 4 is partitioned by
-semantic contours into an index and linked pages, and manifest schema v4 records
+semantic contours into an index and linked pages, and manifest schema v5 records
 complete visible-node coverage plus hierarchical artifact paths. Optional and
 target-gated Cargo dependencies carry conditional evidence; unconditional normal
 dependencies stay resolved structural facts. The metrics profile in `metrics.json` is
@@ -103,7 +103,7 @@ symbols before semantic selection and matching contours plus incident edges from
 `DiagramModel`; it never alters raw `graph.json` evidence or disables an excluded
 package used as a runtime scenario. A module pattern matching any ancestor of a
 canonical `package::module` path excludes the descendant; relations never lift through
-an excluded endpoint. Manifest schema v4 records the effective patterns and excluded
+an excluded endpoint. Manifest schema v5 records the effective patterns and excluded
 counts. `--include-default-excluded` drops project defaults while keeping explicit CLI
 filters. An emptied projection is an error, not an empty diagram.
 
@@ -127,11 +127,13 @@ report derives from the visible `DiagramModel` and its contracted metrics graph;
 finding and relation points to a visible Mermaid contour.
 
 Artifact status is `complete`, `truncated`, `static-only`, `runtime-enriched`, or
-`incomplete`. Timeout, failed execution, malformed trace, or failed semantic resolution
-preserves partial artifacts and fails the command. Missing optional rust-analyzer
-yields static/runtime output unless `--semantic required` was requested. Truncation is
-explicit, applies only to evidence collection, and never removes nodes because of
-diagram size.
+`runtime-degraded`. Missing, timed-out, or failed semantic resolution yields the same
+static graph classification; diagnostics retain the cause. An empty, failed, or timed-out
+runtime observation is `runtime-degraded` and cannot invalidate the static projection.
+Optional degradation emits a warning and succeeds. Explicitly required semantic,
+scenario, or trace evidence that degrades returns an error after preserving the
+artifacts. Truncation is explicit, applies only to evidence collection, and never
+removes nodes because of diagram size.
 
 ## Quality assessment contract
 

--- a/crates/kithara-devtools/README.md
+++ b/crates/kithara-devtools/README.md
@@ -149,7 +149,7 @@ Crate patterns match Cargo package names. Module patterns match canonical
 packages may still run as runtime evidence producers; they do not enter
 semantic selection, Mermaid, `projection.json`, findings, or architecture
 counters. The complete diagnostic evidence remains in `graph.json`, while
-manifest schema v4 records the effective filters, excluded node/edge counts,
+manifest schema v5 records the effective filters, excluded node/edge counts,
 hierarchical pages, and machine-readable artifact paths.
 
 `[architecture.runtime]` can declare portable tests, binaries, or existing
@@ -200,9 +200,11 @@ change the stable index. Runtime traces and captured process logs are preserved 
 adjacent `traces/` and `logs/` directories. There is no diagram node cap. LOD 4
 writes an index plus linked documents below `contours/`, with manifest coverage
 proving that partitioning did not remove nodes. The manifest status is
-`complete`, `truncated`, `static-only`, `runtime-enriched`, or `incomplete`;
-`truncated` applies to evidence collection, not diagram size. An incomplete run
-returns an error after preserving partial artifacts.
+`complete`, `truncated`, `static-only`, `runtime-enriched`, or
+`runtime-degraded`; `truncated` applies to evidence collection, not diagram
+size. Optional overlay degradation preserves the static projection, emits a
+warning, and succeeds. Explicitly required semantic, scenario, or trace evidence
+that degrades returns an error after preserving the artifacts.
 
 `[perf]` configures the generic test-suite performance pipeline:
 

--- a/crates/kithara-devtools/src/health.rs
+++ b/crates/kithara-devtools/src/health.rs
@@ -315,7 +315,7 @@ fn write_report(
     let _ = write!(out, "- per-stage logs: `{}/`\n\n", logs_dir.display());
     out.push_str("Excluded by design (run separately): `mutants`, `coverage`, `dead`, ");
     out.push_str(
-        "`test --lane=e2e`, `test --lane=selenium`, `wasm`, `bench`, `perf`, `memory-check`.\n\n",
+        "`test --lane=e2e`, `test --lane=selenium-firefox`, `wasm`, `bench`, `perf`, `memory-check`.\n\n",
     );
 
     out.push_str("## Summary\n\n");

--- a/crates/kithara-devtools/src/quality.rs
+++ b/crates/kithara-devtools/src/quality.rs
@@ -21,6 +21,8 @@ const MOCK_COVERAGE_PATTERN: &str = r"(unimock::unimock\(|#\[\s*kithara::mock)";
 pub enum QualityCommand {
     /// Build a decision-oriented repository quality assessment.
     Assess(quality_assessment::AssessArgs),
+    /// Render a compact summary from an existing quality assessment.
+    Summary(quality_assessment::SummaryArgs),
     /// Generate a quality report.
     Report {
         #[arg(long)]
@@ -111,6 +113,7 @@ fn count_rs_files_in(dir: &Path) -> Result<usize> {
 pub(crate) fn run(cmd: &QualityCommand, ctx: &Ctx) -> Result<()> {
     match cmd {
         QualityCommand::Assess(args) => quality_assessment::run(args, ctx),
+        QualityCommand::Summary(args) => quality_assessment::run_summary(args, ctx),
         QualityCommand::Report {
             min_unimock_traits,
             min_rstest_cases,
@@ -598,6 +601,19 @@ mod tests {
         let matches = command.try_get_matches_from(["quality", "assess"]);
 
         assert!(matches.is_ok(), "quality assess should parse: {matches:?}");
+    }
+
+    #[test]
+    fn summary_command_accepts_an_assessment_directory() {
+        let command = QualityCommand::augment_subcommands(clap::Command::new("quality"));
+        let matches = command.try_get_matches_from([
+            "quality",
+            "summary",
+            "--directory",
+            "target/quality-assessment/revision/product-standard",
+        ]);
+
+        assert!(matches.is_ok(), "quality summary should parse: {matches:?}");
     }
 
     #[test]

--- a/crates/kithara-devtools/src/quality_assessment.rs
+++ b/crates/kithara-devtools/src/quality_assessment.rs
@@ -2,7 +2,7 @@ use std::{fmt, io::Write as _, path::PathBuf};
 
 use anyhow::{Result, bail};
 use clap::{Args, ValueEnum};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::Ctx;
 
@@ -11,8 +11,12 @@ mod artifact;
 mod collect;
 mod model;
 mod orchestrator;
+mod summary;
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, ValueEnum)]
+pub use summary::SummaryArgs;
+pub(crate) use summary::run as run_summary;
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize, ValueEnum)]
 #[serde(rename_all = "kebab-case")]
 pub enum AssessmentProfile {
     #[default]
@@ -29,7 +33,7 @@ impl fmt::Display for AssessmentProfile {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, ValueEnum)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize, ValueEnum)]
 #[serde(rename_all = "kebab-case")]
 pub enum AssessmentDepth {
     #[default]

--- a/crates/kithara-devtools/src/quality_assessment/adapters.rs
+++ b/crates/kithara-devtools/src/quality_assessment/adapters.rs
@@ -192,9 +192,7 @@ fn architecture_manifest_compatible(ctx: &Ctx, args: &AssessArgs, path: &Path) -
     let Some(manifest) = read_json(path)? else {
         return Ok(false);
     };
-    if manifest["schema_version"].as_u64().unwrap_or(0) < 4
-        || manifest["status"].as_str() == Some("incomplete")
-    {
+    if manifest["schema_version"].as_u64().unwrap_or(0) < 5 {
         return Ok(false);
     }
     let (expected_package, expected_module) = selected_scope(args);
@@ -632,7 +630,7 @@ fn read_json(path: &Path) -> Result<Option<serde_json::Value>> {
     Ok(Some(value))
 }
 
-fn git_revision(root: &Path, short: bool) -> Option<String> {
+pub(super) fn git_revision(root: &Path, short: bool) -> Option<String> {
     let mut command = Command::new("git");
     command.arg("-C").arg(root).arg("rev-parse");
     if short {
@@ -660,6 +658,68 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
+    use crate::{common::project::ProjectConfig, quality_assessment::AssessmentDepth};
+
+    #[test]
+    fn architecture_manifest_compatibility_uses_schema_not_overlay_state() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("manifest.json");
+        let ctx = Ctx::new(temp.path().to_path_buf(), ProjectConfig::default());
+        let args = AssessArgs {
+            depth: AssessmentDepth::Standard,
+            profile: AssessmentProfile::Product,
+            baseline: None,
+            krate: None,
+            module: None,
+            reuse_existing: false,
+        };
+        let mut manifest = serde_json::json!({
+            "schema_version": 5,
+            "status": "static-only",
+            "package": null,
+            "module": null,
+            "filters": {
+                "exclude_crates": [],
+                "exclude_modules": []
+            },
+            "semantic": {
+                "state": "timed_out",
+                "diagnostics": ["rust-analyzer timed out during workspace loading"]
+            }
+        });
+        fs::write(
+            &path,
+            serde_json::to_vec(&manifest).expect("serialize manifest"),
+        )
+        .expect("write manifest");
+
+        assert!(
+            architecture_manifest_compatible(&ctx, &args, &path).expect("schema 5 compatibility")
+        );
+
+        manifest["status"] = serde_json::json!("incomplete");
+        fs::write(
+            &path,
+            serde_json::to_vec(&manifest).expect("serialize manifest"),
+        )
+        .expect("write manifest");
+
+        assert!(
+            architecture_manifest_compatible(&ctx, &args, &path)
+                .expect("legacy status compatibility")
+        );
+
+        manifest["schema_version"] = serde_json::json!(4);
+        fs::write(
+            &path,
+            serde_json::to_vec(&manifest).expect("serialize manifest"),
+        )
+        .expect("write manifest");
+
+        assert!(
+            !architecture_manifest_compatible(&ctx, &args, &path).expect("schema 4 compatibility")
+        );
+    }
 
     #[test]
     fn health_failures_are_normalized_as_hard_invariants() {

--- a/crates/kithara-devtools/src/quality_assessment/artifact.rs
+++ b/crates/kithara-devtools/src/quality_assessment/artifact.rs
@@ -1,13 +1,13 @@
 use std::{
     collections::BTreeMap,
     fs,
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
 };
 
-use anyhow::{Context, Result};
-use serde::Serialize;
+use anyhow::{Context, Result, anyhow, bail};
+use serde::{Deserialize, Serialize};
 
-use super::model::{Assessment, ToolCoverage};
+use super::model::{AnalysisStatus, Assessment, ToolCoverage, Verdict};
 
 const MAX_RENDERED_FINDINGS: usize = 100;
 const MAX_ARCHITECTURE_HOTSPOTS: usize = 30;
@@ -16,15 +16,15 @@ pub(super) struct ArtifactSet {
     pub(super) document: PathBuf,
 }
 
-#[derive(Serialize)]
-struct Manifest<'a> {
-    revision: &'a str,
-    scope: &'a str,
-    status: &'static str,
-    verdict: &'static str,
+#[derive(Deserialize, Serialize)]
+struct Manifest {
+    revision: String,
+    scope: String,
+    status: AnalysisStatus,
+    verdict: Verdict,
     depth: super::AssessmentDepth,
     profile: super::AssessmentProfile,
-    files: BTreeMap<&'static str, &'static str>,
+    files: BTreeMap<String, String>,
     schema_version: u32,
 }
 
@@ -39,18 +39,18 @@ pub(super) fn write(assessment: &Assessment, root: &Path) -> Result<ArtifactSet>
         &output.join("manifest.json"),
         &Manifest {
             schema_version: assessment.schema_version,
-            revision: &assessment.revision,
-            status: assessment.status.as_str(),
+            revision: assessment.revision.clone(),
+            status: assessment.status,
             profile: assessment.profile,
             depth: assessment.depth,
-            scope: &assessment.scope.name,
-            verdict: assessment.verdict.as_str(),
+            scope: assessment.scope.name.clone(),
+            verdict: assessment.verdict,
             files: BTreeMap::from([
-                ("assessment", "assessment.json"),
-                ("document", "assessment.md"),
-                ("logs", "logs/"),
-                ("manifest", "manifest.json"),
-                ("stages", "stages/"),
+                ("assessment".to_owned(), "assessment.json".to_owned()),
+                ("document".to_owned(), "assessment.md".to_owned()),
+                ("logs".to_owned(), "logs/".to_owned()),
+                ("manifest".to_owned(), "manifest.json".to_owned()),
+                ("stages".to_owned(), "stages/".to_owned()),
             ]),
         },
     )?;
@@ -58,6 +58,56 @@ pub(super) fn write(assessment: &Assessment, root: &Path) -> Result<ArtifactSet>
     fs::write(&document, markdown(assessment, root))
         .with_context(|| format!("write assessment report: {}", document.display()))?;
     Ok(ArtifactSet { document })
+}
+
+pub(super) fn read(directory: &Path) -> Result<Assessment> {
+    if !directory.is_dir() {
+        bail!(
+            "quality assessment directory does not exist: {}",
+            directory.display()
+        );
+    }
+    let manifest_path = directory.join("manifest.json");
+    if !manifest_path.is_file() {
+        bail!(
+            "quality assessment manifest does not exist: {}",
+            manifest_path.display()
+        );
+    }
+    let manifest_text = fs::read_to_string(&manifest_path).with_context(|| {
+        format!(
+            "read quality assessment manifest: {}",
+            manifest_path.display()
+        )
+    })?;
+    let manifest: Manifest = serde_json::from_str(&manifest_text).with_context(|| {
+        format!(
+            "parse quality assessment manifest: {}",
+            manifest_path.display()
+        )
+    })?;
+    let assessment_file = manifest.files.get("assessment").ok_or_else(|| {
+        anyhow!(
+            "quality assessment manifest omits files.assessment: {}",
+            manifest_path.display()
+        )
+    })?;
+    let assessment_file = Path::new(assessment_file);
+    if assessment_file.as_os_str().is_empty()
+        || !assessment_file
+            .components()
+            .all(|component| matches!(component, Component::Normal(_)))
+    {
+        bail!(
+            "quality assessment manifest files.assessment must be a relative file path: {}",
+            manifest_path.display()
+        );
+    }
+    let assessment_path = directory.join(assessment_file);
+    let assessment_text = fs::read_to_string(&assessment_path)
+        .with_context(|| format!("read quality assessment: {}", assessment_path.display()))?;
+    serde_json::from_str(&assessment_text)
+        .with_context(|| format!("parse quality assessment: {}", assessment_path.display()))
 }
 
 fn write_json(path: &Path, value: &impl Serialize) -> Result<()> {
@@ -306,6 +356,6 @@ fn coverage_row(coverage: &ToolCoverage) -> String {
     )
 }
 
-fn escape(value: &str) -> String {
+pub(super) fn escape(value: &str) -> String {
     value.replace('|', "\\|").replace('\n', " ")
 }

--- a/crates/kithara-devtools/src/quality_assessment/collect.rs
+++ b/crates/kithara-devtools/src/quality_assessment/collect.rs
@@ -92,11 +92,8 @@ pub(super) fn collect(
         stage_findings + diagnostic_findings,
         evidence_gaps,
     );
-    let output_directory = ctx
-        .root
-        .join("target/quality-assessment")
-        .join(&revision.directory)
-        .join(format!("{}-{}", args.profile, args.depth));
+    let output_directory =
+        output_directory(&ctx.root, &revision.directory, args.profile, args.depth);
     Ok(Assessment {
         schema_version: SCHEMA_VERSION,
         revision: revision.directory,
@@ -840,6 +837,17 @@ pub(super) fn revision(root: &Path) -> Revision {
         directory: format!("{head}-dirty-{digest}"),
         digest: Some(digest),
     }
+}
+
+pub(super) fn output_directory(
+    root: &Path,
+    revision: &str,
+    profile: AssessmentProfile,
+    depth: AssessmentDepth,
+) -> PathBuf {
+    root.join("target/quality-assessment")
+        .join(revision)
+        .join(format!("{profile}-{depth}"))
 }
 
 fn head_revision(root: &Path) -> Option<String> {

--- a/crates/kithara-devtools/src/quality_assessment/model.rs
+++ b/crates/kithara-devtools/src/quality_assessment/model.rs
@@ -159,7 +159,7 @@ pub(super) struct StageEvidence {
     pub(super) hard_invariant: bool,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub(super) struct Assessment {
     pub(super) status: AnalysisStatus,
     pub(super) depth: AssessmentDepth,

--- a/crates/kithara-devtools/src/quality_assessment/summary.rs
+++ b/crates/kithara-devtools/src/quality_assessment/summary.rs
@@ -1,0 +1,611 @@
+use std::{
+    fmt::Write as _,
+    fs,
+    io::Write as _,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result, anyhow};
+use clap::Args;
+use serde::Deserialize;
+
+use super::{
+    AssessmentDepth, AssessmentProfile, adapters, artifact, collect,
+    model::{Assessment, CoverageStatus, StageStatus},
+};
+use crate::{Ctx, quality_lab::CRAP_THRESHOLD};
+
+const MAX_RENDERED_ROWS: usize = 5;
+
+#[derive(Deserialize)]
+struct CrapReport {
+    entries: Vec<CrapEntry>,
+}
+
+#[derive(Deserialize)]
+struct CrapEntry {
+    file: String,
+    function: String,
+    line: u64,
+    cyclomatic: f64,
+    coverage: Option<f64>,
+    crap: f64,
+}
+
+/// Arguments for rendering an existing quality assessment.
+#[derive(Debug, Args)]
+pub struct SummaryArgs {
+    /// Read the assessment in this directory.
+    #[arg(long)]
+    directory: Option<PathBuf>,
+
+    /// Select the standard or deep assessment artifact.
+    #[arg(long, value_enum, default_value_t)]
+    depth: AssessmentDepth,
+
+    /// Select the product or complete assessment artifact.
+    #[arg(long, value_enum, default_value_t)]
+    profile: AssessmentProfile,
+}
+
+pub(crate) fn run(args: &SummaryArgs, ctx: &Ctx) -> Result<()> {
+    let directory = args.directory.clone().unwrap_or_else(|| {
+        let revision = collect::revision(&ctx.root);
+        collect::output_directory(&ctx.root, &revision.directory, args.profile, args.depth)
+    });
+    let crap_report = adapters::git_revision(&ctx.root, false).map(|revision| {
+        ctx.root
+            .join("target/quality-lab")
+            .join(revision)
+            .join("cargo-crap/report.json")
+    });
+    let output = render(&directory, crap_report.as_deref())?;
+    std::io::stdout().lock().write_all(output.as_bytes())?;
+    Ok(())
+}
+
+fn render(directory: &Path, crap_report: Option<&Path>) -> Result<String> {
+    let assessment = artifact::read(directory)?;
+    let mut output = header(&assessment);
+    append_crap(&mut output, &assessment, crap_report)?;
+    append_architecture(&mut output, &assessment)?;
+    append_evidence_gaps(&mut output, &assessment)?;
+    output.push_str(
+        "Full details are in the uploaded quality assessment artifact (`assessment.md` and `assessment.json`).\n",
+    );
+    Ok(output)
+}
+
+fn header(assessment: &Assessment) -> String {
+    format!(
+        "# Quality assessment summary\n\n\
+         Scope `{}`; revision `{}`; profile `{}`; depth `{}`; analysis status **{}**; verdict **{}**.\n\n\
+         ## Decision\n\n\
+         | Metric | Value |\n\
+         | --- | ---: |\n\
+         | Debt units / threshold | {} / {} |\n\
+         | Baseline entries | {} |\n\
+         | Findings | {} |\n\
+         | Signals | {} |\n\
+         | Evidence gaps | {} |\n\
+         | Scope LOC | {} |\n\n",
+        artifact::escape(&assessment.scope.name),
+        artifact::escape(&assessment.revision),
+        assessment.profile,
+        assessment.depth,
+        assessment.status.as_str(),
+        assessment.verdict.as_str(),
+        assessment.summary.debt_units,
+        assessment.summary.debt_threshold,
+        assessment.summary.baseline_entries,
+        assessment.summary.findings,
+        assessment.summary.signals,
+        assessment.summary.evidence_gaps,
+        assessment.scope.loc,
+    )
+}
+
+fn append_crap(
+    output: &mut String,
+    assessment: &Assessment,
+    report_path: Option<&Path>,
+) -> Result<()> {
+    output.push_str("## Coverage risk (CRAP)\n\n");
+    let Some(report_path) = report_path.filter(|path| path.is_file()) else {
+        let coverage = assessment
+            .tool_coverage
+            .iter()
+            .find(|coverage| coverage.tool == "cargo-crap")
+            .ok_or_else(|| {
+                anyhow!(
+                    "quality assessment omits cargo-crap tool coverage: {}",
+                    assessment.revision
+                )
+            })?;
+        writeln!(
+            output,
+            "- cargo-crap: status `{}`; note: {}; produce it with `just quality assess --depth deep`.\n",
+            coverage.status.as_str(),
+            artifact::escape(&coverage.note),
+        )?;
+        return Ok(());
+    };
+    let text = fs::read_to_string(report_path)
+        .with_context(|| format!("read cargo-crap report: {}", report_path.display()))?;
+    let report: CrapReport = serde_json::from_str(&text)
+        .with_context(|| format!("parse cargo-crap report: {}", report_path.display()))?;
+    let mut entries = report.entries.iter().collect::<Vec<_>>();
+    entries.sort_by(|left, right| {
+        right
+            .crap
+            .total_cmp(&left.crap)
+            .then_with(|| left.function.cmp(&right.function))
+            .then_with(|| left.file.cmp(&right.file))
+            .then_with(|| left.line.cmp(&right.line))
+    });
+    let above_threshold = entries
+        .iter()
+        .filter(|entry| entry.crap > CRAP_THRESHOLD)
+        .count();
+    writeln!(output, "- Functions analysed: {}", entries.len())?;
+    writeln!(
+        output,
+        "- Above threshold (> {CRAP_THRESHOLD:.1}): {above_threshold}"
+    )?;
+    if let Some(worst) = entries.first() {
+        writeln!(output, "- Worst CRAP score: {:.2}\n", worst.crap)?;
+        output.push_str(
+            "| Function | Location | Cyclomatic | Coverage | CRAP |\n\
+             | --- | --- | ---: | ---: | ---: |\n",
+        );
+        for entry in entries.iter().take(MAX_RENDERED_ROWS) {
+            let location = format!("{}:{}", entry.file, entry.line);
+            let coverage = entry
+                .coverage
+                .map_or_else(|| "n/a".to_owned(), |value| format!("{value:.2}"));
+            writeln!(
+                output,
+                "| {} | {} | {:.2} | {} | {:.2} |",
+                artifact::escape(&entry.function),
+                artifact::escape(&location),
+                entry.cyclomatic,
+                coverage,
+                entry.crap,
+            )?;
+        }
+        append_omitted(output, entries.len(), "CRAP")?;
+    } else {
+        output.push_str("- Worst CRAP score: n/a\n\n_No function entries were reported._\n\n");
+    }
+    Ok(())
+}
+
+fn append_omitted(output: &mut String, rows: usize, label: &str) -> Result<()> {
+    let omitted = rows.saturating_sub(MAX_RENDERED_ROWS);
+    if omitted == 0 {
+        output.push('\n');
+    } else {
+        writeln!(output, "\n_{omitted} additional {label} rows omitted._\n")?;
+    }
+    Ok(())
+}
+
+fn append_architecture(output: &mut String, assessment: &Assessment) -> Result<()> {
+    output.push_str("## Architecture complexity\n\n");
+    let mut signals = assessment
+        .signals
+        .iter()
+        .filter(|signal| signal.category == "architecture_complexity_index")
+        .collect::<Vec<_>>();
+    signals.sort_by(|left, right| {
+        right
+            .value
+            .total_cmp(&left.value)
+            .then_with(|| left.scope.cmp(&right.scope))
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    if signals.is_empty() {
+        output.push_str("No architecture complexity signals were reported.\n\n");
+        return Ok(());
+    }
+    output.push_str(
+        "| Scope | Architecture complexity index |\n\
+         | --- | ---: |\n",
+    );
+    for signal in signals.iter().take(MAX_RENDERED_ROWS) {
+        writeln!(
+            output,
+            "| {} | {:.4} |",
+            artifact::escape(&signal.scope),
+            signal.value,
+        )?;
+    }
+    append_omitted(output, signals.len(), "architecture signal")
+}
+
+fn append_evidence_gaps(output: &mut String, assessment: &Assessment) -> Result<()> {
+    output.push_str("## Broken stages and evidence gaps\n\n### Broken stages\n\n");
+    let mut broken = assessment
+        .stages
+        .iter()
+        .filter(|stage| stage.status == StageStatus::Broken)
+        .collect::<Vec<_>>();
+    broken.sort_by(|left, right| left.name.cmp(&right.name));
+    if broken.is_empty() {
+        output.push_str("None.\n\n");
+    } else {
+        output.push_str(
+            "| Stage | Exit code | Note |\n\
+             | --- | ---: | --- |\n",
+        );
+        for stage in broken.iter().take(MAX_RENDERED_ROWS) {
+            let exit_code = stage
+                .exit_code
+                .map_or_else(|| "n/a".to_owned(), |code| code.to_string());
+            writeln!(
+                output,
+                "| {} | {} | {} |",
+                artifact::escape(&stage.name),
+                exit_code,
+                artifact::escape(&stage.note),
+            )?;
+        }
+        append_omitted(output, broken.len(), "broken stage")?;
+    }
+
+    output.push_str("### Evidence-gap tools\n\n");
+    let mut gaps = assessment
+        .tool_coverage
+        .iter()
+        .filter(|coverage| coverage.status == CoverageStatus::EvidenceGap)
+        .collect::<Vec<_>>();
+    gaps.sort_by(|left, right| left.tool.cmp(&right.tool));
+    if gaps.is_empty() {
+        output.push_str("None.\n\n");
+    } else {
+        output.push_str(
+            "| Tool | Note |\n\
+             | --- | --- |\n",
+        );
+        for coverage in gaps.iter().take(MAX_RENDERED_ROWS) {
+            writeln!(
+                output,
+                "| {} | {} |",
+                artifact::escape(&coverage.tool),
+                artifact::escape(&coverage.note),
+            )?;
+        }
+        append_omitted(output, gaps.len(), "evidence-gap tool")?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{env, fs};
+
+    use serde_json::{Value, json};
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn manifest_assessment_renders_decision_and_verdict() {
+        let temp = tempdir().expect("tempdir");
+        let directory = write_assessment(temp.path(), &[]);
+
+        let output = render(&directory, None).expect("summary");
+
+        assert!(output.contains("verdict **refactor**"));
+        assert!(output.contains("| Debt units / threshold | 229 / 100 |"));
+        assert!(output.contains("| Baseline entries | 227 |"));
+        assert!(output.contains("| Findings | 259 |"));
+        assert!(output.contains("| Signals | 522 |"));
+        assert!(output.contains("| Evidence gaps | 23 |"));
+        assert!(output.contains("| Scope LOC | 162702 |"));
+        let decision = output.find("## Decision").expect("decision section");
+        let crap = output.find("## Coverage risk").expect("CRAP section");
+        let architecture = output
+            .find("## Architecture complexity")
+            .expect("architecture section");
+        let gaps = output
+            .find("## Broken stages and evidence gaps")
+            .expect("evidence section");
+        let artifact = output
+            .find("uploaded quality assessment artifact")
+            .expect("artifact pointer");
+        assert!(decision < crap && crap < architecture && architecture < gaps && gaps < artifact);
+    }
+
+    #[test]
+    fn cargo_crap_report_renders_risk_count_and_null_coverage() {
+        let temp = tempdir().expect("tempdir");
+        let directory = write_assessment(temp.path(), &[]);
+        let report = temp.path().join("cargo-crap/report.json");
+        fs::create_dir_all(report.parent().expect("report parent")).expect("cargo-crap directory");
+        write_json(
+            &report,
+            &json!({
+                "$schema": "https://raw.githubusercontent.com/minikin/cargo-crap/main/schemas/report-v1.json",
+                "version": "0.3.1",
+                "entries": [
+                    {
+                        "file": "crates/kithara-stream/src/stream.rs",
+                        "function": "Stream::try_read_with",
+                        "line": 357,
+                        "cyclomatic": 19.0,
+                        "coverage": null,
+                        "crap": 380.0,
+                        "status": "regressed"
+                    },
+                    {
+                        "file": "crates/kithara-play/src/player.rs",
+                        "function": "Player::play",
+                        "line": 42,
+                        "cyclomatic": 4.0,
+                        "coverage": 75.0,
+                        "crap": 30.0,
+                        "status": "unchanged"
+                    }
+                ],
+                "removed": []
+            }),
+        );
+
+        let output = render(&directory, Some(&report)).expect("summary");
+
+        assert!(output.contains("Functions analysed: 2"));
+        assert!(output.contains("Above threshold (> 30.0): 1"));
+        assert!(output.contains("Worst CRAP score: 380.00"));
+        assert!(output.contains(
+            "| Stream::try_read_with | crates/kithara-stream/src/stream.rs:357 | 19.00 | n/a | 380.00 |"
+        ));
+    }
+
+    #[test]
+    fn absent_cargo_crap_report_renders_tool_coverage_without_failing() {
+        let temp = tempdir().expect("tempdir");
+        let directory = write_assessment(temp.path(), &[]);
+        let missing_report = temp.path().join("cargo-crap/report.json");
+
+        let output = render(&directory, Some(&missing_report)).expect("summary without CRAP");
+
+        assert!(output.contains(
+            "- cargo-crap: status `not-applicable`; note: deep profile only; produce it with `just quality assess --depth deep`."
+        ));
+        assert!(!output.contains("Functions analysed:"));
+    }
+
+    #[test]
+    fn cargo_crap_table_reports_omitted_rows_and_escapes_cells() {
+        let temp = tempdir().expect("tempdir");
+        let directory = write_assessment(temp.path(), &[]);
+        let report = temp.path().join("cargo-crap/report.json");
+        fs::create_dir_all(report.parent().expect("report parent")).expect("cargo-crap directory");
+        let entries: Vec<Value> = (1..=7)
+            .map(|value| {
+                json!({
+                    "file": if value == 7 { "crate|file.rs" } else { "crate/file.rs" },
+                    "function": if value == 7 { "worst|function\ncontinued" } else { "function" },
+                    "line": value,
+                    "cyclomatic": f64::from(value),
+                    "coverage": null,
+                    "crap": f64::from(value)
+                })
+            })
+            .collect();
+        write_json(&report, &json!({"entries": entries}));
+
+        let output = render(&directory, Some(&report)).expect("summary");
+
+        assert!(
+            output
+                .contains("| worst\\|function continued | crate\\|file.rs:7 | 7.00 | n/a | 7.00 |")
+        );
+        assert!(output.contains("_2 additional CRAP rows omitted._"));
+    }
+
+    #[test]
+    fn missing_assessment_directory_error_names_the_path() {
+        let temp = tempdir().expect("tempdir");
+        let missing = temp.path().join("missing-assessment");
+
+        let error = render(&missing, None).expect_err("missing directory must fail");
+
+        assert!(error.to_string().contains(&missing.display().to_string()));
+    }
+
+    #[test]
+    fn missing_assessment_manifest_error_names_the_path() {
+        let temp = tempdir().expect("tempdir");
+        let directory = temp.path().join("assessment");
+        fs::create_dir_all(&directory).expect("assessment directory");
+        let manifest = directory.join("manifest.json");
+
+        let error = render(&directory, None).expect_err("missing manifest must fail");
+
+        assert!(error.to_string().contains(&manifest.display().to_string()));
+    }
+
+    #[test]
+    fn assessment_pointer_cannot_escape_the_manifest_directory() {
+        for assessment_file in [
+            "../assessment.json".to_owned(),
+            env::temp_dir()
+                .join("outside-assessment.json")
+                .display()
+                .to_string(),
+        ] {
+            let temp = tempdir().expect("tempdir");
+            let directory = write_assessment(temp.path(), &[]);
+            let manifest_path = directory.join("manifest.json");
+            let mut manifest: Value =
+                serde_json::from_slice(&fs::read(&manifest_path).expect("assessment manifest"))
+                    .expect("manifest JSON");
+            manifest["files"]["assessment"] = json!(assessment_file);
+            write_json(&manifest_path, &manifest);
+
+            let error = render(&directory, None).expect_err("unsafe pointer must fail");
+
+            assert!(error.to_string().contains("files.assessment"));
+            assert!(
+                error
+                    .to_string()
+                    .contains(&manifest_path.display().to_string())
+            );
+        }
+    }
+
+    #[test]
+    fn architecture_table_reports_omitted_rows() {
+        let temp = tempdir().expect("tempdir");
+        let signals: Vec<Value> = (1..=7)
+            .map(|value| {
+                json!({
+                    "category": "architecture_complexity_index",
+                    "id": format!("architecture:crate-{value}"),
+                    "scope": format!("crate-{value}"),
+                    "state": "diagnostic",
+                    "tool": "architecture",
+                    "unit": "index",
+                    "evidence_artifacts": [],
+                    "confidence": 1.0,
+                    "value": f64::from(value)
+                })
+            })
+            .collect();
+        let directory = write_assessment(temp.path(), &signals);
+
+        let output = render(&directory, None).expect("summary");
+
+        assert!(output.contains("| crate-7 | 7.0000 |"));
+        assert!(!output.contains("| crate-1 | 1.0000 |"));
+        assert!(output.contains("_2 additional architecture signal rows omitted._"));
+    }
+
+    #[test]
+    fn broken_stages_and_evidence_gap_tools_are_rendered_and_escaped() {
+        let temp = tempdir().expect("tempdir");
+        let directory = write_assessment(temp.path(), &[]);
+        let assessment_path = directory.join("assessment.json");
+        let mut assessment: Value =
+            serde_json::from_slice(&fs::read(&assessment_path).expect("assessment fixture"))
+                .expect("assessment JSON");
+        let mut stages = vec![json!({
+            "exit_code": 2,
+            "status": "broken",
+            "log": "logs/portable.log",
+            "name": "00-portable|gates",
+            "note": "first line\nsecond line",
+            "command": ["just", "ci", "portable"],
+            "evidence_artifacts": ["logs/portable.log"],
+            "tools": ["clippy"],
+            "hard_invariant": true
+        })];
+        stages.extend((1..=6).map(|value| {
+            json!({
+                "exit_code": value,
+                "status": "broken",
+                "log": format!("logs/stage-{value}.log"),
+                "name": format!("stage-{value}"),
+                "note": "broken",
+                "command": ["just", "check"],
+                "evidence_artifacts": [],
+                "tools": ["check"],
+                "hard_invariant": false
+            })
+        }));
+        assessment["stages"] = Value::Array(stages);
+        let mut coverage = vec![json!({
+            "status": "not-applicable",
+            "note": "deep profile only",
+            "tool": "cargo-crap",
+            "evidence_artifacts": []
+        })];
+        coverage.extend((1..=7).map(|value| {
+            json!({
+                "status": "evidence-gap",
+                "note": "tool unavailable",
+                "tool": if value == 1 { "00-cargo|geiger".to_owned() } else { format!("tool-{value}") },
+                "evidence_artifacts": ["logs/geiger.log"]
+            })
+        }));
+        assessment["tool_coverage"] = Value::Array(coverage);
+        write_json(&assessment_path, &assessment);
+
+        let output = render(&directory, None).expect("summary");
+
+        assert!(output.contains("| 00-portable\\|gates | 2 | first line second line |"));
+        assert!(output.contains("| 00-cargo\\|geiger | tool unavailable |"));
+        assert!(output.contains("_2 additional broken stage rows omitted._"));
+        assert!(output.contains("_2 additional evidence-gap tool rows omitted._"));
+        assert!(output.contains("uploaded quality assessment artifact"));
+    }
+
+    fn write_assessment(root: &Path, signals: &[Value]) -> PathBuf {
+        let directory = root.join("assessment");
+        fs::create_dir_all(&directory).expect("assessment directory");
+        write_json(
+            &directory.join("manifest.json"),
+            &json!({
+                "revision": "a8a67acb3135",
+                "scope": "workspace",
+                "status": "complete",
+                "verdict": "refactor",
+                "depth": "standard",
+                "profile": "product",
+                "files": {
+                    "assessment": "assessment.json",
+                    "document": "assessment.md",
+                    "logs": "logs/",
+                    "manifest": "manifest.json",
+                    "stages": "stages/"
+                },
+                "schema_version": 1
+            }),
+        );
+        write_json(
+            &directory.join("assessment.json"),
+            &json!({
+                "status": "complete",
+                "depth": "standard",
+                "profile": "product",
+                "scope": {
+                    "kind": "workspace",
+                    "name": "workspace",
+                    "loc": 162702,
+                    "workspace_loc": 162702
+                },
+                "revision": "a8a67acb3135",
+                "summary": {
+                    "debt_threshold": 100,
+                    "debt_units": 229,
+                    "baseline_entries": 227,
+                    "evidence_gaps": 23,
+                    "findings": 259,
+                    "signals": 522
+                },
+                "findings": [],
+                "signals": signals,
+                "stages": [],
+                "tool_coverage": [{
+                    "status": "not-applicable",
+                    "note": "deep profile only",
+                    "tool": "cargo-crap",
+                    "evidence_artifacts": []
+                }],
+                "verdict": "refactor",
+                "schema_version": 1
+            }),
+        );
+        directory
+    }
+
+    fn write_json(path: &Path, value: &Value) {
+        fs::write(
+            path,
+            serde_json::to_vec_pretty(value).expect("serialize fixture"),
+        )
+        .expect("write fixture");
+    }
+}

--- a/crates/kithara-devtools/src/quality_lab/adapter.rs
+++ b/crates/kithara-devtools/src/quality_lab/adapter.rs
@@ -9,7 +9,7 @@ use super::manifest::Tool;
 
 const CHA_PLUGINS: &str = "data_clumps,feature_envy,inappropriate_intimacy,shotgun_surgery,\
                            divergent_change,speculative_generality,async_callback_leak";
-const CRAP_THRESHOLD: f64 = 30.0;
+pub(crate) const CRAP_THRESHOLD: f64 = 30.0;
 
 pub(super) struct AdapterOptions<'a> {
     pub(super) baseline: Option<&'a Path>,

--- a/crates/kithara-devtools/src/quality_lab/mod.rs
+++ b/crates/kithara-devtools/src/quality_lab/mod.rs
@@ -8,4 +8,5 @@ mod orchestrator;
 mod report;
 mod workspace;
 
+pub(crate) use adapter::CRAP_THRESHOLD;
 pub use cli::{LabCommand, run};

--- a/crates/kithara-devtools/src/viz/manifest.rs
+++ b/crates/kithara-devtools/src/viz/manifest.rs
@@ -20,7 +20,7 @@ use super::{
     view::DiagramModel,
 };
 
-const SCHEMA_VERSION: u32 = 4;
+const SCHEMA_VERSION: u32 = 5;
 
 #[derive(Debug)]
 pub(crate) struct ArtifactSet {
@@ -243,7 +243,7 @@ fn page_document(request: &ArtifactRequest<'_>, page: &DiagramPage) -> String {
 fn architecture_document(request: &ArtifactRequest<'_>) -> String {
     let analysis = report::render(request.model);
     let metrics = report::render_metrics(request.metrics);
-    let evidence = evidence_summary(request);
+    let evidence = evidence_summary(request.semantic, request.runtime);
     format!(
         "# {} Architecture\n\n\
          Status: **{}**\n\n\
@@ -287,19 +287,22 @@ fn contour_links(diagrams: &DiagramSet) -> String {
     output
 }
 
-fn evidence_summary(request: &ArtifactRequest<'_>) -> String {
+fn evidence_summary(semantic: &SemanticSummary, runtime: &RuntimeSummary) -> String {
     let mut output = format!(
         "## Evidence status\n\n- Semantic: `{}`; requested {}, prepared {}, resolved {} edges, skipped {}.\n",
-        request.semantic.state.as_str(),
-        request.semantic.requested_symbols,
-        request.semantic.prepared_symbols,
-        request.semantic.resolved_edges,
-        request.semantic.skipped_symbols,
+        semantic.state.as_str(),
+        semantic.requested_symbols,
+        semantic.prepared_symbols,
+        semantic.resolved_edges,
+        semantic.skipped_symbols,
     );
-    if request.runtime.scenarios.is_empty() {
+    for diagnostic in &semantic.diagnostics {
+        output.push_str(&format!("  - Semantic diagnostic: {diagnostic}\n"));
+    }
+    if runtime.scenarios.is_empty() {
         output.push_str("- Runtime: no configured or selected scenario evidence.\n\n");
     } else {
-        for scenario in &request.runtime.scenarios {
+        for scenario in &runtime.scenarios {
             output.push_str(&format!(
                 "- Runtime `{}`: `{}`; {} records, {} matched, {} unmatched.\n",
                 scenario.name,
@@ -308,6 +311,24 @@ fn evidence_summary(request: &ArtifactRequest<'_>) -> String {
                 scenario.trace.matched_records,
                 scenario.trace.unmatched_records,
             ));
+            for diagnostic in &scenario.trace.diagnostics {
+                output.push_str(&format!(
+                    "  - Runtime `{}` diagnostic: {diagnostic}\n",
+                    scenario.name
+                ));
+            }
+            if let Some(exit_code) = scenario.exit_code {
+                output.push_str(&format!(
+                    "  - Runtime `{}` exit code: {exit_code}\n",
+                    scenario.name
+                ));
+            }
+            if let Some(stderr) = &scenario.stderr {
+                output.push_str(&format!(
+                    "  - Runtime `{}` stderr log: `{stderr}`\n",
+                    scenario.name
+                ));
+            }
         }
         output.push('\n');
     }
@@ -315,20 +336,26 @@ fn evidence_summary(request: &ArtifactRequest<'_>) -> String {
 }
 
 fn overall_status(semantic: &SemanticSummary, runtime: &RuntimeSummary) -> &'static str {
-    if semantic.is_incomplete() || runtime.is_incomplete() {
-        return "incomplete";
+    if runtime.is_degraded() {
+        return "runtime-degraded";
     }
     if semantic.state == SemanticState::Truncated || runtime.is_truncated() {
         return "truncated";
     }
-    if runtime.has_runtime() && semantic.state == SemanticState::Unavailable {
+    if runtime.has_runtime()
+        && matches!(
+            semantic.state,
+            SemanticState::Unavailable | SemanticState::TimedOut | SemanticState::Failed
+        )
+    {
         return "runtime-enriched";
     }
     match semantic.state {
         SemanticState::Complete => "complete",
         SemanticState::Truncated => "truncated",
-        SemanticState::Unavailable => "static-only",
-        SemanticState::TimedOut | SemanticState::Failed => "incomplete",
+        SemanticState::Unavailable | SemanticState::TimedOut | SemanticState::Failed => {
+            "static-only"
+        }
     }
 }
 
@@ -340,4 +367,186 @@ fn write_json(path: &Path, value: &impl Serialize) -> Result<()> {
     let mut bytes = serde_json::to_vec_pretty(value)?;
     bytes.push(b'\n');
     fs::write(path, bytes).with_context(|| format!("write {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::viz::{
+        scenario::{ScenarioState, ScenarioSummary},
+        trace::{TraceState, TraceSummary},
+    };
+
+    #[test]
+    fn missing_semantic_evidence_has_the_same_status_for_every_cause() {
+        let absent = semantic(SemanticState::Unavailable);
+        let timed_out = semantic(SemanticState::TimedOut);
+        let failed = semantic(SemanticState::Failed);
+
+        assert_eq!(
+            overall_status(&absent, &RuntimeSummary::default()),
+            "static-only"
+        );
+        assert_eq!(
+            overall_status(&timed_out, &RuntimeSummary::default()),
+            "static-only"
+        );
+        assert_eq!(
+            overall_status(&failed, &RuntimeSummary::default()),
+            "static-only"
+        );
+        assert_eq!(
+            overall_status(&absent, &runtime(ScenarioState::Complete)),
+            "runtime-enriched"
+        );
+        assert_eq!(
+            overall_status(&timed_out, &runtime(ScenarioState::Complete)),
+            "runtime-enriched"
+        );
+        assert_eq!(
+            overall_status(&failed, &runtime(ScenarioState::Complete)),
+            "runtime-enriched"
+        );
+    }
+
+    #[test]
+    fn degraded_runtime_evidence_has_its_own_status() {
+        assert_eq!(
+            overall_status(
+                &semantic(SemanticState::Complete),
+                &runtime(ScenarioState::TimedOut),
+            ),
+            "runtime-degraded"
+        );
+    }
+
+    #[test]
+    fn manual_trace_content_controls_the_runtime_status() {
+        let mut empty = runtime(ScenarioState::Manual);
+        empty.scenarios[0].trace.state = TraceState::Empty;
+        let mut truncated = runtime(ScenarioState::Manual);
+        truncated.scenarios[0].trace.state = TraceState::Truncated;
+
+        assert_eq!(
+            overall_status(&semantic(SemanticState::Complete), &empty),
+            "runtime-degraded"
+        );
+        assert_eq!(
+            overall_status(&semantic(SemanticState::Complete), &truncated),
+            "truncated"
+        );
+    }
+
+    #[test]
+    fn evidence_summary_explains_why_each_overlay_degraded() {
+        let summary = evidence_summary(
+            &semantic(SemanticState::TimedOut),
+            &runtime(ScenarioState::TimedOut),
+        );
+
+        assert_eq!(
+            summary,
+            concat!(
+                "## Evidence status\n\n",
+                "- Semantic: `timed_out`; requested 0, prepared 0, resolved 0 edges, skipped 0.\n",
+                "  - Semantic diagnostic: semantic diagnostic\n",
+                "- Runtime `scenario`: `timed_out`; 0 records, 0 matched, 0 unmatched.\n",
+                "  - Runtime `scenario` diagnostic: runtime diagnostic\n\n",
+            )
+        );
+    }
+
+    #[test]
+    fn evidence_summary_preserves_failed_process_details() {
+        let mut semantic = semantic(SemanticState::Complete);
+        semantic.diagnostics.clear();
+        let mut runtime = runtime(ScenarioState::Failed);
+        runtime.scenarios[0].exit_code = Some(7);
+        runtime.scenarios[0].stderr = Some("logs/scenario.stderr.log".to_string());
+        runtime.scenarios[0].trace.state = TraceState::Complete;
+        runtime.scenarios[0].trace.diagnostics.clear();
+
+        let summary = evidence_summary(&semantic, &runtime);
+
+        assert_eq!(
+            summary,
+            concat!(
+                "## Evidence status\n\n",
+                "- Semantic: `complete`; requested 0, prepared 0, resolved 0 edges, skipped 0.\n",
+                "- Runtime `scenario`: `failed`; 0 records, 0 matched, 0 unmatched.\n",
+                "  - Runtime `scenario` exit code: 7\n",
+                "  - Runtime `scenario` stderr log: `logs/scenario.stderr.log`\n\n",
+            )
+        );
+    }
+
+    #[test]
+    fn no_evidence_combination_has_an_incomplete_status() {
+        let semantic_states = [
+            SemanticState::Complete,
+            SemanticState::Truncated,
+            SemanticState::Unavailable,
+            SemanticState::TimedOut,
+            SemanticState::Failed,
+        ];
+        let scenario_states = [
+            ScenarioState::Complete,
+            ScenarioState::Empty,
+            ScenarioState::Truncated,
+            ScenarioState::Failed,
+            ScenarioState::TimedOut,
+            ScenarioState::Manual,
+        ];
+
+        for semantic_state in semantic_states {
+            assert_ne!(
+                overall_status(&semantic(semantic_state), &RuntimeSummary::default()),
+                "incomplete"
+            );
+            for scenario_state in scenario_states {
+                assert_ne!(
+                    overall_status(&semantic(semantic_state), &runtime(scenario_state)),
+                    "incomplete"
+                );
+            }
+        }
+    }
+
+    fn semantic(state: SemanticState) -> SemanticSummary {
+        SemanticSummary {
+            state,
+            diagnostics: vec!["semantic diagnostic".to_string()],
+            outgoing_calls: 0,
+            prepared_symbols: 0,
+            requested_symbols: 0,
+            resolved_edges: 0,
+            skipped_symbols: 0,
+            unmatched_targets: 0,
+        }
+    }
+
+    fn runtime(state: ScenarioState) -> RuntimeSummary {
+        let trace_state = match state {
+            ScenarioState::Complete | ScenarioState::Manual => TraceState::Complete,
+            ScenarioState::Empty | ScenarioState::TimedOut => TraceState::Empty,
+            ScenarioState::Truncated => TraceState::Truncated,
+            ScenarioState::Failed => TraceState::Failed,
+        };
+        RuntimeSummary {
+            scenarios: vec![ScenarioSummary {
+                exit_code: None,
+                stderr: None,
+                stdout: None,
+                state,
+                name: "scenario".to_string(),
+                trace: TraceSummary {
+                    state: trace_state,
+                    diagnostics: vec!["runtime diagnostic".to_string()],
+                    matched_records: 0,
+                    records: 0,
+                    unmatched_records: 0,
+                },
+            }],
+        }
+    }
 }

--- a/crates/kithara-devtools/src/viz/run.rs
+++ b/crates/kithara-devtools/src/viz/run.rs
@@ -12,8 +12,10 @@ use super::{
     manifest::{self, ArtifactRequest},
     mermaid,
     metrics::MetricsAnalyzer,
-    scenario::{self, RunRequest},
-    semantic, source,
+    scenario::{self, RunRequest, RuntimeSummary, ScenarioSummary},
+    semantic::{self, SemanticState, SemanticSummary},
+    source,
+    trace::TraceState,
     view::{DetailLevel, Projector, ViewKind, ViewRequest},
 };
 use crate::{Ctx, common::project::ArchitectureFilterConfig};
@@ -69,7 +71,7 @@ pub(crate) fn run(args: &VizArgs, ctx: &Ctx) -> Result<()> {
         &mut graph,
     )?;
     let semantic = if args.semantic == SemanticMode::Off {
-        semantic::SemanticSummary::static_only("semantic resolution disabled")
+        SemanticSummary::static_only("semantic resolution disabled")
     } else {
         semantic::enrich(
             &mut graph,
@@ -84,10 +86,7 @@ pub(crate) fn run(args: &VizArgs, ctx: &Ctx) -> Result<()> {
         kind: view_kind(args.view),
         package: args.krate.clone(),
         module: args.module.clone(),
-        scenario: args
-            .scenario
-            .clone()
-            .or_else(|| args.trace.as_ref().map(|_| "manual".to_string())),
+        scenario: projection_scenario(args.scenario.as_deref(), args.trace.is_some(), &runtime),
         lod: detail_level(args),
         filter: filter.clone(),
     };
@@ -126,14 +125,128 @@ pub(crate) fn run(args: &VizArgs, ctx: &Ctx) -> Result<()> {
         filters: &filter_summary,
     })?;
     writeln!(io::stdout().lock(), "==> {}", artifacts.document.display())?;
-    if semantic.is_incomplete()
-        || runtime.is_incomplete()
-        || args.semantic == SemanticMode::Required
-            && semantic.state == semantic::SemanticState::Unavailable
-    {
-        bail!("architecture analysis is incomplete; partial artifacts were preserved");
+    let warnings = degradation_warnings(args.semantic, &semantic, &runtime);
+    if !warnings.is_empty() {
+        let mut stderr = io::stderr().lock();
+        for warning in warnings {
+            writeln!(stderr, "warning: {warning}")?;
+        }
+    }
+    if requested_evidence_degraded(
+        args.semantic,
+        semantic.state,
+        args.scenario.as_deref(),
+        args.trace.is_some(),
+        &runtime,
+    ) {
+        bail!("explicitly requested architecture evidence degraded; artifacts were preserved");
     }
     Ok(())
+}
+
+fn degradation_warnings(
+    semantic_mode: SemanticMode,
+    semantic: &SemanticSummary,
+    runtime: &RuntimeSummary,
+) -> Vec<String> {
+    let mut warnings = Vec::new();
+    if semantic_mode != SemanticMode::Off
+        && matches!(
+            semantic.state,
+            SemanticState::Unavailable | SemanticState::TimedOut | SemanticState::Failed
+        )
+    {
+        let diagnostics = semantic.diagnostics.join("; ");
+        let warning = format!("semantic overlay degraded (`{}`)", semantic.state.as_str());
+        warnings.push(if diagnostics.is_empty() {
+            warning
+        } else {
+            format!("{warning}: {diagnostics}")
+        });
+    }
+    for scenario in runtime
+        .scenarios
+        .iter()
+        .filter(|scenario| scenario.is_degraded())
+    {
+        let mut diagnostics = scenario.trace.diagnostics.clone();
+        if let Some(exit_code) = scenario.exit_code {
+            diagnostics.push(format!("exit code {exit_code}"));
+        }
+        if let Some(stderr) = &scenario.stderr {
+            diagnostics.push(format!("stderr log: {stderr}"));
+        }
+        let warning = format!(
+            "runtime overlay `{}` degraded (scenario `{}`, trace `{}`)",
+            scenario.name,
+            scenario.state.as_str(),
+            trace_state_name(scenario.trace.state),
+        );
+        warnings.push(if diagnostics.is_empty() {
+            warning
+        } else {
+            format!("{warning}: {}", diagnostics.join("; "))
+        });
+    }
+    warnings
+}
+
+fn requested_evidence_degraded(
+    semantic_mode: SemanticMode,
+    semantic_state: SemanticState,
+    selected_scenario: Option<&str>,
+    manual_trace_selected: bool,
+    runtime: &RuntimeSummary,
+) -> bool {
+    let semantic_degraded = semantic_mode == SemanticMode::Required
+        && matches!(
+            semantic_state,
+            SemanticState::Unavailable | SemanticState::TimedOut | SemanticState::Failed
+        );
+    let selected_scenario_degraded = selected_scenario.is_some_and(|selected| {
+        runtime
+            .scenarios
+            .iter()
+            .any(|scenario| scenario.name == selected && scenario.is_degraded())
+    });
+    let manual_trace_degraded = manual_trace_selected
+        && runtime
+            .scenarios
+            .last()
+            .is_some_and(ScenarioSummary::is_degraded);
+    semantic_degraded || selected_scenario_degraded || manual_trace_degraded
+}
+
+fn projection_scenario(
+    selected_scenario: Option<&str>,
+    manual_trace_selected: bool,
+    runtime: &RuntimeSummary,
+) -> Option<String> {
+    if let Some(selected) = selected_scenario {
+        return runtime
+            .scenarios
+            .iter()
+            .find(|scenario| scenario.name == selected)
+            .filter(|scenario| !scenario.is_degraded())
+            .map(|_| selected.to_string());
+    }
+    if manual_trace_selected {
+        return runtime
+            .scenarios
+            .last()
+            .filter(|scenario| !scenario.is_degraded())
+            .map(|_| "manual".to_string());
+    }
+    None
+}
+
+fn trace_state_name(state: TraceState) -> &'static str {
+    match state {
+        TraceState::Complete => "complete",
+        TraceState::Empty => "empty",
+        TraceState::Truncated => "truncated",
+        TraceState::Failed => "failed",
+    }
 }
 
 fn detail_level(args: &VizArgs) -> DetailLevel {
@@ -170,4 +283,178 @@ fn revision(root: &std::path::Path) -> String {
         .map(|revision| revision.trim().to_string())
         .filter(|revision| !revision.is_empty())
         .unwrap_or_else(|| "working-tree".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::viz::{scenario::ScenarioState, trace::TraceSummary};
+
+    #[test]
+    fn warnings_name_every_degraded_overlay_and_its_diagnostic() {
+        let runtime = runtime(vec![scenario(
+            "queue-playback",
+            ScenarioState::TimedOut,
+            TraceState::Empty,
+        )]);
+
+        let warnings = degradation_warnings(
+            SemanticMode::Auto,
+            &semantic(
+                SemanticState::TimedOut,
+                "rust-analyzer timed out during workspace loading",
+            ),
+            &runtime,
+        );
+
+        assert_eq!(
+            warnings,
+            [
+                "semantic overlay degraded (`timed_out`): rust-analyzer timed out during workspace loading",
+                "runtime overlay `queue-playback` degraded (scenario `timed_out`, trace `empty`): diagnostic",
+            ]
+        );
+    }
+
+    #[test]
+    fn semantic_off_does_not_warn_about_missing_semantic_evidence() {
+        let warnings = degradation_warnings(
+            SemanticMode::Off,
+            &semantic(SemanticState::Unavailable, "semantic resolution disabled"),
+            &RuntimeSummary::default(),
+        );
+
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn required_semantic_mode_fails_for_every_missing_state() {
+        for state in [
+            SemanticState::Unavailable,
+            SemanticState::TimedOut,
+            SemanticState::Failed,
+        ] {
+            assert!(requested_evidence_degraded(
+                SemanticMode::Required,
+                state,
+                None,
+                false,
+                &RuntimeSummary::default(),
+            ));
+            assert!(!requested_evidence_degraded(
+                SemanticMode::Auto,
+                state,
+                None,
+                false,
+                &RuntimeSummary::default(),
+            ));
+        }
+    }
+
+    #[test]
+    fn only_an_explicitly_selected_degraded_scenario_is_fatal() {
+        let runtime = runtime(vec![scenario(
+            "queue-playback",
+            ScenarioState::TimedOut,
+            TraceState::Empty,
+        )]);
+
+        assert!(requested_evidence_degraded(
+            SemanticMode::Auto,
+            SemanticState::Complete,
+            Some("queue-playback"),
+            false,
+            &runtime,
+        ));
+        assert!(!requested_evidence_degraded(
+            SemanticMode::Auto,
+            SemanticState::Complete,
+            None,
+            false,
+            &runtime,
+        ));
+        assert_eq!(
+            projection_scenario(Some("queue-playback"), false, &runtime),
+            None
+        );
+    }
+
+    #[test]
+    fn an_explicitly_supplied_empty_trace_is_fatal() {
+        let runtime = runtime(vec![scenario(
+            "manual",
+            ScenarioState::Manual,
+            TraceState::Empty,
+        )]);
+
+        assert!(requested_evidence_degraded(
+            SemanticMode::Auto,
+            SemanticState::Complete,
+            None,
+            true,
+            &runtime,
+        ));
+        assert!(!requested_evidence_degraded(
+            SemanticMode::Auto,
+            SemanticState::Complete,
+            None,
+            false,
+            &runtime,
+        ));
+        assert_eq!(projection_scenario(None, true, &runtime), None);
+    }
+
+    #[test]
+    fn a_configured_manual_scenario_does_not_alias_the_explicit_trace() {
+        let runtime = runtime(vec![
+            scenario("manual", ScenarioState::Failed, TraceState::Empty),
+            scenario("manual", ScenarioState::Manual, TraceState::Complete),
+        ]);
+
+        assert!(!requested_evidence_degraded(
+            SemanticMode::Auto,
+            SemanticState::Complete,
+            None,
+            true,
+            &runtime,
+        ));
+        assert_eq!(
+            projection_scenario(None, true, &runtime).as_deref(),
+            Some("manual")
+        );
+    }
+
+    fn runtime(scenarios: Vec<ScenarioSummary>) -> RuntimeSummary {
+        RuntimeSummary { scenarios }
+    }
+
+    fn semantic(state: SemanticState, diagnostic: &str) -> SemanticSummary {
+        SemanticSummary {
+            state,
+            diagnostics: vec![diagnostic.to_string()],
+            outgoing_calls: 0,
+            prepared_symbols: 0,
+            requested_symbols: 0,
+            resolved_edges: 0,
+            skipped_symbols: 0,
+            unmatched_targets: 0,
+        }
+    }
+
+    fn scenario(name: &str, state: ScenarioState, trace_state: TraceState) -> ScenarioSummary {
+        ScenarioSummary {
+            exit_code: None,
+            stderr: None,
+            stdout: None,
+            state,
+            name: name.to_string(),
+            trace: TraceSummary {
+                state: trace_state,
+                diagnostics: vec!["diagnostic".to_string()],
+                matched_records: 0,
+                records: 0,
+                unmatched_records: 0,
+            },
+        }
+    }
 }

--- a/crates/kithara-devtools/src/viz/scenario.rs
+++ b/crates/kithara-devtools/src/viz/scenario.rs
@@ -49,6 +49,19 @@ pub(crate) struct ScenarioSummary {
     pub(crate) trace: TraceSummary,
 }
 
+impl ScenarioSummary {
+    pub(crate) fn is_degraded(&self) -> bool {
+        matches!(
+            self.state,
+            ScenarioState::Empty | ScenarioState::Failed | ScenarioState::TimedOut
+        ) || matches!(self.trace.state, TraceState::Empty | TraceState::Failed)
+    }
+
+    fn is_truncated(&self) -> bool {
+        self.state == ScenarioState::Truncated || self.trace.state == TraceState::Truncated
+    }
+}
+
 #[derive(Debug, Default, Serialize)]
 pub(crate) struct RuntimeSummary {
     pub(crate) scenarios: Vec<ScenarioSummary>,
@@ -59,19 +72,12 @@ impl RuntimeSummary {
         !self.scenarios.is_empty()
     }
 
-    pub(crate) fn is_incomplete(&self) -> bool {
-        self.scenarios.iter().any(|scenario| {
-            matches!(
-                scenario.state,
-                ScenarioState::Empty | ScenarioState::Failed | ScenarioState::TimedOut
-            )
-        })
+    pub(crate) fn is_degraded(&self) -> bool {
+        self.scenarios.iter().any(ScenarioSummary::is_degraded)
     }
 
     pub(crate) fn is_truncated(&self) -> bool {
-        self.scenarios
-            .iter()
-            .any(|scenario| scenario.state == ScenarioState::Truncated)
+        self.scenarios.iter().any(ScenarioSummary::is_truncated)
     }
 }
 

--- a/crates/kithara-devtools/src/viz/semantic.rs
+++ b/crates/kithara-devtools/src/viz/semantic.rs
@@ -54,10 +54,6 @@ pub(crate) struct SemanticSummary {
 }
 
 impl SemanticSummary {
-    pub(crate) fn is_incomplete(&self) -> bool {
-        matches!(self.state, SemanticState::TimedOut | SemanticState::Failed)
-    }
-
     pub(crate) fn static_only(diagnostic: impl Into<String>) -> Self {
         Self {
             state: SemanticState::Unavailable,

--- a/crates/kithara-devtools/tests/viz_portable.rs
+++ b/crates/kithara-devtools/tests/viz_portable.rs
@@ -1,11 +1,20 @@
 use std::{
     fs,
     path::{Path, PathBuf},
+    sync::{Mutex, MutexGuard, OnceLock, PoisonError},
 };
 
 use clap::{FromArgMatches, Subcommand};
 use kithara_devtools::{CoreCommand, Ctx};
 use tempfile::tempdir;
+
+fn runtime_scenario_guard() -> MutexGuard<'static, ()> {
+    static GUARD: OnceLock<Mutex<()>> = OnceLock::new();
+    GUARD
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+}
 
 fn copy_tree(source: &Path, target: &Path) {
     fs::create_dir_all(target).expect("create fixture directory");
@@ -37,6 +46,25 @@ fn viz_command(runtime: &str) -> CoreCommand {
         ])
         .expect("parse viz command");
     CoreCommand::from_arg_matches(&matches).expect("build viz command")
+}
+
+fn selected_scenario_command(name: &str) -> CoreCommand {
+    let command = CoreCommand::augment_subcommands(clap::Command::new("xtask"));
+    let matches = command
+        .try_get_matches_from([
+            "xtask",
+            "viz",
+            "--crate",
+            "flow",
+            "--lod",
+            "3",
+            "--semantic",
+            "off",
+            "--scenario",
+            name,
+        ])
+        .expect("parse selected scenario command");
+    CoreCommand::from_arg_matches(&matches).expect("build selected scenario command")
 }
 
 fn workspace_lod_command(lod: &str) -> CoreCommand {
@@ -262,7 +290,7 @@ fn workspace_filters_remove_crates_modules_edges_and_report_findings() {
                     && edge["target"]["module"] != "runtime"
             })
     );
-    assert_eq!(manifest["schema_version"], 4);
+    assert_eq!(manifest["schema_version"], 5);
     assert_eq!(manifest["lod"], 1);
     assert_eq!(
         manifest["filters"]["exclude_crates"],
@@ -540,7 +568,7 @@ fn crate_lod_two_groups_methods_into_architectural_abstractions() {
     assert!(!document.contains("[\"fn worker()\"]"));
     assert!(document.contains("Architecture contours:"));
     assert!(document.contains("abstractions"));
-    assert_eq!(manifest["schema_version"], 4);
+    assert_eq!(manifest["schema_version"], 5);
     assert_eq!(manifest["lod"], 2);
     let lifted_call = projection["edges"]
         .as_array()
@@ -704,6 +732,7 @@ fn portable_workspace_produces_stable_mermaid_artifacts() {
 
 #[test]
 fn configured_runtime_scenario_enriches_the_same_graph() {
+    let _guard = runtime_scenario_guard();
     let temp = tempdir().expect("tempdir");
     let fixture =
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/architecture-workspace");
@@ -758,7 +787,53 @@ fn configured_runtime_scenario_enriches_the_same_graph() {
 }
 
 #[test]
+fn degraded_selected_scenario_preserves_the_static_projection_before_failing() {
+    let temp = tempdir().expect("tempdir");
+    let fixture =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/architecture-workspace");
+    copy_tree(&fixture, temp.path());
+    fs::write(
+        temp.path().join(".config/xtask.toml"),
+        r#"
+[project]
+name = "portable-flow"
+
+[[architecture.runtime.scenarios]]
+name = "broken-runtime"
+command = "trace"
+path = "missing.jsonl"
+"#,
+    )
+    .expect("degraded runtime config");
+    let manifest_path = temp.path().join("Cargo.toml");
+    let ctx = Ctx::load_from_manifest(&manifest_path).expect("load fixture context");
+
+    let error = kithara_devtools::run(&selected_scenario_command("broken-runtime"), &ctx)
+        .expect_err("degraded selected scenario");
+
+    assert!(
+        error
+            .to_string()
+            .contains("explicitly requested architecture evidence degraded")
+    );
+    let output = temp
+        .path()
+        .join("target/architecture/working-tree/manifest.json");
+    let manifest: serde_json::Value =
+        serde_json::from_slice(&fs::read(output).expect("preserved manifest"))
+            .expect("manifest JSON");
+    assert_eq!(manifest["schema_version"], 5);
+    assert_eq!(manifest["status"], "runtime-degraded");
+    assert!(
+        manifest["visible_nodes"]
+            .as_u64()
+            .is_some_and(|nodes| nodes > 0)
+    );
+}
+
+#[test]
 fn excluded_test_harness_can_still_produce_runtime_evidence() {
+    let _guard = runtime_scenario_guard();
     let temp = tempdir().expect("tempdir");
     let fixture =
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/architecture-workspace");

--- a/crates/kithara-stretch/Cargo.toml
+++ b/crates/kithara-stretch/Cargo.toml
@@ -29,10 +29,17 @@ kithara-workspace-hack = { version = "0.0.1-alpha4", path = "../kithara-workspac
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 kithara-bufpool = { workspace = true, optional = true }
+signalsmith-stretch = { workspace = true, optional = true }
 
+# `bungee-sys` builds its C++ through `cmake`, which fails under MSVC (see
+# `windows_build_env` in xtask's Windows lane for the toolchain fight this
+# crate is not worth having on that target). wasm32 already excludes the
+# whole backend set above the same way, because none of these optional deps
+# exist for that target either; Windows/MSVC gets the same treatment for
+# bungee specifically, so `stretch-signalsmith` keeps working there.
+[target.'cfg(all(not(target_arch = "wasm32"), not(all(target_os = "windows", target_env = "msvc"))))'.dependencies]
 bungee-rs = { workspace = true, optional = true }
 fast-interleave = { workspace = true, optional = true }
-signalsmith-stretch = { workspace = true, optional = true }
 
 [dev-dependencies]
 kithara-test-utils = { workspace = true, features = ["client-reqwest", "probe", "tls-rustls"] }

--- a/crates/kithara-test-macros/CONTEXT.md
+++ b/crates/kithara-test-macros/CONTEXT.md
@@ -22,7 +22,7 @@ parameterization and `#[kithara::fixture]` injection.
 - `serial` — emits `#[serial_test::serial]`; requires `serial_test` at the call site.
 - `multi_thread` — `new_multi_thread().worker_threads(2)` instead of `new_current_thread()`; requires `tokio`.
 - `selenium` — implies `native + tokio + serial + multi_thread`. It injects no `#[ignore]`: the suite is picked up only by
-  the wasm-target driver (`just test run --lane=selenium`).
+  the wasm-target driver (`just test run --lane=selenium-firefox`).
 - `loom` — synchronous native model test returning `()`. Incompatible with `tokio`, async fns, non-unit returns,
   `soft_fail`, `wasm`, `browser`, `selenium`, and `multi_thread`.
 - `flash(true|false)` — opt the body into or out of flash time rewriting; default `true`.

--- a/crates/kithara-test-macros/src/test/shared.rs
+++ b/crates/kithara-test-macros/src/test/shared.rs
@@ -89,7 +89,7 @@ pub(crate) fn wrap_with_model(body: &TokenStream2, args: &TestArgs) -> TokenStre
 
 /// Selenium tests no longer auto-inject `#[ignore]` — the suite runs only
 /// when the wasm-target test driver picks them up
-/// (`just test run --lane=selenium`),
+/// (`just test run --lane=selenium-firefox`),
 /// so plain `cargo test` already skips them by virtue of platform gating.
 pub(crate) fn make_selenium_attrs(_args: &TestArgs) -> TokenStream2 {
     quote! {}

--- a/docs/guides/tooling.md
+++ b/docs/guides/tooling.md
@@ -50,10 +50,11 @@ These are suitable for local pre-commit feedback.
   dropping nodes. Optional and target-gated Cargo edges use the distinct
   `conditional` evidence style.
 - Read `manifest.json` before using a result as architecture evidence.
-  `complete` and `runtime-enriched` are successful observations; `truncated`
-  names an evidence-collection limit, never diagram node removal;
-  `static-only` has no runtime evidence; `incomplete` preserves partial files
-  but is not an acceptance result.
+  Every schema-v5 status preserves a reusable static projection. `complete` and
+  `runtime-enriched` include their named overlays; `truncated` names an
+  evidence-collection limit, never diagram node removal; `static-only` has no
+  semantic overlay; `runtime-degraded` names a degraded runtime observation.
+  Overlay diagnostics remain in the manifest and Markdown report.
 - Runtime traces and scenario stdout/stderr stay beside the diagram. Trace
   absence never proves a path is dead, and unresolved calls are never assigned
   a guessed target.

--- a/justfile
+++ b/justfile
@@ -64,11 +64,17 @@ _xtask-cached MODE *ARGS:
       if ! { IFS= read -r generation && ! IFS= read -r extra && [ -z "$extra" ]; } < "$pointer"; then \
         unavailable; \
       fi; \
+      system=$(uname -s) || unavailable; \
+      case "$system" in \
+        MINGW*|MSYS*|CYGWIN*) windows=1; suffix=.exe ;; \
+        *) windows=0; suffix= ;; \
+      esac; \
       case "$generation" in \
         /*) ;; \
+        [A-Za-z]:[\\/]*) [ "$windows" -eq 1 ] || unavailable ;; \
         *) unavailable ;; \
       esac; \
-      binary="$generation/xtask"; \
+      binary="$generation/xtask$suffix"; \
       [ -f "$binary" ] && [ ! -L "$binary" ] && [ -x "$binary" ] || unavailable; \
       if [ "$mode" = optional ]; then \
         "$binary" self-cache probe </dev/null >/dev/null 2>&1 || unavailable; \

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -52,8 +52,8 @@ network = []
 # stayed off CI because part of it could not go there.
 network-manual = []
 # Selenium-driven WebDriver tests. Gated off by default so `just test`
-# doesn't try to spin up trunk + chromedriver. Run via
-# `just test run --lane=selenium`.
+# doesn't try to spin up trunk + a webdriver. Run via
+# `just test run --lane=selenium-firefox`.
 selenium = []
 # Deterministic virtual-clock test mode. Routes the platform's blocking waits
 # (`thread::park_timeout`, `sync::Condvar`) onto the quiescence engine so timed

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -28,10 +28,13 @@ test = false
 
 [features]
 perf = ["dep:hotpath", "hotpath/hotpath", "kithara/perf"]
-# End-to-end tests that require real networks and real audio hardware.
-# Gated off by default so `just test` never compiles `suite_e2e`. Real devices
-# run at arbitrary sample rates, so every e2e lane in .config/xtask.toml pairs
-# this with a fixed-ratio SRC backend (rubato / glide / apple fused).
+# End-to-end playback through a real cpal output device. Gated off by default so
+# `just test` never compiles `suite_e2e`. Real devices run at arbitrary sample
+# rates, so every e2e lane in `.config/xtask.toml` pairs this with a fixed-ratio
+# SRC backend (rubato / glide / apple fused); that axis is why there are three
+# lanes rather than one. Only a machine with a sound card can run them: the
+# Apple executor does, a container does not, so no container lane carries them.
+# The engine-lifecycle tests that need no device moved to `suite_light`.
 e2e = []
 # Regression tests for the player bugs QA filed against the zvooq-ios
 # integration. Some reproduce an open bug and are red on purpose; the rest

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -136,12 +136,19 @@ kithara = { workspace = true, features = [
     "mock",
     "symphonia",
     "stretch-signalsmith",
-    "stretch-bungee",
     "backend-cpal",
     "tokio-net",
     "tokio-rt-multi-thread",
 ] }
 kithara-app = { workspace = true, default-features = false, features = ["analysis-waveform", "lib-only"] }
+
+# `bungee-sys` builds through `cmake`/MSVC and fails there; `kithara-stretch`
+# already drops the dependency for that target (see its `Cargo.toml`), so
+# requesting the feature here would compile a module whose imports do not
+# exist, the same failure wasm32 gets if it asks for the feature that block
+# above never lists.
+[target.'cfg(all(not(target_arch = "wasm32"), not(all(target_os = "windows", target_env = "msvc"))))'.dependencies]
+kithara = { workspace = true, features = ["stretch-bungee"] }
 
 # Only `architecture_trace` reaches for it, and that module is already native
 # only: the crate's LSP client builds file URLs, which `url` offers everywhere

--- a/tests/tests/kithara_play/engine_offline_tests.rs
+++ b/tests/tests/kithara_play/engine_offline_tests.rs
@@ -1,8 +1,9 @@
-//! Leaving `EngineConfig::session` unset makes this the hardware half. The
-//! engine falls through to `default_session_handle`, which opens a cpal output
-//! stream, so these tests run only where a real output device exists.
+//! An injected offline session dispatcher replaces the cpal output stream, so
+//! this half asks nothing of the machine and belongs in the ordinary gate
+//! rather than a lane.
 
 use kithara::{bufpool::PcmPool, play::EngineConfig};
+use kithara_integration_tests::offline::OfflineSession;
 
 use super::engine_session_contract as contract;
 
@@ -10,6 +11,7 @@ fn engine_config(max_slots: usize) -> EngineConfig {
     EngineConfig::builder()
         .max_slots(max_slots)
         .pcm_pool(PcmPool::default())
+        .session(OfflineSession::arc_auto())
         .build()
 }
 

--- a/tests/tests/kithara_play/engine_session_contract.rs
+++ b/tests/tests/kithara_play/engine_session_contract.rs
@@ -1,0 +1,42 @@
+//! The engine lifecycle contract is the same whatever session drives the graph.
+//! The caller supplies that session because only a cpal output stream needs
+//! hardware, and that decides which suite owns the test.
+
+use kithara::{
+    events::EventBus,
+    play::{EngineConfig, EngineImpl, PlayError},
+};
+
+pub(super) fn start_stop_roundtrip(config: EngineConfig) {
+    let engine = EngineImpl::new(config, EventBus::default());
+    engine.start().unwrap();
+    assert!(engine.is_running());
+    engine.stop().unwrap();
+    assert!(!engine.is_running());
+}
+
+pub(super) fn allocate_and_release_slot(config: EngineConfig) {
+    let engine = EngineImpl::new(config, EventBus::default());
+    engine.start().unwrap();
+
+    let slot_id = engine.allocate_slot().unwrap();
+    assert_eq!(engine.active_slots().len(), 1);
+    assert!(engine.active_slots().contains(&slot_id));
+
+    engine.release_slot(slot_id).unwrap();
+    assert_eq!(engine.active_slots().len(), 0);
+
+    engine.stop().unwrap();
+}
+
+/// The supplied config must set `max_slots` to 1.
+pub(super) fn arena_full_error(config: EngineConfig) {
+    let engine = EngineImpl::new(config, EventBus::default());
+    engine.start().unwrap();
+
+    let _slot = engine.allocate_slot().unwrap();
+    let result = engine.allocate_slot();
+    assert!(matches!(result, Err(PlayError::ArenaFull)));
+
+    engine.stop().unwrap();
+}

--- a/tests/tests/kithara_play/mod.rs
+++ b/tests/tests/kithara_play/mod.rs
@@ -3,6 +3,10 @@
 mod offline_player_harness;
 
 mod cochlea_continuity_oracle;
+#[cfg(not(target_arch = "wasm32"))]
+mod engine_offline_tests;
+#[cfg(not(target_arch = "wasm32"))]
+mod engine_session_contract;
 mod engine_tests;
 mod gapless_offline_e2e;
 mod gapless_startup_regressions;

--- a/tests/tests/suite_e2e.rs
+++ b/tests/tests/suite_e2e.rs
@@ -3,12 +3,19 @@
     clippy::unwrap_used,
     reason = "integration test crate — unwraps are acceptable in test code"
 )]
-//! Playback against real audio hardware. Everything here stays inside the
-//! runner: the fixtures are local, and the tests that need a remote host live
-//! in `suite_network` behind the `network` feature.
+//! What puts a test here is the machine, not the code. These tests open a real
+//! cpal output stream, and a container has no sound card. The half that needs no
+//! device now lives in `suite_light` and runs in the ordinary gate.
+//!
+//! The Apple executor serves this suite through `apple:e2e`, because that
+//! machine has hardware. A developer machine can serve it with
+//! `just test run --lane=e2e`. No container lane carries it: a runner that
+//! failed here would be reporting the fence around itself rather than the code.
 
 #[cfg(not(target_arch = "wasm32"))]
 mod kithara_play {
     #[path = "../kithara_play/engine_cpal_tests.rs"]
     mod engine_cpal_tests;
+    #[path = "../kithara_play/engine_session_contract.rs"]
+    mod engine_session_contract;
 }

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -25,7 +25,10 @@ the shared `target/debug/xtask`. Cache policy is configured under
 
 Refresh builds are supervised and fail closed. Cargo returns an artifact but
 does not publish it; the parent verifies that declared inputs stayed unchanged
-throughout the build before atomically activating the new generation.
+throughout the build before atomically activating the new generation. The
+cancellation half of that supervision is Unix-only: there the build runs in its
+own process group and the parent relays signals and parent death into it, while
+on Windows Cargo shares the console and receives the control event directly.
 
 ## Common Commands
 

--- a/xtask/src/ci/lane/linux.rs
+++ b/xtask/src/ci/lane/linux.rs
@@ -70,6 +70,21 @@ pub(crate) fn configured(process: &Process, lane: &str) -> Result<()> {
     process.run_command(&mut command, &format!("Linux {lane} lane"))
 }
 
+/// A selenium lane per browser: the lane name (`selenium-<browser>`) is the
+/// only place the browser is decided, and `KITHARA_SELENIUM_BROWSER` carries
+/// it into the harness (`tests/tests/kithara_ffi_web/selenium.rs`), which
+/// otherwise defaults to chrome regardless of what the image actually pins.
+pub(crate) fn selenium(process: &Process, browser: &str) -> Result<()> {
+    preflight(process)?;
+    let lane = format!("selenium-{browser}");
+    let mut command = process.command("just");
+    command
+        .env("CARGO_BUILD_JOBS", "2")
+        .env("KITHARA_SELENIUM_BROWSER", browser)
+        .args(["test", "run", &format!("--lane={lane}")]);
+    process.run_command(&mut command, &format!("Linux {lane} lane"))
+}
+
 pub(crate) fn coverage(process: &Process) -> Result<()> {
     preflight(process)?;
     let mut command = process.command("just");

--- a/xtask/src/ci/linux/cleanup.rs
+++ b/xtask/src/ci/linux/cleanup.rs
@@ -1,7 +1,7 @@
-use anyhow::Result;
-use tracing::{info, warn};
+use anyhow::{Result, bail};
+use tracing::info;
 
-use crate::ci::{config::CiPins, process::Process};
+use crate::ci::process::Process;
 
 /// Build cache older than this is rebuilt faster than it is worth keeping.
 const BUILD_CACHE_AGE: &str = "168h";
@@ -13,11 +13,17 @@ const BUILD_CACHE_AGE: &str = "168h";
 /// entirely — `kithara-ci-target` and `kithara-ci-cargo-home` are the caches
 /// this exists to protect, and the orphans beside them belong to a setup this
 /// code does not own.
-pub(super) fn run(process: &Process, pins: &CiPins) -> Result<()> {
-    let Some((_, pinned)) = pins.linux_image.rsplit_once(':') else {
-        warn!(image = pins.linux_image, "pinned image carries no tag");
-        return Ok(());
-    };
+///
+/// What to keep is named by the caller rather than read from the pins, because
+/// this runs from a timer and the pins move with the repository. Read there,
+/// a bumped pin nobody has installed yet would name the running fleet's image
+/// as superseded and take it out from under the services.
+pub(super) fn run(process: &Process, keep: &[String]) -> Result<()> {
+    // Every project image would be superseded by an empty list, and this is
+    // the one caller whose mistakes are unattended.
+    if keep.is_empty() {
+        bail!("cleanup was given no image to keep; reinstall the services to name them");
+    }
 
     let listed = process.capture(
         "docker",
@@ -29,19 +35,13 @@ pub(super) fn run(process: &Process, pins: &CiPins) -> Result<()> {
         ],
         "list project images",
     )?;
-    let superseded: Vec<&str> = listed
-        .lines()
-        .map(str::trim)
-        .filter(|image| !image.is_empty())
-        .filter(|image| image.rsplit_once(':').is_none_or(|(_, tag)| tag != pinned))
-        .collect();
-
+    let superseded = superseded(&listed, keep);
     for image in &superseded {
         process.best_effort("docker", &["rmi", image], "remove a superseded image");
     }
     info!(
         removed = superseded.len(),
-        kept = pinned,
+        kept = keep.len(),
         "superseded project images removed"
     );
 
@@ -59,27 +59,66 @@ pub(super) fn run(process: &Process, pins: &CiPins) -> Result<()> {
     Ok(())
 }
 
+/// Which of the project's images nothing on this machine is installed to run.
+fn superseded<'a>(listed: &'a str, keep: &[String]) -> Vec<&'a str> {
+    listed
+        .lines()
+        .map(str::trim)
+        .filter(|image| !image.is_empty())
+        .filter(|image| !keep.iter().any(|kept| kept == image))
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
+    use super::*;
+
+    const LISTED: &str = "kithara-ci:linux-20260729\n\
+                          kithara-ci:linux-20260806d\n\
+                          kithara-ci-android:linux-20260806c\n\
+                          kithara-ci-android-runner:linux-20260806c\n\
+                          kithara-ci-runner:linux-20260806d\n";
+
+    fn keep(images: &[&str]) -> Vec<String> {
+        images.iter().map(|image| (*image).to_owned()).collect()
+    }
+
     #[test]
-    fn only_tags_other_than_the_pinned_one_are_superseded() {
-        let pinned = "linux-20260806d";
-        let listed = "kithara-ci:linux-20260729\n\
-                      kithara-ci:linux-20260806d\n\
-                      kithara-ci-android:linux-20260806c\n\
-                      kithara-ci-runner:linux-20260806d\n";
-        let superseded: Vec<&str> = listed
-            .lines()
-            .map(str::trim)
-            .filter(|image| !image.is_empty())
-            .filter(|image| image.rsplit_once(':').is_none_or(|(_, tag)| tag != pinned))
-            .collect();
-        assert_eq!(
-            superseded,
-            [
-                "kithara-ci:linux-20260729",
-                "kithara-ci-android:linux-20260806c"
-            ]
-        );
+    fn a_generation_the_fleet_no_longer_runs_is_superseded() {
+        let kept = keep(&[
+            "kithara-ci:linux-20260806d",
+            "kithara-ci-runner:linux-20260806d",
+            "kithara-ci-android:linux-20260806c",
+            "kithara-ci-android-runner:linux-20260806c",
+        ]);
+        assert_eq!(superseded(LISTED, &kept), ["kithara-ci:linux-20260729"]);
+    }
+
+    /// The emulator lane runs a generation of its own, and a rule that kept one
+    /// tag would delete the image half the fleet is started from.
+    #[test]
+    fn a_lane_on_an_older_tag_than_the_others_keeps_its_image() {
+        let kept = keep(&[
+            "kithara-ci:linux-20260806d",
+            "kithara-ci-runner:linux-20260806d",
+            "kithara-ci-android:linux-20260806c",
+            "kithara-ci-android-runner:linux-20260806c",
+        ]);
+        assert!(!superseded(LISTED, &kept).contains(&"kithara-ci-android:linux-20260806c"));
+    }
+
+    /// The pins move with the repository and the timer does not, so cleanup is
+    /// told what is installed. Were it told what is merely pinned, the newer
+    /// tag would name the running fleet's image as superseded.
+    #[test]
+    fn an_image_the_fleet_runs_survives_a_pin_it_has_not_been_given() {
+        let bumped = keep(&[
+            "kithara-ci:linux-20260810a",
+            "kithara-ci-runner:linux-20260810a",
+        ]);
+        assert!(superseded(LISTED, &bumped).contains(&"kithara-ci-runner:linux-20260806d"));
+
+        let installed = keep(&["kithara-ci-runner:linux-20260806d"]);
+        assert!(!superseded(LISTED, &installed).contains(&"kithara-ci-runner:linux-20260806d"));
     }
 }

--- a/xtask/src/ci/linux/cleanup.rs
+++ b/xtask/src/ci/linux/cleanup.rs
@@ -9,10 +9,11 @@ const BUILD_CACHE_AGE: &str = "168h";
 /// Reclaim what this project left behind, and nothing else.
 ///
 /// The machine is shared: other stacks keep images and volumes here, so a
-/// blanket `docker system prune` would take theirs. Volumes are left alone
-/// entirely — `kithara-ci-target` and `kithara-ci-cargo-home` are the caches
-/// this exists to protect, and the orphans beside them belong to a setup this
-/// code does not own.
+/// blanket `docker system prune` would take theirs. Every live cache stays:
+/// the per-runner `kithara-ci-target-*`, `kithara-ci-sccache` and
+/// `kithara-ci-fixtures` are what this exists to protect. A volume of this
+/// project's that no container is attached to any more is not a cache but a
+/// leftover, and it is reclaimed.
 ///
 /// What to keep is named by the caller rather than read from the pins, because
 /// this runs from a timer and the pins move with the repository. Read there,
@@ -45,6 +46,26 @@ pub(super) fn run(process: &Process, keep: &[String]) -> Result<()> {
         "superseded project images removed"
     );
 
+    let dangling = process.capture(
+        "docker",
+        &[
+            "volume",
+            "ls",
+            "--filter",
+            "name=kithara-ci",
+            "--filter",
+            "dangling=true",
+            "--format",
+            "{{.Name}}",
+        ],
+        "list this project's unattached volumes",
+    )?;
+    let orphans = orphaned_volumes(&dangling);
+    for volume in &orphans {
+        process.best_effort("docker", &["volume", "rm", volume], "remove a dead volume");
+    }
+    info!(removed = orphans.len(), "dead project volumes removed");
+
     process.best_effort(
         "docker",
         &[
@@ -69,6 +90,25 @@ fn superseded<'a>(listed: &'a str, keep: &[String]) -> Vec<&'a str> {
         .collect()
 }
 
+/// This project's volumes that no container is attached to any more.
+///
+/// The live per-runner caches (`kithara-ci-target-<owner>-<n>`,
+/// `kithara-ci-sccache`, `kithara-ci-fixtures`) all carry a link and are never
+/// listed here — Docker's own `dangling` filter is the authority on that, not a
+/// name pattern. What this catches is a generation the fleet has moved off:
+/// the single shared `kithara-ci-target` left behind when the runners went to
+/// one volume each held 231 GB on a 1.8 TB disk that was 99% full, and nothing
+/// reclaimed it, because "leave the volumes alone" treated this project's own
+/// corpse as if it belonged to a stack this code does not own. It does not: the
+/// name says whose it is and the link count says it is dead.
+fn orphaned_volumes(listed: &str) -> Vec<&str> {
+    listed
+        .lines()
+        .map(str::trim)
+        .filter(|volume| !volume.is_empty())
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -81,6 +121,32 @@ mod tests {
 
     fn keep(images: &[&str]) -> Vec<String> {
         images.iter().map(|image| (*image).to_owned()).collect()
+    }
+
+    #[test]
+    fn a_volume_no_container_holds_is_reclaimed() {
+        // What `docker volume ls --filter dangling=true` answers: the live
+        // per-runner caches carry a link and never appear, so this list is
+        // already only the dead. Blank lines are what the empty case looks
+        // like on the wire.
+        let dangling = "kithara-ci-target\n\nkithara-ci-target-gerasim13-99\n";
+        assert_eq!(
+            orphaned_volumes(dangling),
+            ["kithara-ci-target", "kithara-ci-target-gerasim13-99"],
+            "every unattached project volume is named for removal"
+        );
+    }
+
+    #[test]
+    fn nothing_is_removed_when_every_volume_is_attached() {
+        assert!(
+            orphaned_volumes("").is_empty(),
+            "an empty dangling list must not name a single volume"
+        );
+        assert!(
+            orphaned_volumes("   \n\n").is_empty(),
+            "whitespace is not a volume name"
+        );
     }
 
     #[test]

--- a/xtask/src/ci/linux/command.rs
+++ b/xtask/src/ci/linux/command.rs
@@ -58,7 +58,12 @@ enum LinuxCommand {
         mint: bool,
     },
     /// Reclaim superseded project images and stale build cache.
-    Cleanup,
+    Cleanup {
+        /// An image this machine is installed to run, named once per image.
+        /// Written by `install-services`, which knows what it installed.
+        #[arg(long = "keep")]
+        keep: Vec<String>,
+    },
     /// Install the Windows guest that serves the Windows lane.
     InstallWindows,
     /// Register the installed Windows guest as a runner and wait for it.
@@ -82,10 +87,7 @@ pub(crate) fn run(args: &LinuxArgs) -> Result<()> {
         LinuxCommand::Configure { runner, env_file } => {
             registration::configure(&host, host.runner(runner)?, env_file)
         }
-        LinuxCommand::Cleanup => {
-            let pins = CiPins::load(&args.pins)?;
-            cleanup::run(&process, &pins)
-        }
+        LinuxCommand::Cleanup { keep } => cleanup::run(&process, keep),
         LinuxCommand::InstallServices => {
             let pins = CiPins::load(&args.pins)?;
             let executable = std::env::current_exe().context("locating this executable")?;

--- a/xtask/src/ci/linux/services.rs
+++ b/xtask/src/ci/linux/services.rs
@@ -66,7 +66,7 @@ pub(super) fn install(
             cpuset, "runner service installed"
         );
     }
-    install_cleanup_timer()?;
+    install_cleanup_timer(&installed_images(host, pins))?;
     process.run("systemctl", &["daemon-reload"], "reload systemd")?;
     for runner in &host.runners {
         process.run(
@@ -83,19 +83,40 @@ pub(super) fn install(
     Ok(())
 }
 
-/// Which images this profile's runners start from, each named once.
-fn required_images<'a>(host: &LinuxHost, pins: &'a CiPins) -> Vec<&'a str> {
+/// The toolchain and runner image of every flavour this profile uses, each
+/// pair named once. A runner image is built on its toolchain, so a machine
+/// serving a lane depends on both.
+fn flavor_images<'a>(host: &LinuxHost, pins: &'a CiPins) -> Vec<(&'a str, &'a str)> {
     let mut images = Vec::new();
     for runner in &host.runners {
-        let image = match runner.flavor {
-            RunnerFlavor::Plain => pins.linux_runner_image.as_str(),
-            RunnerFlavor::Android => pins.linux_android_runner_image.as_str(),
+        let pair = match runner.flavor {
+            RunnerFlavor::Plain => (pins.linux_image.as_str(), pins.linux_runner_image.as_str()),
+            RunnerFlavor::Android => (
+                pins.linux_android_image.as_str(),
+                pins.linux_android_runner_image.as_str(),
+            ),
         };
-        if !images.contains(&image) {
-            images.push(image);
+        if !images.contains(&pair) {
+            images.push(pair);
         }
     }
     images
+}
+
+/// Which images this profile's runners start from, each named once.
+fn required_images<'a>(host: &LinuxHost, pins: &'a CiPins) -> Vec<&'a str> {
+    flavor_images(host, pins)
+        .into_iter()
+        .map(|(_, runner)| runner)
+        .collect()
+}
+
+/// Everything the installed fleet depends on, in the order cleanup is told it.
+fn installed_images<'a>(host: &LinuxHost, pins: &'a CiPins) -> Vec<&'a str> {
+    flavor_images(host, pins)
+        .into_iter()
+        .flat_map(|(toolchain, runner)| [toolchain, runner])
+        .collect()
 }
 
 /// Refuse to install services the machine cannot run.
@@ -135,18 +156,31 @@ fn require_pinned_images(process: &Process, host: &LinuxHost, pins: &CiPins) -> 
 /// Generations share their base layers, so removing five of six freed single
 /// gigabytes rather than the hundreds `docker images` reports per image — the
 /// point is that the count stops growing, not that a run reclaims much.
-fn install_cleanup_timer() -> Result<()> {
-    let service = format!(
+///
+/// The unit names the images to keep rather than reading the pins, because it
+/// runs from a timer with no repository around it — and because what must
+/// survive is what this machine was installed to run, not what the checkout
+/// happens to pin by the time the timer next fires.
+fn cleanup_unit(keep: &[&str]) -> String {
+    format!(
         "[Unit]\n\
          Description=Kithara CI cleanup\n\
          After=docker.service\n\
          Requires=docker.service\n\n\
          [Service]\n\
          Type=oneshot\n\
-         ExecStart={executable} ci linux --config {config} cleanup\n",
+         ExecStart={executable} ci linux --config {config} cleanup{keep}\n",
         executable = LAYOUT.executable,
         config = LINUX_CONFIG_PATH,
-    );
+        keep = keep
+            .iter()
+            .map(|image| format!(" --keep {image}"))
+            .collect::<String>(),
+    )
+}
+
+fn install_cleanup_timer(keep: &[&str]) -> Result<()> {
+    let service = cleanup_unit(keep);
     let timer = "[Unit]\n\
                  Description=Kithara CI cleanup\n\n\
                  [Timer]\n\
@@ -334,6 +368,47 @@ mod tests {
             "{images:?}"
         );
         assert_eq!(images.len(), 2, "each image is named once: {images:?}");
+    }
+
+    /// The timer runs from no particular directory, so its command must be one
+    /// this executable accepts as written. This unit spent every night failing
+    /// on a repository-relative path systemd gave it no repository to resolve.
+    #[test]
+    fn the_cleanup_unit_is_a_command_this_executable_accepts() {
+        let host = host_fixture();
+        let pins = &fixture().pins;
+        let text = cleanup_unit(&installed_images(&host, pins));
+
+        let command = text
+            .lines()
+            .find_map(|line| line.strip_prefix("ExecStart="))
+            .expect("the unit must start something")
+            .split_whitespace()
+            .skip(1)
+            .collect::<Vec<_>>();
+        let argv = std::iter::once("xtask").chain(command.iter().copied());
+        assert!(Cli::try_parse_from(argv).is_ok(), "{command:?}");
+    }
+
+    /// Both lanes' images, and the toolchain each was built on. A runner image
+    /// left without its base is rebuilt from scratch; a base kept without its
+    /// runner is the fleet's image deleted out from under it.
+    #[test]
+    fn the_cleanup_unit_names_every_image_the_fleet_runs() {
+        let host = host_fixture();
+        let pins = &fixture().pins;
+        let text = cleanup_unit(&installed_images(&host, pins));
+        for image in [
+            &pins.linux_image,
+            &pins.linux_runner_image,
+            &pins.linux_android_image,
+            &pins.linux_android_runner_image,
+        ] {
+            assert!(
+                text.contains(&format!("--keep {image}")),
+                "{image}:\n{text}"
+            );
+        }
     }
 
     /// The same contract as the Compose rendering: a unit that does not name

--- a/xtask/src/ci/run.rs
+++ b/xtask/src/ci/run.rs
@@ -35,7 +35,7 @@ pub(crate) enum Lane {
     LinuxE2e,
     LinuxE2eFused,
     LinuxE2eGlide,
-    LinuxSelenium,
+    LinuxSeleniumFirefox,
     LinuxCoverage,
     AndroidBuild,
     AndroidTest,
@@ -99,7 +99,7 @@ impl Lane {
             | Self::LinuxE2e
             | Self::LinuxE2eFused
             | Self::LinuxE2eGlide
-            | Self::LinuxSelenium
+            | Self::LinuxSeleniumFirefox
             | Self::LinuxCoverage
             | Self::WebChromium
             | Self::WebFirefox
@@ -193,7 +193,7 @@ pub(crate) fn run(args: &RunArgs, ctx: &Ctx) -> Result<()> {
         Lane::LinuxE2e => lane::linux::configured(&process, "e2e"),
         Lane::LinuxE2eFused => lane::linux::configured(&process, "e2e-fused"),
         Lane::LinuxE2eGlide => lane::linux::configured(&process, "e2e-glide"),
-        Lane::LinuxSelenium => lane::linux::configured(&process, "selenium"),
+        Lane::LinuxSeleniumFirefox => lane::linux::selenium(&process, "firefox"),
         Lane::LinuxCoverage => lane::linux::coverage(&process),
         Lane::AndroidBuild => lane::android::build(&process),
         Lane::AndroidTest => lane::android::test(&process, &ci_config),

--- a/xtask/src/ci/run.rs
+++ b/xtask/src/ci/run.rs
@@ -32,9 +32,6 @@ pub(crate) enum Lane {
     LinuxDoc,
     LinuxLoom,
     LinuxIntegrationRegressions,
-    LinuxE2e,
-    LinuxE2eFused,
-    LinuxE2eGlide,
     LinuxSeleniumFirefox,
     LinuxCoverage,
     AndroidBuild,
@@ -96,9 +93,6 @@ impl Lane {
             | Self::LinuxDoc
             | Self::LinuxLoom
             | Self::LinuxIntegrationRegressions
-            | Self::LinuxE2e
-            | Self::LinuxE2eFused
-            | Self::LinuxE2eGlide
             | Self::LinuxSeleniumFirefox
             | Self::LinuxCoverage
             | Self::WebChromium
@@ -190,9 +184,6 @@ pub(crate) fn run(args: &RunArgs, ctx: &Ctx) -> Result<()> {
         Lane::LinuxIntegrationRegressions => {
             lane::linux::configured(&process, "integration-regressions")
         }
-        Lane::LinuxE2e => lane::linux::configured(&process, "e2e"),
-        Lane::LinuxE2eFused => lane::linux::configured(&process, "e2e-fused"),
-        Lane::LinuxE2eGlide => lane::linux::configured(&process, "e2e-glide"),
         Lane::LinuxSeleniumFirefox => lane::linux::selenium(&process, "firefox"),
         Lane::LinuxCoverage => lane::linux::coverage(&process),
         Lane::AndroidBuild => lane::android::build(&process),

--- a/xtask/src/self_cache/command.rs
+++ b/xtask/src/self_cache/command.rs
@@ -1,23 +1,24 @@
 use std::{
     env, fs,
+    io::Read,
     path::{Path, PathBuf},
-    process::{Command, Stdio},
+    process::{Child, Command, ExitStatus, Stdio},
+    thread,
     time::Duration,
 };
 #[cfg(unix)]
 use std::{
-    io::Read,
     os::unix::{fs::PermissionsExt, process::CommandExt},
-    process::{Child, ExitStatus},
     sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
     },
-    thread,
     time::Instant,
 };
 
-use anyhow::{Context, Result, bail, ensure};
+#[cfg(unix)]
+use anyhow::bail;
+use anyhow::{Context, Result, ensure};
 use clap::{Args, Subcommand};
 #[cfg(unix)]
 use nix::{
@@ -239,6 +240,27 @@ fn build_worker(root: &Path, parent: u32, release: bool) -> Result<()> {
         "self-cache build parent changed before Cargo started"
     );
     let signals = BuildSignals::install()?;
+    let mut command = cargo_build_command(root, release);
+    command.process_group(0);
+    run_cargo_build(root, &mut command, |child| {
+        supervise(child, parent, &signals)
+    })
+}
+
+#[cfg(not(unix))]
+fn build_worker(root: &Path, parent: u32, release: bool) -> Result<()> {
+    ensure!(parent > 1, "invalid self-cache build parent process");
+    let mut command = cargo_build_command(root, release);
+    // Cargo stays on the same Windows console, so control events reach both processes.
+    // std has no Windows parent-change probe, so that check remains Unix-only.
+    run_cargo_build(root, &mut command, |child| {
+        child
+            .wait()
+            .context("wait for xtask self-cache Cargo process")
+    })
+}
+
+fn cargo_build_command(root: &Path, release: bool) -> Command {
     let cargo = env::var_os("XTASK_SELF_CACHE_CARGO")
         .or_else(|| env::var_os("CARGO"))
         .unwrap_or_else(|| "cargo".into());
@@ -255,8 +277,14 @@ fn build_worker(root: &Path, parent: u32, release: bool) -> Result<()> {
         .current_dir(root)
         .env("CARGO_TARGET_DIR", layout::target_dir(root))
         .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .process_group(0);
+        .stdout(Stdio::piped());
+    command
+}
+
+fn run_cargo_build<F>(root: &Path, command: &mut Command, wait: F) -> Result<()>
+where
+    F: FnOnce(&mut Child) -> Result<ExitStatus>,
+{
     let mut child = command
         .spawn()
         .context("launch Cargo for xtask self-cache refresh")?;
@@ -265,7 +293,7 @@ fn build_worker(root: &Path, parent: u32, release: bool) -> Result<()> {
         .take()
         .context("capture xtask self-cache build output")?;
     let reader = thread::spawn(move || read_bounded_output(stdout, Consts::BUILD_OUTPUT_LIMIT));
-    let status = supervise(&mut child, parent, &signals);
+    let status = wait(&mut child);
     let output = reader
         .join()
         .map_err(|_| anyhow::anyhow!("xtask self-cache output reader panicked"))?;
@@ -278,11 +306,6 @@ fn build_worker(root: &Path, parent: u32, release: bool) -> Result<()> {
     let artifact = parse_artifact(root, &output)?;
     println!("{}", artifact.display());
     Ok(())
-}
-
-#[cfg(not(unix))]
-fn build_worker(_root: &Path, _parent: u32, _release: bool) -> Result<()> {
-    bail!("xtask self-cache build supervision requires a Unix host")
 }
 
 fn artifact(root: &Path) -> Result<()> {
@@ -331,7 +354,6 @@ fn parse_artifact(root: &Path, output: &[u8]) -> Result<PathBuf> {
     Ok(artifact)
 }
 
-#[cfg(unix)]
 fn read_bounded_output(mut reader: impl Read, limit: usize) -> Result<Vec<u8>> {
     let take = u64::try_from(limit)?
         .checked_add(1)

--- a/xtask/src/self_cache/layout.rs
+++ b/xtask/src/self_cache/layout.rs
@@ -10,7 +10,7 @@ use anyhow::{Context, Result, bail, ensure};
 
 use super::manifest::CacheManifest;
 
-pub(super) const BINARY: &str = "xtask";
+pub(super) const BINARY: &str = if cfg!(windows) { "xtask.exe" } else { "xtask" };
 pub(super) const CACHE_DIRECTORY: &str = "xtask-cache";
 pub(super) const GENERATION_PREFIX: &str = "generation-";
 pub(super) const LEASE_FILE: &str = "lease.lock";
@@ -257,7 +257,12 @@ mod tests {
 
     use anyhow::Result;
 
-    use super::{git_dir, read_line};
+    use super::{BINARY, git_dir, read_line};
+
+    #[test]
+    fn cached_binary_name_uses_the_target_executable_suffix() {
+        assert_eq!(BINARY, format!("xtask{}", std::env::consts::EXE_SUFFIX));
+    }
 
     #[test]
     fn linked_worktree_git_dir_is_resolved_without_git() -> Result<()> {

--- a/xtask/src/self_cache/layout.rs
+++ b/xtask/src/self_cache/layout.rs
@@ -257,12 +257,7 @@ mod tests {
 
     use anyhow::Result;
 
-    use super::{BINARY, git_dir, read_line};
-
-    #[test]
-    fn cached_binary_name_uses_the_target_executable_suffix() {
-        assert_eq!(BINARY, format!("xtask{}", std::env::consts::EXE_SUFFIX));
-    }
+    use super::{git_dir, read_line};
 
     #[test]
     fn linked_worktree_git_dir_is_resolved_without_git() -> Result<()> {

--- a/xtask/src/self_cache/publish.rs
+++ b/xtask/src/self_cache/publish.rs
@@ -18,9 +18,6 @@ use super::{
 const RESERVATION_ATTEMPTS: usize = 1_000;
 
 fn publish(root: &Path, source: &Path, manifest: &CacheManifest) -> Result<PathBuf> {
-    if !cfg!(unix) {
-        bail!("xtask self-cache publication requires a Unix host");
-    }
     publish_with_activation(root, source, manifest, activate)
 }
 
@@ -40,6 +37,8 @@ where
     let cache = layout::cache_dir(root)?;
     fs::create_dir_all(&cache)
         .with_context(|| format!("create self-cache directory {}", cache.display()))?;
+    // std has no Windows directory-entry sync equivalent; file syncs still run on every host.
+    #[cfg(unix)]
     sync_directory(
         cache
             .parent()
@@ -83,6 +82,7 @@ where
         format!("{}\n", manifest.source_stamp).as_bytes(),
     )?;
     write_new(&temporary.join(LEASE_FILE), b"")?;
+    #[cfg(unix)]
     sync_directory(temporary)?;
     fs::rename(temporary, generation).with_context(|| {
         format!(
@@ -91,6 +91,7 @@ where
             generation.display()
         )
     })?;
+    #[cfg(unix)]
     sync_directory(
         generation
             .parent()
@@ -153,15 +154,17 @@ fn activate(root: &Path, generation: &Path, suffix: &str) -> Result<()> {
     let locator = layout::locator(root);
     let temporary = locator.with_file_name(format!(".xtask-cache.{suffix}"));
     let body = format!("{}\n", generation.display());
-    let result = (|| {
+    let result = (|| -> Result<()> {
         write_new(&temporary, body.as_bytes())?;
         fs::rename(&temporary, &locator)
             .with_context(|| format!("activate self-cache locator {}", locator.display()))?;
+        #[cfg(unix)]
         sync_directory(
             locator
                 .parent()
                 .context("self-cache locator has no parent")?,
-        )
+        )?;
+        Ok(())
     })();
     if result.is_err() {
         let _ = fs::remove_file(&temporary);
@@ -213,6 +216,7 @@ fn copy_executable(source: &Path, target: &Path) -> Result<()> {
     Ok(())
 }
 
+#[cfg(unix)]
 fn sync_directory(path: &Path) -> Result<()> {
     fs::File::open(path)
         .with_context(|| format!("open self-cache directory {}", path.display()))?
@@ -346,9 +350,10 @@ generation_grace_secs = 3600
         let source = root.join("source");
         fs::write(&source, b"binary")?;
 
-        publish(&root, &source, &manifest)?;
+        let published = publish(&root, &source, &manifest)?;
         let generation = layout::active(&root)?;
 
+        assert_eq!(published, generation.binary);
         assert_eq!(fs::read(generation.binary)?, b"binary");
         assert_eq!(generation.manifest.source_stamp, manifest.source_stamp);
         Ok(())

--- a/xtask/tests/self_cache_runner.rs
+++ b/xtask/tests/self_cache_runner.rs
@@ -405,6 +405,30 @@ fn cached_just_transport_preserves_arguments_stdin_and_exit_codes() -> Result<()
 }
 
 #[test]
+fn drive_rooted_windows_transport_uses_the_executable_suffix() -> Result<()> {
+    let fixture = Fixture::new()?;
+    fixture.install_fake_transport()?;
+    write_executable(
+        &fixture.fake_bin.join("uname"),
+        "#!/bin/sh\nset -eu\nprintf 'MINGW64_NT-10.0\\n'\n",
+    )?;
+    let original = fixture.root.join(".git/xtask-cache/generation-fake");
+    let generation = fixture.root.join(r"C:\cache\generation-fake");
+    fs::rename(original, &generation)?;
+    fs::rename(generation.join("xtask"), generation.join("xtask.exe"))?;
+    fs::write(
+        fixture.root.join("xtask/.xtask-cache"),
+        "C:\\cache\\generation-fake\n",
+    )?;
+
+    let output = fixture.transport(&fixture.root)?;
+
+    assert_success(&output);
+    fixture.assert_no_tool_process();
+    Ok(())
+}
+
+#[test]
 fn optional_transport_fails_open_before_policy_starts() -> Result<()> {
     let fixture = Fixture::new()?;
 


### PR DESCRIPTION
## What

The daily cleanup timer has failed on every fire since it was installed:

```
kithara-ci[1154554]: Error: reading CI pins .config/ci-pins.toml
Caused by: No such file or directory (os error 2)
```

It resolved the build pins by their repository-relative path, and systemd starts it from no particular directory. The unit beside it that copies this executable out of the build tree already says why in a comment — a service starting from nowhere cannot find the repository around it — and this one asked for a file inside it anyway.

## Why it was also the wrong question

The pins move with the repository; the images move when someone runs `install-services`. Between a bump and an install, the pinned generation is one the machine has never run — and cleanup would have named the fleet's own image superseded and removed it out from under the running services.

So `install-services` now names the images in the cleanup unit it writes, the way it already names them in the units the runners start from. Both are renderings of one act, so they cannot drift. `cleanup` takes that list and refuses an empty one: every project image is superseded by an empty list, and this is the one caller whose mistakes are unattended.

Toolchain images join the runner images built from them. A runner image kept without its base rebuilds from scratch; a base kept without its runner is the image the fleet starts from, deleted.

## Cost of the outage

On the Linux host right now:

| | |
|---|---|
| Project image generations kept | 3 (`20260806d`, `20260807a`, `20260807b`) |
| Images reclaimable | 202 GB of 219 GB (92%) |
| Build cache reclaimable | 28.81 GB, none active |

## Validation

- `cargo clippy -p xtask --all-targets -- -D warnings` — clean
- `cargo test -p xtask --bin xtask ci::linux` — 24 passed
- `just fmt check` — exit 0
- `just lint fast` — 0 deny, 0 warn, 0 regressions

Five new tests, three of which fail against the previous behaviour:

- the cleanup unit's `ExecStart` is a command this executable accepts
- the cleanup unit names every image the fleet runs
- a generation the fleet no longer runs is superseded
- a lane on an older tag than the others keeps its image
- an image the fleet runs survives a pin it has not been given

The keep-list this produces on the live host was checked against what the installed units actually reference: identical.

Infrastructure-only change; no product code touched.