### PR TITLE
ci: make the Mac mini carry Apple by default, the rest on request

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,6 +21,11 @@ workflow:
 .serialized:
   stage: dispatch
   resource_group: kithara-mac-mini
+  variables:
+    # The child pipeline gates its platform includes on this, and it does not
+    # see what the run was started with unless the trigger forwards it. Unset
+    # is the ordinary case and means Apple alone.
+    KITHARA_PLATFORMS: $KITHARA_PLATFORMS
   trigger:
     include:
       - local: .gitlab/ci/pipeline.yml
@@ -55,6 +60,7 @@ dispatch:branch:
   variables:
     KITHARA_CACHE_TRUST: review
     KITHARA_PIPELINE_KIND: branch
+    KITHARA_PLATFORMS: $KITHARA_PLATFORMS
   rules:
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH != $CI_DEFAULT_BRANCH
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,6 +16,11 @@ workflow:
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_PIPELINE_SOURCE == "web" && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $KITHARA_RELEASE_VERSION =~ /^\d+\.\d+\.\d+(-[0-9A-Za-z.]+)?$/
     - if: $CI_PIPELINE_SOURCE == "api" && $KITHARA_QUARANTINE_SHA
+    # Asking for a platform is only possible on a run that carries variables,
+    # and a push carries none. This is that door: "Run pipeline" with
+    # `KITHARA_PLATFORMS` set. It is deliberately narrow — without the variable
+    # the run would only repeat what a push already does.
+    - if: $KITHARA_PLATFORMS && ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api")
     - when: never
 
 .serialized:
@@ -63,6 +68,25 @@ dispatch:branch:
     KITHARA_PLATFORMS: $KITHARA_PLATFORMS
   rules:
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH != $CI_DEFAULT_BRANCH
+
+# The same subset a branch push runs, started by hand to name platforms a push
+# cannot. It shares the branch queue rather than the main one, so asking for
+# Linux or Windows never puts the default branch behind it.
+dispatch:platforms:
+  stage: dispatch
+  resource_group: kithara-mac-mini-branch
+  allow_failure: true
+  interruptible: true
+  trigger:
+    include:
+      - local: .gitlab/ci/pipeline.yml
+    strategy: depend
+  variables:
+    KITHARA_CACHE_TRUST: review
+    KITHARA_PIPELINE_KIND: branch
+    KITHARA_PLATFORMS: $KITHARA_PLATFORMS
+  rules:
+    - if: $KITHARA_PLATFORMS && ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api")
 
 dispatch:main:
   extends: .serialized

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,8 @@ workflow:
     # and a push carries none. This is that door: "Run pipeline" with
     # `KITHARA_PLATFORMS` set. It is deliberately narrow — without the variable
     # the run would only repeat what a push already does.
-    - if: $KITHARA_PLATFORMS && ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api")
+    - if: $CI_PIPELINE_SOURCE == "web" && $KITHARA_PLATFORMS
+    - if: $CI_PIPELINE_SOURCE == "api" && $KITHARA_PLATFORMS
     - when: never
 
 .serialized:
@@ -86,7 +87,8 @@ dispatch:platforms:
     KITHARA_PIPELINE_KIND: branch
     KITHARA_PLATFORMS: $KITHARA_PLATFORMS
   rules:
-    - if: $KITHARA_PLATFORMS && ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api")
+    - if: $CI_PIPELINE_SOURCE == "web" && $KITHARA_PLATFORMS
+    - if: $CI_PIPELINE_SOURCE == "api" && $KITHARA_PLATFORMS
 
 dispatch:main:
   extends: .serialized

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,9 +70,13 @@ dispatch:branch:
   rules:
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH != $CI_DEFAULT_BRANCH
 
-# The same subset a branch push runs, started by hand to name platforms a push
-# cannot. It shares the branch queue rather than the main one, so asking for
-# Linux or Windows never puts the default branch behind it.
+# Started by hand to name platforms a push cannot. It runs as the `main` kind
+# rather than `branch`, because that is the kind under which the platform lanes
+# exist at all: `linux:*` hangs off the verify set, the web and Android lanes
+# off the integration set, and neither admits `branch`. Asking for a platform
+# on a branch kind would silently produce the Apple-only pipeline and look like
+# the switch was ignored. The branch queue keeps it out of the default branch's
+# way regardless.
 dispatch:platforms:
   stage: dispatch
   resource_group: kithara-mac-mini-branch
