### PR TITLE
ci: bound the build caches the cleanup was protecting

### DIFF
--- a/.config/just/check.just
+++ b/.config/just/check.just
@@ -6,8 +6,11 @@ set working-directory := "../.."
 workspace:
     cargo check --workspace
 
+# Runs without the sccache wrapper: `clippy-driver` is not cached by it either
+# way, and sccache aborts outright rather than fall back when it meets the
+# incremental build that keeps this fast.
 clippy:
-    cargo clippy --workspace -- -D warnings
+    RUSTC_WRAPPER= CARGO_INCREMENTAL=1 cargo clippy --workspace -- -D warnings
 
 [positional-arguments]
 clippy-fix *ARGS:

--- a/justfile
+++ b/justfile
@@ -6,7 +6,8 @@ sccache := `command -v sccache 2>/dev/null || true`
 export RUSTC_WRAPPER := sccache
 
 # sccache refuses incremental compilations, so a wrapper without this is never
-# hit. Only forced alongside one, so a machine without sccache keeps incremental.
+# hit. `check clippy` opts back in: `clippy-driver` is not cached either way,
+# and without incremental it costs 15s where 2.4s would do.
 export CARGO_INCREMENTAL := if sccache == "" { "" } else { "0" }
 
 mod fmt ".config/just/fmt.just"

--- a/justfile
+++ b/justfile
@@ -1,21 +1,12 @@
 set shell := ["bash", "-euo", "pipefail", "-c"]
 
-# Clippy runs `clippy-driver` in place of `rustc`, so it compiles the whole
-# graph before it can lint one line, and it does so into its own profile
-# directory — a suite run in `test-release` leaves it nothing to reuse. The CI
-# image has kept `sccache` for exactly this since it was built; a workstation
-# had no equivalent, so every branch switch bought a full rebuild before the
-# pre-commit hook could say anything. Empty when sccache is absent, which cargo
-# reads as "no wrapper" rather than as an error.
+# Empty when absent: cargo reads that as "no wrapper", not as an error.
 sccache := `command -v sccache 2>/dev/null || true`
 
 export RUSTC_WRAPPER := sccache
 
-# sccache declines to cache an incremental compilation and cargo leaves
-# incremental on, so a wrapper set without this is installed, enabled, and never
-# hit — measured here as ten compile requests and zero of them cached. Left
-# alone when there is no wrapper, so a workstation without sccache keeps the
-# incremental rebuilds it does benefit from.
+# sccache refuses incremental compilations, so a wrapper without this is never
+# hit. Only forced alongside one, so a machine without sccache keeps incremental.
 export CARGO_INCREMENTAL := if sccache == "" { "" } else { "0" }
 
 mod fmt ".config/just/fmt.just"

--- a/justfile
+++ b/justfile
@@ -1,5 +1,23 @@
 set shell := ["bash", "-euo", "pipefail", "-c"]
 
+# Clippy runs `clippy-driver` in place of `rustc`, so it compiles the whole
+# graph before it can lint one line, and it does so into its own profile
+# directory — a suite run in `test-release` leaves it nothing to reuse. The CI
+# image has kept `sccache` for exactly this since it was built; a workstation
+# had no equivalent, so every branch switch bought a full rebuild before the
+# pre-commit hook could say anything. Empty when sccache is absent, which cargo
+# reads as "no wrapper" rather than as an error.
+sccache := `command -v sccache 2>/dev/null || true`
+
+export RUSTC_WRAPPER := sccache
+
+# sccache declines to cache an incremental compilation and cargo leaves
+# incremental on, so a wrapper set without this is installed, enabled, and never
+# hit — measured here as ten compile requests and zero of them cached. Left
+# alone when there is no wrapper, so a workstation without sccache keeps the
+# incremental rebuilds it does benefit from.
+export CARGO_INCREMENTAL := if sccache == "" { "" } else { "0" }
+
 mod fmt ".config/just/fmt.just"
 mod check ".config/just/check.just"
 mod lint ".config/just/lint.just"

