### PR TITLE
fix(ci): let the cleanup load a profile that predates the budget

### DIFF
--- a/xtask/src/ci/config/host.rs
+++ b/xtask/src/ci/config/host.rs
@@ -228,7 +228,7 @@ impl Error for BuildCacheSizeError {}
 /// Budget a profile inherits when it predates the field. Sized so the Linux
 /// host's two dozen runner caches fit its volume with room to spare, and so a
 /// single macOS cache root stays well inside its own.
-fn default_build_cache_size() -> String {
+pub(crate) fn default_build_cache_size() -> String {
     "25GB".to_owned()
 }
 

--- a/xtask/src/ci/config/mod.rs
+++ b/xtask/src/ci/config/mod.rs
@@ -2,7 +2,9 @@ mod host;
 mod pins;
 mod profile;
 
-pub(crate) use host::{LANE_CONFIG_DIR, MAC_CONFIG_PATH, parse_build_cache_size};
+pub(crate) use host::{
+    LANE_CONFIG_DIR, MAC_CONFIG_PATH, default_build_cache_size, parse_build_cache_size,
+};
 pub(crate) use pins::{CiPins, PINS_PATH};
 pub(crate) use profile::CiConfig;
 #[cfg(test)]

--- a/xtask/src/ci/linux/profile.rs
+++ b/xtask/src/ci/linux/profile.rs
@@ -8,7 +8,7 @@ use std::{
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 
-use crate::ci::config::parse_build_cache_size;
+use crate::ci::config::{default_build_cache_size, parse_build_cache_size};
 
 /// Installed profile every Linux CI machine reads through
 /// `KITHARA_CI_LINUX_CONFIG`.
@@ -21,7 +21,9 @@ pub(crate) const LINUX_CONFIG_PATH: &str = "/etc/kithara-ci/linux-host.toml";
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct LinuxHost {
-    /// Positive decimal gigabytes, such as `25GB`.
+    /// Positive decimal gigabytes, such as `25GB`. Defaulted: installed
+    /// profiles predate it, and refusing to load would kill the cleanup.
+    #[serde(default = "default_build_cache_size")]
     pub(crate) build_cache_size: String,
     /// Directory holding the caches jobs keep between runs.
     pub(crate) cache_root: PathBuf,
@@ -310,6 +312,31 @@ fn safe_label(value: &str) -> bool {
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
+
+    /// An installed profile predating the budget must still load: the binary
+    /// reaches every host before its profile does, and one that refused would
+    /// take the cleanup down on each of them.
+    #[test]
+    fn a_profile_without_a_build_cache_size_still_loads() {
+        let directory = tempfile::tempdir().expect("temp dir");
+        let path = directory.path().join("linux-host.toml");
+        let source =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/ci-linux-host.toml");
+        let text = fs::read_to_string(&source).expect("fixture profile");
+        let without: String = text
+            .lines()
+            .filter(|line| !line.trim_start().starts_with("build_cache_size"))
+            .map(|line| format!("{line}\n"))
+            .collect();
+        fs::write(&path, without).expect("write profile");
+
+        assert_eq!(
+            LinuxHost::load(&path)
+                .expect("profile loads")
+                .build_cache_size,
+            default_build_cache_size()
+        );
+    }
 
     /// A profile shaped like the machines this command provisions: one plain
     /// runner and one that reaches the hardware a plain one must not.


### PR DESCRIPTION
## Summary

#164 gave `build_cache_size` a serde default so that a binary carrying it could still read the profiles already installed on the hosts. That default went on `CiHost`. The Linux cleanup reads `LinuxHost`, a separate structure, which did not get one.

Installing the new binary on the Linux host proved it immediately — the first run after the merge died:

```
Error: parsing Linux CI profile /etc/kithara-ci/linux-host.toml
missing field `build_cache_size`
```

That is the precise failure the default exists to prevent, arriving through the structure that did not receive it. The binary reaches a host before its profile does, so refusing to load leaves that machine with no cleanup at all — which is the state that filled the disk to 98% in the first place, and it had been in that state for months because the same service was dying on a different config read.

Both structures now take the same `default_build_cache_size`, and a profile without the field is held by a test instead of by remembering to write the attribute twice.

## Behavior / scope

- contract or behavior: a Linux profile without `build_cache_size` loads with the 25GB default instead of failing. No other behavior changes.
- affected area: `xtask` CI config.

## Validation

- `cargo test -p xtask` — 203 passed, including the new `a_profile_without_a_build_cache_size_still_loads`
- `cargo clippy -p xtask --all-targets` — no issues
- `just fmt`
- Verified against the live host: with the field restored by hand, the freshly built binary ran the cleanup to success and enforced the budget — e.g. `shirokih-android` 40.2GB → freed 39.4GB, `shirokih-04` 35.3GB → freed 21.2GB, while caches already under budget reported `bytes_freed=0`.

## Surface impact

- Public API: none
- Platform/runtime: none
- Perf-sensitive paths: none

## Risks / follow-ups

- The macOS side of the budget is a no-op as written: it looks for target directories under `workspaces/gitlab`, and that host keeps none — its cache root holds `sccache` (21GB), `gradle`, and `cargo`, with no Cargo target trees at all. Harmless, but it buys nothing there; worth either pointing it at what that host actually accumulates or dropping the macOS arm.