@@ -84,7 +88,7 @@ dispatch:platforms:
     strategy: depend
   variables:
     KITHARA_CACHE_TRUST: review
-    KITHARA_PIPELINE_KIND: branch
+    KITHARA_PIPELINE_KIND: main
     KITHARA_PLATFORMS: $KITHARA_PLATFORMS
   rules:
     - if: $CI_PIPELINE_SOURCE == "web" && $KITHARA_PLATFORMS

--- a/.gitlab/ci/android.yml
+++ b/.gitlab/ci/android.yml
@@ -1,7 +1,9 @@
 android:build:
-  extends:
-    - .android-job
-    - .rules-integration
+  extends: .android-job
+  interruptible: false
+  rules:
+    - !reference [.platform-android, rules]
+    - !reference [.rules-integration, rules]
   stage: android
   timeout: 45 minutes
   needs: []
@@ -18,8 +20,11 @@ android:build:
 android:test:
   extends:
     - .android-job
-    - .rules-integration
     - .measured
+  interruptible: false
+  rules:
+    - !reference [.platform-android, rules]
+    - !reference [.rules-integration, rules]
   stage: android
   timeout: 90 minutes
   needs:

--- a/.gitlab/ci/common.yml
+++ b/.gitlab/ci/common.yml
@@ -43,6 +43,39 @@
   tags:
     - kithara-release
 
+# One Mac mini serves every platform: a Linux container under colima, Windows
+# under qemu, Android on the host, the simulator in a throwaway macOS guest.
+# Carrying all of them on every push spends the machine on lanes the GitHub
+# fork already covers, and buries the platform under focus — today iOS — among
+# failures that belong elsewhere. So the others are opt-in: name them in
+# `KITHARA_PLATFORMS`, comma-separated, on a run started for that purpose.
+#
+# These gate the lanes' own rule sets rather than the `include`, because an
+# `include:rules` is resolved before the variables a run carries are visible —
+# a child pipeline that plainly has `KITHARA_PLATFORMS=linux` still saw none of
+# the Linux jobs. As the first entry in a job's `rules` a `when: never` match
+# ends the evaluation, so the platform check comes before anything the lane's
+# own kind rules would allow.
+.platform-linux:
+  rules:
+    - if: $KITHARA_PLATFORMS !~ /(^|,)\s*linux\s*(,|$)/
+      when: never
+
+.platform-web:
+  rules:
+    - if: $KITHARA_PLATFORMS !~ /(^|,)\s*web\s*(,|$)/
+      when: never
+
+.platform-android:
+  rules:
+    - if: $KITHARA_PLATFORMS !~ /(^|,)\s*android\s*(,|$)/
+      when: never
+
+.platform-windows:
+  rules:
+    - if: $KITHARA_PLATFORMS !~ /(^|,)\s*windows\s*(,|$)/
+      when: never
+
 # Jobs declare only the dependencies they really have. Ordering on the shared
 # host belongs to the runners — each takes a single build at a time — so a lane
 # no longer queues behind an unrelated lane, and a lane whose runner is not

--- a/.gitlab/ci/host.yml
+++ b/.gitlab/ci/host.yml
@@ -1,0 +1,26 @@
+# Repairs the host needs on itself, reachable from the pipeline rather than
+# only over ssh.
+
+# The Linux image is built on this machine and never pushed anywhere, so a
+# colima restart — which recreates the VM — takes it with it. Until someone
+# rebuilds it, every `linux:*` job dies in two seconds on
+# `pull access denied for kithara-ci`, and the lane looks broken in a way that
+# says nothing about the code. That happened on 2026-08-07 and cost four days.
+#
+# This job is the repair. It runs on the host's own shell runner, so it stays
+# reachable exactly when the Linux lane is not, and it is manual because
+# rebuilding takes forty minutes and is a decision, not a reaction. `pins` come
+# from the checkout the job already has, so the image is tagged with whatever
+# the commit pins — the mismatch that made the tag change silently break the
+# lane cannot happen here.
+linux:image:
+  extends: .release-job
+  stage: linux
+  timeout: 90 minutes
+  needs: []
+  rules:
+    - when: manual
+      allow_failure: true
+  script:
+    - just ci host build-linux-image docker/ci.Dockerfile
+    - just ci host smoke-linux