--- a/xtask/src/ci/build_cache.rs
+++ b/xtask/src/ci/build_cache.rs
@@ -1,0 +1,295 @@
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
+use std::{
+    ffi::OsStr,
+    fs::{self, File, OpenOptions},
+    path::{Path, PathBuf},
+    time::SystemTime,
+};
+
+use anyhow::{Context, Result, bail};
+use fs4::{FileExt, TryLockError};
+use tracing::info;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct CacheEntry {
+    path: PathBuf,
+    size_bytes: u64,
+    modified: SystemTime,
+}
+
+struct CacheContents {
+    entries: Vec<CacheEntry>,
+    active: bool,
+    locks: Vec<File>,
+}
+
+struct DirectoryScan {
+    bytes: u64,
+    active: bool,
+    locks: Vec<File>,
+}
+
+pub(crate) fn select_evictions(mut entries: Vec<CacheEntry>, budget_bytes: u64) -> Vec<CacheEntry> {
+    let mut remaining_bytes: u128 = entries
+        .iter()
+        .map(|entry| u128::from(entry.size_bytes))
+        .sum();
+    let budget_bytes = u128::from(budget_bytes);
+    if remaining_bytes <= budget_bytes {
+        return Vec::new();
+    }
+
+    entries.sort_by(|left, right| {
+        left.modified
+            .cmp(&right.modified)
+            .then_with(|| left.path.cmp(&right.path))
+    });
+    let mut evictions = Vec::new();
+    for entry in entries {
+        if remaining_bytes <= budget_bytes {
+            break;
+        }
+        remaining_bytes = remaining_bytes.saturating_sub(u128::from(entry.size_bytes));
+        evictions.push(entry);
+    }
+    evictions
+}
+
+pub(crate) fn enforce_budget(target_dirs: &[PathBuf], budget_bytes: u64) -> Result<()> {
+    let mut target_dirs = target_dirs.to_vec();
+    target_dirs.sort();
+    for target_dir in target_dirs {
+        enforce_target_budget(&target_dir, budget_bytes)?;
+    }
+    Ok(())
+}
+
+fn enforce_target_budget(target_dir: &Path, budget_bytes: u64) -> Result<()> {
+    let CacheContents {
+        entries,
+        active,
+        locks: _locks,
+    } = candidate_entries(target_dir)?;
+    let bytes_before = entries
+        .iter()
+        .map(|entry| entry.size_bytes)
+        .fold(0_u64, u64::saturating_add);
+    if active {
+        info!(
+            path = %target_dir.display(),
+            bytes_before,
+            bytes_freed = 0,
+            budget_bytes,
+            "keeping active build cache"
+        );
+        return Ok(());
+    }
+    let evictions = select_evictions(entries, budget_bytes);
+    let bytes_freed = evictions
+        .iter()
+        .map(|entry| entry.size_bytes)
+        .fold(0_u64, u64::saturating_add);
+
+    // Cargo fingerprints describe a complete profile tree, so removing files
+    // within one can leave its dependency artifacts inconsistent.
+    for entry in evictions {
+        fs::remove_dir_all(&entry.path)
+            .with_context(|| format!("removing build cache entry {}", entry.path.display()))?;
+    }
+    info!(
+        path = %target_dir.display(),
+        bytes_before,
+        bytes_freed,
+        budget_bytes,
+        "build cache budget enforced"
+    );
+    Ok(())
+}
+
+fn candidate_entries(target_dir: &Path) -> Result<CacheContents> {
+    if !target_dir.is_absolute() || target_dir.parent().is_none() {
+        bail!(
+            "refusing to inspect unsafe build cache path {}",
+            target_dir.display()
+        );
+    }
+    let metadata = fs::symlink_metadata(target_dir)
+        .with_context(|| format!("reading build cache metadata for {}", target_dir.display()))?;
+    if !metadata.file_type().is_dir() {
+        bail!(
+            "build cache path is not a directory: {}",
+            target_dir.display()
+        );
+    }
+    let entries = fs::read_dir(target_dir)
+        .with_context(|| format!("reading build cache {}", target_dir.display()))?;
+    let mut contents = CacheContents {
+        entries: Vec::new(),
+        active: false,
+        locks: Vec::new(),
+    };
+    for entry in entries {
+        let entry = entry
+            .with_context(|| format!("reading an entry in build cache {}", target_dir.display()))?;
+        let path = entry.path();
+        let metadata = fs::symlink_metadata(&path)
+            .with_context(|| format!("reading build cache metadata for {}", path.display()))?;
+        if !metadata.file_type().is_dir() {
+            continue;
+        }
+        let modified = metadata
+            .modified()
+            .with_context(|| format!("reading modification time for {}", path.display()))?;
+        let scan = scan_directory(&path)?;
+        contents.active |= scan.active;
+        contents.locks.extend(scan.locks);
+        contents.entries.push(CacheEntry {
+            path,
+            size_bytes: scan.bytes,
+            modified,
+        });
+    }
+    Ok(contents)
+}
+
+fn scan_directory(path: &Path) -> Result<DirectoryScan> {
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("reading build cache metadata for {}", path.display()))?;
+    if !metadata.file_type().is_dir() {
+        if metadata.file_type().is_file() && path.file_name() == Some(OsStr::new(".cargo-lock")) {
+            let (active, lock) = cargo_lock(path)?;
+            return Ok(DirectoryScan {
+                bytes: allocated_bytes(&metadata),
+                active,
+                locks: lock.into_iter().collect(),
+            });
+        }
+        return Ok(DirectoryScan {
+            bytes: allocated_bytes(&metadata),
+            active: false,
+            locks: Vec::new(),
+        });
+    }
+
+    let entries = fs::read_dir(path)
+        .with_context(|| format!("reading build cache directory {}", path.display()))?;
+    let mut bytes = allocated_bytes(&metadata);
+    let mut active = false;
+    let mut locks = Vec::new();
+    for entry in entries {
+        let entry =
+            entry.with_context(|| format!("reading an entry in build cache {}", path.display()))?;
+        let scan = scan_directory(&entry.path())?;
+        bytes = bytes.saturating_add(scan.bytes);
+        active |= scan.active;
+        locks.extend(scan.locks);
+    }
+    Ok(DirectoryScan {
+        bytes,
+        active,
+        locks,
+    })
+}
+
+fn cargo_lock(path: &Path) -> Result<(bool, Option<File>)> {
+    let lock = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)
+        .with_context(|| format!("opening Cargo build lock {}", path.display()))?;
+    match FileExt::try_lock(&lock) {
+        Ok(()) => Ok((false, Some(lock))),
+        Err(TryLockError::WouldBlock) => Ok((true, None)),
+        Err(TryLockError::Error(error)) => {
+            Err(error).with_context(|| format!("checking Cargo build lock {}", path.display()))
+        }
+    }
+}
+
+#[cfg(unix)]
+fn allocated_bytes(metadata: &fs::Metadata) -> u64 {
+    metadata.blocks().saturating_mul(512)
+}
+
+#[cfg(not(unix))]
+fn allocated_bytes(metadata: &fs::Metadata) -> u64 {
+    metadata.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs::OpenOptions,
+        time::{Duration, UNIX_EPOCH},
+    };
+
+    use fs4::FileExt;
+
+    use super::*;
+
+    fn entry(path: &str, size_bytes: u64, age: u64) -> CacheEntry {
+        CacheEntry {
+            path: PathBuf::from(path),
+            size_bytes,
+            modified: UNIX_EPOCH + Duration::from_secs(age),
+        }
+    }
+
+    #[test]
+    fn under_budget_deletes_nothing() {
+        let entries = vec![entry("debug", 10, 1), entry("release", 20, 2)];
+
+        assert!(select_evictions(entries, 30).is_empty());
+    }
+
+    #[test]
+    fn over_budget_deletes_oldest_first() {
+        let entries = vec![
+            entry("newest", 10, 3),
+            entry("oldest", 10, 1),
+            entry("middle", 10, 2),
+        ];
+        let paths: Vec<PathBuf> = select_evictions(entries, 0)
+            .into_iter()
+            .map(|entry| entry.path)
+            .collect();
+
+        assert_eq!(paths, ["oldest", "middle", "newest"].map(PathBuf::from));
+    }
+
+    #[test]
+    fn deletion_stops_as_soon_as_the_budget_is_met() {
+        let entries = vec![entry("oldest", 5, 1), entry("newest", 7, 2)];
+
+        assert_eq!(select_evictions(entries, 7).len(), 1);
+    }
+
+    #[test]
+    fn equal_timestamps_break_ties_by_path() {
+        let entries = vec![entry("b", 1, 1), entry("a", 1, 1)];
+        let paths: Vec<PathBuf> = select_evictions(entries, 0)
+            .into_iter()
+            .map(|entry| entry.path)
+            .collect();
+
+        assert_eq!(paths, ["a", "b"].map(PathBuf::from));
+    }
+
+    #[test]
+    fn an_active_cargo_profile_defers_eviction() {
+        let directory = tempfile::tempdir().unwrap();
+        let profile = directory.path().join("debug");
+        fs::create_dir(&profile).unwrap();
+        let lock = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(profile.join(".cargo-lock"))
+            .unwrap();
+        FileExt::lock(&lock).unwrap();
+
+        assert!(candidate_entries(directory.path()).unwrap().active);
+    }
+}

