### PR TITLE
style,lint: name what the code was spelling out, and make two rules mean what they say

### DIFF
--- a/.config/ast-grep/idioms.match-self-conversion.yml
+++ b/.config/ast-grep/idioms.match-self-conversion.yml
@@ -63,5 +63,9 @@ constraints:
       # `Self` returns are already idiomatic; reference returns (`&T`,
       # `Option<&T>`, ...) provably cannot be a `From` impl, which consumes
       # `self` and returns an owned value, so they are accessors, not
-      # conversions. Excluding both keeps the rule on owned `self -> Other`.
-      regex: "Self|&"
+      # conversions. Excluding both keeps the rule on owned `self -> Other`. A
+      # bare `String` return is a `Display` impl, never `impl From<T> for
+      # String`; the sibling rule `rust.prefer-from-not-to-into` already
+      # excludes `^String$` on that ground and `rust.no-to-string-method` owns
+      # the class.
+      regex: "Self|&|^String$"

--- a/crates/kithara-app/src/gui/deck.rs
+++ b/crates/kithara-app/src/gui/deck.rs
@@ -1,4 +1,4 @@
-use kithara::abr::AbrMode;
+use kithara::{abr::AbrMode, events::AdvanceReason};
 use kithara_platform::sync::Arc;
 use kithara_queue::{TrackId, Transition};
 use tracing::{debug, error};
