### PR TITLE
fix(xtask): let the self-cache read only the section it owns

### DIFF
--- a/justfile
+++ b/justfile
@@ -33,16 +33,7 @@ _xtask-refresh:
 [no-exit-message]
 [private]
 _xtask-ready:
-    @if ! just _xtask-cached strict self-cache probe </dev/null >/dev/null 2>&1; then exec just _xtask-bootstrap </dev/null >/dev/null; fi; \
-      if state=$(just _xtask-cached strict self-cache status </dev/null); then \
-        case "$state" in \
-          current) exit 0 ;; \
-          stale) if just _xtask-cached strict self-cache refresh </dev/null >/dev/null; then exit 0; fi ;; \
-          *) printf 'error: invalid xtask cache status: %s\n' "$state" >&2; exit 1 ;; \
-        esac; \
-      fi; \
-      printf 'warning: cached xtask self-cache maintenance failed; rebuilding from source\n' >&2; \
-      exec just _xtask-bootstrap --force </dev/null >/dev/null
+    @if ! just _xtask-cached strict self-cache probe </dev/null >/dev/null 2>&1; then exec just _xtask-bootstrap </dev/null >/dev/null; fi; state=$(just _xtask-cached strict self-cache status </dev/null) || exit $?; case "$state" in current) ;; stale) exec just _xtask-cached strict self-cache refresh </dev/null >/dev/null ;; *) printf 'error: invalid xtask cache status: %s\n' "$state" >&2; exit 1 ;; esac
 
 [no-exit-message]
 [positional-arguments]

--- a/justfile
+++ b/justfile
@@ -25,12 +25,24 @@ _xtask *ARGS: _xtask-ready
 
 [no-exit-message]
 _xtask-refresh:
-    @if just _xtask-cached strict self-cache probe </dev/null >/dev/null 2>&1; then exec just _xtask-cached strict self-cache refresh --force </dev/null; fi; exec just _xtask-bootstrap --force </dev/null
+    @if just _xtask-cached strict self-cache probe </dev/null >/dev/null 2>&1; then \
+      if just _xtask-cached strict self-cache refresh --force </dev/null; then exit 0; fi; \
+      printf 'warning: cached xtask self-cache maintenance failed; rebuilding from source\n' >&2; \
+    fi; exec just _xtask-bootstrap --force </dev/null
 
 [no-exit-message]
 [private]
 _xtask-ready:
-    @if ! just _xtask-cached strict self-cache probe </dev/null >/dev/null 2>&1; then exec just _xtask-bootstrap </dev/null >/dev/null; fi; state=$(just _xtask-cached strict self-cache status </dev/null) || exit $?; case "$state" in current) ;; stale) exec just _xtask-cached strict self-cache refresh </dev/null >/dev/null ;; *) printf 'error: invalid xtask cache status: %s\n' "$state" >&2; exit 1 ;; esac
+    @if ! just _xtask-cached strict self-cache probe </dev/null >/dev/null 2>&1; then exec just _xtask-bootstrap </dev/null >/dev/null; fi; \
+      if state=$(just _xtask-cached strict self-cache status </dev/null); then \
+        case "$state" in \
+          current) exit 0 ;; \
+          stale) if just _xtask-cached strict self-cache refresh </dev/null >/dev/null; then exit 0; fi ;; \
+          *) printf 'error: invalid xtask cache status: %s\n' "$state" >&2; exit 1 ;; \
+        esac; \
+      fi; \
+      printf 'warning: cached xtask self-cache maintenance failed; rebuilding from source\n' >&2; \
+      exec just _xtask-bootstrap --force </dev/null >/dev/null
 
 [no-exit-message]
 [positional-arguments]

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -15,8 +15,11 @@ just tooling xtask <subcommand> [args...]
 All higher-level Just recipes that need xtask delegate to this entry point. It
 uses a worktree-local self-cache: a warm invocation runs an immutable cached
 binary directly, a stale invocation refreshes it once, and a missing cache uses