--- a/.gitlab/ci/host.yml
+++ b/.gitlab/ci/host.yml
@@ -13,12 +13,17 @@
 # from the checkout the job already has, so the image is tagged with whatever
 # the commit pins — the mismatch that made the tag change silently break the
 # lane cannot happen here.
+#
+# It answers for the Linux lane, so it appears only on a run that asked for
+# Linux. A manual job is still a job on the pipeline page, and a repair nobody
+# requested reads as work the run intends to do.
 linux:image:
   extends: .release-job
   stage: linux
   timeout: 90 minutes
   needs: []
   rules:
+    - !reference [.platform-linux, rules]
     - when: manual
       allow_failure: true
   script:

--- a/.gitlab/ci/lanes.yml
+++ b/.gitlab/ci/lanes.yml
@@ -1,7 +1,9 @@
 .lane-job:
-  extends:
-    - .linux-job
-    - .rules-weekly
+  extends: .linux-job
+  interruptible: false
+  rules:
+    - !reference [.platform-linux, rules]
+    - !reference [.rules-weekly, rules]
   stage: lanes
   timeout: 180 minutes
   needs: []

--- a/.gitlab/ci/linux.yml
+++ b/.gitlab/ci/linux.yml
@@ -1,7 +1,9 @@
 .linux-lane:
-  extends:
-    - .linux-job
-    - .rules-verify
+  extends: .linux-job
+  interruptible: true
+  rules:
+    - !reference [.platform-linux, rules]
+    - !reference [.rules-verify, rules]
   stage: linux
   timeout: 60 minutes
   needs: []

--- a/.gitlab/ci/linux.yml
+++ b/.gitlab/ci/linux.yml
@@ -24,11 +24,6 @@ linux:check:
   script:
     - just ci run linux-check
 
-linux:wasm:
-  extends: .linux-lane
-  script:
-    - just ci run linux-wasm
-
 linux:test:
   extends:
     - .linux-job

--- a/.gitlab/ci/linux.yml
+++ b/.gitlab/ci/linux.yml
@@ -32,8 +32,11 @@ linux:wasm:
 linux:test:
   extends:
     - .linux-job
-    - .rules-integration
     - .measured
+  interruptible: false
+  rules:
+    - !reference [.platform-linux, rules]
+    - !reference [.rules-integration, rules]
   stage: linux
   timeout: 60 minutes
   needs:
@@ -51,8 +54,11 @@ linux:test:
 linux:coverage:
   extends:
     - .linux-job
-    - .rules-nightly
     - .measured
+  interruptible: false
+  rules:
+    - !reference [.platform-linux, rules]
+    - !reference [.rules-nightly, rules]
   stage: linux
   timeout: 90 minutes
   needs:

--- a/.gitlab/ci/pipeline.yml
+++ b/.gitlab/ci/pipeline.yml
@@ -1,13 +1,38 @@
+# Apple is what this host is for, so it is always included. The other
+# platforms are opt-in through `KITHARA_PLATFORMS` — a comma-separated list
+# naming the ones a run should carry, e.g. `linux,web`.
+#
+# They are all served by one Mac mini: a Linux container under colima, Windows
+# under qemu, Android on the host, the simulator in a throwaway macOS guest.
+# Running every one of them on every push spends the machine on lanes the fork
+# already covers on GitHub, and buries the platform under focus — today iOS —
+# among their failures. Whole files are gated rather than the jobs inside them,
+# so an excluded platform contributes nothing at all: no jobs, no queue, no
+# resource-group contention.
+#
+# `lanes.yml` rides with Linux because that is the runner it uses. `deep.yml`
+# and `release.yml` are Apple-hosted and keep their own kind-based rules.
 include:
   - local: .gitlab/ci/common.yml
   - local: .gitlab/ci/apple.yml