@@ -75,10 +75,9 @@ pub(crate) fn handle(deck: &mut DeckUi, msg: &DeckMsg) {
         DeckMsg::TogglePlayPause => toggle_play_pause(deck),
         DeckMsg::Pause => deck.controller.queue().pause(),
         DeckMsg::Next => {
-            deck.controller.queue().advance_to_next(
-                Transition::Crossfade,
-                kithara::events::AdvanceReason::UserNext,
-            );
+            deck.controller
+                .queue()
+                .advance_to_next(Transition::Crossfade, AdvanceReason::UserNext);
         }
         DeckMsg::Prev => {
             deck.controller

--- a/crates/kithara-app/src/state.rs
+++ b/crates/kithara-app/src/state.rs
@@ -1,6 +1,6 @@
 use kithara::{
     abr::AbrHandle,
-    events::{AbrMode, DjEvent, Event, MediaTime, PlayerEvent, SlotId, VariantInfo},
+    events::{AbrMode, BpmInfo, DjEvent, Event, MediaTime, PlayerEvent, SlotId, VariantInfo},
     play::StretchControls,
     prelude::EngineLoadSnapshot,
     stream::AudioCodec,
@@ -8,6 +8,7 @@ use kithara::{
 use kithara_platform::{
     CancelToken,
     sync::{Arc, Mutex},
+    time::Duration,
     tokio::task,
 };
 use kithara_queue::{Queue, QueueEvent, TrackEntry};
@@ -308,15 +309,15 @@ fn bpm_info_from_state(
     grid: &kithara::audio::BeatGrid,
     source_frames: u64,
     duration_secs: f64,
-) -> Option<kithara::events::BpmInfo> {
+) -> Option<BpmInfo> {
     let first_beat = *grid.beats().first()?;
     if source_frames == 0 || duration_secs <= 0.0 {
         return None;
     }
-    Some(kithara::events::BpmInfo::new(
+    Some(BpmInfo::new(
         grid.bpm(),
         None,
-        kithara_platform::time::Duration::from_secs_f64(
+        Duration::from_secs_f64(
             (u64_to_f64(first_beat) / u64_to_f64(source_frames)) * duration_secs,
         ),
     ))

--- a/crates/kithara-assets/src/decorator/lease/layer.rs
+++ b/crates/kithara-assets/src/decorator/lease/layer.rs
@@ -6,7 +6,7 @@ use std::{
     path::Path,
 };
 
-use dashmap::DashMap;
+use dashmap::{DashMap, mapref::entry::Entry};
 use kithara_events::{AssetEvent, EventBus};
 use kithara_platform::{CancelToken, sync::Arc};
 use kithara_storage::ResourceStatus;
@@ -121,7 +121,7 @@ where
         let next = AssetResourceState::from(status);
         let entry = self.live.entry(key.clone());
         match entry {
-            dashmap::mapref::entry::Entry::Occupied(mut occ) => {
+            Entry::Occupied(mut occ) => {
                 if let Some(existing) = occ.get().upgrade() {
                     let preserve_live = matches!(
                         existing.snapshot(),
@@ -140,7 +140,7 @@ where
                 occ.insert(Arc::downgrade(&live));
                 live
             }
-            dashmap::mapref::entry::Entry::Vacant(vac) => {
+            Entry::Vacant(vac) => {
                 let live = Arc::new(LiveResource::new(
                     key.clone(),
                     Arc::downgrade(&self.live),

--- a/crates/kithara-assets/src/index/availability/disk.rs
+++ b/crates/kithara-assets/src/index/availability/disk.rs
@@ -1,6 +1,6 @@
 #![forbid(unsafe_code)]
 
-use std::{collections::BTreeMap, fs, path::PathBuf, sync::OnceLock};
+use std::{collections::BTreeMap, fs::OpenOptions, path::PathBuf, sync::OnceLock};
 
 use dashmap::DashMap;
 use kithara_platform::{
@@ -142,7 +142,7 @@ impl InnerIndex {
             .collect();
         for path in queued {
             self.pending_durability.remove(&path);
-            let synced = fs::OpenOptions::new()
+            let synced = OpenOptions::new()
                 .write(true)
                 .open(&path)
                 .and_then(|file| file.sync_data());

--- a/crates/kithara-assets/src/index/lru/core.rs
+++ b/crates/kithara-assets/src/index/lru/core.rs
@@ -2,6 +2,8 @@
 
 #[cfg(not(target_arch = "wasm32"))]
 use std::collections::BTreeMap;
+#[cfg(target_arch = "wasm32")]
+use std::sync::atomic::Ordering;
 use std::{
     collections::{HashMap, HashSet},
     sync::{OnceLock, Weak, atomic::AtomicBool},
@@ -194,8 +196,7 @@ impl Flushable for LruInner {
 #[cfg(target_arch = "wasm32")]
 impl LruInner {
     fn flush_with_durability(&self, _durable: bool) -> AssetsResult<()> {
-        self.dirty
-            .store(false, std::sync::atomic::Ordering::Release);
+        self.dirty.store(false, Ordering::Release);
         Ok(())
     }
 }

--- a/crates/kithara-assets/src/index/pins/core.rs
+++ b/crates/kithara-assets/src/index/pins/core.rs
@@ -1,5 +1,7 @@
 #![forbid(unsafe_code)]
 
+#[cfg(target_arch = "wasm32")]
+use std::sync::atomic::Ordering;
 use std::{
     collections::HashSet,
     sync::{OnceLock, Weak, atomic::AtomicBool},
@@ -245,8 +247,7 @@ impl Flushable for PinsInner {
 #[cfg(target_arch = "wasm32")]
 impl PinsInner {
     fn flush_with_durability(&self, _durable: bool) -> AssetsResult<()> {
-        self.dirty
-            .store(false, std::sync::atomic::Ordering::Release);
+        self.dirty.store(false, Ordering::Release);
         Ok(())
     }
 }

--- a/crates/kithara-audio/src/analysis/analyzer/session.rs
+++ b/crates/kithara-audio/src/analysis/analyzer/session.rs
@@ -5,7 +5,10 @@ use kithara_resampler::ResamplerBackend;
 use num_traits::cast::AsPrimitive;
 
 use crate::{
-    analysis::slots::{beat, waveform},
+    analysis::slots::{
+        beat::{self, Slot},
+        waveform,
+    },
     waveform::{BeatGrid, bucket::Waveform},
 };
 
@@ -15,7 +18,7 @@ pub(crate) struct TrackAnalyzers<B>
 where
     B: ResamplerBackend,
 {
-    pub(super) beat: beat::Slot<B>,
+    pub(super) beat: Slot<B>,
     pub(super) waveform: waveform::Slot,
     #[field(get, vis = "pub(crate)")]
     pub(super) source_frames: u64,
@@ -29,7 +32,7 @@ where
     B: ResamplerBackend,
 {
     pub(crate) fn finish_beat(self, detector: Option<&mut beat::Detector>) -> Option<BeatGrid> {
-        beat::Slot::finish(self.beat, detector)
+        Slot::finish(self.beat, detector)
     }
 
     pub(crate) fn finish_waveform(&mut self) -> Option<Waveform> {
@@ -37,7 +40,7 @@ where
     }
 
     pub(crate) fn has_beat(&self) -> bool {
-        !beat::Slot::is_empty(&self.beat)
+        !Slot::is_empty(&self.beat)
     }
 
     pub(crate) fn push(&mut self, chunk: &PcmChunk, detector: Option<&mut beat::Detector>) {
@@ -45,6 +48,6 @@ where
         self.source_frames = self.source_frames.saturating_add(frames);
 
         waveform::push(&mut self.waveform, chunk);
-        beat::Slot::push(&mut self.beat, chunk, detector);
+        Slot::push(&mut self.beat, chunk, detector);
     }
 }

--- a/crates/kithara-audio/src/analysis/analyzer/set.rs
+++ b/crates/kithara-audio/src/analysis/analyzer/set.rs
@@ -3,14 +3,17 @@ use kithara_decode::PcmSpec;
 use kithara_resampler::ResamplerBackend;
 
 use super::{config::BeatAnalysisConfig, session::TrackAnalyzers};
-use crate::analysis::slots::{beat, waveform};
+use crate::analysis::slots::{
+    beat::{self, Config},
+    waveform,
+};
 
 #[derive(Default)]
 pub struct AnalyzerBuilder<B>
 where
     B: ResamplerBackend,
 {
-    beat: beat::Config<B>,
+    beat: Config<B>,
     waveform: waveform::Config,
     beat_config: Option<BeatAnalysisConfig<B>>,
     pcm_pool: PcmPool,
@@ -22,7 +25,7 @@ where
 {
     pub(crate) fn build(&self, spec: PcmSpec) -> TrackAnalyzers<B> {
         TrackAnalyzers {
-            beat: beat::Config::build(&self.beat, spec, &self.pcm_pool),
+            beat: Config::build(&self.beat, spec, &self.pcm_pool),
             waveform: waveform::build(&self.waveform, spec),
             source_frames: 0,
             source_sample_rate: spec.sample_rate,
@@ -31,11 +34,11 @@ where
 
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        waveform::config_is_empty(&self.waveform) && beat::Config::is_empty(&self.beat)
+        waveform::config_is_empty(&self.waveform) && Config::is_empty(&self.beat)
     }
 
     pub(crate) fn take_detector(&mut self) -> Option<beat::Detector> {
-        beat::Config::take_detector(&mut self.beat)
+        Config::take_detector(&mut self.beat)
     }
 
     #[must_use]
@@ -45,7 +48,7 @@ where
     {
         let mut builder = self;
         let beat_config = builder.beat_config.clone().unwrap_or_default();
-        beat::Config::with_default(&mut builder.beat, beat_config.clone());
+        Config::with_default(&mut builder.beat, beat_config.clone());
         builder.beat_config = Some(beat_config);
         builder
     }
@@ -54,7 +57,7 @@ where
     pub fn with_beat_config(self, config: BeatAnalysisConfig<B>) -> Self {
         let mut builder = self;
         builder.beat_config = Some(config.clone());
-        beat::Config::set_resampler(&mut builder.beat, config);
+        Config::set_resampler(&mut builder.beat, config);
         builder
     }
 

--- a/crates/kithara-audio/src/analysis/grid/core.rs
+++ b/crates/kithara-audio/src/analysis/grid/core.rs
@@ -7,42 +7,62 @@ use super::{
 };
 use crate::{analysis::beat::detector::RawBeats, waveform::BeatGrid};
 
+struct Consts;
+
+impl Consts {
+    const ALIGN_BARS: usize = 4;
+    const BEATS_PER_BAR: f64 = 4.0;
+    const MAX_BAR_RATIO: f64 = 2.0;
+    const MEDIAN_TRUST_RATIO: f64 = 0.10;
+    const MERGE_RATIO_EPS: f64 = 1e-3;
+    const MIN_BAR_RATIO: f64 = 0.5;
+    /// A bar gap needs two downbeats to measure.
+    const MIN_DOWNBEATS: usize = 2;
+    const MIN_GAP_RATIO: f64 = 0.7;
+    const MIN_LEAF_BARS: usize = 8;
+    const OUTLIER_RATIO: f64 = 0.04;
+    const OUTLIER_WINDOW: usize = 4;
+    const RESIDUAL_MS: f64 = 18.0;
+    const SECS_PER_MIN: f64 = 60.0;
+    const STABLE_WINDOW_BARS: usize = 16;
+}
+
 /// Grid-cleanup tuning.
 #[derive(Builder, Debug, Clone, PartialEq)]
 pub(crate) struct GridParams {
-    #[builder(default = 2.0)]
+    #[builder(default = Consts::MAX_BAR_RATIO)]
     pub(crate) max_bar_ratio: f64,
     /// Stable window median must lie within this fraction of nominal.
-    #[builder(default = 0.10)]
+    #[builder(default = Consts::MEDIAN_TRUST_RATIO)]
     pub(crate) median_trust_ratio: f64,
     /// Merge adjacent leaves whose ratio corrections agree within this
     /// epsilon — collinear halves around the anchor collapse to one segment.
-    #[builder(default = 1e-3)]
+    #[builder(default = Consts::MERGE_RATIO_EPS)]
     pub(crate) merge_ratio_eps: f64,
     /// Hard sanity bounds on a bar length, as fractions of the nominal bar.
-    #[builder(default = 0.5)]
+    #[builder(default = Consts::MIN_BAR_RATIO)]
     pub(crate) min_bar_ratio: f64,
     /// Drop a downbeat closer than this fraction of a nominal bar to its
     /// predecessor (double-detection filter).
-    #[builder(default = 0.7)]
+    #[builder(default = Consts::MIN_GAP_RATIO)]
     pub(crate) min_gap_ratio: f64,
     /// Outlier threshold vs the neighbour-window median bar factor.
-    #[builder(default = 0.04)]
+    #[builder(default = Consts::OUTLIER_RATIO)]
     pub(crate) outlier_ratio: f64,
     /// Bisection leaf fit tolerance: worst bar residual, milliseconds.
-    #[builder(default = 18.0)]
+    #[builder(default = Consts::RESIDUAL_MS)]
     pub(crate) residual_ms: f64,
     /// Snap bisection split points to multiples of this many bars.
-    #[builder(default = 4)]
+    #[builder(default = Consts::ALIGN_BARS)]
     pub(crate) align_bars: usize,
     /// Minimum segment length in bars.
-    #[builder(default = 8)]
+    #[builder(default = Consts::MIN_LEAF_BARS)]
     pub(crate) min_leaf_bars: usize,
     /// Neighbour median window (bars each side) for outlier classification.
-    #[builder(default = 4)]
+    #[builder(default = Consts::OUTLIER_WINDOW)]
     pub(crate) outlier_window: usize,
     /// Sliding window length (bars) for the stable-tempo anchor search.
-    #[builder(default = 16)]
+    #[builder(default = Consts::STABLE_WINDOW_BARS)]
     pub(crate) stable_window_bars: usize,
 }
 
@@ -66,7 +86,7 @@ pub(crate) fn build_grid(raw: &RawBeats, sample_rate: u32, params: &GridParams) 
         .filter(|p| p.is_finite() && *p >= 0.0)
         .collect();
     db.sort_by(f64::total_cmp);
-    if db.len() < 2 {
+    if db.len() < Consts::MIN_DOWNBEATS {
         return BeatGrid::new(0.0, beats, positions_to_frames(&db), Vec::new());
     }
 
@@ -114,7 +134,7 @@ fn positions_to_frames(positions: &[f64]) -> Vec<u64> {
 /// 4/4 bars: bpm = beats-per-bar (4) × 60 / bar-seconds.
 fn bar_to_bpm(bar_samples: f64, sr: f64) -> f64 {
     if bar_samples > 0.0 {
-        240.0 * sr / bar_samples
+        Consts::BEATS_PER_BAR * Consts::SECS_PER_MIN * sr / bar_samples
     } else {
         0.0
     }

--- a/crates/kithara-audio/src/analysis/grid/fit.rs
+++ b/crates/kithara-audio/src/analysis/grid/fit.rs
@@ -3,6 +3,16 @@ use num_traits::cast::{AsPrimitive, ToPrimitive};
 use super::core::GridParams;
 use crate::waveform::GridSegment;
 
+struct Consts;
+
+impl Consts {
+    /// A least-squares line needs two trusted points.
+    const MIN_FIT_POINTS: usize = 2;
+    const MS_PER_SEC: f64 = 1000.0;
+    /// A split has to leave two leaves of at least `min_leaf_bars`.
+    const SPLIT_HALVES: usize = 2;
+}
+
 pub(super) struct GridFitCtx<'a> {
     params: &'a GridParams,
     outliers: &'a [bool],
@@ -50,7 +60,7 @@ fn fit_segment(ctx: &GridFitCtx<'_>, segment: Segment) -> (f64, f64, f64) {
             (x, ctx.db[i])
         })
         .collect();
-    if points.len() < 2 {
+    if points.len() < Consts::MIN_FIT_POINTS {
         let span: f64 = (end - start).max(1).as_();
         return (ctx.db[start], (ctx.db[end] - ctx.db[start]) / span, 0.0);
     }
@@ -104,8 +114,10 @@ fn bisect_segment(ctx: &GridFitCtx<'_>, segment: Segment) -> Vec<usize> {
         return vec![start, end];
     }
     let (_, _, max_resid) = fit_segment(ctx, segment);
-    let resid_ms = max_resid / ctx.sample_rate * 1000.0;
-    if resid_ms < ctx.params.residual_ms || (end - start) < 2 * ctx.params.min_leaf_bars {
+    let resid_ms = max_resid / ctx.sample_rate * Consts::MS_PER_SEC;
+    if resid_ms < ctx.params.residual_ms
+        || (end - start) < Consts::SPLIT_HALVES * ctx.params.min_leaf_bars
+    {
         return vec![start, end];
     }
     let mid = aligned_mid(start, end, ctx.params.align_bars, ctx.params.min_leaf_bars);

--- a/crates/kithara-audio/src/audio/core.rs
+++ b/crates/kithara-audio/src/audio/core.rs
@@ -8,7 +8,9 @@ use kithara_bufpool::PcmPool;
 use kithara_decode::{PcmSpec, TrackMetadata};
 use kithara_events::EventBus;
 use kithara_platform::{CancelToken, sync::Arc, time::Duration};
-use kithara_stream::{DeferredWake, PlayheadWrite, SeekControl, SeekObserve, SeekPrepare};
+use kithara_stream::{
+    ChunkPosition, DeferredWake, PlayheadWrite, SeekControl, SeekObserve, SeekPrepare,
+};
 use portable_atomic::AtomicF32;
 
 use super::{
@@ -271,7 +273,7 @@ impl<S: kithara_platform::maybe_send::MaybeSend> PcmRead for Audio<S> {
         self.ring.promote_playing();
         self.session
             .playhead
-            .advance(&kithara_stream::ChunkPosition::from(&chunk.meta));
+            .advance(&ChunkPosition::from(&chunk.meta));
         Ok(ChunkOutcome::Chunk(chunk))
     }
 

--- a/crates/kithara-audio/src/audio/cursor.rs
+++ b/crates/kithara-audio/src/audio/cursor.rs
@@ -3,6 +3,7 @@ use std::num::NonZeroUsize;
 use fast_interleave::deinterleave_variable;
 use kithara_bufpool::{PcmBuf, PcmPool};
 use kithara_decode::{PcmChunk, PcmMeta, PcmSpec};
+use kithara_platform::time::Duration;
 use kithara_stream::{ChunkPosition, PlayheadWrite};
 use kithara_test_utils::kithara;
 
@@ -228,7 +229,7 @@ fn frames_to_samples(frames: u64, channels: u64) -> Result<usize, DecodeError> {
         .map_err(|_| DecodeError::SampleCountOverflow { frames, channels })
 }
 
-fn interpolated_position(meta: PcmMeta, consumed_frames: u64) -> kithara_platform::time::Duration {
+fn interpolated_position(meta: PcmMeta, consumed_frames: u64) -> Duration {
     let total_frames = u64::from(meta.frames).max(1);
     let start_ns = u64::try_from(meta.timestamp.as_nanos()).unwrap_or(u64::MAX);
     let end_ns = u64::try_from(meta.end_timestamp.as_nanos()).unwrap_or(u64::MAX);
@@ -236,7 +237,7 @@ fn interpolated_position(meta: PcmMeta, consumed_frames: u64) -> kithara_platfor
     let offset = span_ns * u128::from(consumed_frames) / u128::from(total_frames);
     let interpolated = u128::from(start_ns).saturating_add(offset);
     let nanos = u64::try_from(interpolated).unwrap_or(u64::MAX);
-    kithara_platform::time::Duration::from_nanos(nanos)
+    Duration::from_nanos(nanos)
 }
 
 fn channel_failed(failure: FailureSource) -> DecodeError {

--- a/crates/kithara-audio/src/audio/event.rs
+++ b/crates/kithara-audio/src/audio/event.rs
@@ -1,13 +1,17 @@
-use kithara_decode::{DecodeError, DecoderResamplerConfig, PcmMeta, PcmSpec};
+use kithara_decode::{
+    DecodeError, DecoderBackend as DecodeBackend, DecoderResamplerConfig, ErrorClass, PcmMeta,
+    PcmSpec,
+};
 use kithara_events::{
-    AudioCodecKind, AudioEvent, DecodeErrorClass, DecodeErrorKind,
+    AudioCodecKind, AudioEvent, ContainerKind, DecodeErrorClass, DecodeErrorKind,
     DecoderBackend as EventDecoderBackend, DecoderChangeCause, DecoderEvent, DeferredBus, Event,
     EventBus, FrameDomain, GaplessSpan, PlaybackResamplerKind, ResamplerKind, SeekLifecycleStage,
     SegmentLocation,
 };
 use kithara_platform::{sync::Arc, time::Duration};
 use kithara_resampler::ResamplerBackend;
-use kithara_stream::{MediaInfo, PlayheadWrite, SeekObserve};
+use kithara_stream::{AudioCodec, ContainerFormat, MediaInfo, PlayheadWrite, SeekObserve};
+use num_traits::cast::ToPrimitive;
 
 use super::{ReadOutcome, ThreadWake, WakeSignal};
 
@@ -176,49 +180,47 @@ impl WakeSignal for ReaderOutputWake {
 }
 
 fn clamp_millis(duration: Duration) -> u64 {
-    num_traits::cast::ToPrimitive::to_u64(&duration.as_millis()).unwrap_or(u64::MAX)
+    ToPrimitive::to_u64(&duration.as_millis()).unwrap_or(u64::MAX)
 }
 
-pub(crate) fn map_audio_codec_kind(codec: kithara_stream::AudioCodec) -> AudioCodecKind {
+pub(crate) fn map_audio_codec_kind(codec: AudioCodec) -> AudioCodecKind {
     match codec {
-        kithara_stream::AudioCodec::AacLc => AudioCodecKind::AacLc,
-        kithara_stream::AudioCodec::AacHe => AudioCodecKind::AacHe,
-        kithara_stream::AudioCodec::AacHeV2 => AudioCodecKind::AacHeV2,
-        kithara_stream::AudioCodec::Mp3 => AudioCodecKind::Mp3,
-        kithara_stream::AudioCodec::Flac => AudioCodecKind::Flac,
-        kithara_stream::AudioCodec::Vorbis => AudioCodecKind::Vorbis,
-        kithara_stream::AudioCodec::Opus => AudioCodecKind::Opus,
-        kithara_stream::AudioCodec::Alac => AudioCodecKind::Alac,
-        kithara_stream::AudioCodec::Pcm => AudioCodecKind::Pcm,
-        kithara_stream::AudioCodec::Adpcm => AudioCodecKind::Adpcm,
+        AudioCodec::AacLc => AudioCodecKind::AacLc,
+        AudioCodec::AacHe => AudioCodecKind::AacHe,
+        AudioCodec::AacHeV2 => AudioCodecKind::AacHeV2,
+        AudioCodec::Mp3 => AudioCodecKind::Mp3,
+        AudioCodec::Flac => AudioCodecKind::Flac,
+        AudioCodec::Vorbis => AudioCodecKind::Vorbis,
+        AudioCodec::Opus => AudioCodecKind::Opus,
+        AudioCodec::Alac => AudioCodecKind::Alac,
+        AudioCodec::Pcm => AudioCodecKind::Pcm,
+        AudioCodec::Adpcm => AudioCodecKind::Adpcm,
     }
 }
 
-pub(crate) fn map_container_kind(
-    container: kithara_stream::ContainerFormat,
-) -> kithara_events::ContainerKind {
+pub(crate) fn map_container_kind(container: ContainerFormat) -> ContainerKind {
     match container {
-        kithara_stream::ContainerFormat::Mp4 => kithara_events::ContainerKind::Mp4,
-        kithara_stream::ContainerFormat::Fmp4 => kithara_events::ContainerKind::Fmp4,
-        kithara_stream::ContainerFormat::MpegTs => kithara_events::ContainerKind::MpegTs,
-        kithara_stream::ContainerFormat::MpegAudio => kithara_events::ContainerKind::MpegAudio,
-        kithara_stream::ContainerFormat::Adts => kithara_events::ContainerKind::Adts,
-        kithara_stream::ContainerFormat::Flac => kithara_events::ContainerKind::Flac,
-        kithara_stream::ContainerFormat::Wav => kithara_events::ContainerKind::Wav,
-        kithara_stream::ContainerFormat::Ogg => kithara_events::ContainerKind::Ogg,
-        kithara_stream::ContainerFormat::Caf => kithara_events::ContainerKind::Caf,
-        kithara_stream::ContainerFormat::Mkv => kithara_events::ContainerKind::Mkv,
+        ContainerFormat::Mp4 => ContainerKind::Mp4,
+        ContainerFormat::Fmp4 => ContainerKind::Fmp4,
+        ContainerFormat::MpegTs => ContainerKind::MpegTs,
+        ContainerFormat::MpegAudio => ContainerKind::MpegAudio,
+        ContainerFormat::Adts => ContainerKind::Adts,
+        ContainerFormat::Flac => ContainerKind::Flac,
+        ContainerFormat::Wav => ContainerKind::Wav,
+        ContainerFormat::Ogg => ContainerKind::Ogg,
+        ContainerFormat::Caf => ContainerKind::Caf,
+        ContainerFormat::Mkv => ContainerKind::Mkv,
     }
 }
 
-pub(crate) fn map_decoder_backend(backend: kithara_decode::DecoderBackend) -> EventDecoderBackend {
+pub(crate) fn map_decoder_backend(backend: DecodeBackend) -> EventDecoderBackend {
     match backend {
         #[cfg(all(feature = "apple", any(target_os = "macos", target_os = "ios")))]
         kithara_decode::DecoderBackend::Apple => EventDecoderBackend::Apple,
         #[cfg(all(feature = "android", target_os = "android"))]
         kithara_decode::DecoderBackend::Android => EventDecoderBackend::Android,
         #[cfg(feature = "symphonia")]
-        kithara_decode::DecoderBackend::Symphonia => EventDecoderBackend::Symphonia,
+        DecodeBackend::Symphonia => EventDecoderBackend::Symphonia,
         _ => EventDecoderBackend::Symphonia,
     }
 }
@@ -258,10 +260,10 @@ pub(crate) fn map_decode_error_kind(error: &DecodeError) -> DecodeErrorKind {
     }
 }
 
-pub(crate) fn map_decode_error_class(class: kithara_decode::ErrorClass) -> DecodeErrorClass {
+pub(crate) fn map_decode_error_class(class: ErrorClass) -> DecodeErrorClass {
     match class {
-        kithara_decode::ErrorClass::Interrupted => DecodeErrorClass::Interrupted,
-        kithara_decode::ErrorClass::VariantChange => DecodeErrorClass::VariantChange,
+        ErrorClass::Interrupted => DecodeErrorClass::Interrupted,
+        ErrorClass::VariantChange => DecodeErrorClass::VariantChange,
         _ => DecodeErrorClass::Other,
     }
 }
@@ -293,7 +295,7 @@ fn gapless_span(track_info: &kithara_decode::DecoderTrackInfo) -> Option<Gapless
 #[derive(Clone, Copy)]
 pub(crate) struct DecoderChangedEventData<'a> {
     pub(crate) track_info: &'a kithara_decode::DecoderTrackInfo,
-    pub(crate) backend: kithara_decode::DecoderBackend,
+    pub(crate) backend: DecodeBackend,
     pub(crate) cause: DecoderChangeCause,
     pub(crate) duration: Option<Duration>,
     pub(crate) media_info: Option<&'a MediaInfo>,

--- a/crates/kithara-audio/src/audio/park.rs
+++ b/crates/kithara-audio/src/audio/park.rs
@@ -1,3 +1,5 @@
+#[cfg(not(target_arch = "wasm32"))]
+use kithara_platform::thread::park_timeout;
 use kithara_test_utils::kithara;
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -13,7 +15,7 @@ pub(super) fn receive_is_nonblocking(_preloaded: bool, _block_on_underrun: bool)
 #[cfg(not(target_arch = "wasm32"))]
 #[kithara::allow_block]
 pub(super) fn wait_for_fetch(timeout: kithara_platform::time::Duration) {
-    kithara_platform::thread::park_timeout(timeout);
+    park_timeout(timeout);
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/crates/kithara-audio/src/effects/eq/band.rs
+++ b/crates/kithara-audio/src/effects/eq/band.rs
@@ -6,6 +6,8 @@ struct Consts;
 impl Consts {
     const BAND_MAX_FREQ: f32 = 18000.0;
     const BAND_MIN_FREQ: f32 = 60.0;
+    /// Centre frequency a band starts at before the caller places it.
+    const DEFAULT_FREQ: f32 = 1000.0;
     const HIGH_SHELF_DISCRIMINANT: u8 = 2;
     const LOG_FREQ_BASE: f32 = 10.0;
     const Q_REFERENCE_BANDS: f32 = 10.0;
@@ -47,7 +49,7 @@ pub struct EqBandConfig {
     #[builder(default)]
     #[field(get(copy))]
     kind: FilterKind,
-    #[builder(default = 1000.0)]
+    #[builder(default = Consts::DEFAULT_FREQ)]
     frequency: f32,
     #[builder(default)]
     gain_db: f32,

--- a/crates/kithara-audio/src/effects/limiter.rs
+++ b/crates/kithara-audio/src/effects/limiter.rs
@@ -3,6 +3,10 @@ use core::num::{NonZeroU32, NonZeroUsize};
 use kithara_decode::sanitize_sample;
 use num_traits::ToPrimitive;
 
+/// Milliseconds per second: the release time arrives in ms, the coefficient
+/// is computed in samples.
+const MS_PER_SEC: f32 = 1000.0;
+
 /// Configuration rejected by [`PeakLimiter::new`].
 #[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
@@ -43,7 +47,7 @@ impl PeakLimiter {
             return Err(LimiterError::Release { release_ms });
         }
 
-        let samples = release_ms / 1000.0 * sample_rate.get().to_f32().unwrap_or(1.0);
+        let samples = release_ms / MS_PER_SEC * sample_rate.get().to_f32().unwrap_or(1.0);
         let release_coeff = (-1.0 / samples).exp();
 
         Ok(Self {

--- a/crates/kithara-audio/src/effects/timestretch/processor.rs
+++ b/crates/kithara-audio/src/effects/timestretch/processor.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+use std::collections::HashSet;
+
 use kithara_bufpool::PcmPool;
 use kithara_decode::{PcmChunk, PcmMeta, PcmSpec};
 use kithara_platform::sync::Arc;
@@ -495,7 +498,7 @@ mod tests {
         let mut fx = keylocked(StretchKind::default(), 0.5);
         let cf = 1024usize;
         let block = sine(cf);
-        let mut fed_ends = std::collections::HashSet::new();
+        let mut fed_ends = HashSet::new();
         let mut emitted = Vec::new();
         for i in 0..40u64 {
             let mut c = chunk(&block);

--- a/crates/kithara-audio/src/pipeline/blend/core.rs
+++ b/crates/kithara-audio/src/pipeline/blend/core.rs
@@ -5,6 +5,12 @@ struct Consts;
 impl Consts {
     const HISTORY_FRAMES: usize = 32;
     const JOIN_MICROS: u32 = 20_000;
+    /// A stable second-order recurrence has coefficient `2·cos θ`, so `|c| ≤ 2`.
+    const MAX_RECURRENCE_COEFF: f32 = 2.0;
+    const MICROS_PER_SEC: u32 = 1_000_000;
+    const MIN_JOIN_FRAMES: u16 = 2;
+    const MIN_JOIN_HISTORY: usize = 3;
+    const RECURRENCE_ORDER: usize = 2;
 }
 
 enum JoinState {
@@ -80,13 +86,20 @@ impl PcmBlender {
             return;
         }
         let channels = usize::from(chunk.spec().channels.max(1));
-        if chunk.samples.len() < channels.saturating_mul(2) {
+        if chunk.samples.len() < channels.saturating_mul(Consts::RECURRENCE_ORDER) {
             return;
         }
         for channel in 0..channels {
-            let coefficient = recurrence(&self.history, channels, channel, 2, self.history_frames)
-                .clamp(-2.0, 2.0);
-            let previous = self.history[(self.history_frames - 2) * channels + channel];
+            let coefficient = recurrence(
+                &self.history,
+                channels,
+                channel,
+                Consts::RECURRENCE_ORDER,
+                self.history_frames,
+            )
+            .clamp(-Consts::MAX_RECURRENCE_COEFF, Consts::MAX_RECURRENCE_COEFF);
+            let previous =
+                self.history[(self.history_frames - Consts::RECURRENCE_ORDER) * channels + channel];
             let current = self.history[(self.history_frames - 1) * channels + channel];
             let observed_bound = self
                 .history
@@ -115,15 +128,15 @@ impl PcmBlender {
                 .sample_rate
                 .get()
                 .saturating_mul(Consts::JOIN_MICROS)
-                .div_ceil(1_000_000),
+                .div_ceil(Consts::MICROS_PER_SEC),
         )
         .unwrap_or(u16::MAX)
-        .max(2);
+        .max(Consts::MIN_JOIN_FRAMES);
         self.join = JoinState::Active { frames, frame: 0 };
     }
 
     pub(crate) fn join_active(&mut self, active: BlenderProfile) {
-        if self.active.spec() == active.spec() && self.history_frames >= 3 {
+        if self.active.spec() == active.spec() && self.history_frames >= Consts::MIN_JOIN_HISTORY {
             self.active = active;
             self.join = JoinState::Pending;
         } else {
@@ -179,7 +192,7 @@ fn recurrence(history: &[f32], channels: usize, channel: usize, start: usize, en
     let mut numerator = 0.0;
     let mut denominator = 0.0;
     for frame in start..end {
-        let antecedent = history[(frame - 2) * channels + channel];
+        let antecedent = history[(frame - Consts::RECURRENCE_ORDER) * channels + channel];
         let previous = history[(frame - 1) * channels + channel];
         let current = history[frame * channels + channel];
         numerator = previous.mul_add(current + antecedent, numerator);
@@ -188,12 +201,12 @@ fn recurrence(history: &[f32], channels: usize, channel: usize, start: usize, en
     if denominator > f32::EPSILON {
         numerator / denominator
     } else {
-        2.0
+        Consts::MAX_RECURRENCE_COEFF
     }
 }
 
 fn recurrence_amplitude(previous: f32, current: f32, coefficient: f32) -> f32 {
-    let cosine = coefficient * 0.5;
+    let cosine = coefficient / Consts::MAX_RECURRENCE_COEFF;
     let sine_squared = 1.0 - cosine * cosine;
     if sine_squared <= f32::EPSILON {
         return 0.0;

--- a/crates/kithara-audio/src/pipeline/config/audio.rs
+++ b/crates/kithara-audio/src/pipeline/config/audio.rs
@@ -15,6 +15,19 @@ use crate::{
     traits::AudioEffect,
 };
 
+struct Consts;
+
+impl Consts {
+    /// PCM ring depth, ~100 ms per chunk. wasm needs a deeper ring because
+    /// its worker is scheduled coarsely.
+    #[cfg(not(target_arch = "wasm32"))]
+    const PCM_BUFFER_CHUNKS: usize = 10;
+    #[cfg(target_arch = "wasm32")]
+    const PCM_BUFFER_CHUNKS: usize = 32;
+    /// Chunks buffered before preload readiness is signalled.
+    const PRELOAD_CHUNKS: usize = 3;
+}
+
 /// Configuration for audio pipeline with stream config.
 ///
 /// Generic over `StreamType` to include stream-specific configuration.
@@ -36,7 +49,7 @@ pub struct AudioConfig<T: StreamType, B = NoResamplerBackend> {
     #[field(get)]
     pub(crate) byte_pool: BytePool,
     /// Number of chunks to buffer before signaling preload readiness.
-    #[builder(default = NonZeroUsize::new(3).expect("3 is non-zero"))]
+    #[builder(default = NonZeroUsize::new(Consts::PRELOAD_CHUNKS).expect("preload chunk count is non-zero"))]
     #[field(get, copy)]
     pub(crate) preload_chunks: NonZeroUsize,
     /// Unified event bus (optional — if not provided, one is created internally).
@@ -84,19 +97,9 @@ pub struct AudioConfig<T: StreamType, B = NoResamplerBackend> {
     pub(crate) block_on_underrun: bool,
     /// PCM buffer size in chunks (~100ms per chunk = 10 chunks ≈ 1s).
     /// Default: 10 on native, 32 on wasm32.
-    #[builder(default = default_pcm_buffer_chunks())]
+    #[builder(default = Consts::PCM_BUFFER_CHUNKS)]
     #[field(get)]
     pub(crate) pcm_buffer_chunks: usize,
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-const fn default_pcm_buffer_chunks() -> usize {
-    10
-}
-
-#[cfg(target_arch = "wasm32")]
-const fn default_pcm_buffer_chunks() -> usize {
-    32
 }
 
 impl<T, B> AudioConfig<T, B>

--- a/crates/kithara-audio/src/pipeline/decode/core.rs
+++ b/crates/kithara-audio/src/pipeline/decode/core.rs
@@ -6,8 +6,8 @@ use std::{
 };
 
 use kithara_decode::{
-    ChunkRetire, DecodeError, DecodeResult, Decoder, DecoderChunkOutcome, DecoderSeekOutcome,
-    GaplessMode, PcmChunk,
+    ChunkRetire, DecodeError, DecodeResult, Decoder, DecoderChunkOutcome,
+    DecoderFactory as BackendDecoderFactory, DecoderSeekOutcome, GaplessMode, PcmChunk,
 };
 use kithara_events::{DeferredBus, Event};
 use kithara_platform::sync::Arc;
@@ -80,7 +80,7 @@ impl DecoderFactory {
                 resolved.container = configured.container;
             }
         }
-        kithara_decode::DecoderFactory::reader_profile(&resolved, byte_map)
+        BackendDecoderFactory::reader_profile(&resolved, byte_map)
     }
 }
 

--- a/crates/kithara-audio/src/pipeline/decode/gate.rs
+++ b/crates/kithara-audio/src/pipeline/decode/gate.rs
@@ -1,5 +1,6 @@
 use std::ops::Range;
 
+use kithara_decode::DecoderFactory;
 use kithara_platform::sync::Arc;
 use kithara_stream::{DeferredWake, ReaderInput, SeekControl, SourcePhase, StreamType};
 use tracing::trace;
@@ -200,8 +201,7 @@ fn recreate_ready_range<T: StreamType>(
     recreate: &RecreateState,
 ) -> Range<u64> {
     let byte_map = stream.byte_map();
-    let profile =
-        kithara_decode::DecoderFactory::reader_profile(&recreate.media_info, byte_map.as_deref());
+    let profile = DecoderFactory::reader_profile(&recreate.media_info, byte_map.as_deref());
     let read_ahead_bytes = profile.read_ahead_bytes().get();
     if matches!(profile.input(), ReaderInput::Incremental) {
         return recreate.offset..range_end(stream, recreate.offset, read_ahead_bytes);

--- a/crates/kithara-audio/src/pipeline/rebuild/port.rs
+++ b/crates/kithara-audio/src/pipeline/rebuild/port.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use crossbeam_queue::ArrayQueue;
-use kithara_decode::{DecoderSeekOutcome, DropChunks, GaplessMode};
+use kithara_decode::{DecodeError, DecoderSeekOutcome, DropChunks, GaplessMode};
 use kithara_platform::{
     sync::Arc,
     time::Duration,
@@ -148,7 +148,7 @@ impl<T: StreamType> RebuildPort<T> {
             && matches!(recreate.next, RecreateNext::Decode)
         {
             if let Err(error) = stream.probe_seek(SeekFrom::Start(recreate.offset)) {
-                let outcome = classify(&kithara_decode::DecodeError::from(error));
+                let outcome = classify(&DecodeError::from(error));
                 return Err((recreate, outcome));
             }
         } else if stream.probe_seek(SeekFrom::Start(recreate.offset)).is_err() {

--- a/crates/kithara-audio/src/pipeline/seek/emit.rs
+++ b/crates/kithara-audio/src/pipeline/seek/emit.rs
@@ -2,6 +2,7 @@ use kithara_decode::DecoderSeekOutcome;
 use kithara_events::{AudioEvent, DeferredBus, Event, SeekLifecycleStage, SegmentLocation};
 use kithara_platform::time::Duration;
 use kithara_stream::{PlayheadWrite, SeekObserve, StreamType};
+use num_traits::cast::ToPrimitive;
 
 use crate::pipeline::{
     decode::{DecoderGeneration, core::ActiveDecode},
@@ -26,10 +27,8 @@ pub(crate) fn commit_outcome<T: StreamType>(
             ..
         } => (landed_frame, landed_at, landed_byte),
         DecoderSeekOutcome::PastEof { duration } => {
-            let frame = num_traits::cast::ToPrimitive::to_u64(
-                &(duration.as_secs_f64() * f64::from(sample_rate)),
-            )
-            .unwrap_or(u64::MAX);
+            let frame = ToPrimitive::to_u64(&(duration.as_secs_f64() * f64::from(sample_rate)))
+                .unwrap_or(u64::MAX);
             (frame, duration, None)
         }
     };
@@ -133,8 +132,7 @@ pub(crate) fn land_eof(
 ) {
     let sample_rate = active.decoder().spec().sample_rate.get();
     let frame_offset =
-        num_traits::cast::ToPrimitive::to_u64(&(duration.as_secs_f64() * f64::from(sample_rate)))
-            .unwrap_or(u64::MAX);
+        ToPrimitive::to_u64(&(duration.as_secs_f64() * f64::from(sample_rate))).unwrap_or(u64::MAX);
     playhead.land(&kithara_stream::ChunkPosition {
         frame_offset,
         end_position_ns: u64::try_from(duration.as_nanos()).unwrap_or(u64::MAX),

--- a/crates/kithara-audio/src/pipeline/seek/engine.rs
+++ b/crates/kithara-audio/src/pipeline/seek/engine.rs
@@ -14,7 +14,7 @@ use crate::pipeline::{
     },
     rebuild::{RecreateCause, RecreateNext, RecreateState},
     seek::{
-        anchor,
+        anchor::{self, AnchorPlan},
         emit::{emit, land_eof, location, update_len},
         recover::SeekRecovery,
         skip::estimate_target_byte,
@@ -141,17 +141,17 @@ impl SeekEngine {
         ctx: &mut SeekApplyCtx<'_, T>,
     ) -> SeekTransition {
         match anchor::resolve(ctx.stream, ctx.decode.active(), request, anchor_value) {
-            anchor::AnchorPlan::Failed { context, error } => {
+            AnchorPlan::Failed { context, error } => {
                 return SeekTransition::Failed {
                     request,
                     error,
                     context,
                 };
             }
-            anchor::AnchorPlan::Recreate(recreate) => {
+            AnchorPlan::Recreate(recreate) => {
                 return SeekTransition::Recreate(recreate);
             }
-            anchor::AnchorPlan::Seek => {}
+            AnchorPlan::Seek => {}
         }
         update_len(ctx.decode, ctx.stream);
         match ctx

--- a/crates/kithara-audio/src/pipeline/seek/skip.rs
+++ b/crates/kithara-audio/src/pipeline/seek/skip.rs
@@ -1,6 +1,7 @@
 use kithara_decode::{PcmChunk, PcmSpec};
 use kithara_platform::time::Duration;
 use kithara_stream::StreamType;
+use num_traits::cast::ToPrimitive;
 use tracing::debug;
 
 use crate::pipeline::{decode::DecoderGeneration, seek::ResumeState, stream::shared::SharedStream};
@@ -15,7 +16,7 @@ pub(crate) fn duration(spec: PcmSpec, frames: usize) -> Duration {
     let nanos = (frames as u128)
         .saturating_mul(Consts::NANOS_PER_SEC)
         .saturating_div(u128::from(spec.sample_rate.get()));
-    let nanos = num_traits::cast::ToPrimitive::to_u64(&nanos).unwrap_or(u64::MAX);
+    let nanos = ToPrimitive::to_u64(&nanos).unwrap_or(u64::MAX);
     Duration::from_nanos(nanos)
 }
 

--- a/crates/kithara-audio/src/pipeline/source.rs
+++ b/crates/kithara-audio/src/pipeline/source.rs
@@ -25,7 +25,7 @@ use crate::{
         parts::SourceParts,
         rebuild::{DecoderBuildComplete, DecoderBuildPurpose, port::RebuildPort, retire::Retired},
         seek::SeekEngine,
-        track::{self, CurrentFsm, Decoding, Track, TrackStep, WaitContext},
+        track::{self, CurrentFsm, Decoding, Track, TrackFailure, TrackStep, WaitContext},
     },
     renderer::AudioWorkerSource,
 };
@@ -579,13 +579,13 @@ pub(crate) fn playing_for_state(state: &CurrentFsm) -> bool {
     !matches!(state, CurrentFsm::AtEof(_) | CurrentFsm::Failed(_))
 }
 
-fn map_track_failure_kind(failure: &track::TrackFailure) -> TrackFailureKind {
+fn map_track_failure_kind(failure: &TrackFailure) -> TrackFailureKind {
     match failure {
-        track::TrackFailure::Decode(_) => TrackFailureKind::Decode,
-        track::TrackFailure::RecreateFailed { offset } => {
+        TrackFailure::Decode(_) => TrackFailureKind::Decode,
+        TrackFailure::RecreateFailed { offset } => {
             TrackFailureKind::RecreateFailed { offset: *offset }
         }
-        track::TrackFailure::SourceCancelled => TrackFailureKind::SourceCancelled,
+        TrackFailure::SourceCancelled => TrackFailureKind::SourceCancelled,
     }
 }
 

--- a/crates/kithara-audio/src/pipeline/track/recreate.rs
+++ b/crates/kithara-audio/src/pipeline/track/recreate.rs
@@ -1,5 +1,5 @@
 use kithara_decode::PcmChunk;
-use kithara_events::{AudioEvent, DecoderChangeCause};
+use kithara_events::{AudioEvent, DecoderChangeCause, SeekLifecycleStage, SegmentLocation};
 use kithara_stream::{SourcePhase, StreamType};
 use tracing::{debug, warn};
 
@@ -272,9 +272,9 @@ fn finish_apply_seek_after_recreate<T: StreamType>(
             if let Some(ref emit) = src.emit {
                 emit.enqueue(
                     AudioEvent::SeekLifecycle {
-                        stage: kithara_events::SeekLifecycleStage::SeekApplied,
+                        stage: SeekLifecycleStage::SeekApplied,
                         seek_epoch: request.seek.epoch,
-                        location: kithara_events::SegmentLocation::new(
+                        location: SegmentLocation::new(
                             src.shared_stream
                                 .abr_handle()
                                 .and_then(|handle| handle.current_variant_index()),

--- a/crates/kithara-audio/src/renderer/load.rs
+++ b/crates/kithara-audio/src/renderer/load.rs
@@ -3,8 +3,13 @@ use std::sync::atomic::Ordering;
 use kithara_platform::time::Duration;
 use portable_atomic::AtomicF32;
 
-/// EWMA weight for per-chunk samples (≈ last ~10 chunks dominate).
-const LOAD_ALPHA: f32 = 0.2;
+struct Consts;
+
+impl Consts {
+    /// EWMA weight for per-chunk samples (≈ last ~10 chunks dominate).
+    const LOAD_ALPHA: f32 = 0.2;
+    const MS_PER_SEC: f64 = 1000.0;
+}
 
 fn to_f64(x: usize) -> f64 {
     num_traits::cast(x).unwrap_or_default()
@@ -20,7 +25,7 @@ fn ewma(prev: f32, sample: f32) -> f32 {
     if prev <= 0.0 {
         sample
     } else {
-        prev * (1.0 - LOAD_ALPHA) + sample * LOAD_ALPHA
+        prev * (1.0 - Consts::LOAD_ALPHA) + sample * Consts::LOAD_ALPHA
     }
 }
 
@@ -67,7 +72,10 @@ impl EngineLoad {
             self.load.load(Ordering::Relaxed),
             to_f32(busy_secs / audio_secs),
         );
-        let ms = ewma(self.ms.load(Ordering::Relaxed), to_f32(busy_secs * 1000.0));
+        let ms = ewma(
+            self.ms.load(Ordering::Relaxed),
+            to_f32(busy_secs * Consts::MS_PER_SEC),
+        );
         let realtime = if load > 0.0 { 1.0 / load } else { 0.0 };
         self.realtime.store(realtime, Ordering::Relaxed);
         self.load.store(load, Ordering::Relaxed);

--- a/crates/kithara-audio/src/renderer/node.rs
+++ b/crates/kithara-audio/src/renderer/node.rs
@@ -469,7 +469,7 @@ mod tests {
             runtime: DecoderRuntime::default(),
         };
 
-        let now = kithara_platform::time::Instant::now();
+        let now = Instant::now();
         node.maybe_emit_worker_telemetry(now);
         node.maybe_emit_worker_telemetry(now);
         emit.flush();

--- a/crates/kithara-audio/src/waveform/analyzer.rs
+++ b/crates/kithara-audio/src/waveform/analyzer.rs
@@ -1,12 +1,26 @@
+use std::array;
+
 use kithara_platform::sync::Arc;
 use num_traits::cast::ToPrimitive;
 use realfft::{RealFftPlanner, RealToComplex, num_complex::Complex};
 
 use super::{
+    Band,
     bucket::{Bucket, Waveform},
     bucketize::bucketize,
     params::AnalysisParams,
 };
+
+struct Consts;
+
+impl Consts {
+    /// Hann `a0`: `w[n] = a0 - a0·cos(2πn/(N-1))`.
+    const HANN_A0: f32 = 0.5;
+    /// 75 % overlap: the window advances by a quarter of its length.
+    const HOP_DIVISOR: usize = 4;
+    /// A real FFT needs at least two input samples.
+    const MIN_FFT_SIZE: usize = 2;
+}
 
 /// Synchronous streaming waveform analyzer. Downmixes to mono once (channel
 /// mean) and reduces the spectrum to an overlapping-window (75% Hann overlap)
@@ -20,8 +34,8 @@ pub struct WaveformAnalyzer {
     fft_scratch: Vec<Complex<f32>>,
     fill: Vec<f32>,
     hann: Vec<f32>,
-    raw_bands: Vec<[f32; 3]>,
-    band_bin_inv: [f32; 3],
+    raw_bands: Vec<[f32; Band::COUNT]>,
+    band_bin_inv: [f32; Band::COUNT],
     low_mid_bin: usize,
     mid_high_bin: usize,
     window_hop: usize,
@@ -30,7 +44,7 @@ pub struct WaveformAnalyzer {
 impl WaveformAnalyzer {
     #[must_use]
     pub fn new(sample_rate: u32, params: AnalysisParams) -> Self {
-        let fft_size = params.fft_size().max(2);
+        let fft_size = params.fft_size().max(Consts::MIN_FFT_SIZE);
         let mut planner = RealFftPlanner::<f32>::new();
         let fft = planner.plan_fft_forward(fft_size);
         let fft_input = fft.make_input_vec();
@@ -64,7 +78,7 @@ impl WaveformAnalyzer {
             fft_input,
             fft_output,
             fft_scratch,
-            window_hop: (fft_size / 4).max(1),
+            window_hop: (fft_size / Consts::HOP_DIVISOR).max(1),
             fill: Vec::with_capacity(fft_size),
             raw_bands: Vec::new(),
         }
@@ -83,13 +97,13 @@ impl WaveformAnalyzer {
         }
 
         let buckets = buckets.min(self.raw_bands.len());
-        let max = |a: [f32; 3], b: [f32; 3]| [a[0].max(b[0]), a[1].max(b[1]), a[2].max(b[2])];
-        let energy = bucketize(&self.raw_bands, buckets, [0.0; 3], max);
+        let max = |a: [f32; Band::COUNT], b: [f32; Band::COUNT]| array::from_fn(|i| a[i].max(b[i]));
+        let energy = bucketize(&self.raw_bands, buckets, [0.0; Band::COUNT], max);
         let bands = normalize_bands(energy, self.params.band_gain());
 
         let out: Vec<Bucket> = bands
             .into_iter()
-            .map(|b| Bucket::new(b[0], b[1], b[2]))
+            .map(|b| Bucket::new(b[Band::Low.idx()], b[Band::Mid.idx()], b[Band::High.idx()]))
             .collect();
         Waveform::from(out)
     }
@@ -142,7 +156,7 @@ impl WaveformAnalyzer {
         {
             self.window_bands()
         } else {
-            [0.0; 3]
+            [0.0; Band::COUNT]
         };
         self.raw_bands.push(bands);
     }
@@ -161,31 +175,27 @@ impl WaveformAnalyzer {
         self.push_window_bands();
     }
 
-    fn window_bands(&self) -> [f32; 3] {
+    fn window_bands(&self) -> [f32; Band::COUNT] {
         // Zero the DC bin so a constant offset never colors the low band.
         let bins = &self.fft_output[1..];
         let total: f32 = bins.iter().map(Complex::norm_sqr).sum();
         let rms = (total / self.fft_input.len().to_f32().unwrap_or(1.0)).sqrt();
         if rms < self.params.energy_floor() {
-            return [0.0; 3];
+            return [0.0; Band::COUNT];
         }
 
-        let mut band = [0.0_f32; 3];
+        let mut band = [0.0_f32; Band::COUNT];
         for (i, c) in self.fft_output.iter().enumerate().skip(1) {
             let energy = c.norm_sqr();
             if i < self.low_mid_bin {
-                band[0] += energy;
+                band[Band::Low.idx()] += energy;
             } else if i < self.mid_high_bin {
-                band[1] += energy;
+                band[Band::Mid.idx()] += energy;
             } else {
-                band[2] += energy;
+                band[Band::High.idx()] += energy;
             }
         }
-        [
-            band[0] * self.band_bin_inv[0],
-            band[1] * self.band_bin_inv[1],
-            band[2] * self.band_bin_inv[2],
-        ]
+        array::from_fn(|i| band[i] * self.band_bin_inv[i])
     }
 }
 
@@ -198,7 +208,7 @@ fn hann_window(size: usize) -> Vec<f32> {
     (0..size)
         .map(|n| {
             let phase = scale * n.to_f32().unwrap_or(0.0);
-            0.5 - 0.5 * phase.cos()
+            Consts::HANN_A0 - Consts::HANN_A0 * phase.cos()
         })
         .collect()
 }
@@ -214,16 +224,13 @@ fn crossover_bin(hz: f32, bin_hz: f32, bins: usize) -> usize {
 /// Per-bucket band energies -> heights: `sqrt` to magnitude, apply per-band
 /// gain, then divide all three by one shared global max so the relative band
 /// sizes (the loudness tilt) survive while every value lands in `[0, 1]`.
-fn normalize_bands(energy: Vec<[f32; 3]>, gain: [f32; 3]) -> Vec<[f32; 3]> {
-    let mut mags: Vec<[f32; 3]> = energy
+fn normalize_bands(
+    energy: Vec<[f32; Band::COUNT]>,
+    gain: [f32; Band::COUNT],
+) -> Vec<[f32; Band::COUNT]> {
+    let mut mags: Vec<[f32; Band::COUNT]> = energy
         .into_iter()
-        .map(|e| {
-            [
-                e[0].sqrt() * gain[0],
-                e[1].sqrt() * gain[1],
-                e[2].sqrt() * gain[2],
-            ]
-        })
+        .map(|e| array::from_fn(|i| e[i].sqrt() * gain[i]))
         .collect();
 
     let max = mags
@@ -233,9 +240,9 @@ fn normalize_bands(energy: Vec<[f32; 3]>, gain: [f32; 3]) -> Vec<[f32; 3]> {
     if max > 0.0 {
         let inv = 1.0 / max;
         for m in &mut mags {
-            m[0] *= inv;
-            m[1] *= inv;
-            m[2] *= inv;
+            for v in &mut *m {
+                *v *= inv;
+            }
         }
     }
     mags

--- a/crates/kithara-audio/src/waveform/band.rs
+++ b/crates/kithara-audio/src/waveform/band.rs
@@ -1,0 +1,22 @@
+/// The three concentric envelopes one waveform column carries. The
+/// discriminants are the indices into every `[T; Band::COUNT]` band array in
+/// this module, and the order is the wire order: low, mid, high.
+#[derive(Clone, Copy, Debug)]
+#[repr(usize)]
+pub(crate) enum Band {
+    Low = 0,
+    Mid = 1,
+    High = 2,
+}
+
+impl Band {
+    /// Every band, in index order.
+    pub(crate) const ALL: [Self; Self::COUNT] = [Self::Low, Self::Mid, Self::High];
+    /// Length of a band array.
+    pub(crate) const COUNT: usize = 3;
+
+    /// Index of this band in a `[T; Band::COUNT]` array.
+    pub(crate) const fn idx(self) -> usize {
+        self as usize
+    }
+}

--- a/crates/kithara-audio/src/waveform/beats.rs
+++ b/crates/kithara-audio/src/waveform/beats.rs
@@ -1,7 +1,25 @@
+use std::mem::size_of;
+
 use crate::{
     blob::{self, Blob, BlobError, MAX_PREALLOC, Reader, Writer},
     region::GridSegment,
 };
+
+struct Consts;
+
+impl Consts {
+    /// One frame position on the wire.
+    const FRAME_BYTES: usize = size_of::<u64>();
+    /// A length prefix on the wire.
+    const LEN_PREFIX_BYTES: usize = size_of::<u64>();
+    /// `beats`, `downbeats`, `segments` — three length-prefixed lists.
+    const LIST_COUNT: usize = 3;
+    /// `start_frame`, `end_frame`, `ratio_correction`.
+    const SEGMENT_BYTES: usize = size_of::<u64>() * 2 + size_of::<f64>();
+    /// Wire/disk format version for the [`BeatGrid`] blob. Bump when the
+    /// encoding changes.
+    const VERSION: u32 = 1;
+}
 
 /// Cleaned beat grid for one track. All positions are source frames
 /// (decoder/song time, `PcmMeta.frame_offset` space) — never output/stretched
@@ -19,10 +37,6 @@ pub struct BeatGrid {
     /// Stable-window tempo of the track, beats per minute.
     bpm: f64,
 }
-
-/// Wire/disk format version for the [`BeatGrid`] blob. Bump when the
-/// encoding changes.
-const BEAT_GRID_BYTES_VERSION: u32 = 1;
 
 impl BeatGrid {
     /// Construct from already-cleaned parts.
@@ -58,7 +72,7 @@ impl TryFrom<&[u8]> for BeatGrid {
 }
 
 impl Blob for BeatGrid {
-    const VERSION: u32 = BEAT_GRID_BYTES_VERSION;
+    const VERSION: u32 = Consts::VERSION;
 
     fn decode(r: &mut Reader<'_>) -> Result<Self, BlobError> {
         let bpm = read_finite(r)?;
@@ -78,7 +92,10 @@ impl Blob for BeatGrid {
 
     fn encode(&self, w: &mut Writer<'_>) {
         w.reserve(
-            8 + 3 * 8 + 8 * (self.beats.len() + self.downbeats.len()) + 24 * self.segments.len(),
+            size_of::<f64>()
+                + Consts::LIST_COUNT * Consts::LEN_PREFIX_BYTES
+                + Consts::FRAME_BYTES * (self.beats.len() + self.downbeats.len())
+                + Consts::SEGMENT_BYTES * self.segments.len(),
         );
         w.write_f64(self.bpm);
         w.write_frames(&self.beats);

--- a/crates/kithara-audio/src/waveform/bucket.rs
+++ b/crates/kithara-audio/src/waveform/bucket.rs
@@ -1,5 +1,8 @@
+use std::mem::size_of;
+
 use kithara_platform::sync::Arc;
 
+use super::Band;
 use crate::blob::{self, Blob, BlobError, Reader, Writer};
 
 /// Wire/disk format version for the [`Waveform`] blob. Bump when the encoding,
@@ -7,7 +10,7 @@ use crate::blob::{self, Blob, BlobError, Reader, Writer};
 pub(crate) const WAVEFORM_BYTES_VERSION: u32 = 1;
 
 /// Bytes per serialized bucket: three little-endian `f32` band heights.
-const BUCKET_BYTES: usize = 12;
+const BUCKET_BYTES: usize = Band::COUNT * size_of::<f32>();
 
 /// One waveform column: three normalized frequency-band heights, each in
 /// `[0, 1]` on a shared scale after per-band perceptual gain. The deck paints
@@ -26,6 +29,15 @@ impl Bucket {
     #[must_use]
     pub fn new(low: f32, mid: f32, high: f32) -> Self {
         Self { high, low, mid }
+    }
+
+    /// Height of one band — the order the analyzer and the wire both use.
+    pub(crate) fn band(self, band: Band) -> f32 {
+        match band {
+            Band::Low => self.low,
+            Band::Mid => self.mid,
+            Band::High => self.high,
+        }
     }
 }
 
@@ -89,16 +101,21 @@ impl Blob for Waveform {
         let count = r.remaining() / BUCKET_BYTES;
         let mut buckets = Vec::with_capacity(count);
         for _ in 0..count {
-            let low = r.read_f32()?;
-            let mid = r.read_f32()?;
-            let high = r.read_f32()?;
+            let mut heights = [0.0; Band::COUNT];
+            for height in &mut heights {
+                *height = r.read_f32()?;
+            }
             // `(0.0..=1.0).contains` is false for NaN/infinities, so this one
             // check covers finiteness and the `[0, 1]` invariant.
             let ok = |v: f32| (0.0..=1.0).contains(&v);
-            if !(ok(low) && ok(mid) && ok(high)) {
+            if !heights.iter().copied().all(ok) {
                 return Err(BlobError::Corrupt);
             }
-            buckets.push(Bucket::new(low, mid, high));
+            buckets.push(Bucket::new(
+                heights[Band::Low.idx()],
+                heights[Band::Mid.idx()],
+                heights[Band::High.idx()],
+            ));
         }
         Ok(Self::from(buckets))
     }
@@ -106,9 +123,9 @@ impl Blob for Waveform {
     fn encode(&self, w: &mut Writer<'_>) {
         w.reserve(self.0.len() * BUCKET_BYTES);
         for b in self.0.iter() {
-            w.write_f32(b.low());
-            w.write_f32(b.mid());
-            w.write_f32(b.high());
+            for band in Band::ALL {
+                w.write_f32(b.band(band));
+            }
         }
     }
 }

--- a/crates/kithara-audio/src/waveform/mod.rs
+++ b/crates/kithara-audio/src/waveform/mod.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "analysis-waveform")]
 mod analyzer;
+mod band;
 mod beats;
 pub(crate) mod bucket;
 #[cfg(feature = "analysis-waveform")]
@@ -8,6 +9,7 @@ mod params;
 
 #[cfg(feature = "analysis-waveform")]
 pub use analyzer::WaveformAnalyzer;
+pub(crate) use band::Band;
 pub use beats::BeatGrid;
 pub use bucket::Bucket;
 pub use params::AnalysisParams;

--- a/crates/kithara-audio/src/waveform/params.rs
+++ b/crates/kithara-audio/src/waveform/params.rs
@@ -1,9 +1,11 @@
 use bon::Builder;
 
+use super::Band;
+
 struct Consts;
 
 impl Consts {
-    const BAND_GAIN: [f32; 3] = [1.0, 2.5, 12.0];
+    const BAND_GAIN: [f32; Band::COUNT] = [1.0, 2.5, 12.0];
     const ENERGY_FLOOR: f32 = 1e-4;
     const FFT_SIZE: usize = 4096;
     const LOW_MID_HZ: f32 = 250.0;
@@ -22,7 +24,7 @@ pub struct AnalysisParams {
     /// This is the balance knob, not a color: low stays the dominant hull.
     #[builder(default = Consts::BAND_GAIN)]
     #[field(get(copy))]
-    band_gain: [f32; 3],
+    band_gain: [f32; Band::COUNT],
     /// Per-window RMS gate; windows below it contribute no band energy.
     #[builder(default = Consts::ENERGY_FLOOR)]
     energy_floor: f32,

--- a/crates/kithara-decode/src/apple/audio_file_demuxer.rs
+++ b/crates/kithara-decode/src/apple/audio_file_demuxer.rs
@@ -392,7 +392,7 @@ mod tests {
     };
     use kithara_test_utils::kithara;
 
-    use super::{AppleAudioFileDemuxer, SourceOpenMode};
+    use super::{AppleAudioFileDemuxer, Duration, SourceOpenMode};
     use crate::demuxer::{DemuxOutcome, Demuxer};
 
     fn read_asset(name: &str) -> Vec<u8> {
@@ -560,7 +560,7 @@ mod tests {
             AudioCodec::Mp3,
             Some(ContainerFormat::MpegAudio),
             SourceOpenMode::Streaming,
-            Some(kithara_platform::time::Duration::from_secs(2)),
+            Some(Duration::from_secs(2)),
         )
         .expect("MP3 streaming open must not require tail bytes");
         assert!(
@@ -569,7 +569,7 @@ mod tests {
         );
         assert_eq!(
             dx.duration(),
-            Some(kithara_platform::time::Duration::from_secs(2)),
+            Some(Duration::from_secs(2)),
             "MP3 streaming open must use the caller's prefix duration hint"
         );
 

--- a/crates/kithara-decode/src/apple/codec.rs
+++ b/crates/kithara-decode/src/apple/codec.rs
@@ -3,8 +3,8 @@ use std::{ffi::c_void, mem::size_of};
 use kithara_apple::audio_toolbox::{
     AUDIO_CONVERTER_DECOMPRESSION_MAGIC_COOKIE, AudioConverter, AudioFormatInfo,
     AudioFormatListItem, AudioStreamBasicDescription, AudioStreamPacketDescription,
-    SingleAudioBufferList, audio_format_get_property, audio_format_get_property_info,
-    pod_from_prefix,
+    AudioToolboxError, SingleAudioBufferList, audio_format_get_property,
+    audio_format_get_property_info, pod_from_prefix,
 };
 use kithara_bufpool::PcmBuf;
 use kithara_platform::time::Duration;
@@ -689,10 +689,10 @@ fn build_pcm_output_format(
     }
 }
 
-fn audio_toolbox_status(err: &kithara_apple::audio_toolbox::AudioToolboxError) -> i32 {
+fn audio_toolbox_status(err: &AudioToolboxError) -> i32 {
     match err {
-        kithara_apple::audio_toolbox::AudioToolboxError::Status { status, .. } => *status,
-        kithara_apple::audio_toolbox::AudioToolboxError::Config { .. } => -50,
+        AudioToolboxError::Status { status, .. } => *status,
+        AudioToolboxError::Config { .. } => -50,
     }
 }
 

--- a/crates/kithara-decode/src/apple/consts.rs
+++ b/crates/kithara-decode/src/apple/consts.rs
@@ -3,7 +3,8 @@ use kithara_apple::audio_toolbox::{
     AUDIO_FILE_FLAC_TYPE, AUDIO_FILE_M4A_TYPE, AUDIO_FILE_MP3_TYPE, AUDIO_FILE_WAVE_TYPE,
     AUDIO_FORMAT_APPLE_LOSSLESS, AUDIO_FORMAT_FLAC, AUDIO_FORMAT_FLAGS_NATIVE_FLOAT_PACKED,
     AUDIO_FORMAT_LINEAR_PCM, AUDIO_FORMAT_MPEG_LAYER3, AUDIO_FORMAT_MPEG4_AAC,
-    AUDIO_FORMAT_PROPERTY_FORMAT_LIST, AudioFormatFlags, AudioFormatID, OSStatus,
+    AUDIO_FORMAT_PROPERTY_FORMAT_LIST, AudioFormatFlags, AudioFormatID, NO_ERR, OSStatus,
+    os_status_to_string as format_os_status,
 };
 
 pub(crate) struct Consts;
@@ -57,12 +58,12 @@ impl Consts {
     /// 44.1 kHz for HE-AAC v2). Specifier = `AudioFormatInfo` struct
     /// containing a partial ASBD (`format_id` required) + ESDS cookie.
     pub(crate) const FORMAT_PROPERTY_FORMAT_LIST: u32 = AUDIO_FORMAT_PROPERTY_FORMAT_LIST;
-    pub(crate) const NO_ERR: OSStatus = kithara_apple::audio_toolbox::NO_ERR;
+    pub(crate) const NO_ERR: OSStatus = NO_ERR;
 }
 
 /// Decode a `FourCC`-style `OSStatus` into an ASCII tag when possible.
 pub(crate) fn os_status_to_string(status: OSStatus) -> String {
-    kithara_apple::audio_toolbox::os_status_to_string(status)
+    format_os_status(status)
 }
 
 #[cfg(test)]

--- a/crates/kithara-decode/src/factory/inner.rs
+++ b/crates/kithara-decode/src/factory/inner.rs
@@ -7,6 +7,8 @@ use std::{
 use bon::Builder;
 use kithara_bufpool::{BytePool, PcmPool};
 use kithara_platform::sync::Arc;
+#[cfg(test)]
+use kithara_resampler::rubato::RubatoBackend;
 use kithara_resampler::{NoResamplerBackend, ResamplerBackend, ResamplerOptions, ResamplerQuality};
 use kithara_stream::{
     AudioCodec, BoxedEventSink, ByteMap, ContainerFormat, MediaInfo, ReaderInput, ReaderProfile,
@@ -914,17 +916,13 @@ mod tests {
     #[test]
     fn decoder_resampler_config_keeps_typed_backend() {
         let target_sample_rate = NonZeroU32::new(48_000).expect("test rate");
-        let config: DecoderResamplerConfig<kithara_resampler::rubato::RubatoBackend> =
-            DecoderResamplerConfig::builder()
-                .target_sample_rate(target_sample_rate)
-                .backend(kithara_resampler::rubato::RubatoBackend::default())
-                .build();
+        let config: DecoderResamplerConfig<RubatoBackend> = DecoderResamplerConfig::builder()
+            .target_sample_rate(target_sample_rate)
+            .backend(RubatoBackend::default())
+            .build();
 
         assert_eq!(config.target_sample_rate, target_sample_rate);
-        assert_eq!(
-            config.backend.name(),
-            kithara_resampler::rubato::RubatoBackend::default().name()
-        );
+        assert_eq!(config.backend.name(), RubatoBackend::default().name());
     }
 }
 

--- a/crates/kithara-decode/src/fmp4/parsing.rs
+++ b/crates/kithara-decode/src/fmp4/parsing.rs
@@ -1,7 +1,7 @@
 use std::io::{Cursor, Read, Seek, SeekFrom};
 
 use kithara_stream::AudioCodec;
-use re_mp4::{BoxHeader, BoxType, MoofBox, Mp4, ReadBox, StsdBoxContent};
+use re_mp4::{BoxHeader, BoxType, MoofBox, Mp4, ReadBox, StsdBoxContent, TfhdBox, TrunBox};
 
 use crate::error::{DecodeError, DecodeResult};
 
@@ -478,7 +478,7 @@ fn collect_frames(parse: &SegmentParse, out: &mut Vec<Fmp4Frame>) -> DecodeResul
         })?;
 
     let tfhd = &traf.tfhd;
-    let default_base_is_moof = (tfhd.flags & re_mp4::TfhdBox::FLAG_DEFAULT_BASE_IS_MOOF) != 0;
+    let default_base_is_moof = (tfhd.flags & TfhdBox::FLAG_DEFAULT_BASE_IS_MOOF) != 0;
     let mut decode_time = traf.tfdt.as_ref().map_or(0, |t| t.base_media_decode_time);
 
     let sample_total: usize = traf
@@ -534,12 +534,8 @@ fn collect_frames(parse: &SegmentParse, out: &mut Vec<Fmp4Frame>) -> DecodeResul
     Ok(())
 }
 
-fn sample_size_for(
-    trun: &re_mp4::TrunBox,
-    tfhd: &re_mp4::TfhdBox,
-    idx: usize,
-) -> DecodeResult<u32> {
-    if (trun.flags & re_mp4::TrunBox::FLAG_SAMPLE_SIZE) != 0 {
+fn sample_size_for(trun: &TrunBox, tfhd: &TfhdBox, idx: usize) -> DecodeResult<u32> {
+    if (trun.flags & TrunBox::FLAG_SAMPLE_SIZE) != 0 {
         return trun
             .sample_sizes
             .get(idx)
@@ -554,8 +550,8 @@ fn sample_size_for(
         })
 }
 
-fn sample_duration_for(trun: &re_mp4::TrunBox, tfhd: &re_mp4::TfhdBox, idx: usize) -> u32 {
-    if (trun.flags & re_mp4::TrunBox::FLAG_SAMPLE_DURATION) != 0 {
+fn sample_duration_for(trun: &TrunBox, tfhd: &TfhdBox, idx: usize) -> u32 {
+    if (trun.flags & TrunBox::FLAG_SAMPLE_DURATION) != 0 {
         return trun.sample_durations.get(idx).copied().unwrap_or(0);
     }
     tfhd.default_sample_duration.unwrap_or(0)

--- a/crates/kithara-decode/src/symphonia/demuxer.rs
+++ b/crates/kithara-decode/src/symphonia/demuxer.rs
@@ -37,7 +37,7 @@ use symphonia::core::{
     errors::{Error as SymphoniaError, SeekErrorKind},
     formats::{FormatOptions, FormatReader, SeekMode, SeekTo, Track, TrackType},
     packet::Packet,
-    units::{Time, TimeBase, Timestamp},
+    units::{Duration as SymphoniaDuration, Time, TimeBase, Timestamp},
 };
 
 use crate::{
@@ -110,7 +110,7 @@ impl SymphoniaDemuxer {
             .map(|h| h.load(Ordering::Acquire))
     }
 
-    fn dur_to_duration(&self, dur: symphonia::core::units::Duration) -> Duration {
+    fn dur_to_duration(&self, dur: SymphoniaDuration) -> Duration {
         let Some(tb) = self.time_base else {
             return Duration::ZERO;
         };

--- a/crates/kithara-decode/src/symphonia/echain.rs
+++ b/crates/kithara-decode/src/symphonia/echain.rs
@@ -1,5 +1,7 @@
 use std::{error::Error as StdError, io};
 
+#[cfg(test)]
+use kithara_stream::PendingReason::SeekPending;
 use symphonia::core::errors::Error;
 
 pub(crate) type SymphoniaError = Error;
@@ -39,7 +41,7 @@ mod tests {
     #[kithara::test]
     fn test_backend_symphonia_seek_pending_counts_as_interrupted() {
         let decode_err = DecodeError::backend(super::SymphoniaError::IoError(IoError::other(
-            kithara_stream::PendingReason::SeekPending,
+            super::SeekPending,
         )));
         assert!(decode_err.is_interrupted());
     }

--- a/crates/kithara-decode/src/symphonia/registry.rs
+++ b/crates/kithara-decode/src/symphonia/registry.rs
@@ -1,13 +1,13 @@
 use std::sync::OnceLock;
 
-use symphonia::core::codecs::registry::CodecRegistry;
+use symphonia::{core::codecs::registry::CodecRegistry, default::register_enabled_codecs};
 
 static CODEC_REGISTRY: OnceLock<CodecRegistry> = OnceLock::new();
 
 pub(crate) fn get_codecs() -> &'static CodecRegistry {
     CODEC_REGISTRY.get_or_init(|| {
         let mut registry = CodecRegistry::new();
-        symphonia::default::register_enabled_codecs(&mut registry);
+        register_enabled_codecs(&mut registry);
         #[cfg(feature = "fdk-aac")]
         registry.register_audio_decoder::<crate::symphonia::aac_fdk::AacDecoder>();
         registry

--- a/crates/kithara-devtools/src/viz/manifest.rs
+++ b/crates/kithara-devtools/src/viz/manifest.rs
@@ -150,7 +150,7 @@ pub(crate) fn write(request: &ArtifactRequest<'_>) -> Result<ArtifactSet> {
         revision: request.revision,
         status: overall_status(request.semantic, request.runtime),
         view: request.args.view.as_str(),
-        lod: request.args.lod.resolve(request.model.lod.as_u8()),
+        lod: request.args.lod.resolve(u8::from(request.model.lod)),
         package: request.args.krate.as_deref(),
         module: request.args.module.as_deref(),
         visible_nodes: request.model.nodes.len(),

--- a/crates/kithara-devtools/src/viz/view.rs
+++ b/crates/kithara-devtools/src/viz/view.rs
@@ -28,14 +28,14 @@ pub(crate) enum DetailLevel {
     Full,
 }
 
-impl DetailLevel {
-    pub(crate) fn as_u8(self) -> u8 {
-        match self {
-            Self::Crates => 0,
-            Self::Modules => 1,
-            Self::Abstractions => 2,
-            Self::Methods => 3,
-            Self::Full => 4,
+impl From<DetailLevel> for u8 {
+    fn from(lod: DetailLevel) -> Self {
+        match lod {
+            DetailLevel::Crates => 0,
+            DetailLevel::Modules => 1,
+            DetailLevel::Abstractions => 2,
+            DetailLevel::Methods => 3,
+            DetailLevel::Full => 4,
         }
     }
 }

--- a/crates/kithara-file/src/session/inner.rs
+++ b/crates/kithara-file/src/session/inner.rs
@@ -13,7 +13,7 @@ use kithara_platform::{
     CancelToken,
     sync::{Arc, Mutex},
 };
-use kithara_stream::{MediaInfo, WorkerWake};
+use kithara_stream::{AudioCodec, ContainerFormat, MediaInfo, WorkerWake};
 use url::Url;
 
 use super::segments::FileSegmentIndex;
@@ -260,32 +260,32 @@ fn map_media_info(info: &MediaInfo) -> (Option<AudioCodecKind>, Option<Container
     )
 }
 
-fn map_audio_codec(codec: kithara_stream::AudioCodec) -> AudioCodecKind {
+fn map_audio_codec(codec: AudioCodec) -> AudioCodecKind {
     match codec {
-        kithara_stream::AudioCodec::AacLc => AudioCodecKind::AacLc,
-        kithara_stream::AudioCodec::AacHe => AudioCodecKind::AacHe,
-        kithara_stream::AudioCodec::AacHeV2 => AudioCodecKind::AacHeV2,
-        kithara_stream::AudioCodec::Mp3 => AudioCodecKind::Mp3,
-        kithara_stream::AudioCodec::Flac => AudioCodecKind::Flac,
-        kithara_stream::AudioCodec::Vorbis => AudioCodecKind::Vorbis,
-        kithara_stream::AudioCodec::Opus => AudioCodecKind::Opus,
-        kithara_stream::AudioCodec::Alac => AudioCodecKind::Alac,
-        kithara_stream::AudioCodec::Pcm => AudioCodecKind::Pcm,
-        kithara_stream::AudioCodec::Adpcm => AudioCodecKind::Adpcm,
+        AudioCodec::AacLc => AudioCodecKind::AacLc,
+        AudioCodec::AacHe => AudioCodecKind::AacHe,
+        AudioCodec::AacHeV2 => AudioCodecKind::AacHeV2,
+        AudioCodec::Mp3 => AudioCodecKind::Mp3,
+        AudioCodec::Flac => AudioCodecKind::Flac,
+        AudioCodec::Vorbis => AudioCodecKind::Vorbis,
+        AudioCodec::Opus => AudioCodecKind::Opus,
+        AudioCodec::Alac => AudioCodecKind::Alac,
+        AudioCodec::Pcm => AudioCodecKind::Pcm,
+        AudioCodec::Adpcm => AudioCodecKind::Adpcm,
     }
 }
 
-fn map_container(container: kithara_stream::ContainerFormat) -> ContainerKind {
+fn map_container(container: ContainerFormat) -> ContainerKind {
     match container {
-        kithara_stream::ContainerFormat::Mp4 => ContainerKind::Mp4,
-        kithara_stream::ContainerFormat::Fmp4 => ContainerKind::Fmp4,
-        kithara_stream::ContainerFormat::MpegTs => ContainerKind::MpegTs,
-        kithara_stream::ContainerFormat::MpegAudio => ContainerKind::MpegAudio,
-        kithara_stream::ContainerFormat::Adts => ContainerKind::Adts,
-        kithara_stream::ContainerFormat::Flac => ContainerKind::Flac,
-        kithara_stream::ContainerFormat::Wav => ContainerKind::Wav,
-        kithara_stream::ContainerFormat::Ogg => ContainerKind::Ogg,
-        kithara_stream::ContainerFormat::Caf => ContainerKind::Caf,
-        kithara_stream::ContainerFormat::Mkv => ContainerKind::Mkv,
+        ContainerFormat::Mp4 => ContainerKind::Mp4,
+        ContainerFormat::Fmp4 => ContainerKind::Fmp4,
+        ContainerFormat::MpegTs => ContainerKind::MpegTs,
+        ContainerFormat::MpegAudio => ContainerKind::MpegAudio,
+        ContainerFormat::Adts => ContainerKind::Adts,
+        ContainerFormat::Flac => ContainerKind::Flac,
+        ContainerFormat::Wav => ContainerKind::Wav,
+        ContainerFormat::Ogg => ContainerKind::Ogg,
+        ContainerFormat::Caf => ContainerKind::Caf,
+        ContainerFormat::Mkv => ContainerKind::Mkv,
     }
 }

--- a/crates/kithara-file/src/session/source.rs
+++ b/crates/kithara-file/src/session/source.rs
@@ -1,7 +1,7 @@
 use std::{num::NonZeroUsize, ops::Range};
 
 use kithara_assets::{AssetReader, AssetStore, ReadSide, ResourceKey};
-use kithara_events::EventBus;
+use kithara_events::{EventBus, TotalBytesSource};
 use kithara_platform::{
     CancelToken,
     sync::{Arc, Mutex},
@@ -88,7 +88,7 @@ impl FileSource {
         inner.publish_opened(
             total_bytes,
             true,
-            total_bytes.map(|_| kithara_events::TotalBytesSource::CommittedLen),
+            total_bytes.map(|_| TotalBytesSource::CommittedLen),
         );
         Self {
             coord,

--- a/crates/kithara-file/src/stream.rs
+++ b/crates/kithara-file/src/stream.rs
@@ -17,6 +17,7 @@ use kithara_stream::{
     dl::{Downloader, DownloaderConfig},
 };
 use kithara_test_utils::kithara;
+use url::Url;
 
 use crate::{
     config::{FileConfig, FileSrc},
@@ -45,7 +46,7 @@ struct RemoteFileOpen {
     headers: Option<Headers>,
     look_ahead_bytes: Option<u64>,
     key: ResourceKey,
-    url: url::Url,
+    url: Url,
 }
 
 fn local_key(path: PathBuf) -> Result<ResourceKey, SourceError> {
@@ -107,7 +108,7 @@ fn valid_extension(extension: &str) -> Option<String> {
     .then(|| extension.to_ascii_lowercase())
 }
 
-fn source_extension(url: &url::Url, hint: Option<&str>) -> String {
+fn source_extension(url: &Url, hint: Option<&str>) -> String {
     hint.and_then(valid_extension)
         .or_else(|| {
             url.path_segments()
@@ -121,7 +122,7 @@ fn source_extension(url: &url::Url, hint: Option<&str>) -> String {
 
 fn remote_key(
     store: &AssetStore,
-    url: &url::Url,
+    url: &Url,
     discriminator: Option<String>,
     extension: Option<&str>,
 ) -> Result<ResourceKey, SourceError> {
@@ -245,7 +246,7 @@ impl File {
     /// `on_connect` callback when the HTTP response arrives. Until then,
     /// `len()` returns `None`.
     fn create_remote(
-        url: url::Url,
+        url: Url,
         config: FileConfig,
         cancel: CancelToken,
     ) -> Result<FileSource, SourceError> {
@@ -313,7 +314,7 @@ impl File {
     /// longer than the watchdog timeout.
     #[kithara::hang_watchdog]
     async fn create_remote_wait_for_claim(
-        url: url::Url,
+        url: Url,
         config: FileConfig,
         cancel: CancelToken,
     ) -> Result<FileSource, StreamSourceError> {
@@ -358,8 +359,8 @@ mod tests {
 
     use super::*;
 
-    fn url(value: &str) -> url::Url {
-        url::Url::parse(value).expect("valid test URL")
+    fn url(value: &str) -> Url {
+        Url::parse(value).expect("valid test URL")
     }
 
     #[kithara::test]

--- a/crates/kithara-hls/src/playlist/keys.rs
+++ b/crates/kithara-hls/src/playlist/keys.rs
@@ -4,7 +4,9 @@ use std::collections::{HashMap, HashSet};
 
 use bytes::Bytes;
 use dashmap::DashMap;
+use futures::future::try_join_all;
 use kithara_assets::{AssetResource, AssetScope, ReadSide, ResourceKey};
+use kithara_bufpool::BytePool;
 use kithara_drm::{DecryptContext, KeyProcessor, KeyProcessorRegistry, PreparedKeyRequest};
 use kithara_events::{
     DrmEvent, EventBus, HlsError as EventHlsError, HlsEvent, KeyFailureStage, KeySource,
@@ -30,7 +32,7 @@ pub struct KeyStore {
     keys: Arc<DashMap<Url, Bytes>>,
     scope: AssetScope,
     /// Byte buffer pool for reading cached key bodies.
-    byte_pool: kithara_bufpool::BytePool,
+    byte_pool: BytePool,
     bus: EventBus,
     /// Cache-first + downloader pipeline for HLS-AES / DRM key bodies.
     key_peer: KeyPeer,
@@ -53,7 +55,7 @@ impl KeyStore {
         bus: EventBus,
         base_headers: Option<Headers>,
         key_registry: Option<KeyProcessorRegistry>,
-        byte_pool: kithara_bufpool::BytePool,
+        byte_pool: BytePool,
     ) -> Self {
         Self {
             key_peer: KeyPeer::new(downloader, scope.clone(), byte_pool.clone()),
@@ -306,7 +308,7 @@ impl KeyStore {
         let futs = urls
             .into_iter()
             .map(|url| async move { self.get_raw_key(&url, None).await.map(drop) });
-        futures::future::try_join_all(futs).await?;
+        try_join_all(futs).await?;
         Ok(())
     }
 
@@ -380,7 +382,7 @@ impl KeyStore {
         bus: EventBus,
         base_headers: Option<Headers>,
         options: crate::config::KeyOptions,
-        byte_pool: kithara_bufpool::BytePool,
+        byte_pool: BytePool,
     ) -> Self {
         Self::new(
             downloader,
@@ -851,7 +853,7 @@ mod tests {
             bus.clone(),
             None,
             registry,
-            kithara_bufpool::BytePool::default(),
+            BytePool::default(),
         )
     }
 

--- a/crates/kithara-hls/src/playlist/variant_playlist.rs
+++ b/crates/kithara-hls/src/playlist/variant_playlist.rs
@@ -1,5 +1,6 @@
 #![forbid(unsafe_code)]
 
+use futures::future::try_join_all;
 use kithara_assets::{AssetResource, AssetScope, ResourceKey};
 use url::Url;
 
@@ -71,5 +72,5 @@ pub(crate) async fn load_variant_playlists(
         .iter()
         .map(|variant| VariantPlaylist::for_variant(cache, scope, master_url, master_key, variant))
         .collect::<HlsResult<Vec<_>>>()?;
-    futures::future::try_join_all(loadables.iter().map(VariantPlaylist::load)).await
+    try_join_all(loadables.iter().map(VariantPlaylist::load)).await
 }

--- a/crates/kithara-hls/src/reader.rs
+++ b/crates/kithara-hls/src/reader.rs
@@ -2,6 +2,8 @@
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
+#[cfg(test)]
+use kithara_events::{AbrMode, VariantIndex};
 use kithara_events::{DeferredBus, HlsEvent};
 use kithara_platform::sync::Arc;
 use kithara_stream::{PrerollHint, ReaderChunkSignal, ReaderEventSink, ReaderSeekSignal};
@@ -355,9 +357,7 @@ mod tests {
             container: playlist.variant_container(0),
         }
         .into_variant(0, &ctx);
-        let state = Arc::new(AbrState::new(kithara_events::AbrMode::Auto(Some(
-            kithara_events::VariantIndex::new(0),
-        ))));
+        let state = Arc::new(AbrState::new(AbrMode::Auto(Some(VariantIndex::new(0)))));
         let publisher = state.publisher();
         let peer: Arc<dyn Abr> = Arc::new(TestAbrPeer { state });
         let controller = Arc::new(AbrController::new(AbrSettings::default()));

--- a/crates/kithara-hls/src/stream/session.rs
+++ b/crates/kithara-hls/src/stream/session.rs
@@ -2,7 +2,7 @@ mod cancel;
 mod reader;
 
 use std::{
-    io::{self, ErrorKind},
+    io::{self, Error, ErrorKind},
     ops::Range,
     sync::atomic::{AtomicBool, AtomicU64, Ordering},
 };
@@ -129,7 +129,7 @@ impl HlsSession {
 
     fn check_live(&self) -> io::Result<()> {
         if self.cancel.root.is_cancelled() {
-            return Err(io::Error::other("HLS reader session cancelled"));
+            return Err(Error::other("HLS reader session cancelled"));
         }
         if !self.active.load(Ordering::Acquire)
             && self
@@ -261,7 +261,7 @@ impl HlsSession {
             profile,
         } = &self.readiness
         else {
-            return Err(StreamError::Source(SourceError::Io(io::Error::new(
+            return Err(StreamError::Source(SourceError::Io(Error::new(
                 ErrorKind::Unsupported,
                 "active HLS session does not carry a decoder reader profile",
             ))));
@@ -378,6 +378,6 @@ impl ByteMap for HlsSession {
     }
 }
 
-fn pending(reason: PendingReason) -> io::Error {
-    io::Error::new(ErrorKind::Interrupted, reason)
+fn pending(reason: PendingReason) -> Error {
+    Error::new(ErrorKind::Interrupted, reason)
 }

--- a/crates/kithara-hls/src/stream/session/reader.rs
+++ b/crates/kithara-hls/src/stream/session/reader.rs
@@ -1,4 +1,4 @@
-use std::io::{self, ErrorKind, Read, Seek, SeekFrom};
+use std::io::{self, Error, ErrorKind, Read, Seek, SeekFrom};
 
 use kithara_platform::{sync::Arc, time::Duration};
 use kithara_storage::WaitOutcome;
@@ -24,7 +24,7 @@ impl HlsSessionReader {
             SeekFrom::Current(delta) => i128::from(current).saturating_add(i128::from(delta)),
             SeekFrom::End(delta) => {
                 let len = self.session.len().ok_or_else(|| {
-                    io::Error::new(
+                    Error::new(
                         ErrorKind::Unsupported,
                         "seek from end requires known length",
                     )
@@ -33,7 +33,7 @@ impl HlsSessionReader {
             }
         };
         if position < 0 {
-            return Err(io::Error::new(
+            return Err(Error::new(
                 ErrorKind::InvalidInput,
                 "negative seek position",
             ));
@@ -42,7 +42,7 @@ impl HlsSessionReader {
         if let Some(len) = self.session.len()
             && position > len
         {
-            return Err(io::Error::new(
+            return Err(Error::new(
                 ErrorKind::InvalidInput,
                 StreamSeekPastEof {
                     len,
@@ -97,7 +97,7 @@ impl Read for HlsSessionReader {
                     NotReadyCause::WaitBudgetExhausted,
                 )));
             }
-            Err(error) => return Err(io::Error::other(error.to_string())),
+            Err(error) => return Err(Error::other(error.to_string())),
         }
         self.session.check_live()?;
         match self.session.variant.read_at(byte, buf) {
@@ -111,7 +111,7 @@ impl Read for HlsSessionReader {
                 self.session.arm_peer();
                 Err(pending(reason))
             }
-            Err(error) => Err(io::Error::other(error.to_string())),
+            Err(error) => Err(Error::other(error.to_string())),
         }
     }
 }

--- a/crates/kithara-net/src/backend/apple/delegate.rs
+++ b/crates/kithara-net/src/backend/apple/delegate.rs
@@ -1,8 +1,10 @@
 use dashmap::DashMap;
 use kithara_apple::foundation::{
     ns::{NSData, NSError, NSURLResponse, NSURLSessionTaskMetrics},
+    objc::rc::Retained,
     urlsession::{
-        self, AuthenticationChallenge, AuthenticationChallengeDisposition, TaskId, UrlSessionEvents,
+        AuthenticationChallenge, AuthenticationChallengeDisposition, TaskId, UrlSessionDelegate,
+        UrlSessionEvents,
     },
 };
 use kithara_platform::{sync::Arc, tokio::sync::oneshot};
@@ -127,9 +129,7 @@ impl UrlSessionEvents for AppleSessionEvents {
     }
 }
 
-pub(super) fn make_delegate(
-    events: &Arc<AppleSessionEvents>,
-) -> kithara_apple::foundation::objc::rc::Retained<urlsession::UrlSessionDelegate> {
+pub(super) fn make_delegate(events: &Arc<AppleSessionEvents>) -> Retained<UrlSessionDelegate> {
     let event_sink: Arc<dyn UrlSessionEvents> = events.clone();
-    urlsession::UrlSessionDelegate::new(event_sink)
+    UrlSessionDelegate::new(event_sink)
 }

--- a/crates/kithara-net/src/client.rs
+++ b/crates/kithara-net/src/client.rs
@@ -3,6 +3,8 @@ use std::{fmt::Write, num::NonZeroU16};
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::{StreamExt, TryStreamExt};
+#[cfg(all(test, not(target_arch = "wasm32")))]
+use kithara_platform::sync::Mutex;
 use kithara_platform::{
     CancelToken,
     sync::Arc,
@@ -766,7 +768,7 @@ mod tests {
             0x51, 0x3e, 0xd3, 0x2d, 0x00, 0x00, 0x00,
         ];
 
-        let seen = Arc::new(kithara_platform::sync::Mutex::new(Vec::new()));
+        let seen = Arc::new(Mutex::new(Vec::new()));
         let handler_seen = Arc::clone(&seen);
         let app = Router::new().route(
             "/master.m3u8",

--- a/crates/kithara-play/src/rt/node.rs
+++ b/crates/kithara-play/src/rt/node.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+use std::sync::atomic::Ordering;
+
 use firewheel::{
     channel_config::{ChannelConfig, ChannelCount},
     diff::{Diff, Patch},
@@ -124,7 +127,7 @@ mod tests {
             .expect("inputs not yet taken")
             .playback
             .playing
-            .load(std::sync::atomic::Ordering::Relaxed);
+            .load(Ordering::Relaxed);
         assert!(!playing);
     }
 }

--- a/crates/kithara-play/src/session/transport/node.rs
+++ b/crates/kithara-play/src/session/transport/node.rs
@@ -8,6 +8,7 @@ use firewheel::{
         NodeID, ProcBuffers, ProcExtra, ProcInfo, ProcStreamCtx, ProcessStatus,
     },
 };
+use kithara_test_utils::kithara::rtsan_forbid_blocking;
 use triple_buffer::{Output, triple_buffer};
 
 use super::{
@@ -116,7 +117,7 @@ impl AudioNodeProcessor for SessionTransportProcessor {
         }
     }
 
-    #[kithara_test_utils::kithara::rtsan_forbid_blocking]
+    #[rtsan_forbid_blocking]
     fn process(
         &mut self,
         info: &ProcInfo,

--- a/crates/kithara-queue/src/queue/types.rs
+++ b/crates/kithara-queue/src/queue/types.rs
@@ -1,6 +1,8 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use kithara_events::TrackId;
+#[cfg(test)]
+use kithara_play::PlaybackShared;
 use kithara_play::{PlaybackSnapshot, ResourceSrc};
 
 use crate::track::TrackSource;
@@ -400,7 +402,7 @@ mod tests {
     }
 
     fn view_of(frontier: f64, cached: f64) -> PlaybackView {
-        let shared = kithara_play::PlaybackShared::default();
+        let shared = PlaybackShared::default();
         shared.duration.store(200.0, Ordering::Relaxed);
         shared.frontier.store(frontier, Ordering::Relaxed);
         shared.cached.store(cached, Ordering::Relaxed);

--- a/crates/kithara-resampler/src/apple/resampler.rs
+++ b/crates/kithara-resampler/src/apple/resampler.rs
@@ -2,8 +2,8 @@ use std::num::{NonZeroU32, NonZeroUsize};
 
 use kithara_apple::audio_toolbox::{
     AUDIO_CONVERTER_ERR_NO_DATA_NOW, AUDIO_FORMAT_LINEAR_PCM, AudioConverter,
-    AudioStreamBasicDescription, BITS_PER_F32_SAMPLE, BYTES_PER_F32_SAMPLE, FLOAT32_PLANAR_FLAGS,
-    NO_ERR, OSStatus, OwnedAudioBufferList, os_status_to_string,
+    AudioStreamBasicDescription, AudioToolboxError, BITS_PER_F32_SAMPLE, BYTES_PER_F32_SAMPLE,
+    FLOAT32_PLANAR_FLAGS, NO_ERR, OSStatus, OwnedAudioBufferList, os_status_to_string,
 };
 use kithara_bufpool::PcmPool;
 use num_traits::cast::ToPrimitive;
@@ -329,10 +329,10 @@ fn apple_error_status(op: &'static str, status: OSStatus) -> ResamplerError {
     }
 }
 
-fn err_status(err: &kithara_apple::audio_toolbox::AudioToolboxError) -> OSStatus {
+fn err_status(err: &AudioToolboxError) -> OSStatus {
     match err {
-        kithara_apple::audio_toolbox::AudioToolboxError::Status { status, .. } => *status,
-        kithara_apple::audio_toolbox::AudioToolboxError::Config { .. } => -50,
+        AudioToolboxError::Status { status, .. } => *status,
+        AudioToolboxError::Config { .. } => -50,
     }
 }
 

--- a/crates/kithara-storage/src/decorator/chunked/core.rs
+++ b/crates/kithara-storage/src/decorator/chunked/core.rs
@@ -2,7 +2,7 @@
 
 use std::{
     fs::{self, OpenOptions},
-    io,
+    io::ErrorKind,
     ops::Range,
     path::{Path, PathBuf},
 };
@@ -237,7 +237,7 @@ impl<D: DriverIo> AtomicChunked<D> {
             Ok(file) => {
                 drop(file);
             }
-            Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
+            Err(e) if e.kind() == ErrorKind::AlreadyExists => {
                 return Err(StorageError::TmpClaimed(tmp_path));
             }
             Err(e) => return Err(StorageError::Io(e)),

--- a/crates/kithara-stream/src/dl/downloader.rs
+++ b/crates/kithara-stream/src/dl/downloader.rs
@@ -4,6 +4,8 @@ use futures::task::AtomicWaker;
 use kithara_abr::{Abr, AbrController, AbrPeerId};
 use kithara_events::{EventBus, RequestId};
 use kithara_net::HttpClient;
+#[cfg(target_arch = "wasm32")]
+use kithara_platform::thread::{keep_worker_alive, spawn};
 use kithara_platform::{
     CancelScope, CancelToken,
     sync::{Arc, Mutex, Notify, RwLock},
@@ -254,8 +256,8 @@ impl Downloader {
         // workers via `Atomics.notify`, so the engine worker's blocked read
         // is woken once this worker commits bytes. `keep_worker_alive` keeps
         // the worker's event loop pumping for the page's lifetime.
-        kithara_platform::thread::spawn(move || {
-            kithara_platform::thread::keep_worker_alive();
+        spawn(move || {
+            keep_worker_alive();
             drop(task::spawn(async move {
                 this.run(rx).await;
             }));


### PR DESCRIPTION
The lint-debt batch, kept apart from the tests PR (#158) and the CI PR (#159) because it stands on its own and can land in any order.

Branched off today's `main`; `just lint fast` exits 0 on it, reproduced independently.

## Qualified paths

Three commits name the imports the modules were spelling out inline, across `kithara-audio`, `kithara-file`, `kithara-decode` and the small crates.

An earlier attempt at this was reverted, and the reason is worth stating because it is the whole point of the batch: it reduced the rule's own count from 401 to 90 honestly, and left the tree uncompilable. Adding a `use` orphans the imports whose last user it rewrote and makes redundant the qualifications the new import shortens — under `-D warnings` both are hard errors, and neither appears in the rule's count. This time the acceptance criterion was the gate, not the count. Probed past it with `--all-targets --keep-going`: zero `unused_imports` workspace-wide, and the single `unused_qualifications` left sits in a file this branch does not touch and is present on `main`.

## Magic numbers

`kithara-audio` gets named constants, and the three band indices become one identity instead of three loose `0`/`1`/`2`. The previous attempt here was also reverted — it traded 74 magic-number findings for 17 violations of `style.multiple-private-module-consts`, which is a deny rule. Grouping was the fix that rule was asking for all along.

## Two rules

- `idioms.match-self-conversion` no longer fires on a method returning `String`. The canon there is `Display`, owned by `rust.no-to-string-method`, and the sibling rule `rust.prefer-from-not-to-into` already excludes `^(String|Self|&.*)$` — this makes the two agree. Measured: 7 sites before, 6 after the real `impl From<DetailLevel> for u8`, 5 after the carve-out, so it excuses exactly one.
- The last two `ast-grep-ignore` markers in `kithara-devtools` are gone, with the sites fixed rather than annotated.

## Not verified

`just test` was not run on this branch. The sweep rewrites imports across 62 files, so that is the uncovered risk; clippy over `--all-targets` is the strongest evidence here and it is compile-level, not behavioural.