-Cargo for the cold bootstrap. Force a rebuild after an undeclared environment
-change with `just tooling refresh`.
+Cargo for the cold bootstrap. A cached generation whose own probe, status, or
+refresh exits nonzero (for example, a binary older than the current
+`.config/xtask.toml` schema) is unusable for cache maintenance, so the
+transport rebuilds it through the same Cargo bootstrap automatically. Force a
+rebuild after an undeclared environment change with `just tooling refresh`.
 
 The ignored `xtask/.xtask-cache` file locates the active generation owned by
 the concrete worktree. Cached commands do not use another worktree's binary or

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -15,11 +15,16 @@ just tooling xtask <subcommand> [args...]
 All higher-level Just recipes that need xtask delegate to this entry point. It
 uses a worktree-local self-cache: a warm invocation runs an immutable cached
 binary directly, a stale invocation refreshes it once, and a missing cache uses
-Cargo for the cold bootstrap. A cached generation whose own probe, status, or
-refresh exits nonzero (for example, a binary older than the current
-`.config/xtask.toml` schema) is unusable for cache maintenance, so the
-transport rebuilds it through the same Cargo bootstrap automatically. Force a
-rebuild after an undeclared environment change with `just tooling refresh`.
+Cargo for the cold bootstrap. Force a rebuild after an undeclared environment
+change with `just tooling refresh`.
+
+Self-cache commands read `[ext.xtask.cache]` and ignore the rest of
+`.config/xtask.toml`. A cached binary therefore keeps reporting its own
+freshness after the project schema gains a field that binary predates: the
+sources that carry the new field are part of the cache inputs, so the
+generation reports stale and refreshes itself. Reading the whole schema would
+make that generation fail before it could say so, leaving the refresh path
+unreachable.
 
 The ignored `xtask/.xtask-cache` file locates the active generation owned by
 the concrete worktree. Cached commands do not use another worktree's binary or

--- a/xtask/src/config.rs
+++ b/xtask/src/config.rs
@@ -16,7 +16,6 @@ pub(crate) struct KitharaExt {
     pub(crate) ci: CiProjectConfig,
     pub(crate) release: ReleaseConfig,
     pub(crate) publish: PublishConfig,
-    xtask: Option<XtaskConfig>,
     agent_hook: Option<AgentHookConfig>,
 }
 
@@ -57,16 +56,6 @@ impl KitharaExt {
             .context("parse project config [ext]")
     }
 