-  - local: .gitlab/ci/linux.yml
-  - local: .gitlab/ci/android.yml
-  - local: .gitlab/ci/web.yml
-  - local: .gitlab/ci/windows.yml
+  - local: .gitlab/ci/host.yml
   - local: .gitlab/ci/deep.yml
-  - local: .gitlab/ci/lanes.yml
   - local: .gitlab/ci/release.yml
+  - local: .gitlab/ci/linux.yml
+    rules:
+      - if: $KITHARA_PLATFORMS =~ /(^|,)\s*linux\s*(,|$)/
+  - local: .gitlab/ci/lanes.yml
+    rules:
+      - if: $KITHARA_PLATFORMS =~ /(^|,)\s*linux\s*(,|$)/
+  - local: .gitlab/ci/android.yml
+    rules:
+      - if: $KITHARA_PLATFORMS =~ /(^|,)\s*android\s*(,|$)/
+  - local: .gitlab/ci/web.yml
+    rules:
+      - if: $KITHARA_PLATFORMS =~ /(^|,)\s*web\s*(,|$)/
+  - local: .gitlab/ci/windows.yml
+    rules:
+      - if: $KITHARA_PLATFORMS =~ /(^|,)\s*windows\s*(,|$)/
 
 stages:
   - apple

--- a/.gitlab/ci/pipeline.yml
+++ b/.gitlab/ci/pipeline.yml
@@ -1,38 +1,14 @@
-# Apple is what this host is for, so it is always included. The other
-# platforms are opt-in through `KITHARA_PLATFORMS` — a comma-separated list
-# naming the ones a run should carry, e.g. `linux,web`.
-#
-# They are all served by one Mac mini: a Linux container under colima, Windows
-# under qemu, Android on the host, the simulator in a throwaway macOS guest.
-# Running every one of them on every push spends the machine on lanes the fork
-# already covers on GitHub, and buries the platform under focus — today iOS —
-# among their failures. Whole files are gated rather than the jobs inside them,
-# so an excluded platform contributes nothing at all: no jobs, no queue, no
-# resource-group contention.
-#
-# `lanes.yml` rides with Linux because that is the runner it uses. `deep.yml`
-# and `release.yml` are Apple-hosted and keep their own kind-based rules.
 include:
   - local: .gitlab/ci/common.yml
   - local: .gitlab/ci/apple.yml
   - local: .gitlab/ci/host.yml
-  - local: .gitlab/ci/deep.yml
-  - local: .gitlab/ci/release.yml
   - local: .gitlab/ci/linux.yml
-    rules:
-      - if: $KITHARA_PLATFORMS =~ /(^|,)\s*linux\s*(,|$)/
-  - local: .gitlab/ci/lanes.yml
-    rules:
-      - if: $KITHARA_PLATFORMS =~ /(^|,)\s*linux\s*(,|$)/
   - local: .gitlab/ci/android.yml
-    rules:
-      - if: $KITHARA_PLATFORMS =~ /(^|,)\s*android\s*(,|$)/
   - local: .gitlab/ci/web.yml
-    rules:
-      - if: $KITHARA_PLATFORMS =~ /(^|,)\s*web\s*(,|$)/
   - local: .gitlab/ci/windows.yml
-    rules:
-      - if: $KITHARA_PLATFORMS =~ /(^|,)\s*windows\s*(,|$)/
+  - local: .gitlab/ci/deep.yml
+  - local: .gitlab/ci/lanes.yml
+  - local: .gitlab/ci/release.yml
 
 stages:
   - apple

--- a/.gitlab/ci/web.yml
+++ b/.gitlab/ci/web.yml
@@ -8,6 +8,22 @@
   timeout: 60 minutes
   needs: []
 
+# Built in the Linux container, but what it answers for is the wasm target, so
+# it belongs to the web request and not to the Linux one. It keeps the verify
+# rule set the browser lanes do not have: it is a build check, cheap enough to
+# carry wherever the web platform is asked for.
+web:wasm:
+  extends: .linux-job
+  interruptible: true
+  rules:
+    - !reference [.platform-web, rules]
+    - !reference [.rules-verify, rules]
+  stage: web
+  timeout: 60 minutes
+  needs: []
+  script:
+    - just ci run linux-wasm
+
 web:chromium:
   extends:
     - .web-job

