### PR TITLE
fix(audio): let the construction gate pick the read mode, not the seek mode

### DIFF
--- a/crates/kithara-audio/CONTEXT.md
+++ b/crates/kithara-audio/CONTEXT.md
@@ -304,7 +304,13 @@ shared only with that reader's `SharedStream` clone. The initial builder and
 disarm it after a normal return, join error, or caught panic. A rebuild therefore
 cannot switch an active decoder reader into blocking mode. Steady-state reads
 use non-blocking `Stream::probe_read`; on-core seeks use `probe_seek` (position
-math only, no `prime_seek_range` spin on the forbid path). Blocking makes a
+math only, no `prime_seek_range` spin on the forbid path). The gate selects the
+read mode and nothing else: `SharedStream`'s `Seek` is the blocking adapter in
+both phases, because a decoder seeks past residual lateness in steady state as
+well, and a probe seek there only reports not-ready to a caller that can do
+nothing but ask again. Staying off the blocking path is `OffsetReader`'s own
+choice, made by naming `probe_seek` — not a consequence of a disarmed gate.
+Blocking makes a
 slow-but-arriving prefix wait, off the RT worker, up to the stream's blocking-read
 budget rather than error on the first not-ready probe. A construction-range byte
 that never arrives surfaces the **stream layer's** typed terminal verbatim; the

--- a/crates/kithara-audio/src/pipeline/stream/offset.rs
+++ b/crates/kithara-audio/src/pipeline/stream/offset.rs
@@ -36,21 +36,20 @@ impl<T: StreamType> Read for OffsetReader<T> {
 
 impl<T: StreamType> Seek for OffsetReader<T> {
     fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
-        // The reader-local construction gate selects blocking off-RT seek
-        // during decoder creation and non-blocking probe seek on the produce
-        // core after the builder disarms it.
+        // The decoder runs on the produce core, so seek through the real-time
+        // `probe_seek` (no `prime_seek_range` spin on the forbid path).
         match pos {
             SeekFrom::Start(p) => {
                 let abs = self.base_offset + p;
-                let real_pos = self.shared.seek(SeekFrom::Start(abs))?;
+                let real_pos = self.shared.probe_seek(SeekFrom::Start(abs))?;
                 Ok(real_pos.saturating_sub(self.base_offset))
             }
             SeekFrom::Current(delta) => {
-                let real_pos = self.shared.seek(SeekFrom::Current(delta))?;
+                let real_pos = self.shared.probe_seek(SeekFrom::Current(delta))?;
                 Ok(real_pos.saturating_sub(self.base_offset))
             }
             SeekFrom::End(delta) => {
-                let real_pos = self.shared.seek(SeekFrom::End(delta))?;
+                let real_pos = self.shared.probe_seek(SeekFrom::End(delta))?;
                 Ok(real_pos.saturating_sub(self.base_offset))
             }
         }

--- a/crates/kithara-audio/src/pipeline/stream/shared.rs
+++ b/crates/kithara-audio/src/pipeline/stream/shared.rs
@@ -149,16 +149,15 @@ impl<T: StreamType> Read for SharedStream<T> {
 }
 
 impl<T: StreamType> Seek for SharedStream<T> {
-    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
-        let mut stream = self.inner.lock();
-        if self
-            .construction_gate
-            .as_ref()
-            .is_some_and(ConstructionGate::is_armed)
-        {
-            stream.seek(pos)
-        } else {
-            stream.probe_seek(pos)
+    delegate! {
+        to self.inner.lock() {
+            /// Always the blocking [`Stream::seek`]. The construction gate
+            /// picks the read mode, not the seek mode: a decoder seeks past
+            /// residual lateness in steady state too, and a probe seek there
+            /// answers not-ready to a caller that can only ask again. Staying
+            /// off the blocking path is `OffsetReader`'s own choice, made by
+            /// naming `probe_seek`.
+            fn seek(&mut self, pos: SeekFrom) -> io::Result<u64>;
         }
     }
 }


### PR DESCRIPTION
Three HLS tests have been hanging to a hard timeout since #168, on Linux and macOS alike:

- `packaged_hls_single_variant_continuity_is_stable_{aac,flac}_{symphonia,apple}`
- `packaged_abr_switch_keeps_player_continuity`

## What broke

#168 gave every reader its own `ConstructionGate` — the right fix for a real bug. It also made the gate decide how a **seek** is served: armed, the blocking `Stream::seek`; disarmed, `probe_seek`.

The gate answers a different question. Construction is when a *read* must wait for a range instead of erroring on the first not-ready probe. A decoder seeks past residual lateness in steady state as well, and there a probe seek answers not-ready to a caller that has nothing to wait on and can only ask again.

So the initial reader's steady-state seek became non-blocking. An HLS decoder seeking into a range still downloading kept re-asking instead of waiting; nothing parked, the Flash runtime never went quiescent, the virtual clock stopped, and the test aborted at its hard timeout. With the wall clock the range still arrives, which is why `apple:test-flash-off` stayed green and hid it. A file source never shows it — its bytes are always ready.

The crate contract already asked for the restored shape: `kithara-audio/CONTEXT.md` says on-core seeks use `probe_seek` by name.

## The change

`SharedStream`'s `Seek` is the blocking adapter again in both phases, and `OffsetReader` names `probe_seek` itself — so the produce core stays off the blocking path by the caller's decision rather than by the gate's state. **Per-reader gate ownership, the point of #168, is untouched.**

## How it was found

Each step is a run, not an argument:

| checked | result |
|---|---|
| #170 without #168 | 3/3 pass in 0.2–0.8 s |
| #168 without the `yield_now` in `peer.rs` | still hangs — first hypothesis rejected |
| #168 without the audio/stream half | pass |
| `offset.rs` alone reverted | still hangs |
| `shared.rs` (`reader.rs` is a doc-comment change) | the cause |

The hang dump names `kithara-hls/src/peer.rs` as the `active_async` holder, which is only where the task was spawned — that misled the first attempt.

## Validation

- The 3 hung tests plus #168's own `decoder_readers_have_isolated_construction_gates` and `promotion_preserves_the_normalized_timeline_gap`: 5/5 pass.
- Full `just test`: **4825/4825 passed**, 67 skipped.

Unrelated and pre-existing, not addressed here: `apple:test` carries 27 `no_block BRIDGED` failures that are already present at `960a3820` — before #168 and #170 — with no SIGABRT among them.