-    pub(crate) fn xtask_cache(&self) -> Result<&XtaskCacheConfig> {
-        let config = self
-            .xtask
-            .as_ref()
-            .and_then(|xtask| xtask.cache.as_ref())
-            .context("ext.xtask.cache is not set in .config/xtask.toml")?;
-        config.validate()?;
-        Ok(config)
-    }
-
     pub(crate) fn agent_hook(&self) -> Result<&AgentHookConfig> {
         let config = self
             .agent_hook
@@ -83,6 +72,22 @@ struct XtaskConfig {
     cache: Option<XtaskCacheConfig>,
 }
 
+/// The self-cache view of `.config/xtask.toml`: `ext.xtask.cache` and nothing
+/// else. A cached binary must stay able to report its own freshness across a
+/// schema change in a section it does not own, or the generation that predates
+/// the change can never be refreshed.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct CacheDocument {
+    ext: CacheExt,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct CacheExt {
+    xtask: XtaskConfig,
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct XtaskCacheConfig {
@@ -92,6 +97,21 @@ pub(crate) struct XtaskCacheConfig {
 }
 
 impl XtaskCacheConfig {
+    pub(crate) fn load(root: &Path) -> Result<Self> {
+        let path = root.join(".config/xtask.toml");
+        let text = std::fs::read_to_string(&path)
+            .with_context(|| format!("read project config {}", path.display()))?;
+        let document: CacheDocument = toml::from_str(&text)
+            .with_context(|| format!("parse project config {}", path.display()))?;
+        let config = document
+            .ext
+            .xtask
+            .cache
+            .context("ext.xtask.cache is not set in .config/xtask.toml")?;
+        config.validate()?;
+        Ok(config)
+    }
+
     fn validate(&self) -> Result<()> {
         if self.keep_generations < 2 {
             bail!("ext.xtask.cache.keep_generations must be at least 2");
@@ -335,8 +355,17 @@ mod tests {
     use std::path::PathBuf;
 
     use kithara_devtools::Ctx;
+    use tempfile::TempDir;
 
-    use super::KitharaExt;
+    use super::{KitharaExt, XtaskCacheConfig};
+
+    fn config_root(body: &str) -> (TempDir, PathBuf) {
+        let temp = tempfile::tempdir().expect("create fixture root");
+        let root = temp.path().to_path_buf();
+        std::fs::create_dir_all(root.join(".config")).expect("create config dir");
+        std::fs::write(root.join(".config/xtask.toml"), body).expect("write project config");
+        (temp, root)
+    }
 
     fn ctx_from_config(text: &str) -> Ctx {
         Ctx::new(
@@ -463,14 +492,9 @@ typo = true
     }
 
     #[test]
-    fn self_cache_and_hook_sections_are_required_and_typed() {
+    fn hook_section_is_required_and_typed() {
         let ctx = ctx_from_config(
             r#"
-[ext.xtask.cache]
-extra_inputs = ["justfile"]
-keep_generations = 2
-generation_grace_secs = 3600
-
 [ext.agent_hook]
 destructive_git_override_env = "KITHARA_AGENT_ALLOW_DESTRUCTIVE_GIT"
 
@@ -482,21 +506,16 @@ handler = "command-guard"
         );
 
         let ext = KitharaExt::from_ctx(&ctx).expect("parse kithara extension");
-        let cache = ext.xtask_cache().expect("resolve xtask cache config");
         let hook = ext.agent_hook().expect("resolve agent hook config");
 
-        assert_eq!(cache.keep_generations, 2);
-        assert_eq!(cache.generation_grace_secs, 3600);
-        assert_eq!(cache.extra_inputs, [PathBuf::from("justfile")]);
         assert_eq!(hook.routes.len(), 1);
     }
 
     #[test]
-    fn missing_self_cache_and_hook_sections_fail_resolution() {
+    fn missing_hook_section_fails_resolution() {
         let ctx = ctx_from_config("");
         let ext = KitharaExt::from_ctx(&ctx).expect("parse empty extension");
 
-        assert!(ext.xtask_cache().is_err());
         assert!(ext.agent_hook().is_err());
     }
 
@@ -523,8 +542,49 @@ handler = "command-guard"
     }
 
     #[test]
+    fn cache_policy_loads_across_schema_drift_it_does_not_own() {
+        let (_temp, root) = config_root(
+            r#"
+[ext.xtask.cache]
+extra_inputs = ["justfile"]
+keep_generations = 2
+generation_grace_secs = 3600
+
+[ext.apple]
+default_simulator = "iPhone 17 Pro Max"
+field_from_a_later_schema = true
+
+[[health.feature_invariants]]
+when_feature = "resample"
+always = ["kithara/resample-glide"]
+"#,
+        );
+
+        let config = XtaskCacheConfig::load(&root).expect("load cache policy");
+
+        assert_eq!(config.keep_generations, 2);
+        assert_eq!(config.extra_inputs, [PathBuf::from("justfile")]);
+    }
+
+    #[test]
+    fn unparsable_project_config_is_a_parse_error() {
+        let (_temp, root) = config_root("this is not valid TOML\n");
+
+        let error = XtaskCacheConfig::load(&root).expect_err("invalid TOML fails");
+
+        assert!(format!("{error:#}").contains("parse"));
+    }
+
+    #[test]
+    fn missing_self_cache_section_fails_resolution() {
+        let (_temp, root) = config_root("[project]\nname = \"fixture\"\n");
+
+        assert!(XtaskCacheConfig::load(&root).is_err());
+    }
+
+    #[test]
     fn owned_self_cache_section_rejects_unknown_fields() {
-        let ctx = ctx_from_config(
+        let (_temp, root) = config_root(
             r#"
 [ext.xtask.cache]
 extra_inputs = []
@@ -534,7 +594,7 @@ typo = true
 "#,
         );
 
-        let error = KitharaExt::from_ctx(&ctx).expect_err("cache typo fails");
+        let error = XtaskCacheConfig::load(&root).expect_err("cache typo fails");
 
         assert!(format!("{error:#}").contains("typo"));
     }

--- a/xtask/src/self_cache/command.rs
+++ b/xtask/src/self_cache/command.rs
@@ -37,7 +37,7 @@ use super::{
     manifest::{CacheManifest, Freshness},
     publish,
 };
-use crate::config::{KitharaExt, XtaskCacheConfig};
+use crate::config::XtaskCacheConfig;
 
 struct Consts;
 
@@ -98,9 +98,8 @@ fn probe() -> Result<()> {
 
 fn status(root: &Path) -> Result<()> {
     let generation = layout::current()?.context("xtask is not running from a cache generation")?;
-    let config = KitharaExt::load(root)?;
-    let config = config.xtask_cache()?;
-    let freshness = generation.manifest.freshness(root, config)?;
+    let config = XtaskCacheConfig::load(root)?;
+    let freshness = generation.manifest.freshness(root, &config)?;
     if let Err(error) = lease::cleanup(
         root,
         &generation.path,
@@ -117,9 +116,8 @@ fn status(root: &Path) -> Result<()> {
 }
 
 fn refresh(root: &Path, force: bool) -> Result<()> {
-    let config = KitharaExt::load(root)?;
-    let config = config.xtask_cache()?;
-    refresh_with(root, config, force, || rebuild(root, config))
+    let config = XtaskCacheConfig::load(root)?;
+    refresh_with(root, &config, force, || rebuild(root, &config))
 }
 
 fn refresh_with<F>(root: &Path, config: &XtaskCacheConfig, force: bool, build: F) -> Result<()>
@@ -144,20 +142,19 @@ where
 }
 
 fn bootstrap(root: &Path, force: bool) -> Result<()> {
-    let config = KitharaExt::load(root)?;
-    let config = config.xtask_cache()?;
+    let config = XtaskCacheConfig::load(root)?;
     let observed = layout::locator_snapshot(root)?;
     let _lock = lease::refresh(root)?;
     let another_bootstrap_published = layout::locator_snapshot(root)? != observed;
     if (!force || another_bootstrap_published)
-        && active_is_current(root, config)
+        && active_is_current(root, &config)
         && active_is_runnable(root)
     {
         return Ok(());
     }
-    rebuild(root, config)?;
+    rebuild(root, &config)?;
     ensure!(
-        active_is_current(root, config) && active_is_runnable(root),
+        active_is_current(root, &config) && active_is_runnable(root),
         "xtask self-cache bootstrap did not publish a runnable current generation"
     );
     Ok(())

--- a/xtask/src/self_cache/manifest.rs
+++ b/xtask/src/self_cache/manifest.rs
@@ -442,7 +442,7 @@ mod tests {
     use anyhow::Result;
 
     use super::{CacheManifest, Freshness};
-    use crate::config::{KitharaExt, XtaskCacheConfig};
+    use crate::config::XtaskCacheConfig;
 
     fn fixture() -> Result<(tempfile::TempDir, PathBuf, XtaskCacheConfig)> {
         let temp = tempfile::tempdir()?;
@@ -522,12 +522,9 @@ tool_kind = "file-edit"
 handler = "format-edited-paths"
 "#,
         )?;
-        let loaded = KitharaExt::load(&root)?;
+        let loaded = XtaskCacheConfig::load(&root)?;
 
-        assert_eq!(
-            manifest.freshness(&root, loaded.xtask_cache()?)?,
-            Freshness::Current
-        );
+        assert_eq!(manifest.freshness(&root, &loaded)?, Freshness::Current);
         Ok(())
     }
 

--- a/xtask/tests/self_cache_runner.rs
+++ b/xtask/tests/self_cache_runner.rs
@@ -453,6 +453,27 @@ fn source_changes_stale_but_hook_routes_do_not() -> Result<()> {
 }
 
 #[test]
+fn foreign_schema_drift_does_not_wedge_the_cached_transport() -> Result<()> {
+    let fixture = Fixture::new()?;
+    assert_success(&fixture.bootstrap()?);
+    let config = fixture.root.join(".config/xtask.toml");
+    let drifted = format!(
+        "{}\n[ext.apple]\nfield_from_a_later_schema = true\n",
+        fs::read_to_string(&config)?
+    );
+    fs::write(&config, drifted)?;
+
+    let status = fixture.cached(&["self-cache", "status"])?;
+    assert_success(&status);
+    assert_eq!(status.stdout, b"current\n");
+
+    let warm = fixture.just(&fixture.root, &["tooling", "xtask", "--help"], None)?;
+    assert_success(&warm);
+    fixture.assert_no_tool_process();
+    Ok(())
+}
+
+#[test]
 fn linked_worktrees_publish_distinct_caches() -> Result<()> {
     let common = tempfile::tempdir()?;
     let first = Fixture::new()?;


### PR DESCRIPTION
## Summary
Adding a field to `.config/xtask.toml` could wedge every Just recipe in a worktree until someone ran the private bootstrap recipe by hand. `#148` added `[[health.feature_invariants]]`, and from then on `just fmt` and `just lint` in a worktree holding an older cached xtask died with `unknown field feature_invariants` — including the refresh path meant to fix exactly that.

The cache was already right about being stale: the sources carrying the new field are cache inputs, so the generation should have refreshed itself. It never got the chance. Self-cache commands own `[ext.xtask.cache]` and nothing else, but they reached that section through the whole-project loader, where every sibling section denies unknown fields. So `self-cache status` died on a section it does not own, before it could answer "stale" — and reporting stale is the only path that leads to a rebuild.

The self-cache now parses its own policy out of `.config/xtask.toml` and ignores sections it does not own. A generation that predates a schema change keeps answering for itself, reports stale, and refreshes; a config that does not parse at all still fails fast without paying for a Cargo build to report the same thing.

The first commit fixed this in the Just transport instead, by rebuilding whenever the cached binary failed to report its cache state. `public_status_errors_do_not_start_cargo` rejected it, correctly: that is a fallback over a boundary the code had already crossed. The second commit replaces it with the fix above and restores `_xtask-ready` to its fail-fast shape. `_xtask-refresh` keeps the fallback, since invoking Cargo is what that recipe is for — and it is what makes `just tooling refresh` able to recover a worktree whose cached binary predates this change.

## Behavior / scope
- contract or behavior: self-cache `status`, `refresh`, and `bootstrap` read `ext.xtask.cache` and ignore the rest of the project schema; `ext.xtask.cache` parsing moves from `KitharaExt` to `XtaskCacheConfig::load`; `just tooling refresh` falls back to the Cargo bootstrap when the cached binary cannot refresh itself.
- affected area: `xtask` self-cache and the Just transport. No product crate changes.

## Validation
- `cargo test -p xtask` — 192 tests, all green (`self_cache_runner` 14/14, including `public_status_errors_do_not_start_cargo`, which the first commit had turned red, and the new `foreign_schema_drift_does_not_wedge_the_cached_transport`).
- `cargo clippy -p xtask --all-targets` — clean; `cargo fmt -p xtask -- --check` — clean.
- End-to-end, forward: with a generation cached before the change, a field added to `HealthConfig` and to `[health]` makes `just fmt check` rebuild the cache and proceed. Cache status afterwards: `current`.
- End-to-end, current wedge: a generation built at `3a09f9f9` (pre-`#148` schema) still fails on `just fmt check` — no code shipped now changes what an older binary does — and `just tooling refresh` recovers it in one command.
- `just fmt check` / `just lint fast` do not pass on this branch: `tidy-json --indent 2 --check` fails on 128 files, which reproduces identically without these commits.

## Surface impact
- Public API: none
- Platform/runtime: changed: tooling surface (Just recipes `_xtask-ready`, `_xtask-refresh`; xtask self-cache)
- Perf-sensitive paths: none

## Risks / follow-ups
- Worktrees whose cached xtask predates this change are not healed by it and need one `just tooling refresh`; every generation built after it survives future schema drift on its own.
- `agent_hook` still resolves its config through the whole-project loader and stays exposed to the same class of drift. Left alone deliberately: it fails open in the transport and does not wedge a build.
