### PR TITLE
test: fail when a new kithara-encode dependency escapes the fixture fingerprint

### DIFF
--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -232,6 +232,9 @@ kithara = { workspace = true, features = ["android", "client-wreq"] }
 # unrelated dependency bump.
 toml = { workspace = true }
 
+[dev-dependencies]
+toml = { workspace = true }
+
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 criterion = { workspace = true }
 

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -10,6 +10,9 @@
 //! - a change to the encoding code or to an encoder crate's resolved version
 //!   yields a fresh namespace, so a stale cache can never serve outdated bytes.
 
+#[path = "src/encoder_crates.rs"]
+mod encoder_crates;
+
 use std::{
     collections::hash_map::DefaultHasher,
     fs,
@@ -17,6 +20,7 @@ use std::{
     path::Path,
 };
 
+use encoder_crates::ENCODERS;
 use toml::{Table, Value};
 
 /// Hash every `.rs` file under `dir` (path + contents) and register each for
@@ -39,11 +43,6 @@ fn hash_rs_tree(dir: &Path, hasher: &mut DefaultHasher) {
         }
     }
 }
-
-/// The crates whose resolved build determines an encoded byte. Read from the
-/// lockfile by name, so a version bump to any of them still lands in a fresh
-/// namespace.
-const ENCODERS: &[&str] = &["fdk-aac", "fdk-aac-sys", "ffmpeg-next", "ffmpeg-sys-next"];
 
 const LOCKFILE: &str = "../Cargo.lock";
 

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -20,8 +20,7 @@ use std::{
     path::Path,
 };
 
-use encoder_crates::ENCODERS;
-use toml::{Table, Value};
+use encoder_crates::Lockfile;
 
 /// Hash every `.rs` file under `dir` (path + contents) and register each for
 /// change-tracking so the fingerprint refreshes whenever encoding code changes.
