### PR TITLE
fix(ci): let the simulator lane reach its tests

### DIFF
--- a/.config/just/platform.just
+++ b/.config/just/platform.just
@@ -115,12 +115,18 @@ apple MODE="xcframework" *ARGS:
           just platform apple xcframework --profile debug
         fi
         just platform _xcodegen-local
+        # Explicit modules build the SDK's own PCMs into a shared module cache,
+        # and on a cold cache Xcode 26.6 fails that step for this scheme with
+        # `redefinition of module 'SwiftShims'` — every fresh CI guest hit it
+        # before any test ran. A warm cache hides it, which is why it looks
+        # intermittent.
         KITHARA_LOCAL_DEV=1 \
         TEST_RUNNER_KITHARA_TEST_SERVER_URL="$test_server_url" \
           xcodebuild test \
             -project apple/Examples/KitharaDemo/KitharaDemo.xcodeproj \
             -scheme KitharaDemoUnitTests_iOS \
-            -destination "$destination"
+            -destination "$destination" \
+            SWIFT_ENABLE_EXPLICIT_MODULES=NO
         ;;
       integration-regressions)
         # One xcodebuild invocation for the whole suite: the tests share a
@@ -149,7 +155,8 @@ apple MODE="xcframework" *ARGS:
         KITHARA_LOCAL_DEV=1 xcodebuild build-for-testing \
             -project apple/Examples/KitharaDemo/KitharaDemo.xcodeproj \
             -scheme KitharaDemoUnitTests_iOS \
-            -destination "$destination" || exit 1
+            -destination "$destination" \
+            SWIFT_ENABLE_EXPLICIT_MODULES=NO || exit 1
         selection=(-only-testing:KitharaDemoUnitTests_iOS/IntegrationRegressionsIOS)
         log="$TMPDIR/kithara-integration-regressions.log"
         if [[ -n "$only_test" ]]; then

