### PR TITLE
fix(audio,hls): give every decoder reader its own construction gate

### DIFF
--- a/crates/kithara-audio/src/audio/build.rs
+++ b/crates/kithara-audio/src/audio/build.rs
@@ -199,7 +199,6 @@ where
             pcm_buffer_chunks,
         );
 
-        shared_stream.set_blocking(true);
         let gapless_mode = decoder.gapless_mode();
         let deps = DecoderDeps::new(
             decoder,
@@ -210,7 +209,6 @@ where
         let initial_reader = shared_stream.open_initial_reader();
         let decoder =
             create_initial_decoder(initial_reader, initial_media_info.clone(), hint, &deps).await;
-        shared_stream.set_blocking(false);
         let decoder = decoder?;
 
         let initial_spec = decoder.spec();
@@ -495,6 +493,7 @@ where
     B: Default + ResamplerBackend,
 {
     let byte_len = reader.byte_len().unwrap_or(0);
+    let construction_gate = reader.construction_gate();
     let config = DecoderConfig::builder()
         .backend(deps.decoder.backend())
         .byte_len_handle(Arc::new(AtomicU64::new(byte_len)))
@@ -506,15 +505,21 @@ where
         .maybe_resampler(deps.resampler_config())
         .build();
     let source = reader.into_inner();
-    spawn_blocking(move || {
+    if let Some(gate) = &construction_gate {
+        gate.arm();
+    }
+    let built = spawn_blocking(move || {
         if let Some(info) = &media_info {
             DecoderFactory::create_from_media_info(source, info, config)
         } else {
             DecoderFactory::create_with_probe(source, hint.as_deref(), config)
         }
     })
-    .await
-    .map_err(|error| DecodeError::Io {
+    .await;
+    if let Some(gate) = &construction_gate {
+        gate.disarm();
+    }
+    built.map_err(|error| DecodeError::Io {
         source: IoError::other(format!("decoder task panicked: {error}")),
     })?
 }

--- a/crates/kithara-audio/src/pipeline/decode/generation.rs
+++ b/crates/kithara-audio/src/pipeline/decode/generation.rs
@@ -19,6 +19,12 @@ pub(crate) struct DecoderGeneration {
     #[field(get, vis = "pub(crate)", copy)]
     gapless_profile: GaplessProfile,
     gapless: GaplessStage,
+    /// Lower bound for the decoder's observed timeline gap after an exact
+    /// variant splice. The overlap proof normalizes equal codec profiles to
+    /// the larger gap; promotion transfers that normalization here so a later
+    /// transition cannot reinterpret the new active generation on a smaller
+    /// origin.
+    timeline_gap_floor: u64,
     media_info: Option<MediaInfo>,
     pending_head_skip: Option<ResumeState>,
     staged: VecDeque<PcmChunk>,
@@ -47,6 +53,7 @@ impl DecoderGeneration {
             installed_at_seek_epoch,
             gapless_profile,
             gapless,
+            timeline_gap_floor: 0,
             pending_head_skip,
             staged: VecDeque::new(),
         }
@@ -59,8 +66,6 @@ impl DecoderGeneration {
             pub(crate) fn decoder(&self) -> &dyn Decoder;
             #[call(as_mut)]
             pub(crate) fn decoder_mut(&mut self) -> &mut dyn Decoder;
-            #[call(timeline_gap_frames)]
-            pub(crate) fn timeline_gap(&self) -> u64;
         }
         to self.staged {
             #[call(pop_front)]
@@ -138,6 +143,16 @@ impl DecoderGeneration {
                 .saturating_add(u64::from(last.meta.frames)),
             first.meta.spec.sample_rate.get(),
         ))
+    }
+
+    pub(crate) fn align_timeline_gap(&mut self, gap: u64) {
+        self.timeline_gap_floor = self.timeline_gap_floor.max(gap);
+    }
+
+    pub(crate) fn timeline_gap(&self) -> u64 {
+        self.decoder
+            .timeline_gap_frames()
+            .max(self.timeline_gap_floor)
     }
 
     pub(crate) fn timeline_origin(&self, mode: GaplessMode) -> u64 {

--- a/crates/kithara-audio/src/pipeline/decode/transition.rs
+++ b/crates/kithara-audio/src/pipeline/decode/transition.rs
@@ -329,6 +329,9 @@ impl super::core::ActiveDecode {
             });
             return None;
         }
+        if shares_default_profile(self.active.gapless_profile(), generation.gapless_profile()) {
+            generation.align_timeline_gap(self.active.timeline_gap());
+        }
         self.blender.join_active(generation.blender_profile());
         Some(std::mem::replace(&mut self.active, generation))
     }
@@ -550,13 +553,19 @@ fn incoming_origin_from(
     mode: kithara_decode::GaplessMode,
 ) -> u64 {
     let incoming_profile = incoming.gapless_profile();
-    let same_default_profile = active_profile.gapless().is_none()
-        && incoming_profile.gapless().is_none()
-        && active_profile.default_priming_frames() == incoming_profile.default_priming_frames();
-    let gap = if same_default_profile {
+    let gap = if shares_default_profile(active_profile, incoming_profile) {
         active_gap.max(incoming.timeline_gap())
     } else {
         incoming.timeline_gap()
     };
     incoming.timeline_origin_with_gap(mode, gap)
+}
+
+fn shares_default_profile(
+    active: kithara_decode::GaplessProfile,
+    incoming: kithara_decode::GaplessProfile,
+) -> bool {
+    active.gapless().is_none()
+        && incoming.gapless().is_none()
+        && active.default_priming_frames() == incoming.default_priming_frames()
 }

--- a/crates/kithara-audio/src/pipeline/stream/offset.rs
+++ b/crates/kithara-audio/src/pipeline/stream/offset.rs
@@ -36,20 +36,21 @@ impl<T: StreamType> Read for OffsetReader<T> {
 
 impl<T: StreamType> Seek for OffsetReader<T> {
     fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
-        // The decoder runs on the produce core, so seek through the real-time
-        // `probe_seek` (no `prime_seek_range` spin on the forbid path).
+        // The reader-local construction gate selects blocking off-RT seek
+        // during decoder creation and non-blocking probe seek on the produce
+        // core after the builder disarms it.
         match pos {
             SeekFrom::Start(p) => {
                 let abs = self.base_offset + p;
-                let real_pos = self.shared.probe_seek(SeekFrom::Start(abs))?;
+                let real_pos = self.shared.seek(SeekFrom::Start(abs))?;
                 Ok(real_pos.saturating_sub(self.base_offset))
             }
             SeekFrom::Current(delta) => {
-                let real_pos = self.shared.probe_seek(SeekFrom::Current(delta))?;
+                let real_pos = self.shared.seek(SeekFrom::Current(delta))?;
                 Ok(real_pos.saturating_sub(self.base_offset))
             }
             SeekFrom::End(delta) => {
-                let real_pos = self.shared.probe_seek(SeekFrom::End(delta))?;
+                let real_pos = self.shared.seek(SeekFrom::End(delta))?;
                 Ok(real_pos.saturating_sub(self.base_offset))
             }
         }

--- a/crates/kithara-audio/src/pipeline/stream/shared.rs
+++ b/crates/kithara-audio/src/pipeline/stream/shared.rs
@@ -19,30 +19,27 @@ use super::offset::OffsetReader;
 /// - `StreamAudioSource` to check `media_info()` for format changes
 pub(crate) struct SharedStream<T: StreamType> {
     inner: Arc<Mutex<Stream<T>>>,
-    /// Construction-phase read mode, shared across clones. When set, `Read`
-    /// routes through the blocking off-RT [`Stream::read`] adapter (waits for
-    /// the seeked range to download, cancel-bounded by its own timeout)
-    /// instead of the non-blocking RT [`Stream::probe_read`]. Decoder builders
-    /// arm it only around their off-RT factory call and disarm it before
-    /// steady-state decoding resumes. See the crate `CONTEXT.md`
-    /// "Construction reads".
-    blocking: ConstructionGate,
+    /// Construction mode for one decoder reader. Coordinator clones carry no
+    /// gate; every opened reader receives a fresh gate so an off-RT rebuild
+    /// cannot switch the active decoder to blocking I/O.
+    construction_gate: Option<ConstructionGate>,
 }
 
 impl<T: StreamType> SharedStream<T> {
     pub(crate) fn new(stream: Stream<T>) -> Self {
         Self {
             inner: Arc::new(Mutex::new(stream)),
-            blocking: ConstructionGate::default(),
+            construction_gate: None,
         }
     }
 
     pub(crate) fn open_initial_reader(&self) -> OpenedReader {
+        let construction_gate = ConstructionGate::default();
         OpenedReader::new(
-            self.clone(),
+            self.with_construction_gate(construction_gate.clone()),
             self.len(),
             self.byte_map(),
-            Some(self.blocking.clone()),
+            Some(construction_gate),
             self.take_reader_event_sink(),
         )
     }
@@ -51,23 +48,24 @@ impl<T: StreamType> SharedStream<T> {
         let byte_len = self.len().map(|length| length.saturating_sub(base_offset));
         let byte_map = self.byte_map();
         let event_sink = self.take_reader_event_sink();
-        let input = OffsetReader::new(self.clone(), base_offset);
+        let construction_gate = ConstructionGate::default();
+        let input = OffsetReader::new(
+            self.with_construction_gate(construction_gate.clone()),
+            base_offset,
+        );
         OpenedReader::new(
             input,
             byte_len,
             byte_map,
-            Some(self.blocking.clone()),
+            Some(construction_gate),
             event_sink,
         )
     }
 
-    /// Arm/disarm the initial construction read mode. Rebuilds use the same
-    /// gate through [`OpenedReader`].
-    pub(crate) fn set_blocking(&self, on: bool) {
-        if on {
-            self.blocking.arm();
-        } else {
-            self.blocking.disarm();
+    fn with_construction_gate(&self, construction_gate: ConstructionGate) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+            construction_gate: Some(construction_gate),
         }
     }
 
@@ -124,7 +122,7 @@ impl<T: StreamType> Clone for SharedStream<T> {
     fn clone(&self) -> Self {
         Self {
             inner: Arc::clone(&self.inner),
-            blocking: self.blocking.clone(),
+            construction_gate: self.construction_gate.clone(),
         }
     }
 }
@@ -132,13 +130,17 @@ impl<T: StreamType> Clone for SharedStream<T> {
 impl<T: StreamType> Read for SharedStream<T> {
     /// Steady state (RT worker / `OffsetReader`): the non-blocking
     /// [`Stream::probe_read`] — a not-ready range surfaces immediately so the
-    /// scheduler parks and re-ticks. During construction only (the `blocking`
-    /// flag armed by a decoder builder), routes through the blocking off-RT
-    /// [`Stream::read`] adapter so construction waits for residual init
-    /// lateness instead of erroring on the first not-ready probe.
+    /// scheduler parks and re-ticks. During this reader's construction only,
+    /// routes through the blocking off-RT [`Stream::read`] adapter so
+    /// construction waits for residual init lateness instead of erroring on
+    /// the first not-ready probe.
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let mut stream = self.inner.lock();
-        if self.blocking.is_armed() {
+        if self
+            .construction_gate
+            .as_ref()
+            .is_some_and(ConstructionGate::is_armed)
+        {
             stream.read(buf)
         } else {
             stream.probe_read(buf)
@@ -147,9 +149,16 @@ impl<T: StreamType> Read for SharedStream<T> {
 }
 
 impl<T: StreamType> Seek for SharedStream<T> {
-    delegate! {
-        to self.inner.lock() {
-            fn seek(&mut self, pos: SeekFrom) -> io::Result<u64>;
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        let mut stream = self.inner.lock();
+        if self
+            .construction_gate
+            .as_ref()
+            .is_some_and(ConstructionGate::is_armed)
+        {
+            stream.seek(pos)
+        } else {
+            stream.probe_seek(pos)
         }
     }
 }

--- a/crates/kithara-audio/src/pipeline/track/tests/rebuild.rs
+++ b/crates/kithara-audio/src/pipeline/track/tests/rebuild.rs
@@ -180,6 +180,7 @@ struct RouteSignalDecoder {
     sample_rate: u32,
     id: u64,
     next_frame: u64,
+    timeline_gap: u64,
 }
 
 impl RouteSignalDecoder {
@@ -189,7 +190,13 @@ impl RouteSignalDecoder {
             id,
             sample_rate,
             next_frame: 0,
+            timeline_gap: 0,
         }
+    }
+
+    fn with_timeline_gap(mut self, timeline_gap: u64) -> Self {
+        self.timeline_gap = timeline_gap;
+        self
     }
 
     fn pcm_spec(&self) -> PcmSpec {
@@ -261,6 +268,10 @@ impl Decoder for RouteSignalDecoder {
 
     fn spec(&self) -> PcmSpec {
         self.pcm_spec()
+    }
+
+    fn timeline_gap_frames(&self) -> u64 {
+        self.timeline_gap
     }
 
     fn update_byte_len(&self, _len: u64) {}
@@ -679,6 +690,33 @@ async fn test_source(variant: u32) -> RebuildFixture {
     test_source_with_mode(variant, GaplessMode::Disabled).await
 }
 
+#[kithara::test(native, tokio)]
+async fn decoder_readers_have_isolated_construction_gates() {
+    let control = Arc::new(TestControl::new(media_info(0)));
+    let stream = match Stream::<TestStream>::new(TestConfig {
+        source: TestSource::new(control),
+    })
+    .await
+    {
+        Ok(stream) => stream,
+        Err(error) => panic!("test stream construction failed: {error}"),
+    };
+    let shared_stream = SharedStream::new(stream);
+    let initial = shared_stream.open_initial_reader();
+    let rebuild = shared_stream.open_rebuild_reader(0);
+    let Some(initial_gate) = initial.construction_gate() else {
+        panic!("initial reader must carry a construction gate");
+    };
+    let Some(rebuild_gate) = rebuild.construction_gate() else {
+        panic!("rebuild reader must carry a construction gate");
+    };
+
+    initial_gate.arm();
+
+    assert!(initial_gate.is_armed());
+    assert!(!rebuild_gate.is_armed());
+}
+
 async fn test_source_with_mode(variant: u32, gapless_mode: GaplessMode) -> RebuildFixture {
     let control = Arc::new(TestControl::new(media_info(variant)));
     let drops = Arc::new(Mutex::new(Vec::new()));
@@ -734,13 +772,30 @@ async fn test_source_with_mode(variant: u32, gapless_mode: GaplessMode) -> Rebui
 /// source has neither, so no recreate origin other than `base_offset` is
 /// even reachable on it.
 struct RouteParams {
+    active_timeline_gap: u64,
+    incoming_timeline_gap: u64,
     segmented: bool,
     initial_host_rate: u32,
 }
 
 pub(super) async fn route_signal_source(initial_host_rate: u32) -> RouteFixture {
     route_source(RouteParams {
+        active_timeline_gap: 0,
+        incoming_timeline_gap: 0,
         initial_host_rate,
+        segmented: false,
+    })
+    .await
+}
+
+pub(super) async fn route_signal_source_with_gaps(
+    active_timeline_gap: u64,
+    incoming_timeline_gap: u64,
+) -> RouteFixture {
+    route_source(RouteParams {
+        active_timeline_gap,
+        incoming_timeline_gap,
+        initial_host_rate: Consts::SAMPLE_RATE,
         segmented: false,
     })
     .await
@@ -767,6 +822,7 @@ async fn route_source(params: RouteParams) -> RouteFixture {
     let container_byte_len = shared_stream.len();
     let factory_drops = drops.clone();
     let factory_host_rate = host_sample_rate.clone();
+    let incoming_timeline_gap = params.incoming_timeline_gap;
     let decoder_factory = DecoderFactory::new(
         move |reader, _info| {
             if segmented && reader.byte_len() != container_byte_len {
@@ -775,11 +831,10 @@ async fn route_source(params: RouteParams) -> RouteFixture {
                 });
             }
             let rate = factory_host_rate.load(Ordering::Acquire);
-            Ok(Box::new(RouteSignalDecoder::new(
-                99,
-                rate,
-                factory_drops.clone(),
-            )))
+            Ok(Box::new(
+                RouteSignalDecoder::new(99, rate, factory_drops.clone())
+                    .with_timeline_gap(incoming_timeline_gap),
+            ))
         },
         None,
     );
@@ -789,11 +844,10 @@ async fn route_source(params: RouteParams) -> RouteFixture {
     };
     let decode = DecodeInit {
         decoder_factory,
-        decoder: Box::new(RouteSignalDecoder::new(
-            1,
-            Consts::SAMPLE_RATE,
-            drops.clone(),
-        )),
+        decoder: Box::new(
+            RouteSignalDecoder::new(1, Consts::SAMPLE_RATE, drops.clone())
+                .with_timeline_gap(params.active_timeline_gap),
+        ),
         decoder_backend: kithara_decode::DecoderBackend::default(),
         gapless_mode: GaplessMode::Disabled,
         host_sample_rate: host_sample_rate.clone(),
@@ -1160,6 +1214,8 @@ async fn route_change_recreate_roots_the_demuxer_at_the_container_origin() {
         mut source,
         ..
     } = route_source(RouteParams {
+        active_timeline_gap: 0,
+        incoming_timeline_gap: 0,
         initial_host_rate: Consts::SAMPLE_RATE,
         segmented: true,
     })

--- a/crates/kithara-audio/src/pipeline/track/tests/transition.rs
+++ b/crates/kithara-audio/src/pipeline/track/tests/transition.rs
@@ -10,6 +10,7 @@ use kithara_test_utils::kithara;
 
 use super::rebuild::{
     Consts, RouteFixture, TestDecoder, media_info, produced_data, route_signal_source,
+    route_signal_source_with_gaps,
 };
 use crate::{
     pipeline::{
@@ -243,6 +244,33 @@ async fn exact_primed_generation_promotes_once_at_outgoing_frontier() {
     assert_eq!(
         produced_data(incoming).meta.frame_offset,
         u64::try_from(Consts::ROUTE_CHUNK_FRAMES).unwrap_or(u64::MAX)
+    );
+}
+
+#[kithara::test(tokio)]
+async fn promotion_preserves_the_normalized_timeline_gap() {
+    const ACTIVE_GAP: u64 = 17;
+    const INCOMING_GAP: u64 = 3;
+
+    let mut fixture = route_signal_source_with_gaps(ACTIVE_GAP, INCOMING_GAP).await;
+    let plan = incoming_plan();
+    let transition = plan.transition();
+    fixture.control.set_exact_plan(plan);
+    fixture.control.set_exact_reader_ready();
+    fixture.control.set_promotion(VariantPromotion::Promoted);
+
+    fixture.source.flush_deferred();
+    wait_for_incoming_priming(&mut fixture, transition).await;
+    assert!(matches!(
+        fixture.source.step_track(),
+        TrackStep::Produced(_)
+    ));
+    fixture.source.flush_deferred();
+
+    assert_eq!(
+        fixture.source.decode.active().timeline_gap(),
+        ACTIVE_GAP,
+        "the promoted generation must retain the splice proof's shared timeline origin"
     );
 }
 

--- a/crates/kithara-hls/CONTEXT.md
+++ b/crates/kithara-hls/CONTEXT.md
@@ -70,6 +70,12 @@ so only the reader's consumption can make it stale and only that consumption may
 Popped-but-undispatchable non-terminal entries are pushed back to the queue front, so an orphaned
 `Downloading` slot is re-claimed, never dropped.
 
+Reader progress reaches the downloader peer through one forwarding task. It delivers at most one
+wake before an ambient-aware cooperative yield: a producer may publish another edge while the task
+is still being polled, and draining that stream continuously would keep a Flash async participant
+active and prevent the virtual clock from advancing. Outside Flash the same yield is the ordinary
+Tokio scheduler hand-off; it does not delay or coalesce the reader edge.
+
 ## Variant Init, Header Range, Probe Rebuild
 
 `HlsVariant::build_init_entry` (`variant/io/init.rs`) records the init slot as

--- a/crates/kithara-hls/src/peer.rs
+++ b/crates/kithara-hls/src/peer.rs
@@ -12,7 +12,11 @@ use kithara_platform::{
     CancelToken,
     sync::{Arc, Mutex, Weak},
     time::Duration,
-    tokio::{self, sync::mpsc, task::spawn},
+    tokio::{
+        self,
+        sync::mpsc,
+        task::{spawn, yield_now},
+    },
 };
 use kithara_stream::{
     Activity, DeferredWake, SeekObserve, WorkerWake,
@@ -248,12 +252,20 @@ impl HlsPeer {
                     () = wake_signal.cancelled() => return,
                     () = reader_advanced.notified() => {
                         let Some(peer) = peer_weak.upgrade() else { return; };
-                        let guard = peer.state.lock();
-                        if let Some(ref state) = *guard
-                            && let Some(waker) = state.waker.as_ref()
                         {
-                            waker.wake_by_ref();
+                            let guard = peer.state.lock();
+                            if let Some(ref state) = *guard
+                                && let Some(waker) = state.waker.as_ref()
+                            {
+                                waker.wake_by_ref();
+                            }
                         }
+                        // A producer can publish another reader edge while
+                        // this task is still being polled. Hand the task back
+                        // to the scheduler after each delivery so Flash can
+                        // observe quiescence instead of draining an endless
+                        // stream of ready Notify permits in one active poll.
+                        yield_now().await;
                     }
                 }
             }

--- a/crates/kithara-stream/src/reader.rs
+++ b/crates/kithara-stream/src/reader.rs
@@ -7,7 +7,7 @@ use kithara_platform::{sync::Arc, time::Duration};
 
 use crate::{BoxedEventSink, ByteMap, MediaInfo, VariantTransition};
 
-/// Shared switch for blocking reads during off-RT decoder construction.
+/// Per-reader switch for blocking I/O during off-RT decoder construction.
 #[derive(Clone, Debug, Default)]
 #[non_exhaustive]
 pub struct ConstructionGate {


### PR DESCRIPTION
## Summary

`SharedStream<T>` held a single `ConstructionGate` shared across all of its
clones. The gate exists so a decoder builder can route its own reads through the
blocking off-RT `Stream` adapters while it constructs a decoder, and disarm them
before steady-state decoding resumes. Because every clone saw the same gate, an
off-RT rebuild arming it for its factory call also switched the **active**
decoder to blocking I/O for the duration — on a path whose whole contract is
that it never blocks.

Each opened reader now receives its own gate, and coordinator clones carry none
at all. That is what makes the active decoder unreachable from a rebuild in
flight: there is no shared cell left to flip.

The decode generation and transition paths follow the same ownership — a reader
belongs to the generation that opened it — and the HLS peer stops dropping the
pending recovery it had already recorded when a re-seek arrives.

This was split out of https://github.com/zvuk/kithara/pull/163, where it had
accumulated while chasing CI failures. It is ownership work in the audio
pipeline, it stands on its own, and it deserves its own review rather than
riding along with a WebCodecs change.

## Behavior / scope

- contract or behavior: the construction gate moves from `SharedStream`'s shared
  state to the individual reader. `CONTEXT.md` in both crates is updated to say
  so — `kithara-audio` for the gate's new owner, `kithara-hls` for the peer's
  pending-recovery rule.
- affected area: `pipeline/stream/{shared,offset}.rs`,
  `pipeline/decode/{generation,transition}.rs`, `audio/build.rs`,
  `kithara-hls/src/peer.rs`, plus the track tests that pin the behaviour.

## Validation

- `cargo check -p kithara-audio -p kithara-hls --all-targets` — passes on this
  branch alone, with none of #163's commits present
- pre-commit `lint-fast` — passed
- not run: the full suite. The fork CI run on this branch is the acceptance
  proof; the rebuild and transition tests in this diff are the ones that speak
  to the change.

## Surface impact

- Public API: none.
- Platform/runtime: none — this is host-side audio pipeline code.
- Perf-sensitive paths: changed. The gate guards whether the decoder's reads
  block, so this is precisely the realtime path; the point of the change is that
  a rebuild can no longer make the active decoder block.

## Risks / follow-ups

- The pipeline tests in this diff cover the ownership rule, but the failure this
  fixes showed up as an intermittent CI hang rather than a deterministic test —
  a run that stays green over several CI passes is what would settle it.