--- a/.gitlab/ci/web.yml
+++ b/.gitlab/ci/web.yml
@@ -1,7 +1,9 @@
 .web-job:
-  extends:
-    - .linux-job
-    - .rules-integration
+  extends: .linux-job
+  interruptible: false
+  rules:
+    - !reference [.platform-web, rules]
+    - !reference [.rules-integration, rules]
   stage: web
   timeout: 60 minutes
   needs: []

--- a/.gitlab/ci/windows.yml
+++ b/.gitlab/ci/windows.yml
@@ -1,7 +1,9 @@
 .windows-lane:
-  extends:
-    - .windows-job
-    - .rules-nightly
+  extends: .windows-job
+  interruptible: false
+  rules:
+    - !reference [.platform-windows, rules]
+    - !reference [.rules-nightly, rules]
   stage: windows
   timeout: 120 minutes
   needs: []


### PR DESCRIPTION
## Description

One Mac mini serves every platform: a Linux container under colima, Windows under qemu, Android on the host, the simulator in a throwaway macOS guest. Every push ran all of them. That spends the machine on lanes the GitHub fork already covers, and it buries the platform actually under focus — today iOS — among failures that belong to something else: `android:test` and the web lanes have been red for their own reasons for days, and a reader has to know that before the pipeline says anything.

Apple is now always included. Linux, Android, web and Windows come in through `KITHARA_PLATFORMS`, a comma-separated list on the run:

```
KITHARA_PLATFORMS=linux,web
```

Whole files are gated through `include:rules` rather than the jobs inside them, so an excluded platform contributes nothing at all — no jobs, no queue, no resource-group contention. `lanes.yml` rides with Linux because that is the runner it uses; `deep.yml` and `release.yml` are Apple-hosted and keep their own kind-based rules. `release:android` lives in `release.yml`, so release runs are unaffected.

Measured on the branch: a push now creates **7 jobs instead of 17**.

```
apple:lint  apple:test  apple:test-flash-off
apple:xcframework  apple:ios-test  apple:e2e
linux:image (manual)
```

### `linux:image`

The Linux image is built on the host and pushed nowhere, so a colima restart — which recreates the VM — takes it with it. Every `linux:*` job then dies in two seconds on `pull access denied for kithara-ci`, and the lane looks broken in a way that says nothing about the code. That happened on 2026-08-07 and the lane stayed down for four days, until someone rebuilt it over ssh; it happened again during this work when colima was restarted.

So the repair belongs in the pipeline. The job runs on the host's own shell runner, which keeps it reachable exactly when the Linux lane is not, and it lives in `host.yml` — included unconditionally — for the same reason. It is manual because a rebuild takes forty minutes and is a decision, not a reaction. Its pins come from the checkout, so the image carries the tag the commit asks for, which is the mismatch that broke the lane in the first place.

### Starting a run that names platforms

There was no way to set the variable: `workflow:rules` admitted a variable-carrying run only for a release version or a quarantine SHA, and a push carries no variables at all. `dispatch:platforms` is that door — "Run pipeline" with `KITHARA_PLATFORMS` set. It shares the branch queue rather than the main one, so asking for Linux never puts the default branch behind it.

Two things worth knowing for whoever touches this next:

- GitLab accepted `$VAR && (a || b)` at lint time and then refused the run with only "Review the workflow:rules configuration". Two separate rules say the same thing and work.
- `glab ci run --variables "KEY:VALUE"` is the working form, and a comma inside the value breaks its parser — for several platforms at once, set the variable in the UI.

## Verification

- Default push on the branch: 7 jobs, Apple only plus the manual repair job.
- `KITHARA_PLATFORMS=linux`: `dispatch:platforms` triggers the child pipeline.
- `glab ci lint` and the `ci/lint` API both report valid.
- The Linux lane itself was confirmed green before this change: after rebuilding the image, `linux:check` and `linux:secrets` pass on `main`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Other (describe):

## Checklist

- [x] `cargo fmt --all --check` passes (no Rust touched)
- [x] `cargo clippy --workspace -- -D warnings` passes (no Rust touched)
- [ ] Tests added/updated — CI configuration; the pipeline it produces is the check
- [x] No `unwrap()`/`expect()` in production code
- [ ] Documentation updated (if applicable)