--- a/xtask/src/ci/config/host.rs
+++ b/xtask/src/ci/config/host.rs
@@ -1,5 +1,6 @@
 use std::{
-    fs,
+    error::Error,
+    fmt, fs,
     path::{Path, PathBuf},
 };
 
@@ -25,6 +26,12 @@ pub(crate) struct CiHost {
     pub(crate) aggressive_cleanup_bytes: u64,
     pub(crate) android_home: PathBuf,
     pub(crate) brew_root: PathBuf,
+    /// Positive decimal gigabytes, such as `25GB`. Defaulted because the
+    /// installed profiles predate it: a binary that refused to load without it
+    /// would take the cleanup down on every host it reached, which is the
+    /// failure this budget exists to prevent.
+    #[serde(default = "default_build_cache_size")]
+    pub(crate) build_cache_size: String,
     pub(crate) cache_root_macos: PathBuf,
     pub(crate) cache_root_linux: PathBuf,
     pub(crate) cache_root_windows: PathBuf,
@@ -84,6 +91,10 @@ impl CiHost {
         if self.sccache_size.trim().is_empty() {
             bail!("CI host profile sccache_size must not be empty");
         }
+        if self.build_cache_size.trim().is_empty() {
+            bail!("CI host profile build_cache_size must not be empty");
+        }
+        self.build_cache_budget_bytes()?;
         if self.soft_cleanup_bytes == 0
             || self.soft_cleanup_bytes >= self.aggressive_cleanup_bytes
             || self.aggressive_cleanup_bytes >= self.reject_bytes
@@ -145,6 +156,11 @@ impl CiHost {
         self.gitlab_url.as_str().trim_end_matches('/').to_string()
     }
 
+    pub(crate) fn build_cache_budget_bytes(&self) -> Result<u64> {
+        parse_build_cache_size(&self.build_cache_size)
+            .context("CI host profile build_cache_size is invalid")
+    }
+
     /// The headroom a job insists on before it starts. The host stops handing
     /// out work once the CI volume passes `reject_bytes`, so the room left at
     /// that point is what the policy already considers too little to start on.
@@ -194,6 +210,48 @@ impl CiHost {
     }
 }
 
+#[derive(Debug)]
+pub(crate) struct BuildCacheSizeError {
+    value: String,
+}
+
+impl fmt::Display for BuildCacheSizeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "build_cache_size {:?} must be a positive whole number followed by GB and fit in u64 bytes",
+            self.value
+        )
+    }
+}
+
+impl Error for BuildCacheSizeError {}
+
+/// Budget a profile inherits when it predates the field. Sized so the Linux
+/// host's two dozen runner caches fit its volume with room to spare, and so a
+/// single macOS cache root stays well inside its own.
+fn default_build_cache_size() -> String {
+    "25GB".to_owned()
+}
+
+pub(crate) fn parse_build_cache_size(value: &str) -> Result<u64, BuildCacheSizeError> {
+    const BYTES_PER_GIGABYTE: u64 = 1_000_000_000;
+
+    let invalid = || BuildCacheSizeError {
+        value: value.to_owned(),
+    };
+    let digits = value.strip_suffix("GB").ok_or_else(&invalid)?;
+    if digits.is_empty() || !digits.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(invalid());
+    }
+    digits
+        .parse::<u64>()
+        .ok()
+        .filter(|gigabytes| *gigabytes > 0)
+        .and_then(|gigabytes| gigabytes.checked_mul(BYTES_PER_GIGABYTE))
+        .ok_or_else(invalid)
+}
+
 fn safe_account(value: &str) -> bool {
     !value.is_empty()
         && value
@@ -204,6 +262,57 @@ fn safe_account(value: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn build_cache_size_converts_decimal_gigabytes_to_bytes() {
+        assert_eq!(parse_build_cache_size("25GB").unwrap(), 25_000_000_000);
+    }
+
+    #[test]
+    fn build_cache_size_rejects_garbage() {
+        assert!(parse_build_cache_size("twenty-five").is_err());
+    }
+
+    #[test]
+    fn ci_host_rejects_an_empty_build_cache_size() {
+        let mut host = super::super::fixture().host;
+        host.build_cache_size.clear();
+
+        assert!(host.validate().is_err());
+    }
+
+    #[test]
+    fn ci_host_load_accepts_a_profile_without_a_build_cache_size() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("host.toml");
+        let host = super::super::fixture().host;
+        host.write(&path).unwrap();
+        let text = fs::read_to_string(&path).unwrap();
+        let without: String = text
+            .lines()
+            .filter(|line| !line.trim_start().starts_with("build_cache_size"))
+            .map(|line| format!("{line}\n"))
+            .collect();
+        fs::write(&path, without).unwrap();
+
+        assert_eq!(
+            CiHost::load(&path).unwrap().build_cache_size,
+            default_build_cache_size()
+        );
+    }
+
+    #[test]
+    fn ci_host_load_rejects_garbage_build_cache_size() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("host.toml");
+        let mut host = super::super::fixture().host;
+        host.build_cache_size = "25GiB".to_owned();
+        host.write(&path).unwrap();
+
+        let error = CiHost::load(&path).unwrap_err();
+
+        assert!(format!("{error:#}").contains("positive whole number followed by GB"));
+    }
 
     #[test]
     fn account_names_are_bounded() {

--- a/xtask/src/ci/config/host.rs
+++ b/xtask/src/ci/config/host.rs
@@ -26,10 +26,8 @@ pub(crate) struct CiHost {
     pub(crate) aggressive_cleanup_bytes: u64,
     pub(crate) android_home: PathBuf,
     pub(crate) brew_root: PathBuf,
-    /// Positive decimal gigabytes, such as `25GB`. Defaulted because the
-    /// installed profiles predate it: a binary that refused to load without it
-    /// would take the cleanup down on every host it reached, which is the
-    /// failure this budget exists to prevent.
+    /// Positive decimal gigabytes, such as `25GB`. Defaulted: installed
+    /// profiles predate it, and refusing to load would kill the cleanup.
     #[serde(default = "default_build_cache_size")]
     pub(crate) build_cache_size: String,
     pub(crate) cache_root_macos: PathBuf,

--- a/xtask/src/ci/config/mod.rs
+++ b/xtask/src/ci/config/mod.rs
@@ -2,7 +2,7 @@ mod host;
 mod pins;
 mod profile;
 
-pub(crate) use host::{LANE_CONFIG_DIR, MAC_CONFIG_PATH};
+pub(crate) use host::{LANE_CONFIG_DIR, MAC_CONFIG_PATH, parse_build_cache_size};
 pub(crate) use pins::{CiPins, PINS_PATH};
 pub(crate) use profile::CiConfig;
 #[cfg(test)]

--- a/xtask/src/ci/host/storage.rs
+++ b/xtask/src/ci/host/storage.rs
@@ -9,7 +9,7 @@ use anyhow::{Context, Result, bail};
 use serde::Serialize;
 use tracing::{info, warn};
 
-use crate::ci::{config::CiConfig, process::Process};
+use crate::ci::{build_cache, config::CiConfig, process::Process};
 
 /// Ordered least to most urgent: the watchdog reports the worst volume, not
 /// the total, so that a roomy one cannot hide a full one.
@@ -170,6 +170,9 @@ impl<'a> HostStorage<'a> {
             }
             Pressure::Normal => {}
         }
+
+        let target_dirs = persistent_target_dirs(&self.root.join("workspaces/gitlab"))?;
+        build_cache::enforce_budget(&target_dirs, self.config.host.build_cache_budget_bytes()?)?;
 
         let (mut final_pressure, _) = self.worst_pressure()?;
         if final_pressure == Pressure::Reject {
@@ -612,6 +615,55 @@ pub(super) fn pressure_for(used: u64, soft: u64, aggressive: u64, reject: u64) -
     } else {
         Pressure::Normal
     }
+}
+
+fn persistent_target_dirs(root: &Path) -> Result<Vec<PathBuf>> {
+    if !root.is_dir() {
+        return Ok(Vec::new());
+    }
+
+    let mut pending = vec![root.to_path_buf()];
+    let mut targets = Vec::new();
+    while let Some(directory) = pending.pop() {
+        if directory.join("Cargo.toml").is_file() {
+            for name in ["target", "target-flash-off"] {
+                let path = directory.join(name);
+                let metadata = match fs::symlink_metadata(&path) {
+                    Ok(metadata) => metadata,
+                    Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+                    Err(error) => {
+                        return Err(error).with_context(|| format!("reading {}", path.display()));
+                    }
+                };
+                if metadata.file_type().is_dir() {
+                    targets.push(path);
+                }
+            }
+            continue;
+        }
+
+        let entries = fs::read_dir(&directory)
+            .with_context(|| format!("reading CI workspace directory {}", directory.display()))?;
+        for entry in entries {
+            let entry = entry.with_context(|| {
+                format!(
+                    "reading an entry in CI workspace directory {}",
+                    directory.display()
+                )
+            })?;
+            if entry.file_name().to_string_lossy().starts_with('.') {
+                continue;
+            }
+            let path = entry.path();
+            let metadata = fs::symlink_metadata(&path)
+                .with_context(|| format!("reading CI workspace metadata for {}", path.display()))?;
+            if metadata.file_type().is_dir() {
+                pending.push(path);
+            }
+        }
+    }
+    targets.sort();
+    Ok(targets)
 }
 
 fn validate_root(root: &Path) -> Result<()> {

--- a/xtask/src/ci/linux/cleanup.rs
+++ b/xtask/src/ci/linux/cleanup.rs
@@ -1,7 +1,10 @@
-use anyhow::Result;
+use std::path::PathBuf;
+
+use anyhow::{Result, bail};
 use tracing::{info, warn};
 
-use crate::ci::{config::CiPins, process::Process};
+use super::profile::LinuxHost;
+use crate::ci::{build_cache, config::CiPins, process::Process};
 
 /// Build cache older than this is rebuilt faster than it is worth keeping.
 const BUILD_CACHE_AGE: &str = "168h";
@@ -9,11 +12,10 @@ const BUILD_CACHE_AGE: &str = "168h";
 /// Reclaim what this project left behind, and nothing else.
 ///
 /// The machine is shared: other stacks keep images and volumes here, so a
-/// blanket `docker system prune` would take theirs. Volumes are left alone
-/// entirely — `kithara-ci-target` and `kithara-ci-cargo-home` are the caches
-/// this exists to protect, and the orphans beside them belong to a setup this
-/// code does not own.
-pub(super) fn run(process: &Process, pins: &CiPins) -> Result<()> {
+/// blanket `docker system prune` would take theirs. Project volumes stay in
+/// place: target contents are budgeted here, Cargo home remains protected, and
+/// orphan volumes belong to a setup this code does not own.
+pub(super) fn run(process: &Process, host: &LinuxHost, pins: &CiPins) -> Result<()> {
     let Some((_, pinned)) = pins.linux_image.rsplit_once(':') else {
         warn!(image = pins.linux_image, "pinned image carries no tag");
         return Ok(());
@@ -56,7 +58,42 @@ pub(super) fn run(process: &Process, pins: &CiPins) -> Result<()> {
         ],
         "prune the build cache",
     );
+    let target_dirs = target_dirs(process)?;
+    build_cache::enforce_budget(&target_dirs, host.build_cache_budget_bytes()?)?;
     Ok(())
+}
+
+fn target_dirs(process: &Process) -> Result<Vec<PathBuf>> {
+    const VOLUME_PREFIX: &str = "kithara-ci-target";
+
+    let filter = format!("name={VOLUME_PREFIX}");
+    let listed = process.capture(
+        "docker",
+        &["volume", "ls", "--filter", &filter, "--format", "{{.Name}}"],
+        "list project target volumes",
+    )?;
+    let mut names: Vec<&str> = listed
+        .lines()
+        .map(str::trim)
+        .filter(|name| name.starts_with(VOLUME_PREFIX))
+        .collect();
+    names.sort_unstable();
+
+    let mut target_dirs = Vec::with_capacity(names.len());
+    for name in names {
+        let label = format!("inspect project target volume {name}");
+        let mountpoint = process.capture(
+            "docker",
+            &["volume", "inspect", "--format", "{{.Mountpoint}}", name],
+            &label,
+        )?;
+        let path = PathBuf::from(mountpoint);
+        if !path.is_absolute() {
+            bail!("Docker target volume {name} returned a non-absolute mountpoint");
+        }
+        target_dirs.push(path);
+    }
+    Ok(target_dirs)
 }
 
 #[cfg(test)]

--- a/xtask/src/ci/linux/command.rs
+++ b/xtask/src/ci/linux/command.rs
@@ -84,7 +84,7 @@ pub(crate) fn run(args: &LinuxArgs) -> Result<()> {
         }
         LinuxCommand::Cleanup => {
             let pins = CiPins::load(&args.pins)?;
-            cleanup::run(&process, &pins)
+            cleanup::run(&process, &host, &pins)
         }
         LinuxCommand::InstallServices => {
             let pins = CiPins::load(&args.pins)?;

--- a/xtask/src/ci/linux/profile.rs
+++ b/xtask/src/ci/linux/profile.rs
@@ -8,6 +8,8 @@ use std::{
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 
+use crate::ci::config::parse_build_cache_size;
+
 /// Installed profile every Linux CI machine reads through
 /// `KITHARA_CI_LINUX_CONFIG`.
 pub(crate) const LINUX_CONFIG_PATH: &str = "/etc/kithara-ci/linux-host.toml";
@@ -19,6 +21,8 @@ pub(crate) const LINUX_CONFIG_PATH: &str = "/etc/kithara-ci/linux-host.toml";
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct LinuxHost {
+    /// Positive decimal gigabytes, such as `25GB`.
+    pub(crate) build_cache_size: String,
     /// Directory holding the caches jobs keep between runs.
     pub(crate) cache_root: PathBuf,
     /// Docker network the runners are confined to.
@@ -131,6 +135,10 @@ impl LinuxHost {
     }
 
     pub(crate) fn validate(&self) -> Result<()> {
+        if self.build_cache_size.trim().is_empty() {
+            bail!("Linux CI profile build_cache_size must not be empty");
+        }
+        self.build_cache_budget_bytes()?;
         if !self.cache_root.is_absolute() {
             bail!("Linux CI profile cache_root must be an absolute path");
         }
@@ -167,6 +175,11 @@ impl LinuxHost {
             }
         }
         Ok(())
+    }
+
+    pub(crate) fn build_cache_budget_bytes(&self) -> Result<u64> {
+        parse_build_cache_size(&self.build_cache_size)
+            .context("Linux CI profile build_cache_size is invalid")
     }
 
     /// The credential a runner or guest registers with, by the repository it

--- a/xtask/src/ci/mod.rs
+++ b/xtask/src/ci/mod.rs
@@ -1,4 +1,5 @@
 mod bridge;
+mod build_cache;
 mod command;
 mod config;
 mod environment;

--- a/xtask/tests/fixtures/ci-linux-host.toml
+++ b/xtask/tests/fixtures/ci-linux-host.toml
@@ -1,3 +1,4 @@
+build_cache_size = "25GB"
 cache_root = "/var/lib/kithara-ci"
 network = "kithara-ci"
 subnet = "172.16.240.0/24"

--- a/xtask/tests/fixtures/ci-mac-host.toml
+++ b/xtask/tests/fixtures/ci-mac-host.toml
@@ -2,6 +2,7 @@ admin_user = "operator"
 aggressive_cleanup_bytes = 270000000000
 android_home = "/Volumes/KitharaCI/toolchains/android"
 brew_root = "/opt/homebrew"
+build_cache_size = "25GB"
 cache_root_macos = "/Volumes/My Shared Files/kithara-cache"
 cache_root_linux = "/kithara-cache"
 cache_root_windows = "C:/KitharaCI/cache"


### PR DESCRIPTION
## Summary

`cleanup` reclaims superseded images and stale build cache, and states plainly that volumes are off limits: `kithara-ci-target` and `kithara-ci-cargo-home` are "the caches this exists to protect". Protecting them was right; leaving them unbounded was not. Nothing ever capped their size, so they grew until the disk could not hold them.

Measured on the Linux host today: 98% full, `/var/lib/docker` at 1.5TB, of which **1.34TB was target volumes** — 24 runner caches of 50–96GB each. Tests with no relation to any of it died on `No space left on device`. Inside one volume: `debug/` 39G, `test-release/` 30G, `llvm-cov-target/` 16G — overwhelmingly artifacts of branches long gone. The caches were not the accident; the missing ceiling was.

Each cache now carries a size budget. Over budget, whole top-level profiles are evicted oldest first until it fits. **Profiles, not files**: a Cargo fingerprint describes a complete profile tree, so deleting files inside one can leave its artifacts inconsistent, whereas losing a whole profile only costs a rebuild.

A cache whose `.cargo-lock` is held is skipped entirely — that job is mid-build, and a rebuild is cheaper than a job failing because its target directory moved underneath it.

Linux keeps these caches in Docker volumes and macOS keeps them in the workspace tree, so **enumeration differs per host and the eviction does not**: both hand what they found to the same budget. That is the whole point — one policy, both fleets.

`build_cache_size` defaults instead of being required. The installed profiles predate it, and a binary that refused to load without it would take the cleanup down on every host it reached — which is precisely the failure this budget exists to prevent. (That failure is not hypothetical: the Linux cleanup timer had been dying on a config read since installation, so nothing was reclaimed for months while `list-timers` looked healthy.)

## Behavior / scope

- contract or behavior: `cleanup` gains a step that evicts build-cache profiles past a configured budget. No product code touched.
- affected area: `xtask` CI tooling on both the Linux and macOS hosts.

## Validation

- `cargo test -p xtask` — 202 passed
- `cargo clippy -p xtask --all-targets` — no issues
- `just lint fast` — 0 regression(s), 0 new
- `just fmt`
- **Applied by hand on the Linux host with the same policy and budget: 1.1TB reclaimed, 94% → 31% (109GB → 1.2TB free), with active builds skipped.** That is the eviction this PR automates.
- Full `just test` was not completed locally: the host was saturated by other worktrees compiling (zero of the 48 `rustc` processes were mine), so the run failed while building its test list. The fork's CI is the honest gate here — it has Linux lanes this laptop does not.

## Surface impact

- Public API: none
- Platform/runtime: tooling surface — cleanup does more work on both CI hosts
- Perf-sensitive paths: none

## Risks / follow-ups

- With two dozen runners nearly always busy, some volumes will be skipped as active on any given pass. The timer now runs every two hours (it was daily, and broken), so caches come due at different times rather than all at once.
- The budget defaults to 25GB per cache. On the Linux host that is 24 × 25GB ≈ 600GB against a 1.8TB disk; tune per host in the installed profile if a fleet needs a different ceiling.
- Deploying this needs the binary refreshed on each host — a repo change is not an executor change. The macOS host also needs its launchd cleanup verified the way the Linux one was.

---

## Second commit: let a workstation reuse what it already compiled

The CI image has carried `sccache` since it was built; a workstation had no equivalent. Every branch switch therefore paid for the whole graph again, and a `just test` run leaves `cargo clippy` nothing to reuse regardless, because one fills `target/test-release` and the other reads `target/debug`. That is what a 30-minute pre-commit hook was made of.

Measured after discarding three crates' artifacts: **20 of 20 rustc invocations returned from the cache, none recompiled**.

Two details worth knowing, both measured rather than assumed:

- `CARGO_INCREMENTAL` is forced off only alongside a wrapper. sccache declines to cache an incremental compilation, and the CI image already pairs the two with a comment warning that setting one without the other yields a cache that is installed, enabled, and never hit. Confirmed here first: ten requests, zero cached.
- **This does not speed up Clippy.** `cargo clippy` drives workspace crates through `RUSTC_WORKSPACE_WRAPPER=clippy-driver`, which sccache does not handle — the same 53 requests it caches under `cargo check` (29 executed) pass through uncached under `cargo clippy` (0 executed). Dependencies still come from the cache; the workspace crates do not.

The wrapper resolves to empty when sccache is absent, which cargo reads as "no wrapper" rather than as an error, so a machine without it is unaffected and keeps its incremental rebuilds.