--- a/apple/Examples/KitharaDemo/UnitTests/PlaybackResumesAfterConnectivityReturns.swift
+++ b/apple/Examples/KitharaDemo/UnitTests/PlaybackResumesAfterConnectivityReturns.swift
@@ -27,7 +27,7 @@ extension IntegrationRegressionsIOS {
 
         let player = KitharaPlayer(config: .init(store: AssetStore(root: cacheURL.path)))
         let item = KitharaPlayerItem(
-            url: try TestServerFixture.asset("hls/master.m3u8").absoluteString
+            url: try await TestServerFixture.pacedHlsMasterURL().absoluteString
         )
         let signals = ResumeSignals()
         let stallCancellable = item.didStall.sink {

--- a/apple/Examples/KitharaDemo/UnitTests/TestServerFixture.swift
+++ b/apple/Examples/KitharaDemo/UnitTests/TestServerFixture.swift
@@ -164,6 +164,91 @@ enum TestServerFixture {
         return result
     }
 
+    /// A single-variant HLS master whose media segments arrive at roughly the
+    /// rate they are consumed.
+    ///
+    /// The fixture server answers over loopback, so a player drains the whole
+    /// track into its store within a second of `play()`. A test that then
+    /// takes the network away observes nothing — playback runs on from what is
+    /// already stored. Pacing the segments, while the playlists stay
+    /// immediate, bounds how far ahead the player can get, which is what makes
+    /// an outage observable at all.
+    static func pacedHlsMasterURL(
+        chunk: Int = 3072,
+        delayMilliseconds: UInt64 = 250
+    ) async throws -> URL {
+        let variant = "index-slq-a1.m3u8"
+        let initialization = "init-slq-a1.mp4"
+        let playlist = try await fixtureText(at: asset("hls/\(variant)"))
+
+        var rewritten: [String] = []
+        for substring in playlist.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = String(substring)
+            if line.hasPrefix("#EXT-X-MAP:") {
+                rewritten.append(
+                    line.replacingOccurrences(
+                        of: initialization,
+                        with: try asset("hls/\(initialization)").absoluteString
+                    )
+                )
+            } else if !line.isEmpty, !line.hasPrefix("#") {
+                let segment = try await registerBehavior(
+                    .init(
+                        content: .asset(name: "hls/\(line)"),
+                        delivery: .throttle(
+                            chunk: chunk,
+                            delayMilliseconds: delayMilliseconds
+                        )
+                    )
+                )
+                rewritten.append(segment.childURL(line).absoluteString)
+            } else {
+                rewritten.append(line)
+            }
+        }
+
+        let media = try await registerBehavior(
+            .init(
+                content: .bytes(
+                    Data(rewritten.joined(separator: "\n").utf8),
+                    contentType: "application/vnd.apple.mpegurl"
+                ),
+                delivery: .normal
+            )
+        )
+        let master = """
+        #EXTM3U
+        #EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=66005,CODECS="mp4a.40.2"
+        \(media.childURL(variant).absoluteString)
+
+        """
+        let masterHandle = try await registerBehavior(
+            .init(
+                content: .bytes(
+                    Data(master.utf8),
+                    contentType: "application/vnd.apple.mpegurl"
+                ),
+                delivery: .normal
+            )
+        )
+        return masterHandle.childURL("master.m3u8")
+    }
+
+    private static func fixtureText(at url: URL) async throws -> String {
+        let (data, response) = try await URLSession.shared.data(from: url)
+        guard let http = response as? HTTPURLResponse else {
+            throw FixtureError.invalidResponse(url)
+        }
+        guard http.statusCode == 200 else {
+            let body = String(data: data, encoding: .utf8) ?? "<non-UTF-8 body>"
+            throw FixtureError.unexpectedStatus(url, http.statusCode, body)
+        }
+        guard let text = String(data: data, encoding: .utf8) else {
+            throw FixtureError.invalidResponse(url)
+        }
+        return text
+    }
+
     static func setNetwork(online: Bool) async throws {
         _ = try await post(
             NetworkRequest(online: online),

--- a/apple/Examples/KitharaDemo/UnitTests/TransientFailureKeepsCurrentTrack.swift
+++ b/apple/Examples/KitharaDemo/UnitTests/TransientFailureKeepsCurrentTrack.swift
@@ -22,7 +22,7 @@ extension IntegrationRegressionsIOS {
 
         let player = KitharaPlayer(config: .init(store: AssetStore(root: cacheURL.path)))
         let target = KitharaPlayerItem(
-            url: try TestServerFixture.asset("hls/master.m3u8").absoluteString
+            url: try await TestServerFixture.pacedHlsMasterURL().absoluteString
         )
         let fallback = KitharaPlayerItem(
             url: try TestServerFixture.asset("test.mp3").absoluteString

--- a/crates/kithara-assets/src/store/builder.rs
+++ b/crates/kithara-assets/src/store/builder.rs
@@ -372,6 +372,41 @@ mod tests {
         )));
     }
 
+    /// A failed fetch must not cost the resource its future. The network
+    /// going away for a moment is the ordinary case: the same segment is
+    /// asked for again once it is back, and that request has to open a fresh
+    /// download rather than trip over the wreckage of the last one.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[kithara::test(timeout(Duration::from_secs(5)))]
+    fn reacquire_after_failure_opens_a_fresh_download() {
+        let dir = tempdir().unwrap();
+        let store = AssetStore::builder()
+            .backend(StorageBackend::Disk {
+                root: dir.path().into(),
+            })
+            .build();
+        let key = ResourceKey::relative(ROOT, "seg.m4s");
+
+        let AcquisitionResult::Pending(writer) = store.acquire_resource(&key, None).unwrap() else {
+            panic!("expected a Pending writer");
+        };
+        // The reader the player parks on outlives the download, which is what
+        // routes the retry through the cached in-flight entry rather than a
+        // clean first acquisition.
+        let parked = writer.reader();
+        writer.write_at(0, b"half").unwrap();
+        writer.fail("network away".to_string());
+
+        let reacquired = store
+            .acquire_resource(&key, None)
+            .expect("a failed segment must be fetchable again");
+        assert!(
+            matches!(reacquired, AcquisitionResult::Pending(_)),
+            "the retry must get a writer, not the failed resource"
+        );
+        drop(parked);
+    }
+
     #[kithara::test(timeout(Duration::from_secs(5)))]
     fn fail_publishes_asset_failed() {
         let bus = EventBus::new(8);

--- a/crates/kithara-hls/src/segment/fetch.rs
+++ b/crates/kithara-hls/src/segment/fetch.rs
@@ -36,7 +36,21 @@ use crate::{
 fn is_terminal_fetch_error(e: &NetError) -> bool {
     match e {
         NetError::Cancelled => false,
-        NetError::RetryExhausted { source, .. } => is_terminal_fetch_error(source),
+        // The budget is spent on one download in well under a second, while
+        // the slot it parks may not be read for another half a minute — so
+        // what matters is whether the segment is obtainable later, not
+        // whether this attempt failed. A reachable server that answered
+        // "not now" (503, 429, 408) says nothing about later, and an outage
+        // of a few seconds must not cost the track every segment that
+        // happened to be in flight. Anything else that burnt the budget —
+        // a body that stopped arriving, a socket that never answered — the
+        // resilient body already re-fetched and gave up on; parking it is
+        // right, and a reader waiting on it gets a terminal error rather
+        // than a retry loop with nothing behind it.
+        NetError::RetryExhausted { source, .. } => match source.as_ref() {
+            status @ NetError::Status { .. } => status.retryability() != Retryability::Transient,
+            _ => true,
+        },
         other => other.retryability() == Retryability::Fatal,
     }
 }

--- a/crates/kithara-hls/src/segment/fetch.rs
+++ b/crates/kithara-hls/src/segment/fetch.rs
@@ -326,14 +326,20 @@ impl FetchSlot {
                 });
                 handle.into_failed();
             } else {
+                // Freeing the slot is not enough to get this segment fetched
+                // again. Dispatch popped its plan entry when it sent the
+                // fetch, and `poll_next` only runs on reader progress or the
+                // slow-fetch hook — neither of which a failed download
+                // produces. So the work has to go back on the plan, and the
+                // peer has to be woken to take it; without both, the segment
+                // is never asked for again and playback stops at the gap it
+                // leaves, even once the network is back.
+                let planned = handle.planned();
+                let variant = handle.variant();
                 handle.into_missing();
-                // Returning the slot to the pool is not enough to get it
-                // fetched again: `poll_next` is driven by reader progress and
-                // by the slow-fetch hook, and a download that failed produces
-                // neither. Without this wake the peer emits no further
-                // command, so a segment freed here is simply never asked for
-                // — playback stops at the gap and stays there even once the
-                // network is back. Wake the peer so it re-aims.
+                if let Some(variant) = variant {
+                    variant.requeue_planned(planned);
+                }
                 signal.wake_peer();
             }
         }

--- a/crates/kithara-hls/src/segment/fetch.rs
+++ b/crates/kithara-hls/src/segment/fetch.rs
@@ -21,14 +21,24 @@ use crate::{
     variant::HlsVariant,
 };
 
-/// Whether a fetch error is terminal for the slot. The net layer's
-/// resilient body already retried stalls and transient body errors, so a
-/// `Fatal` error reaching the settle path means the downloader gave up —
-/// the slot must be parked `Failed` rather than re-dispatched. `Cancelled`
-/// is the one `Fatal` variant that stays recoverable: a cancel marks an
-/// epoch rebuild, which owns the re-dispatch, so it keeps `Missing`.
+/// Whether a fetch error is terminal for the slot — whether this segment is
+/// unobtainable, not whether this download failed.
+///
+/// `Cancelled` stays recoverable: a cancel marks an epoch rebuild, which owns
+/// the re-dispatch. `RetryExhausted` is unwrapped to the cause underneath it.
+/// The net layer spends its budget on one download in well under a second,
+/// while the slot it parks may not be read for another half a minute — so
+/// treating "the network was briefly away" as a permanent verdict strands a
+/// segment that would fetch fine by the time anyone wants it. A transient
+/// cause therefore returns the slot to the pool and the next dispatch asks
+/// again; a fatal one (a missing resource, a body that will not decode) parks
+/// it, because asking again cannot change the answer.
 fn is_terminal_fetch_error(e: &NetError) -> bool {
-    !matches!(e, NetError::Cancelled) && e.retryability() == Retryability::Fatal
+    match e {
+        NetError::Cancelled => false,
+        NetError::RetryExhausted { source, .. } => is_terminal_fetch_error(source),
+        other => other.retryability() == Retryability::Fatal,
+    }
 }
 
 /// Phantom-typed handle to a segment / init slot. `S` is one of
@@ -283,6 +293,7 @@ impl FetchSlot {
             writer,
             reader,
             bus,
+            signal,
             ..
         } = self;
         let committed = matches!(reader.status(), ResourceStatus::Committed { .. });
@@ -298,14 +309,12 @@ impl FetchSlot {
             }
         } else {
             writer.fail(e.to_string());
-            // The net layer's resilient body already retried stalls and
-            // transient body errors; a `Fatal` error here (e.g.
-            // `RetryExhausted`) means the downloader gave up, so the slot
-            // is terminal — parking it as `Failed` stops the re-dispatch
-            // loop and lets a waiting reader surface a terminal error.
-            // `Cancelled` is recoverable (epoch rebuild owns it) and stays
-            // `Missing`. The typed cause is logged here; readers see only
-            // the fixed terminal message (no transport detail).
+            // A terminal cause parks the slot `Failed`, which stops the
+            // re-dispatch loop and lets a waiting reader surface a terminal
+            // error. Everything else — a cancel (the epoch rebuild owns the
+            // re-dispatch) and a spent retry budget over a transient cause —
+            // returns to `Missing`. The typed cause is logged here; readers
+            // see only the fixed terminal message (no transport detail).
             if is_terminal_fetch_error(e) {
                 error!(
                     target: "kithara_hls::settle",
@@ -318,6 +327,14 @@ impl FetchSlot {
                 handle.into_failed();
             } else {
                 handle.into_missing();
+                // Returning the slot to the pool is not enough to get it
+                // fetched again: `poll_next` is driven by reader progress and
+                // by the slow-fetch hook, and a download that failed produces
+                // neither. Without this wake the peer emits no further
+                // command, so a segment freed here is simply never asked for
+                // — playback stops at the gap and stays there even once the
+                // network is back. Wake the peer so it re-aims.
+                signal.wake_peer();
             }
         }
     }

--- a/crates/kithara-hls/src/variant/flow/queue.rs
+++ b/crates/kithara-hls/src/variant/flow/queue.rs
@@ -83,6 +83,22 @@ impl HlsVariant {
         Some(seg)
     }
 
+    /// Put a fetch that failed recoverably back on the plan.
+    ///
+    /// Freeing the slot is only half of it: dispatch popped the entry when it
+    /// sent the fetch, so a slot returned to `Missing` describes work nobody
+    /// holds. The peer then wakes to an empty plan and asks for nothing, and
+    /// the segment is never fetched again — playback stops at that gap even
+    /// once the network is back. Front of the queue, because playback is
+    /// waiting on it; only when absent, so a rebuild that already re-planned
+    /// it is not duplicated.
+    pub(crate) fn requeue_planned(&self, planned: PlannedFetch) {
+        let mut queue = self.flow.queue.lock();
+        if !queue.contains(&planned) {
+            queue.push_front(planned);
+        }
+    }
+
     #[kithara::probe]
     pub(super) fn rebuild_queue(&self, from_seg: u32, probe_seg: Option<u32>) {
         let segs_len = self.num_segments();

--- a/tests/tests/integration_regressions/offline_resume.rs
+++ b/tests/tests/integration_regressions/offline_resume.rs
@@ -1,5 +1,7 @@
 #![cfg(not(target_arch = "wasm32"))]
 
+use std::{fs, path::PathBuf};
+
 use kithara::{
     events::{AudioEvent, DownloaderEvent, Event},
     hls::AbrMode,
@@ -15,7 +17,7 @@ use kithara::{
     stream::dl::{Downloader, DownloaderConfig},
 };
 use kithara_integration_tests::{
-    PrivateTestServer, TestTempDir, kithara,
+    Content, Delivery, FixtureBehavior, PrivateTestServer, TestTempDir, kithara,
     offline::OfflineSession,
     temp_dir,
     waits::{wait_for_event, wait_for_loader_done_event, wait_for_position_event},
@@ -39,6 +41,13 @@ use kithara_integration_tests::{
 /// the cached bytes drain, and draining is paced by real playback. At 256 KiB
 /// the drain outlasted the wait on roughly one run in five.
 const LOOK_AHEAD_BYTES: u64 = 64 * 1024;
+/// Wide enough that an outage catches several fetches mid-body, which is
+/// what a device does and what the narrow window above deliberately avoids.
+const PACED_LOOK_AHEAD_BYTES: u64 = 1024 * 1024;
+/// ~12 KiB/s: the slq variant carries ~50 KiB per 5 s of audio, so the
+/// downloader gains on playback slowly instead of racing to the end.
+const SEGMENT_CHUNK_BYTES: usize = 3 * 1024;
+const SEGMENT_CHUNK_DELAY_MS: u64 = 250;
 const PLAY_BEFORE_OUTAGE_SECS: f64 = 1.0;
 const MIN_RESUME_PROGRESS_SECS: f64 = 1.0;
 
@@ -66,8 +75,91 @@ async fn playback_resumes_after_network_returns(temp_dir: TestTempDir) {
     // A private server: this test takes the network down, and the switch covers
     // every data route on whichever server it runs against.
     let server = PrivateTestServer::start().await;
-    let url = server.helper().asset("hls/master.m3u8");
+    let url = server.helper().asset("hls/master.m3u8").to_string();
+    resumes_after_outage(temp_dir, &server, url, LOOK_AHEAD_BYTES).await;
+}
 
+/// The same contract, with the segments arriving at the rate they are played
+/// and a look-ahead wide enough to keep several of them in flight.
+///
+/// [`playback_resumes_after_network_returns`] serves them from loopback into a
+/// 64 KiB window, so at most one fetch is open when the network goes: it fails,
+/// and the next attempt happens after connectivity is back. On a device the
+/// window is wider and the segments take real time to arrive, so an outage
+/// catches a handful of part-written bodies at once — the case that stranded
+/// the iOS lane, where every one of them was written off permanently and
+/// playback stopped at the first of the gaps they left.
+#[kithara::test(tokio, multi_thread, timeout(Duration::from_secs(180)))]
+async fn playback_resumes_after_network_returns_with_paced_segments(temp_dir: TestTempDir) {
+    let server = PrivateTestServer::start().await;
+    let url = paced_master(&server);
+    resumes_after_outage(temp_dir, &server, url, PACED_LOOK_AHEAD_BYTES).await;
+}
+
+/// Re-serve the packaged variant with every media segment throttled to roughly
+/// the rate it is consumed (~50 KiB of audio per 5 s). The playlists stay
+/// immediate: pacing those would only delay the start.
+fn paced_master(server: &PrivateTestServer) -> String {
+    const VARIANT: &str = "index-slq-a1.m3u8";
+    const INITIALIZATION: &str = "init-slq-a1.mp4";
+    const PLAYLIST_TYPE: Option<&'static str> = Some("application/vnd.apple.mpegurl");
+
+    let hls = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("repo root from tests/")
+        .join("assets/hls");
+    let playlist = fs::read_to_string(hls.join(VARIANT)).expect("read the packaged variant");
+
+    let mut rewritten = Vec::new();
+    for line in playlist.split('\n') {
+        if line.starts_with("#EXT-X-MAP:") {
+            let init = server.helper().asset(&format!("hls/{INITIALIZATION}"));
+            rewritten.push(line.replace(INITIALIZATION, init.as_str()));
+        } else if !line.is_empty() && !line.starts_with('#') {
+            let bytes = fs::read(hls.join(line)).expect("read a packaged segment");
+            let handle = server.helper().register_behavior(FixtureBehavior {
+                content: Content::StaticBytes {
+                    bytes: Arc::new(bytes),
+                    content_type: None,
+                },
+                delivery: Delivery::Throttle {
+                    chunk: SEGMENT_CHUNK_BYTES,
+                    delay_ms: SEGMENT_CHUNK_DELAY_MS,
+                },
+            });
+            rewritten.push(handle.child_url(line).to_string());
+        } else {
+            rewritten.push(line.to_string());
+        }
+    }
+
+    let media = server.helper().register_behavior(FixtureBehavior {
+        content: Content::StaticBytes {
+            bytes: Arc::new(rewritten.join("\n").into_bytes()),
+            content_type: PLAYLIST_TYPE,
+        },
+        delivery: Delivery::Normal,
+    });
+    let master = format!(
+        "#EXTM3U\n#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=66005,CODECS=\"mp4a.40.2\"\n{}\n",
+        media.child_url(VARIANT)
+    );
+    let handle = server.helper().register_behavior(FixtureBehavior {
+        content: Content::StaticBytes {
+            bytes: Arc::new(master.into_bytes()),
+            content_type: PLAYLIST_TYPE,
+        },
+        delivery: Delivery::Normal,
+    });
+    handle.child_url("master.m3u8").to_string()
+}
+
+async fn resumes_after_outage(
+    temp_dir: TestTempDir,
+    server: &PrivateTestServer,
+    url: String,
+    look_ahead_bytes: u64,
+) {
     let net = NetOptions::builder()
         .inactivity_timeout(Duration::from_millis(500))
         .retry_policy(
@@ -95,7 +187,7 @@ async fn playback_resumes_after_network_returns(temp_dir: TestTempDir) {
             .pcm_pool(kithara::bufpool::PcmPool::default())
             .downloader(downloader)
             .initial_abr_mode(AbrMode::manual(0))
-            .look_ahead_bytes(LOOK_AHEAD_BYTES)
+            .look_ahead_bytes(look_ahead_bytes)
             .store(kithara_integration_tests::disk_asset_store(temp_dir.path()))
             .build();
 

--- a/xtask/src/ci/host/runner_images.rs
+++ b/xtask/src/ci/host/runner_images.rs
@@ -297,7 +297,16 @@ impl RunnerManager<'_> {
     fn boot_job_vm(&self, tart: &str) -> Result<String> {
         let mut command = self.process.command(tart);
         command
-            .args(["run", "--no-graphics"])
+            // `--no-audio` is what makes the iOS Simulator usable here. With
+            // the pass-through on, the guest's virtual sound device carries an
+            // input channel that leads nowhere, and `AudioUnitInitialize` on
+            // `AURemoteIO` inside a simulator blocks on it: CoreAudio waits
+            // nine seconds, reports "Initialize: RPC timeout. Apparently
+            // deadlocked" and aborts the process. Every test that starts
+            // playback died that way. Without the pass-through the device is
+            // output-only and the same unit initializes in two seconds. The
+            // jobs never play audible sound, so nothing is lost.
+            .args(["run", "--no-graphics", "--no-audio"])
             .args(self.job_vm_mounts())
             .arg(JobVm::NAME)
             .stdout(Stdio::null())


### PR DESCRIPTION
## Description

`apple:ios-test` had been red since the lane landed on 2026-08-06. Three separate causes, none of them in the code the lane exists to test. All three are fixed: the lane now runs **12 of 12 green** in CI.

### 1. The guest VM booted with tart's audio pass-through

That hands the guest a virtual sound device carrying an input channel that leads nowhere. `AudioUnitInitialize` on `AURemoteIO` inside a simulator blocks on it: CoreAudio waits nine seconds, logs `Initialize: RPC timeout. Apparently deadlocked. Aborting now.` and aborts the process. Every test that started playback died there — one process per test, ten restarts per run — and the only green test was the one that never touches audio.

Measured with a standalone `AVAudioEngine` probe (56 KB, no Kithara code) through `xcrun simctl spawn`:

| environment | Xcode / runtime | result |
|---|---|---|
| developer Mac (bare metal) | 26.3 / iOS 26.3.1 | `ENGINE STARTED ok` |
| the Mac mini itself (bare metal) | 26.6 / iOS 26.5 | `ENGINE STARTED ok` |
| CI guest as it booted | 26.6 / iOS 26.5 | abort after 11 s |
| CI guest booted `--no-audio` | 26.6 / iOS 26.5 | `ENGINE STARTED ok`, 2 s |

Rows two and three share a machine and a runtime, so the variable is the pass-through. Ruled out: the ssh-vs-Aqua session the runner lives in (identical abort in both), a missing audio device (the guest has one, `afplay` works), the input node itself (`EnableIO=0` aborts the same), `AVAudioSession` activation (it succeeds; `AudioUnitInitialize` still hangs), and restarting `coreaudiod`. The jobs never play audible sound, so the pass-through costs nothing.

### 2. The test scheme's own build

Xcode 26.6 builds the SDK's PCMs through explicit modules, and on a cold module cache that step fails with `redefinition of module 'SwiftShims'`. The cache lives in the throwaway guest, so a fresh guest always hit it; a warm cache hid it, which made it read as intermittent. Verified back to back in the guest, both from scratch: default `exit 65` with 32 `redefinition` errors, `SWIFT_ENABLE_EXPLICIT_MODULES=NO` `exit 0`.

### 3. A brief outage stranded the track permanently

With the lane reaching its tests, two of them still failed — on a precondition that could not happen. They take the fixture server offline a second into playback and wait for the player to run dry, but the server answers over loopback: the whole 185-second track is stored before the outage begins, playback runs the full window without a stall, and the property under test is never exercised. Pacing the media segments at the rate they are consumed keeps the buffer shallow, so the outage is felt.

`transientFailureKeepsCurrentTrack` passed with that. The other one then failed on its real subject, and it was a genuine defect: a two-second outage left playback stopped at the first gap forever, with no fetch even attempted after connectivity returned. Three things had to agree for that:

- **A spent retry budget was read as "this segment does not exist."** The net layer spends it on one download in well under a second and promotes the cause to `RetryExhausted`, classified `Fatal`; the slot parked `Failed`, and `try_claim` only CAS's from `Missing`, so it was never re-dispatched. Now the cause underneath is what decides — and only a server that *answered* (503, 429, 408) earns another attempt. Silence still parks the slot, so a reader waiting on a body that stopped arriving gets its terminal error instead of an unbounded retry loop.
- **Nothing woke the downloader.** `poll_next` runs on reader progress and on the slow-fetch hook; a failed download produces neither.
- **The work was gone from the plan.** Dispatch pops the queue entry when it sends a fetch, so a slot returned to `Missing` described work nobody held: the peer woke to an empty plan and asked for nothing. This was the load-bearing one — it is why the first two fixes alone changed nothing on iOS.

The regression comes with it. The existing `playback_resumes_after_network_returns` passes without any of this, because it serves the fixture over loopback into a 64 KiB window: at most one fetch is open when the network goes, and the retry lands after it is back. That is why the core looked healthy while the device did not — the test's own comment called itself "the alibi placing the reported bug above the Rust layer", and the alibi was wrong. The new `..._with_paced_segments` case paces the segments and widens the window, so the outage catches several part-written bodies at once. It fails without these fixes (68.7 s) and passes with them (26.8 s).

## Verification

- `apple:ios-test` in CI: **12 of 12 green**, 83.9 s (job 9120992).
- `just test`: 4823 passed, 0 failed — same as the baseline without these changes.
- `audio_new_bounded_failure_when_first_segment_withheld`: 1.38 s, inside its 5 s budget.
- Both `offline_resume` cases green; `kithara-hls` unit tests (171) green; clippy clean on the crates touched.

The Mac mini already runs the updated binary and pins, so its guests boot `--no-audio` today.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Other (describe):

## Checklist

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes (scoped to the crates touched: `xtask`, `kithara-hls`)
- [x] Tests added/updated
- [x] No `unwrap()`/`expect()` in production code
- [ ] Documentation updated (if applicable)