@@ -46,48 +45,28 @@ fn hash_rs_tree(dir: &Path, hasher: &mut DefaultHasher) {
 
 const LOCKFILE: &str = "../Cargo.lock";
 
-/// Hash what the lockfile resolved for [`ENCODERS`], rather than the lockfile.
-///
-/// The whole file was hashed here before, on the reasoning that a dependency
-/// version determines the encoded bytes. Only these ones do: bumping an XML
-/// parser cannot change an AAC frame, but hashing the file said it could, so
-/// every unrelated dependency bump moved the namespace and left the suite with
-/// an empty cache — and a cold cache means per-test ffmpeg re-encodes, which
-/// blow the budgets of tests that assert against a deadline. That is the same
-/// failure the `src/native` narrowing above was written to stop; the lockfile
-/// was the remaining wide input.
 fn hash_encoder_versions(hasher: &mut DefaultHasher) {
     println!("cargo:rerun-if-changed={LOCKFILE}");
     let text = fs::read_to_string(LOCKFILE).expect("the workspace lockfile must be readable");
-    let lock: Table = text.parse().expect("the workspace lockfile must be TOML");
-    let packages = lock
-        .get("package")
-        .and_then(Value::as_array)
-        .expect("the workspace lockfile must list packages");
+    let lockfile = Lockfile::parse(&text).unwrap_or_else(|error| panic!("{LOCKFILE}: {error}"));
 
-    let mut resolved: Vec<String> = packages
-        .iter()
-        .filter_map(|package| {
-            let name = package.get("name").and_then(Value::as_str)?;
-            ENCODERS.contains(&name).then(|| {
-                let field = |key| package.get(key).and_then(Value::as_str).unwrap_or_default();
-                // The checksum pins the exact bytes the version resolves to,
-                // which a re-release under one version number would not.
-                format!("{name} {} {}", field("version"), field("checksum"))
-            })
-        })
-        .collect();
-    resolved.sort();
-
-    // A crate leaving the lock under a name listed here would silently stop
-    // being tracked, and an untracked encoder change is a cache serving bytes
-    // it should not. Fail the build instead.
-    assert_eq!(
-        resolved.len(),
-        ENCODERS.len(),
-        "{LOCKFILE} resolved {resolved:?} for {ENCODERS:?}; update ENCODERS to \
-         match the crates that encode fixtures"
+    // The list this hashes is hand-written, so it is guarded from both sides:
+    // `encoder_versions` fails when a listed crate stops resolving, and an
+    // unclassified new dependency of `kithara-encode` fails here — its version
+    // would otherwise never reach the fingerprint, leaving the cache free to
+    // serve bytes the previous encoder produced.
+    let unclassified = lockfile
+        .unclassified_encode_dependencies()
+        .unwrap_or_else(|error| panic!("{LOCKFILE}: {error}"));
+    assert!(
+        unclassified.is_empty(),
+        "{LOCKFILE}: unclassified kithara-encode dependencies: {unclassified:?}; add each crate \
+         to ENCODERS if it can change an encoded byte, otherwise to NON_ENCODING_DEPENDENCIES"
     );
+
+    let resolved = lockfile
+        .encoder_versions()
+        .unwrap_or_else(|error| panic!("{LOCKFILE}: {error}"));
     resolved.hash(hasher);
 }
 

--- a/tests/src/encoder_crates.rs
+++ b/tests/src/encoder_crates.rs
@@ -1,7 +1,5 @@
-#[cfg(test)]
 use std::collections::BTreeSet;
 
-#[cfg(test)]
 use toml::{Table, Value};
 
 /// The crates whose resolved build determines an encoded byte. Read from the
@@ -11,78 +9,127 @@ pub(crate) const ENCODERS: &[&str] = &["fdk-aac", "fdk-aac-sys", "ffmpeg-next", 
 
 // Keeping byte-neutral crates separate makes every addition an explicit
 // cache-invalidation decision.
-#[cfg(test)]
 pub(crate) const NON_ENCODING_DEPENDENCIES: &[&str] = &["tempfile", "thiserror", "tracing"];
 
-#[cfg(test)]
-fn package_for_dependency<'a>(packages: &'a [Value], dependency: &str) -> Option<&'a Value> {
-    let mut fields = dependency.split_whitespace();
-    let name = fields.next()?;
-    let version = fields.next();
-    let source = fields
-        .next()
-        .map(|source| source.trim_matches(&['(', ')'][..]));
-
-    packages.iter().find(|package| {
-        package.get("name").and_then(Value::as_str) == Some(name)
-            && version.is_none_or(|version| {
-                package.get("version").and_then(Value::as_str) == Some(version)
-            })
-            && source
-                .is_none_or(|source| package.get("source").and_then(Value::as_str) == Some(source))
-    })
+pub(crate) struct Lockfile {
+    packages: Vec<Value>,
 }
 
-#[cfg(test)]
-pub(crate) fn unaccounted_direct_external_dependencies(
-    lockfile: &str,
-) -> Result<BTreeSet<String>, &'static str> {
-    let lock: Table = lockfile.parse().map_err(|_| "lockfile must be TOML")?;
-    let packages = lock
-        .get("package")
-        .and_then(Value::as_array)
-        .ok_or("lockfile must list packages")?;
-    let encoder = packages
-        .iter()
-        .find(|package| {
-            package.get("name").and_then(Value::as_str) == Some("kithara-encode")
-                && package.get("source").is_none()
+impl Lockfile {
+    pub(crate) fn parse(text: &str) -> Result<Self, String> {
+        let mut lock: Table = text
+            .parse()
+            .map_err(|_| "lockfile must be TOML".to_owned())?;
+        let Some(Value::Array(packages)) = lock.remove("package") else {
+            return Err("lockfile must list packages".to_owned());
+        };
+
+        Ok(Self { packages })
+    }
+
+    /// Return what the fingerprint hashes for [`ENCODERS`], rather than the
+    /// lockfile.
+    ///
+    /// The whole file was hashed here before, on the reasoning that a dependency
+    /// version determines the encoded bytes. Only these ones do: bumping an XML
+    /// parser cannot change an AAC frame, but hashing the file said it could, so
+    /// every unrelated dependency bump moved the namespace and left the suite with
+    /// an empty cache — and a cold cache means per-test ffmpeg re-encodes, which
+    /// blow the budgets of tests that assert against a deadline. That is the same
+    /// failure the `src/native` narrowing above was written to stop; the lockfile
+    /// was the remaining wide input.
+    pub(crate) fn encoder_versions(&self) -> Result<Vec<String>, String> {
+        let mut resolved: Vec<String> = self
+            .packages
+            .iter()
+            .filter_map(|package| {
+                let name = package.get("name").and_then(Value::as_str)?;
+                ENCODERS.contains(&name).then(|| {
+                    let field = |key| package.get(key).and_then(Value::as_str).unwrap_or_default();
+                    // The checksum pins the exact bytes the version resolves to,
+                    // which a re-release under one version number would not.
+                    format!("{name} {} {}", field("version"), field("checksum"))
+                })
+            })
+            .collect();
+        resolved.sort();
+
+        // A crate leaving the lock under a name listed here would silently stop
+        // being tracked, and an untracked encoder change is a cache serving bytes
+        // it should not. Fail the build instead.
+        if resolved.len() != ENCODERS.len() {
+            return Err(format!(
+                "resolved {resolved:?} for {ENCODERS:?}; update ENCODERS to match the crates that \
+                 encode fixtures"
+            ));
+        }
+
+        Ok(resolved)
+    }
+
+    pub(crate) fn unclassified_encode_dependencies(&self) -> Result<BTreeSet<String>, String> {
+        let encoder = self
+            .packages
+            .iter()
+            .find(|package| {
+                package.get("name").and_then(Value::as_str) == Some("kithara-encode")
+                    && package.get("source").is_none()
+            })
+            .ok_or_else(|| "lockfile must list the workspace kithara-encode package".to_owned())?;
+        let dependencies = encoder
+            .get("dependencies")
+            .and_then(Value::as_array)
+            .ok_or_else(|| "kithara-encode must list dependencies".to_owned())?;
+
+        dependencies
+            .iter()
+            .try_fold(BTreeSet::new(), |mut unclassified, dependency| {
+                let dependency = dependency
+                    .as_str()
+                    .ok_or_else(|| "package dependency must be a string".to_owned())?;
+                let package = self
+                    .package_for_dependency(dependency)
+                    .ok_or_else(|| "direct dependency must resolve to a package".to_owned())?;
+                let name = package
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| "package must have a name".to_owned())?;
+
+                if package.get("source").is_some()
+                    && !ENCODERS.contains(&name)
+                    && !NON_ENCODING_DEPENDENCIES.contains(&name)
+                {
+                    unclassified.insert(name.to_owned());
+                }
+
+                Ok(unclassified)
+            })
+    }
+
+    fn package_for_dependency(&self, dependency: &str) -> Option<&Value> {
+        let mut fields = dependency.split_whitespace();
+        let name = fields.next()?;
+        let version = fields.next();
+        let source = fields
+            .next()
+            .map(|source| source.trim_matches(&['(', ')'][..]));
+
+        self.packages.iter().find(|package| {
+            package.get("name").and_then(Value::as_str) == Some(name)
+                && version.is_none_or(|version| {
+                    package.get("version").and_then(Value::as_str) == Some(version)
+                })
+                && source.is_none_or(|source| {
+                    package.get("source").and_then(Value::as_str) == Some(source)
+                })
         })
-        .ok_or("lockfile must list the workspace kithara-encode package")?;
-    let dependencies = encoder
-        .get("dependencies")
-        .and_then(Value::as_array)
-        .ok_or("kithara-encode must list dependencies")?;
-
-    dependencies
-        .iter()
-        .try_fold(BTreeSet::new(), |mut unaccounted, dependency| {
-            let dependency = dependency
-                .as_str()
-                .ok_or("package dependency must be a string")?;
-            let package = package_for_dependency(packages, dependency)
-                .ok_or("direct dependency must resolve to a package")?;
-            let name = package
-                .get("name")
-                .and_then(Value::as_str)
-                .ok_or("package must have a name")?;
-
-            if package.get("source").is_some()
-                && !ENCODERS.contains(&name)
-                && !NON_ENCODING_DEPENDENCIES.contains(&name)
-            {
-                unaccounted.insert(name.to_owned());
-            }
-
-            Ok(unaccounted)
-        })
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{BTreeSet, unaccounted_direct_external_dependencies};
+    use super::{BTreeSet, Lockfile};
 
-    const WORKSPACE_LOCKFILE: &str = include_str!("../../Cargo.lock");
     const UNCLASSIFIED_DIRECT_DEPENDENCY: &str = r#"
 version = 4
 
@@ -127,22 +174,36 @@ name = "mp3lame-sys"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 "#;
+    const MISSING_ENCODER: &str = r#"
+version = 4
+
+[[package]]
+name = "fdk-aac"
+version = "0.8.0"
+checksum = "fdk-aac-checksum"
+
+[[package]]
+name = "fdk-aac-sys"
+version = "0.5.0"
+checksum = "fdk-aac-sys-checksum"
+
+[[package]]
+name = "ffmpeg-next"
+version = "8.1.0"
+checksum = "ffmpeg-next-checksum"
+"#;
 
     fn unaccounted(lockfile: &str) -> BTreeSet<String> {
-        unaccounted_direct_external_dependencies(lockfile)
+        Lockfile::parse(lockfile)
+            .and_then(|lockfile| lockfile.unclassified_encode_dependencies())
             .expect("test lockfile must describe kithara-encode dependencies")
     }
 
     #[test]
-    fn direct_external_dependencies_are_classified() {
-        let unaccounted = unaccounted(WORKSPACE_LOCKFILE);
+    fn encoder_versions_rejects_missing_encoder() {
+        let lockfile = Lockfile::parse(MISSING_ENCODER).expect("test lockfile must be TOML");
 
-        assert!(
-            unaccounted.is_empty(),
-            "unclassified direct external kithara-encode dependencies: {unaccounted:?}; add each \
-             crate to ENCODERS if it can change encoded bytes, otherwise to \
-             NON_ENCODING_DEPENDENCIES"
-        );
+        assert!(lockfile.encoder_versions().is_err());
     }
 
     #[test]

--- a/tests/src/encoder_crates.rs
+++ b/tests/src/encoder_crates.rs
@@ -1,0 +1,168 @@
+#[cfg(test)]
+use std::collections::BTreeSet;
+
+#[cfg(test)]
+use toml::{Table, Value};
+
+/// The crates whose resolved build determines an encoded byte. Read from the
+/// lockfile by name, so a version bump to any of them still lands in a fresh
+/// namespace.
+pub(crate) const ENCODERS: &[&str] = &["fdk-aac", "fdk-aac-sys", "ffmpeg-next", "ffmpeg-sys-next"];
+
+// Keeping byte-neutral crates separate makes every addition an explicit
+// cache-invalidation decision.
+#[cfg(test)]
+pub(crate) const NON_ENCODING_DEPENDENCIES: &[&str] = &["tempfile", "thiserror", "tracing"];
+
+#[cfg(test)]
+fn package_for_dependency<'a>(packages: &'a [Value], dependency: &str) -> Option<&'a Value> {
+    let mut fields = dependency.split_whitespace();
+    let name = fields.next()?;
+    let version = fields.next();
+    let source = fields
+        .next()
+        .map(|source| source.trim_matches(&['(', ')'][..]));
+
+    packages.iter().find(|package| {
+        package.get("name").and_then(Value::as_str) == Some(name)
+            && version.is_none_or(|version| {
+                package.get("version").and_then(Value::as_str) == Some(version)
+            })
+            && source
+                .is_none_or(|source| package.get("source").and_then(Value::as_str) == Some(source))
+    })
+}
+
+#[cfg(test)]
+pub(crate) fn unaccounted_direct_external_dependencies(
+    lockfile: &str,
+) -> Result<BTreeSet<String>, &'static str> {
+    let lock: Table = lockfile.parse().map_err(|_| "lockfile must be TOML")?;
+    let packages = lock
+        .get("package")
+        .and_then(Value::as_array)
+        .ok_or("lockfile must list packages")?;
+    let encoder = packages
+        .iter()
+        .find(|package| {
+            package.get("name").and_then(Value::as_str) == Some("kithara-encode")
+                && package.get("source").is_none()
+        })
+        .ok_or("lockfile must list the workspace kithara-encode package")?;
+    let dependencies = encoder
+        .get("dependencies")
+        .and_then(Value::as_array)
+        .ok_or("kithara-encode must list dependencies")?;
+
+    dependencies
+        .iter()
+        .try_fold(BTreeSet::new(), |mut unaccounted, dependency| {
+            let dependency = dependency
+                .as_str()
+                .ok_or("package dependency must be a string")?;
+            let package = package_for_dependency(packages, dependency)
+                .ok_or("direct dependency must resolve to a package")?;
+            let name = package
+                .get("name")
+                .and_then(Value::as_str)
+                .ok_or("package must have a name")?;
+
+            if package.get("source").is_some()
+                && !ENCODERS.contains(&name)
+                && !NON_ENCODING_DEPENDENCIES.contains(&name)
+            {
+                unaccounted.insert(name.to_owned());
+            }
+
+            Ok(unaccounted)
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BTreeSet, unaccounted_direct_external_dependencies};
+
+    const WORKSPACE_LOCKFILE: &str = include_str!("../../Cargo.lock");
+    const UNCLASSIFIED_DIRECT_DEPENDENCY: &str = r#"
+version = 4
+
+[[package]]
+name = "kithara-encode"
+version = "0.0.1"
+dependencies = ["mp3lame-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)"]
+
+[[package]]
+name = "mp3lame-sys"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+"#;
+    const CLASSIFIED_ENCODER_DEPENDENCY: &str = r#"
+version = 4
+
+[[package]]
+name = "kithara-encode"
+version = "0.0.1"
+dependencies = ["fdk-aac 0.7.0"]
+
+[[package]]
+name = "fdk-aac"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+"#;
+    const TRANSITIVE_DEPENDENCY_OF_LOCAL_PACKAGE: &str = r#"
+version = 4
+
+[[package]]
+name = "kithara-encode"
+version = "0.0.1"
+dependencies = ["kithara-workspace-hack"]
+
+[[package]]
+name = "kithara-workspace-hack"
+version = "0.0.0"
+dependencies = ["mp3lame-sys"]
+
+[[package]]
+name = "mp3lame-sys"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+"#;
+
+    fn unaccounted(lockfile: &str) -> BTreeSet<String> {
+        unaccounted_direct_external_dependencies(lockfile)
+            .expect("test lockfile must describe kithara-encode dependencies")
+    }
+
+    #[test]
+    fn direct_external_dependencies_are_classified() {
+        let unaccounted = unaccounted(WORKSPACE_LOCKFILE);
+
+        assert!(
+            unaccounted.is_empty(),
+            "unclassified direct external kithara-encode dependencies: {unaccounted:?}; add each \
+             crate to ENCODERS if it can change encoded bytes, otherwise to \
+             NON_ENCODING_DEPENDENCIES"
+        );
+    }
+
+    #[test]
+    fn unclassified_direct_external_dependency_is_reported() {
+        let unaccounted = unaccounted(UNCLASSIFIED_DIRECT_DEPENDENCY);
+
+        assert_eq!(unaccounted, BTreeSet::from(["mp3lame-sys".to_owned()]));
+    }
+
+    #[test]
+    fn classified_encoder_dependency_is_not_reported() {
+        let unaccounted = unaccounted(CLASSIFIED_ENCODER_DEPENDENCY);
+
+        assert!(unaccounted.is_empty());
+    }
+
+    #[test]
+    fn dependency_through_local_package_is_not_reported() {
+        let unaccounted = unaccounted(TRANSITIVE_DEPENDENCY_OF_LOCAL_PACKAGE);
+
+        assert!(unaccounted.is_empty());
+    }
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -33,6 +33,8 @@ pub mod e2e;
 pub mod encode_ext;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod encode_test_pcm;
+#[cfg(test)]
+pub(crate) mod encoder_crates;
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) mod fixture_cache;
 pub mod fixture_protocol;


### PR DESCRIPTION
## Summary

`KITHARA_FIXTURE_BUILD` namespaces the L2 cache of encoded fixtures. Since #151 it hashes the versions and checksums the lockfile resolved for a hand-written list, `ENCODERS`, instead of the whole lockfile — that is what stopped an unrelated dependency bump from emptying the cache.

That list was guarded in one direction only. `hash_encoder_versions` fails the build when a name in `ENCODERS` stops resolving, because an encoder that silently left the lock would be a cache serving bytes it should not. The opposite case was unguarded: a codec crate *added* to `kithara-encode` is absent from `ENCODERS`, its version never reaches the fingerprint, and the cache keeps handing out fixtures the previous encoder produced. The list is hand-written and nothing made anyone revisit it.

Both directions are now the same rule, asked at the same point. Every direct dependency of `kithara-encode` must be classified: either an encoder whose resolved version is hashed, or a crate that cannot change an encoded byte. Adding `mp3lame-sys` or `opus` tomorrow fails the build with the two options spelled out, instead of quietly serving stale bytes.

Local workspace members are skipped by the absence of `source` in the lock rather than by name. That is deliberate: `kithara-encode` depends on `kithara-workspace-hack`, and the hakari crate's dependency list is the whole workspace — matching on names would drag 395 unrelated packages into the encoder set.

The second commit removes a duplication this created. The check parsed `Cargo.lock` with its own code while `build.rs` parsed it with another, sharing only the `ENCODERS` constant; two readers of one file shape drift apart. `Lockfile` now owns the parse and answers both questions, `build.rs` does no TOML handling of its own, and the tests state their properties on synthetic lockfiles rather than re-deriving them from the real one. Nothing in the module is compiled only under `cfg(test)`.

## Behavior / scope

- contract or behavior: no runtime or product behavior changes. `KITHARA_FIXTURE_BUILD` is byte-identical before and after (`0a726cffd4b6d078`), so no cache is invalidated. A new unclassified dependency of `kithara-encode` now fails `cargo build` for this package.
- affected area: `tests/` build script and its lockfile handling.

## Validation

- `just test` — 4682 tests, 4681 passed. The one failure, `xtask::self_cache_runner killed_refresh_parent_does_not_leave_builder_descendants` (`supervised process did not exit`), passes in isolation in 3.86 s versus failing at 19.56 s under the suite — load-correlated by TESTING.md's own criterion, in xtask, untouched by this change, and already failing before it.
- `cargo test -p kithara-integration-tests --lib encoder_crates` — 4 passed
- `cargo clippy -p kithara-integration-tests --all-targets` — 0 errors
- fingerprint compared across the refactor: `0a726cffd4b6d078` both times
- `just lint fast` — passed via the pre-commit gate
- `just fmt`

## Surface impact

- Public API: none
- Platform/runtime: none
- Perf-sensitive paths: none

## Risks / follow-ups

- The check covers *direct* dependencies of `kithara-encode`, which is where a codec is added by hand. A new encoder arriving transitively (say, `ffmpeg-next` starting to pull one) is still untracked; catching that would mean widening the fingerprint to the transitive closure, which measures 107 of 920 lock packages and would put `serde` and `syn` bumps back in the cache-invalidating set — the cost #151 set out to remove.
- Overlaps #162 in `tests/build.rs` and `tests/Cargo.toml`; whichever lands second needs a trivial rebase.
