### PR TITLE
ci: make a green pipeline mean no regressions, and let the bridge run on a token

### DIFF
--- a/.config/just/platform.just
+++ b/.config/just/platform.just
@@ -120,12 +120,19 @@ apple MODE="xcframework" *ARGS:
         # `redefinition of module 'SwiftShims'` — every fresh CI guest hit it
         # before any test ran. A warm cache hides it, which is why it looks
         # intermittent.
+        #
+        # xcodebuild writes no JUnit, and it refuses to overwrite a bundle.
+        # `xtask ci run apple-ios-test` turns this into the report CI collects.
+        bundle="target/xcresult/ios-test.xcresult"
+        rm -rf "$bundle"
+        mkdir -p "$(dirname "$bundle")"
         KITHARA_LOCAL_DEV=1 \
         TEST_RUNNER_KITHARA_TEST_SERVER_URL="$test_server_url" \
           xcodebuild test \
             -project apple/Examples/KitharaDemo/KitharaDemo.xcodeproj \
             -scheme KitharaDemoUnitTests_iOS \
             -destination "$destination" \
+            -resultBundlePath "$bundle" \
             SWIFT_ENABLE_EXPLICIT_MODULES=NO
         ;;
       integration-regressions)

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -34,11 +34,16 @@ leak-timeout = "2s"
 
 [profile.ci]
 fail-fast = false
-
-[profile.ci.junit]
-path = "target/nextest/ci/junit.xml"
 test-threads = "num-cpus"
 leak-timeout = "2s"
+
+# `path` resolves against the profile's store directory
+# (`target/nextest/ci/`), so it must stay relative: spelling it out from the
+# repository root nests the file under itself and the report never reaches CI.
+# Keep this table last — a `[profile.ci.junit]` header placed above the
+# profile's own keys silently swallows them.
+[profile.ci.junit]
+path = "junit.xml"
 
 # Fast-only profile: heavy tests are excluded via -E filter in justfile.
 [profile.fast]

--- a/.gitlab/ci/android.yml
+++ b/.gitlab/ci/android.yml
@@ -20,6 +20,7 @@ android:build:
 android:test:
   extends:
     - .android-job
+    - .judged
     - .measured
   interruptible: false
   rules:

--- a/.gitlab/ci/android.yml
+++ b/.gitlab/ci/android.yml
@@ -41,3 +41,4 @@ android:test:
     paths:
       - android/lib/build/reports/androidTests/
       - android/lib/build/outputs/androidTest-results/
+      - target/junit/

--- a/.gitlab/ci/apple.yml
+++ b/.gitlab/ci/apple.yml
@@ -84,6 +84,12 @@ apple:swift-test:
     - apple:xcframework
   script:
     - just ci run apple-swift-test
+  artifacts:
+    when: always
+    reports:
+      junit: target/xcresult/swift-test.junit.xml
+    paths:
+      - target/xcresult/swift-test.junit.xml
 
 apple:ios:
   extends: .apple-job
@@ -95,10 +101,14 @@ apple:ios:
 # The suite plays audio and asserts on what came back, so it takes the measured
 # group: a simulator sharing the host with a full build reports on the load
 # rather than on the commit.
+# It carries the merge-request kind on top of the branch one: this is the only
+# lane that runs the iOS regressions, and a push stops producing pipelines once
+# a merge request is open, so without it a merge request carrying one of those
+# regressions would go through without ever running it.
 apple:ios-test:
   extends:
     - .macos-job
-    - .rules-integration-and-branch
+    - .rules-verify-and-branch
     - .measured
   stage: apple
   timeout: 60 minutes
@@ -107,6 +117,12 @@ apple:ios-test:
       artifacts: true
   script:
     - just ci run apple-ios-test
+  artifacts:
+    when: always
+    reports:
+      junit: target/xcresult/ios-test.junit.xml
+    paths:
+      - target/xcresult/ios-test.junit.xml
 
 # The resampler axis: the same end-to-end playback through three source-rate
 # conversion shapes, which is what a change to decode, blending or output can

--- a/.gitlab/ci/apple.yml
+++ b/.gitlab/ci/apple.yml
@@ -41,7 +41,7 @@ apple:test:
     reports:
       junit: target/nextest/ci/junit.xml
     paths:
-      - target/nextest/ci/junit.xml
+      - target/junit/
 
 apple:test-flash-off:
   extends:
@@ -58,9 +58,9 @@ apple:test-flash-off:
     when: always
     expire_in: 30 days
     reports:
-      junit: target/nextest/ci/junit.xml
+      junit: target-flash-off/nextest/ci/junit.xml
     paths:
-      - target/nextest/ci/junit.xml
+      - target/junit/
 
 apple:xcframework:
   extends:
@@ -89,7 +89,7 @@ apple:swift-test:
     reports:
       junit: target/xcresult/swift-test.junit.xml
     paths:
-      - target/xcresult/swift-test.junit.xml
+      - target/junit/
 
 apple:ios:
   extends: .apple-job
@@ -122,7 +122,7 @@ apple:ios-test:
     reports:
       junit: target/xcresult/ios-test.junit.xml
     paths:
-      - target/xcresult/ios-test.junit.xml
+      - target/junit/
 
 # The resampler axis: the same end-to-end playback through three source-rate
 # conversion shapes, which is what a change to decode, blending or output can

--- a/.gitlab/ci/apple.yml
+++ b/.gitlab/ci/apple.yml
@@ -29,6 +29,7 @@ apple:msrv:
 apple:test:
   extends:
     - .apple-job
+    - .judged
     - .measured
     - .rules-verify-and-branch
   needs:
@@ -46,6 +47,7 @@ apple:test:
 apple:test-flash-off:
   extends:
     - .macos-job
+    - .judged
     - .rules-integration-and-branch
     - .measured
   stage: apple
@@ -79,7 +81,9 @@ apple:xcframework:
       - apple/KitharaFFIInternal.xcframework
 
 apple:swift-test:
-  extends: .apple-job
+  extends:
+    - .apple-job
+    - .judged
   needs:
     - apple:xcframework
   script:
@@ -108,6 +112,7 @@ apple:ios:
 apple:ios-test:
   extends:
     - .macos-job
+    - .judged
     - .rules-verify-and-branch
     - .measured
   stage: apple

--- a/.gitlab/ci/common.yml
+++ b/.gitlab/ci/common.yml
@@ -56,6 +56,15 @@
 # the Linux jobs. As the first entry in a job's `rules` a `when: never` match
 # ends the evaluation, so the platform check comes before anything the lane's
 # own kind rules would allow.
+# A lane the verdict judges does not gate on its own: it reports, and the
+# verdict decides by comparing what failed here with what the default branch is
+# already failing. Gating on each lane means gating on a suite that is not
+# green, which holds every change behind accumulated red rather than behind its
+# own. A failure here is still not free — it reaches the verdict as a report or,
+# for a lane that can name no test, as a marker carrying the lane's name.
+.judged:
+  allow_failure: true
+
 .platform-linux:
   rules:
     - if: $KITHARA_PLATFORMS !~ /(^|,)\s*linux\s*(,|$)/

--- a/.gitlab/ci/deep.yml
+++ b/.gitlab/ci/deep.yml
@@ -42,9 +42,15 @@ deep:bench:
   stage: deep
   needs: []
 
+# Advisories and licence bans are the only dependency check on the import path.
+# The bridge no longer refuses a merged pull request for moving a manifest, so
+# this runs on quarantine as well as on the weekly sweep.
 deps:deny:
   extends: .deps-job
   timeout: 30 minutes
+  rules:
+    - if: $KITHARA_PIPELINE_KIND == "weekly"
+    - if: $KITHARA_PIPELINE_KIND == "quarantine"
   script:
     - just ci run deps-deny
 

--- a/.gitlab/ci/linux.yml
+++ b/.gitlab/ci/linux.yml
@@ -44,7 +44,7 @@ linux:test:
     reports:
       junit: target/nextest/ci/junit.xml
     paths:
-      - target/nextest/ci/junit.xml
+      - target/junit/
 
 linux:coverage:
   extends:

--- a/.gitlab/ci/linux.yml
+++ b/.gitlab/ci/linux.yml
@@ -27,6 +27,7 @@ linux:check:
 linux:test:
   extends:
     - .linux-job
+    - .judged
     - .measured
   interruptible: false
   rules:

--- a/.gitlab/ci/pipeline.yml
+++ b/.gitlab/ci/pipeline.yml
@@ -6,6 +6,7 @@ include:
   - local: .gitlab/ci/android.yml
   - local: .gitlab/ci/web.yml
   - local: .gitlab/ci/windows.yml
+  - local: .gitlab/ci/verdict.yml
   - local: .gitlab/ci/deep.yml
   - local: .gitlab/ci/lanes.yml
   - local: .gitlab/ci/release.yml
@@ -16,6 +17,7 @@ stages:
   - android
   - web
   - windows
+  - verdict
   - deep
   - lanes
   - release-build

--- a/.gitlab/ci/verdict.yml
+++ b/.gitlab/ci/verdict.yml
@@ -1,0 +1,51 @@
+# The gate the merge decision hangs on. Everything else may be red — the suite
+# is not green and waiting for it to be green blocks every change behind it —
+# but nothing may be red here that the default branch has not already been
+# failing.
+#
+# It runs on the Linux executor because that is the one whose cache directory is
+# mounted from the host: the journal has to outlive the job that writes it, and
+# a macOS job runs in a throwaway guest. It carries no platform rule for the
+# same reason a lint gate carries none.
+verdict:
+  extends:
+    - .linux-job
+    - .rules-verify-and-branch
+  stage: verdict
+  interruptible: true
+  # Every lane it judges, and every one of them optional: platforms are opt-in,
+  # so a pipeline that did not ask for Android has no Android job to wait for.
+  needs:
+    - job: apple:test
+      artifacts: true
+      optional: true
+    - job: apple:test-flash-off
+      artifacts: true
+      optional: true
+    - job: apple:swift-test
+      artifacts: true
+      optional: true
+    - job: apple:ios-test
+      artifacts: true
+      optional: true
+    - job: linux:test
+      artifacts: true
+      optional: true
+    - job: android:test
+      artifacts: true
+      optional: true
+    - job: web:chromium
+      artifacts: true
+      optional: true
+    - job: web:firefox
+      artifacts: true
+      optional: true
+  # A lane that failed is exactly the one whose report is needed, so this runs
+  # after a failure rather than instead of one.
+  when: always
+  script:
+    - just ci run verdict
+  artifacts:
+    when: always
+    paths:
+      - target/junit/

--- a/.gitlab/ci/web.yml
+++ b/.gitlab/ci/web.yml
@@ -27,6 +27,7 @@ web:wasm:
 web:chromium:
   extends:
     - .web-job
+    - .judged
     - .measured
   script:
     - just ci run web-chromium
@@ -39,6 +40,7 @@ web:chromium:
 web:firefox:
   extends:
     - .web-job
+    - .judged
     - .measured
   script:
     - just ci run web-firefox

--- a/.gitlab/ci/web.yml
+++ b/.gitlab/ci/web.yml
@@ -30,6 +30,11 @@ web:chromium:
     - .measured
   script:
     - just ci run web-chromium
+  artifacts:
+    when: always
+    expire_in: 30 days
+    paths:
+      - target/junit/
 
 web:firefox:
   extends:
@@ -37,6 +42,11 @@ web:firefox:
     - .measured
   script:
     - just ci run web-firefox
+  artifacts:
+    when: always
+    expire_in: 30 days
+    paths:
+      - target/junit/
 
 web:size:
   extends: .web-job

--- a/ci/bridge/config.example.toml
+++ b/ci/bridge/config.example.toml
@@ -1,8 +1,6 @@
 branch = "main"
-github_app_id = 1
-github_installation_id = 1
-github_private_key = "/path/to/github-app.pem"
 github_repo = "zvuk/kithara"
+github_token_file = "/path/to/github-token"
 gitlab_project_id = 1
 gitlab_project_path = "group/kithara"
 gitlab_token_file = "/path/to/gitlab-token"

--- a/crates/kithara-devtools/src/junit.rs
+++ b/crates/kithara-devtools/src/junit.rs
@@ -1,14 +1,21 @@
+//! Reading a `JUnit` report. Both the perf matrix and the CI verdict need
+//! one, so it belongs to the crate rather than to either of them.
+
 use anyhow::{Context, Result};
 
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) struct CaseTiming {
-    pub(crate) name: String,
-    pub(crate) suite: String,
-    pub(crate) failed: bool,
-    pub(crate) secs: f64,
+pub struct CaseTiming {
+    pub name: String,
+    pub suite: String,
+    pub failed: bool,
+    pub secs: f64,
 }
 
-pub(crate) fn parse_junit(xml: &str) -> Result<Vec<CaseTiming>> {
+/// # Errors
+///
+/// Fails when the document is not XML, or when a `testcase` carries a
+/// `time` attribute that is not a number.
+pub fn parse_junit(xml: &str) -> Result<Vec<CaseTiming>> {
     let doc = roxmltree::Document::parse(xml).context("parse junit xml")?;
     let mut cases = Vec::new();
     for node in doc.descendants().filter(|n| n.has_tag_name("testcase")) {

--- a/crates/kithara-devtools/src/lib.rs
+++ b/crates/kithara-devtools/src/lib.rs
@@ -11,6 +11,7 @@ pub mod health;
 #[cfg(feature = "lint")]
 pub mod idioms;
 pub mod init;
+pub mod junit;
 #[cfg(feature = "lint")]
 pub mod lint;
 pub mod manifest;

--- a/crates/kithara-devtools/src/perf/matrix.rs
+++ b/crates/kithara-devtools/src/perf/matrix.rs
@@ -9,10 +9,8 @@ use anyhow::{Context, Result, bail};
 
 use crate::{
     common::project::{PerfConfig, ProjectConfig},
-    perf::{
-        junit::parse_junit,
-        lanes::{Lane, RepeatMeta, RunPaths, sanitize},
-    },
+    junit::parse_junit,
+    perf::lanes::{Lane, RepeatMeta, RunPaths, sanitize},
     test::{LaneToggles, nextest_lane_command},
 };
 

--- a/crates/kithara-devtools/src/perf/mod.rs
+++ b/crates/kithara-devtools/src/perf/mod.rs
@@ -1,6 +1,5 @@
 mod cli;
 mod gecko;
-mod junit;
 mod lanes;
 mod list;
 mod matrix;

--- a/crates/kithara-devtools/src/perf/slow.rs
+++ b/crates/kithara-devtools/src/perf/slow.rs
@@ -10,10 +10,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     common::project::ProjectConfig,
-    perf::{
-        junit::{CaseTiming, parse_junit},
-        lanes::{RunPaths, primary_lane_name},
-    },
+    junit::{CaseTiming, parse_junit},
+    perf::lanes::{RunPaths, primary_lane_name},
 };
 
 type TestKey = (String, String);
@@ -232,7 +230,7 @@ pub(crate) fn run(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::perf::junit::CaseTiming;
+    use crate::junit::CaseTiming;
 
     fn case(suite: &str, name: &str, secs: f64) -> CaseTiming {
         CaseTiming {

--- a/docs/guides/ci-host.md
+++ b/docs/guides/ci-host.md
@@ -190,10 +190,19 @@ sudo -E /Volumes/KitharaCI/services/bin/kithara-ci ci host activate-bridge
 ```
 
 GitLab `main` fast-forwards to GitHub only after the exact commit has a
-successful GitLab push pipeline. A GitHub `main` update is imported only when
-it belongs to a merged pull request, changes no CI control path, and passes the
-private quarantine pipeline. Divergence is fail-closed and opens one
+successful GitLab push pipeline, judged on the child pipeline the dispatch
+stage triggers rather than on its parent. A GitHub `main` update is imported
+only when it belongs to a merged pull request, changes no CI control path, and
+passes the private quarantine pipeline. Manifests are not control paths:
+`deps:deny` runs on quarantine instead. Divergence is fail-closed and opens one
 deduplicated GitLab incident.
+
+A rejection is recorded and refused on sight. Once its reason has been dealt
+with, clear the head so the import runs again:
+
+```text
+/Volumes/KitharaCI/services/bin/kithara-ci ci bridge retry --config /Volumes/KitharaCI/services/bridge/config.toml --github-sha <sha>
+```
 
 ## Storage policy
 

--- a/docs/guides/ci-host.md
+++ b/docs/guides/ci-host.md
@@ -175,8 +175,11 @@ Android, and web checks.
 ## Repository bridge
 
 Copy `ci/bridge/config.example.toml` to
-`/Volumes/KitharaCI/services/bridge/config.toml`. The config, GitHub App key,
-and GitLab token must belong to UID 504 (`kithara-sync`) and have mode `0600`.
+`/Volumes/KitharaCI/services/bridge/config.toml`. The config and the two
+tokens must belong to UID 504 (`kithara-sync`) and have mode `0600`. The GitHub
+token needs `Contents: write` to publish `main`, `Pull requests: read` to
+recognise a merged pull request, and `Commit statuses: write` to report the
+verdict — check runs are a GitHub App API and the bridge does not use one.
 Validate without network mutation:
 
 ```text

--- a/docs/guides/ci-host.md
+++ b/docs/guides/ci-host.md
@@ -207,6 +207,34 @@ with, clear the head so the import runs again:
 /Volumes/KitharaCI/services/bin/kithara-ci ci bridge retry --config /Volumes/KitharaCI/services/bridge/config.toml --github-sha <sha>
 ```
 
+## The verdict
+
+The suite is not green, and gating on it being green holds every change behind
+red it did not cause. The lanes the verdict judges therefore carry
+`allow_failure: true` and one job decides: a run is held for failing something
+the default branch is not.
+
+Each lane leaves what it produced in `target/junit/`, collected by the lane
+dispatcher rather than by the lane itself — the build directory survives between
+jobs, so the report a lane is expected to write is removed before it runs. A
+lane that can name no test leaves a marker carrying its own name, because GitLab
+hands a job no status for the jobs it needed.
+
+The journal lives on the Linux executor, whose cache directory is mounted from
+the host, at `<cache root>/verdict/journal.json`. A macOS job runs in a
+throwaway guest, where nothing written survives it. `main` and the nightly chain
+record; branch, merge-request and quarantine runs check. The window unions the
+last five recorded runs: a test that fails a quarter of the time would otherwise
+read as a regression whenever the run it was compared with happened to be green.
+
+A merge request is told which of the failures it is being let through with were
+already failing at the commit it was branched from, when the journal still
+remembers that commit.
+
+The first check after this lands has no journal to read and says so; a `main`
+run has to record before a regression can be told from what the branch already
+carries.
+
 ## Storage policy
 
 The CI volume has a 300 GB APFS quota. New work stops at 285 GB. Cleanup starts

--- a/xtask/src/ci/bridge/api.rs
+++ b/xtask/src/ci/bridge/api.rs
@@ -1,15 +1,7 @@
-use std::{
-    fs,
-    io::Write,
-    process::{Command, Stdio},
-    time::Duration,
-};
+use std::{fs, time::Duration};
 
 use anyhow::{Context, Result, bail};
-use base64::{
-    Engine,
-    engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
-};
+use base64::{Engine, engine::general_purpose::STANDARD};
 use reqwest::{
     Method, Url,
     blocking::{Client, RequestBuilder},
@@ -79,13 +71,20 @@ fn response_json(request: RequestBuilder, method: &Method, url: &Url) -> Result<
 pub(super) struct Github {
     config: BridgeConfig,
     api: Api,
+    token: String,
 }
+
+/// The name the verification wears on a pull request. Commit statuses are keyed
+/// by it, so a later report replaces the earlier one.
+const STATUS_CONTEXT: &str = "kithara/gitlab-verification";
 
 impl Github {
     pub(super) fn new(config: &BridgeConfig) -> Result<Self> {
+        let token = read_secret(&config.github_token_file, "GitHub token")?;
         Ok(Self {
             config: config.clone(),
             api: Api::new()?,
+            token,
         })
     }
 
@@ -122,96 +121,38 @@ impl Github {
         }))
     }
 
-    pub(super) fn create_check(&self, sha: &str) -> Result<u64> {
-        let response = self.request(
-            &Method::POST,
-            &format!("/repos/{}/check-runs", self.config.github_repo),
-            Some(&json!({
-                "name": "Kithara / GitLab verification",
-                "head_sha": sha,
-                "status": "in_progress",
-                "started_at": utc_timestamp()?,
-            })),
-        )?;
-        response["id"]
-            .as_u64()
-            .context("GitHub check response has no numeric id")
-    }
-
-    pub(super) fn finish_check(
-        &self,
-        check_run_id: u64,
-        conclusion: &str,
-        summary: &str,
-    ) -> Result<()> {
+    /// Check runs are a GitHub App API, and this bridge authenticates with a
+    /// token. A commit status draws the same mark on the pull request and is
+    /// keyed by its context rather than by an id, so nothing has to be carried
+    /// between the two calls.
+    pub(super) fn report_status(&self, sha: &str, state: &str, description: &str) -> Result<()> {
         self.request(
-            &Method::PATCH,
-            &format!(
-                "/repos/{}/check-runs/{check_run_id}",
-                self.config.github_repo
-            ),
+            &Method::POST,
+            &format!("/repos/{}/statuses/{sha}", self.config.github_repo),
             Some(&json!({
-                "status": "completed",
-                "conclusion": conclusion,
-                "completed_at": utc_timestamp()?,
-                "output": {
-                    "title": "GitLab verification",
-                    "summary": summary,
-                },
+                "state": state,
+                "context": STATUS_CONTEXT,
+                "description": status_description(description),
             })),
         )?;
         Ok(())
     }
 
-    pub(super) fn git_header(&self) -> Result<String> {
-        let basic = STANDARD.encode(format!("x-access-token:{}", self.app_token()?));
-        Ok(format!("Authorization: Basic {basic}"))
+    pub(super) fn git_header(&self) -> String {
+        let basic = STANDARD.encode(format!("x-access-token:{}", self.token));
+        format!("Authorization: Basic {basic}")
     }
 
     fn request(&self, method: &Method, path: &str, body: Option<&Value>) -> Result<Value> {
-        let token = self.app_token()?;
         let url = Url::parse(&format!("https://api.github.com{path}"))
             .with_context(|| format!("building GitHub API URL for {path}"))?;
         let payload = body.map(Payload::Json);
         self.api.request(
             method,
             &url,
-            ("Authorization", &format!("Bearer {token}")),
+            ("Authorization", &format!("Bearer {}", self.token)),
             payload.as_ref(),
         )
-    }
-
-    fn app_token(&self) -> Result<String> {
-        let now = unix_time()?;
-        let header = URL_SAFE_NO_PAD.encode(br#"{"alg":"RS256","typ":"JWT"}"#);
-        let payload = URL_SAFE_NO_PAD.encode(
-            serde_json::to_vec(&json!({
-                "iat": now.saturating_sub(30),
-                "exp": now + 540,
-                "iss": self.config.github_app_id,
-            }))
-            .context("serializing GitHub App JWT")?,
-        );
-        let signing_input = format!("{header}.{payload}");
-        let signature = openssl_sign(&self.config.github_private_key, signing_input.as_bytes())?;
-        let jwt = format!("{signing_input}.{}", URL_SAFE_NO_PAD.encode(signature));
-        let url = Url::parse(&format!(
-            "https://api.github.com/app/installations/{}/access_tokens",
-            self.config.github_installation_id
-        ))
-        .context("building GitHub installation token URL")?;
-        let body = json!({});
-        let payload = Payload::Json(&body);
-        let response = self.api.request(
-            &Method::POST,
-            &url,
-            ("Authorization", &format!("Bearer {jwt}")),
-            Some(&payload),
-        )?;
-        response["token"]
-            .as_str()
-            .map(str::to_string)
-            .context("GitHub installation token response has no token")
     }
 }
 
@@ -223,18 +164,7 @@ pub(super) struct Gitlab {
 
 impl Gitlab {
     pub(super) fn new(config: &BridgeConfig) -> Result<Self> {
-        let token = fs::read_to_string(&config.gitlab_token_file)
-            .with_context(|| {
-                format!(
-                    "reading GitLab token {}",
-                    config.gitlab_token_file.display()
-                )
-            })?
-            .trim()
-            .to_string();
-        if token.is_empty() {
-            bail!("GitLab token file is empty");
-        }
+        let token = read_secret(&config.gitlab_token_file, "GitLab token")?;
         Ok(Self {
             config: config.clone(),
             api: Api::new()?,
@@ -344,31 +274,30 @@ impl Gitlab {
     }
 }
 
-fn openssl_sign(key: &std::path::Path, payload: &[u8]) -> Result<Vec<u8>> {
-    let mut child = Command::new("openssl")
-        .args(["dgst", "-sha256", "-sign"])
-        .arg(key)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .context("starting OpenSSL for GitHub App JWT")?;
-    child
-        .stdin
-        .take()
-        .context("OpenSSL stdin was not piped")?
-        .write_all(payload)
-        .context("writing GitHub App JWT to OpenSSL")?;
-    let output = child
-        .wait_with_output()
-        .context("waiting for OpenSSL JWT signature")?;
-    if !output.status.success() {
-        bail!(
-            "OpenSSL JWT signing failed: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        );
+fn read_secret(path: &std::path::Path, label: &str) -> Result<String> {
+    let secret = fs::read_to_string(path)
+        .with_context(|| format!("reading {label} {}", path.display()))?
+        .trim()
+        .to_string();
+    if secret.is_empty() {
+        bail!("{label} file is empty");
     }
-    Ok(output.stdout)
+    Ok(secret)
+}
+
+/// GitHub rejects a commit status whose description exceeds 140 characters, and
+/// a rejection detail naming several control paths goes well past that.
+fn status_description(detail: &str) -> String {
+    const LIMIT: usize = 140;
+    let single_line = detail.split_whitespace().collect::<Vec<_>>().join(" ");
+    if single_line.chars().count() <= LIMIT {
+        return single_line;
+    }
+    single_line
+        .chars()
+        .take(LIMIT - 1)
+        .chain(std::iter::once('…'))
+        .collect()
 }
 
 fn string_field(value: &Value, path: &[&str], label: &str) -> Result<String> {
@@ -421,29 +350,6 @@ fn blocking_downstream_status(value: &Value) -> Result<Option<String>> {
     Ok(None)
 }
 
-fn unix_time() -> Result<u64> {
-    Ok(std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .context("system clock is before Unix epoch")?
-        .as_secs())
-}
-
-fn utc_timestamp() -> Result<String> {
-    let output = Command::new("date")
-        .args(["-u", "+%Y-%m-%dT%H:%M:%SZ"])
-        .output()
-        .context("running date for API timestamp")?;
-    if !output.status.success() {
-        bail!(
-            "date failed: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        );
-    }
-    String::from_utf8(output.stdout)
-        .context("date timestamp was not UTF-8")
-        .map(|value| value.trim().to_string())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -457,6 +363,22 @@ mod tests {
         assert_eq!(first_pipeline(&json!([])).unwrap(), None);
         assert!(first_pipeline(&json!([{"id": 7}])).is_err());
         assert!(first_pipeline(&json!([{"status": "success"}])).is_err());
+    }
+
+    #[test]
+    fn a_status_description_survives_a_multi_line_rejection() {
+        let detail = "The merged GitHub pull request changes CI control files.\n\n- `xtask/`";
+        assert_eq!(
+            status_description(detail),
+            "The merged GitHub pull request changes CI control files. - `xtask/`"
+        );
+    }
+
+    #[test]
+    fn a_status_description_stays_within_what_github_accepts() {
+        let described = status_description(&"path ".repeat(80));
+        assert_eq!(described.chars().count(), 140);
+        assert!(described.ends_with('…'));
     }
 
     #[test]

--- a/xtask/src/ci/bridge/api.rs
+++ b/xtask/src/ci/bridge/api.rs
@@ -284,7 +284,16 @@ impl Gitlab {
         let pipelines =
             self.api
                 .request(&Method::GET, &url, ("PRIVATE-TOKEN", &self.token), None)?;
-        pipeline_status_from_list(&pipelines)
+        let Some((id, status)) = first_pipeline(&pipelines)? else {
+            return Ok(None);
+        };
+        if status != "success" {
+            return Ok(Some(status));
+        }
+        let bridges = self.request(&Method::GET, &format!("pipelines/{id}/bridges"), None)?;
+        Ok(Some(
+            blocking_downstream_status(&bridges)?.unwrap_or(status),
+        ))
     }
 
     pub(super) fn ensure_issue(&self, title: &str, description: &str) -> Result<()> {
@@ -375,19 +384,41 @@ fn string_field(value: &Value, path: &[&str], label: &str) -> Result<String> {
         .with_context(|| format!("{label} is not a string"))
 }
 
-fn pipeline_status_from_list(value: &Value) -> Result<Option<String>> {
+fn first_pipeline(value: &Value) -> Result<Option<(u64, String)>> {
     let pipelines = value
         .as_array()
         .context("GitLab pipelines response was not an array")?;
     pipelines
         .first()
         .map(|pipeline| {
-            pipeline["status"]
+            let id = pipeline["id"]
+                .as_u64()
+                .context("GitLab pipeline response has no numeric id")?;
+            let status = pipeline["status"]
                 .as_str()
                 .map(str::to_string)
-                .context("GitLab pipeline response has no status")
+                .context("GitLab pipeline response has no status")?;
+            Ok((id, status))
         })
         .transpose()
+}
+
+/// Every job that proves anything lives in the child pipeline the dispatch
+/// stage triggers. A cancelled child under a `success` parent is a state this
+/// project has produced, so the parent's own status is not evidence that the
+/// tests ran.
+fn blocking_downstream_status(value: &Value) -> Result<Option<String>> {
+    let bridges = value
+        .as_array()
+        .context("GitLab bridges response was not an array")?;
+    for bridge in bridges {
+        match bridge["downstream_pipeline"]["status"].as_str() {
+            Some("success") => {}
+            Some(status) => return Ok(Some(status.to_owned())),
+            None => return Ok(Some("missing".to_owned())),
+        }
+    }
+    Ok(None)
 }
 
 fn unix_time() -> Result<u64> {
@@ -420,10 +451,40 @@ mod tests {
     #[test]
     fn latest_pipeline_status_is_optional_but_typed() {
         assert_eq!(
-            pipeline_status_from_list(&json!([{"status": "success"}])).unwrap(),
-            Some("success".into())
+            first_pipeline(&json!([{"id": 7, "status": "success"}])).unwrap(),
+            Some((7, "success".into()))
         );
-        assert_eq!(pipeline_status_from_list(&json!([])).unwrap(), None);
-        assert!(pipeline_status_from_list(&json!([{}])).is_err());
+        assert_eq!(first_pipeline(&json!([])).unwrap(), None);
+        assert!(first_pipeline(&json!([{"id": 7}])).is_err());
+        assert!(first_pipeline(&json!([{"status": "success"}])).is_err());
+    }
+
+    #[test]
+    fn a_cancelled_child_blocks_a_green_parent() {
+        assert_eq!(
+            blocking_downstream_status(&json!([{"downstream_pipeline": {"status": "canceled"}}]))
+                .unwrap(),
+            Some("canceled".into())
+        );
+    }
+
+    #[test]
+    fn a_dispatch_job_without_a_child_proves_nothing() {
+        assert_eq!(
+            blocking_downstream_status(&json!([{"downstream_pipeline": null}])).unwrap(),
+            Some("missing".into())
+        );
+    }
+
+    #[test]
+    fn every_green_child_leaves_the_parent_status_standing() {
+        assert_eq!(
+            blocking_downstream_status(&json!([
+                {"downstream_pipeline": {"status": "success"}},
+                {"downstream_pipeline": {"status": "success"}}
+            ]))
+            .unwrap(),
+            None
+        );
     }
 }

--- a/xtask/src/ci/bridge/command.rs
+++ b/xtask/src/ci/bridge/command.rs
@@ -8,9 +8,11 @@ use anyhow::{Context, Result, bail};
 use clap::{Args, Subcommand};
 use reqwest::Url;
 use serde::Deserialize;
+use tracing::info;
 
 use super::{
-    model::{regular_file, simple_branch, simple_repository},
+    ledger::Ledger,
+    model::{regular_file, simple_branch, simple_repository, validate_sha},
     reconcile::Bridge,
 };
 
@@ -33,6 +35,15 @@ enum BridgeCommand {
         /// Bridge configuration file.
         #[arg(long, env = "KITHARA_BRIDGE_CONFIG")]
         config: PathBuf,
+    },
+    /// Forget a GitHub head so a rejected import can be attempted again.
+    Retry {
+        /// Bridge configuration file.
+        #[arg(long, env = "KITHARA_BRIDGE_CONFIG")]
+        config: PathBuf,
+        /// Full commit SHA of the GitHub head to clear.
+        #[arg(long)]
+        github_sha: String,
     },
 }
 
@@ -144,6 +155,20 @@ pub(crate) fn run(args: &BridgeArgs) -> Result<()> {
         BridgeCommand::Reconcile { config } => {
             Bridge::new(BridgeConfig::load(config)?)?.reconcile_once()
         }
+        BridgeCommand::Retry { config, github_sha } => {
+            if !validate_sha(github_sha) {
+                bail!("github-sha must be a full 40-character commit SHA");
+            }
+            let config = BridgeConfig::load(config)?;
+            let cleared = Ledger::new(&config.state_dir)?.forget(github_sha)?;
+            if cleared.is_empty() {
+                bail!("no ledger entry recorded for {github_sha}");
+            }
+            for key in cleared {
+                info!(entry = %key, "ledger entry cleared");
+            }
+            Ok(())
+        }
     }
 }
 
@@ -202,6 +227,27 @@ mod tests {
                 "reconcile",
                 "--config",
                 "bridge.toml"
+            ])
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn retry_names_the_head_it_forgets() {
+        assert!(
+            Cli::try_parse_from(["xtask", "ci", "bridge", "retry", "--config", "bridge.toml"])
+                .is_err()
+        );
+        assert!(
+            Cli::try_parse_from([
+                "xtask",
+                "ci",
+                "bridge",
+                "retry",
+                "--config",
+                "bridge.toml",
+                "--github-sha",
+                "0123456789abcdef0123456789abcdef01234567"
             ])
             .is_ok()
         );

--- a/xtask/src/ci/bridge/command.rs
+++ b/xtask/src/ci/bridge/command.rs
@@ -51,9 +51,7 @@ enum BridgeCommand {
 #[serde(deny_unknown_fields)]
 pub(super) struct BridgeConfig {
     pub(super) github_repo: String,
-    pub(super) github_app_id: u64,
-    pub(super) github_installation_id: u64,
-    pub(super) github_private_key: PathBuf,
+    pub(super) github_token_file: PathBuf,
     pub(super) gitlab_url: Url,
     pub(super) gitlab_project_id: u64,
     pub(super) gitlab_project_path: String,
@@ -84,14 +82,11 @@ impl BridgeConfig {
         if !simple_repository(&self.gitlab_project_path) {
             bail!("gitlab_project_path must use a safe group/name form");
         }
-        if self.github_app_id == 0
-            || self.github_installation_id == 0
-            || self.gitlab_project_id == 0
-        {
-            bail!("GitHub App, installation, and GitLab project ids must be positive");
+        if self.gitlab_project_id == 0 {
+            bail!("GitLab project id must be positive");
         }
         for (label, path) in [
-            ("GitHub App private key", &self.github_private_key),
+            ("GitHub token", &self.github_token_file),
             ("GitLab token", &self.gitlab_token_file),
         ] {
             if !regular_file(path) {

--- a/xtask/src/ci/bridge/git.rs
+++ b/xtask/src/ci/bridge/git.rs
@@ -49,7 +49,7 @@ impl GitRepo {
                     self.config.branch
                 ),
             ],
-            Some(github.git_header()?),
+            Some(github.git_header()),
         )?;
 
         let gitlab_url = format!(
@@ -128,7 +128,7 @@ impl GitRepo {
                 &url,
                 &format!("{sha}:refs/heads/{}", self.config.branch),
             ],
-            Some(github.git_header()?),
+            Some(github.git_header()),
         )?;
         Ok(())
     }

--- a/xtask/src/ci/bridge/ledger.rs
+++ b/xtask/src/ci/bridge/ledger.rs
@@ -84,6 +84,29 @@ impl Ledger {
         })
     }
 
+    /// Drop every entry recorded for one GitHub head, whatever base it was
+    /// judged against. A rejection is otherwise permanent — `import_github`
+    /// refuses the pair on sight — and a maintainer who has dealt with the
+    /// reason has no other way to let the commit through.
+    pub(super) fn forget(&self, github_sha: &str) -> Result<Vec<String>> {
+        self.with_locked_data(|data| {
+            let prefix = format!("{github_sha}:");
+            let cleared: Vec<String> = data
+                .imports
+                .keys()
+                .filter(|key| key.starts_with(&prefix))
+                .cloned()
+                .collect();
+            for key in &cleared {
+                data.imports.remove(key);
+            }
+            if !cleared.is_empty() {
+                self.write(data)?;
+            }
+            Ok(cleared)
+        })
+    }
+
     fn with_locked_data<T>(
         &self,
         operation: impl FnOnce(&mut LedgerData) -> Result<T>,
@@ -190,5 +213,31 @@ mod tests {
         assert_eq!(entry.pipeline_id, Some(42));
         assert_eq!(entry.check_run_id, Some(84));
         assert_eq!(entry.detail.as_deref(), Some("done"));
+    }
+
+    #[test]
+    fn forgetting_a_head_clears_every_base_it_was_judged_against() {
+        let directory = tempfile::tempdir().unwrap();
+        let ledger = Ledger::new(directory.path()).unwrap();
+        for base in ["one", "two"] {
+            ledger
+                .put("github", base, ImportState::Rejected, None, None, None)
+                .unwrap();
+        }
+        ledger
+            .put("other", "one", ImportState::Rejected, None, None, None)
+            .unwrap();
+
+        assert_eq!(ledger.forget("github").unwrap().len(), 2);
+        assert_eq!(ledger.get("github", "one").unwrap(), None);
+        assert_eq!(ledger.get("github", "two").unwrap(), None);
+        assert!(ledger.get("other", "one").unwrap().is_some());
+    }
+
+    #[test]
+    fn forgetting_an_unknown_head_clears_nothing() {
+        let directory = tempfile::tempdir().unwrap();
+        let ledger = Ledger::new(directory.path()).unwrap();
+        assert!(ledger.forget("github").unwrap().is_empty());
     }
 }

--- a/xtask/src/ci/bridge/ledger.rs
+++ b/xtask/src/ci/bridge/ledger.rs
@@ -17,7 +17,6 @@ use super::model::ImportState;
 pub(super) struct LedgerEntry {
     pub(super) state: ImportState,
     pub(super) pipeline_id: Option<u64>,
-    pub(super) check_run_id: Option<u64>,
     pub(super) detail: Option<String>,
     updated_at: u64,
 }
@@ -62,7 +61,6 @@ impl Ledger {
         gitlab_base_sha: &str,
         state: ImportState,
         pipeline_id: Option<u64>,
-        check_run_id: Option<u64>,
         detail: Option<String>,
     ) -> Result<()> {
         self.with_locked_data(|data| {
@@ -74,8 +72,6 @@ impl Ledger {
                     state,
                     pipeline_id: pipeline_id
                         .or_else(|| previous.and_then(|entry| entry.pipeline_id)),
-                    check_run_id: check_run_id
-                        .or_else(|| previous.and_then(|entry| entry.check_run_id)),
                     detail,
                     updated_at: unix_time()?,
                 },
@@ -184,25 +180,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn transition_is_idempotent_and_preserves_ids() {
+    fn transition_is_idempotent_and_preserves_the_pipeline() {
         let directory = tempfile::tempdir().unwrap();
         let ledger = Ledger::new(directory.path()).unwrap();
         ledger
-            .put(
-                "github",
-                "gitlab",
-                ImportState::Testing,
-                Some(42),
-                Some(84),
-                None,
-            )
+            .put("github", "gitlab", ImportState::Testing, Some(42), None)
             .unwrap();
         ledger
             .put(
                 "github",
                 "gitlab",
                 ImportState::Promoted,
-                None,
                 None,
                 Some("done".into()),
             )
@@ -211,7 +199,6 @@ mod tests {
         let entry = ledger.get("github", "gitlab").unwrap().unwrap();
         assert_eq!(entry.state, ImportState::Promoted);
         assert_eq!(entry.pipeline_id, Some(42));
-        assert_eq!(entry.check_run_id, Some(84));
         assert_eq!(entry.detail.as_deref(), Some("done"));
     }
 
@@ -221,11 +208,11 @@ mod tests {
         let ledger = Ledger::new(directory.path()).unwrap();
         for base in ["one", "two"] {
             ledger
-                .put("github", base, ImportState::Rejected, None, None, None)
+                .put("github", base, ImportState::Rejected, None, None)
                 .unwrap();
         }
         ledger
-            .put("other", "one", ImportState::Rejected, None, None, None)
+            .put("other", "one", ImportState::Rejected, None, None)
             .unwrap();
 
         assert_eq!(ledger.forget("github").unwrap().len(), 2);

--- a/xtask/src/ci/bridge/model.rs
+++ b/xtask/src/ci/bridge/model.rs
@@ -3,6 +3,15 @@ use std::path::Path;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
+/// Paths that define the pipeline judging an imported commit. A merged pull
+/// request touching one of these would rewrite its own judge, so the import
+/// stops and the change is ported through a reviewed merge request instead.
+///
+/// Manifests are deliberately absent. `Cargo.toml` and `Cargo.lock` do not
+/// touch the judge — the trusted pipeline runs the real suite against them —
+/// and refusing them outright turned every dependency bump into a manual port.
+/// Their risk is a build script running on the runner, which is what
+/// `deps:deny` covers on the quarantine pipeline.
 pub(super) const CONTROL_PATHS: &[&str] = &[
     ".gitlab-ci.yml",
     ".gitlab/",
@@ -11,8 +20,6 @@ pub(super) const CONTROL_PATHS: &[&str] = &[
     ".config/mutation-suites.toml",
     ".config/nextest.toml",
     ".config/xtask.toml",
-    "Cargo.lock",
-    "Cargo.toml",
     "ci/",
     "docker/",
     "justfile",
@@ -140,14 +147,24 @@ mod tests {
                 "xtask/src/ci/run.rs".to_string(),
                 ".gitlab-ci.yml".to_string(),
                 ".config/just/ci.just".to_string(),
-                "Cargo.lock".to_string(),
             ]),
             [
                 ".config/just/ci.just",
                 ".gitlab-ci.yml",
-                "Cargo.lock",
                 "xtask/src/ci/run.rs",
             ]
+        );
+    }
+
+    #[test]
+    fn a_manifest_change_alone_does_not_block_the_import() {
+        assert!(
+            changed_control_paths([
+                "Cargo.toml".to_string(),
+                "Cargo.lock".to_string(),
+                "crates/kithara-net/Cargo.toml".to_string(),
+            ])
+            .is_empty()
         );
     }
 

--- a/xtask/src/ci/bridge/reconcile.rs
+++ b/xtask/src/ci/bridge/reconcile.rs
@@ -104,7 +104,6 @@ impl Bridge {
                 gitlab_base_sha,
                 ImportState::Rejected,
                 None,
-                None,
                 Some(detail.clone()),
             )?;
             self.gitlab
@@ -112,10 +111,8 @@ impl Bridge {
             bail!("{detail}");
         };
 
-        let check_run_id = match entry.as_ref().and_then(|entry| entry.check_run_id) {
-            Some(id) => id,
-            None => self.github.create_check(github_sha)?,
-        };
+        self.github
+            .report_status(github_sha, "pending", "GitLab verification running")?;
         let control_paths =
             changed_control_paths(self.repo.changed_paths(gitlab_base_sha, github_sha)?);
         if !control_paths.is_empty() {
@@ -128,14 +125,7 @@ impl Bridge {
                 "The merged GitHub pull request changes CI control files. Import stopped; port \
                  these changes through a reviewed GitLab merge request instead:\n\n{paths}"
             );
-            self.reject(
-                github_sha,
-                gitlab_base_sha,
-                None,
-                check_run_id,
-                "action_required",
-                &detail,
-            )?;
+            self.reject(github_sha, gitlab_base_sha, None, "failure", &detail)?;
             self.gitlab
                 .ensure_issue("GitHub import requires CI control review", &detail)?;
             bail!("{detail}");
@@ -153,7 +143,6 @@ impl Bridge {
                 gitlab_base_sha,
                 ImportState::Testing,
                 Some(id),
-                Some(check_run_id),
                 Some(format!("GitHub PR #{pull_number}")),
             )?;
             id
@@ -166,7 +155,6 @@ impl Bridge {
                 github_sha,
                 gitlab_base_sha,
                 Some(pipeline_id),
-                check_run_id,
                 "failure",
                 &detail,
             )?;
@@ -182,8 +170,7 @@ impl Bridge {
                 github_sha,
                 gitlab_base_sha,
                 Some(pipeline_id),
-                check_run_id,
-                "cancelled",
+                "error",
                 detail,
             )?;
             bail!("{detail}");
@@ -196,11 +183,10 @@ impl Bridge {
             gitlab_base_sha,
             ImportState::Promoted,
             Some(pipeline_id),
-            Some(check_run_id),
             Some(format!("promoted from GitHub PR #{pull_number}")),
         )?;
-        self.github.finish_check(
-            check_run_id,
+        self.github.report_status(
+            github_sha,
             "success",
             &format!("GitLab pipeline {pipeline_id} passed; commit promoted."),
         )
@@ -211,8 +197,7 @@ impl Bridge {
         github_sha: &str,
         gitlab_base_sha: &str,
         pipeline_id: Option<u64>,
-        check_run_id: u64,
-        conclusion: &str,
+        state: &str,
         detail: &str,
     ) -> Result<()> {
         self.ledger.put(
@@ -220,10 +205,9 @@ impl Bridge {
             gitlab_base_sha,
             ImportState::Rejected,
             pipeline_id,
-            Some(check_run_id),
             Some(detail.to_string()),
         )?;
-        self.github.finish_check(check_run_id, conclusion, detail)
+        self.github.report_status(github_sha, state, detail)
     }
 
     fn wait_for_pipeline(&self, pipeline_id: u64) -> Result<String> {

--- a/xtask/src/ci/command.rs
+++ b/xtask/src/ci/command.rs
@@ -2,7 +2,10 @@ use anyhow::{Result, bail};
 use clap::{Args, Subcommand};
 use kithara_devtools::Ctx;
 
-use super::{bridge::BridgeArgs, host::HostArgs, image::ImageArgs, linux::LinuxArgs, run::RunArgs};
+use super::{
+    bridge::BridgeArgs, host::HostArgs, image::ImageArgs, linux::LinuxArgs, run::RunArgs,
+    verdict::VerdictArgs,
+};
 
 #[derive(Debug, Args)]
 pub(crate) struct CiArgs {
@@ -22,12 +25,18 @@ enum CiCommand {
     Linux(LinuxArgs),
     /// Execute one repository CI lane.
     Run(RunArgs),
+    /// Record what the default branch fails, and hold a run that fails more.
+    Verdict(VerdictArgs),
 }
 
 pub(crate) fn is_standalone(args: &CiArgs) -> bool {
     matches!(
         args.command,
-        CiCommand::Bridge(_) | CiCommand::Host(_) | CiCommand::Image(_) | CiCommand::Linux(_)
+        CiCommand::Bridge(_)
+            | CiCommand::Host(_)
+            | CiCommand::Image(_)
+            | CiCommand::Linux(_)
+            | CiCommand::Verdict(_)
     )
 }
 
@@ -37,15 +46,18 @@ pub(crate) fn run_standalone(args: &CiArgs) -> Result<()> {
         CiCommand::Host(args) => super::host::run(args),
         CiCommand::Image(args) => super::image::run(args),
         CiCommand::Linux(args) => super::linux::run(args),
+        CiCommand::Verdict(args) => super::verdict::run(args),
         CiCommand::Run(_) => bail!("repository CI lanes require a workspace"),
     }
 }
 
 pub(crate) fn run(args: &CiArgs, ctx: &Ctx) -> Result<()> {
     match &args.command {
-        CiCommand::Bridge(_) | CiCommand::Host(_) | CiCommand::Image(_) | CiCommand::Linux(_) => {
-            run_standalone(args)
-        }
+        CiCommand::Bridge(_)
+        | CiCommand::Host(_)
+        | CiCommand::Image(_)
+        | CiCommand::Linux(_)
+        | CiCommand::Verdict(_) => run_standalone(args),
         CiCommand::Run(args) => super::run::run(args, ctx),
     }
 }

--- a/xtask/src/ci/config/profile.rs
+++ b/xtask/src/ci/config/profile.rs
@@ -48,7 +48,52 @@ pub(crate) fn fixture() -> CiConfig {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
     use super::*;
+
+    /// Keys nextest reads on a profile. Inside a `junit` table it drops them
+    /// with a warning, which is how `[profile.ci.junit]` swallowed two of them.
+    const PROFILE_KEYS: &[&str] = &["fail-fast", "leak-timeout", "slow-timeout", "test-threads"];
+
+    #[test]
+    fn the_ci_junit_report_lands_where_the_lanes_collect_it() {
+        let nextest: toml::Value = toml::from_str(
+            &fs::read_to_string(workspace_root().join(".config/nextest.toml")).unwrap(),
+        )
+        .unwrap();
+        let junit = nextest["profile"]["ci"]["junit"].as_table().unwrap();
+
+        let path = junit["path"].as_str().unwrap();
+        assert!(
+            !path.contains('/'),
+            "nextest resolves junit.path against the profile store directory, so `{path}` \
+             nests the report under `target/nextest/ci/` twice and CI collects nothing"
+        );
+        for key in PROFILE_KEYS {
+            assert!(
+                !junit.contains_key(*key),
+                "`{key}` belongs on `[profile.ci]`; inside the junit table nextest ignores it"
+            );
+        }
+
+        let produced = format!("target/nextest/ci/{path}");
+        for lane in ["apple", "linux", "windows"] {
+            let yaml = fs::read_to_string(workspace_root().join(format!(".gitlab/ci/{lane}.yml")))
+                .unwrap();
+            let declared = yaml
+                .lines()
+                .filter_map(|line| line.trim().strip_prefix("junit:"))
+                .map(str::trim)
+                .filter(|value| value.starts_with("target/nextest/"));
+            for value in declared {
+                assert_eq!(
+                    value, produced,
+                    "{lane}.yml collects a report that nextest does not write"
+                );
+            }
+        }
+    }
 
     #[test]
     fn tracked_pins_are_valid_on_every_build_platform() {

--- a/xtask/src/ci/lane/apple.rs
+++ b/xtask/src/ci/lane/apple.rs
@@ -12,6 +12,7 @@ use crate::ci::{
     config::CiConfig,
     process::{Process, require_os},
     run::PipelineKind,
+    xcresult,
 };
 
 /// Every Apple job repeats this preflight instead of inheriting it from a
@@ -130,12 +131,20 @@ pub(crate) fn swift_test(process: &Process, config: &CiConfig, swiftpm_cache: &P
     // this job builds it too. Repeated work is nearly free — the jobs share a
     // target directory on the executor — and it keeps the job self-contained.
     build_xcframework(process)?;
+    // SwiftPM writes xUnit on request, so this lane needs no conversion.
+    let report = process.root().join("target/xcresult/swift-test.junit.xml");
+    if let Some(parent) = report.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating {}", parent.display()))?;
+    }
     let mut command = process.command("swift");
     command
         .env("KITHARA_LOCAL_DEV", "1")
         .arg("test")
         .arg("--cache-path")
-        .arg(swiftpm_cache);
+        .arg(swiftpm_cache)
+        .arg("--xunit-output")
+        .arg(&report);
     process.run_command(&mut command, "Swift package tests")
 }
 
@@ -164,7 +173,18 @@ pub(crate) fn ios_test(process: &Process, config: &CiConfig) -> Result<()> {
         // measured group while a simulator runs, and rebuilding what another
         // job already produced spends that window twice.
         .args(["platform", "apple", "test", "--skip-build"]);
-    process.run_command(&mut command, "iOS Simulator tests")
+    let outcome = process.run_command(&mut command, "iOS Simulator tests");
+    // A failing run is exactly the one whose report matters, so the bundle is
+    // converted either way and the test outcome is returned afterwards.
+    let bundle = process.root().join("target/xcresult/ios-test.xcresult");
+    if bundle.exists() {
+        xcresult::write_junit(
+            process,
+            &bundle,
+            &process.root().join("target/xcresult/ios-test.junit.xml"),
+        )?;
+    }
+    outcome
 }
 
 struct Consts;

--- a/xtask/src/ci/mod.rs
+++ b/xtask/src/ci/mod.rs
@@ -10,6 +10,7 @@ mod linux;
 mod process;
 mod release;
 mod run;
+mod verdict;
 mod xcresult;
 
 pub(crate) use command::{CiArgs, is_standalone, run, run_standalone};

--- a/xtask/src/ci/mod.rs
+++ b/xtask/src/ci/mod.rs
@@ -10,5 +10,6 @@ mod linux;
 mod process;
 mod release;
 mod run;
+mod xcresult;
 
 pub(crate) use command::{CiArgs, is_standalone, run, run_standalone};

--- a/xtask/src/ci/run.rs
+++ b/xtask/src/ci/run.rs
@@ -3,9 +3,9 @@ use std::{env, path::PathBuf};
 use anyhow::{Context, Result};
 use clap::{Args, ValueEnum};
 use kithara_devtools::Ctx;
-use tracing::info;
+use tracing::{info, warn};
 
-use super::{config::CiConfig, environment::CiEnvironment, lane, process::Process};
+use super::{config::CiConfig, environment::CiEnvironment, lane, process::Process, verdict};
 use crate::config::KitharaExt;
 
 /// One CI job. Lanes are deliberately narrow: a job that does one thing can be
@@ -57,6 +57,7 @@ pub(crate) enum Lane {
     ReleaseWasm,
     ReleaseAndroid,
     ReleasePublish,
+    Verdict,
 }
 
 /// Which shared cache a lane leases. Lanes sharing an executor share its cache,
@@ -89,7 +90,8 @@ impl Lane {
             | Self::ReleaseXcframework
             | Self::ReleaseDocs
             | Self::ReleaseWasm => CacheGroup::Macos,
-            Self::LinuxSecrets
+            Self::Verdict
+            | Self::LinuxSecrets
             | Self::LinuxCheck
             | Self::LinuxWasm
             | Self::LinuxTest
@@ -170,6 +172,12 @@ pub(crate) fn run(args: &RunArgs, ctx: &Ctx) -> Result<()> {
     // for; the cache on disk is untouched.
     process.ensure("sccache", &["--stop-server"], "retire the compiler cache");
 
+    let lane_name = args
+        .lane
+        .to_possible_value()
+        .map_or_else(|| "lane".to_owned(), |value| value.get_name().to_owned());
+    verdict::clear(&ctx.root, &lane_name)?;
+
     let result = match args.lane {
         Lane::AppleLint => lane::apple::lint(&process, &ci_config),
         Lane::AppleMsrv => lane::apple::msrv(&process, &ci_config),
@@ -217,8 +225,15 @@ pub(crate) fn run(args: &RunArgs, ctx: &Ctx) -> Result<()> {
         Lane::ReleaseWasm => super::release::wasm(&process, ctx, &ext),
         Lane::ReleaseAndroid => super::release::build_android(&process, ctx, &ext),
         Lane::ReleasePublish => super::release::publish(&process, ctx, &ext, args.kind),
+        Lane::Verdict => verdict::lane(&ctx.root, &ci_config, args.kind),
     };
     process.best_effort("sccache", &["--show-stats"], "sccache statistics");
+    // The verdict reads what every lane leaves here, so collection cannot be
+    // conditional on the lane passing — a failing lane is the one whose report
+    // decides whether a merge request is held.
+    if let Err(error) = verdict::gather(&ctx.root, &lane_name, result.is_err()) {
+        warn!(%error, lane = %lane_name, "could not collect this lane's test report");
+    }
     result
 }
 

--- a/xtask/src/ci/verdict.rs
+++ b/xtask/src/ci/verdict.rs
@@ -49,6 +49,11 @@ struct Common {
     /// Journal kept on the executor, outliving artifact expiry.
     #[arg(long, env = "KITHARA_VERDICT_JOURNAL")]
     journal: PathBuf,
+    /// Commit this run is based on. When the journal remembers that exact
+    /// commit, the comparison is against what it failed rather than against
+    /// the window alone.
+    #[arg(long, env = "CI_MERGE_REQUEST_DIFF_BASE_SHA")]
+    base: Option<String>,
 }
 
 /// One run of the default branch, as the journal remembers it.
@@ -91,6 +96,10 @@ impl Journal {
         self.runs.push(run);
         let excess = self.runs.len().saturating_sub(REMEMBERED_RUNS);
         self.runs.drain(..excess);
+    }
+
+    fn run_at(&self, sha: &str) -> Option<&Run> {
+        self.runs.iter().find(|run| run.sha == sha)
     }
 
     fn tests(&self) -> BTreeSet<&str> {
@@ -150,7 +159,7 @@ fn check(common: &Common) -> Result<()> {
     }
     let known_tests = journal.tests();
     let known_jobs = journal.jobs();
-
+    let at_base = attested_at_base(&journal, common.base.as_deref());
     let new_tests: Vec<&String> = observed
         .tests
         .iter()
@@ -161,26 +170,13 @@ fn check(common: &Common) -> Result<()> {
         .iter()
         .filter(|job| !known_jobs.contains(job.as_str()))
         .collect();
-
-    for id in observed
-        .tests
-        .iter()
-        .filter(|id| known_tests.contains(id.as_str()))
-    {
-        warn!(test = %id, "failing, and already failing on the default branch");
-    }
-    for id in &new_tests {
-        warn!(test = %id, "failing here and not on the default branch");
-    }
-    for job in &new_jobs {
-        warn!(job = %job, "lane failed without per-test identity, and not on the default branch");
-    }
-    info!(
-        cases = observed.cases,
-        regressed_tests = new_tests.len(),
-        regressed_jobs = new_jobs.len(),
-        remembered_runs = journal.runs.len(),
-        "verdict"
+    report(
+        &observed,
+        &known_tests,
+        &at_base,
+        &new_tests,
+        &new_jobs,
+        &journal,
     );
     if new_tests.is_empty() && new_jobs.is_empty() {
         return Ok(());
@@ -190,6 +186,71 @@ fn check(common: &Common) -> Result<()> {
         new_tests.len(),
         new_jobs.len()
     )
+}
+
+/// The window is what a failure has to be new against: it unions the last runs
+/// of the default branch, so a test that fails a quarter of the time does not
+/// read as a regression whenever the run it is compared with happened to be
+/// green.
+///
+/// The base commit does not widen it — that run is already one of the five —
+/// but it is what makes a known failure arguable: "this was failing at the
+/// commit you branched from" is evidence, "this failed sometime last week" is
+/// not. Returned separately for exactly that.
+fn attested_at_base<'a>(journal: &'a Journal, base: Option<&str>) -> BTreeSet<&'a str> {
+    let Some(sha) = base else {
+        warn!("no base commit named; a known failure cannot be attributed to one");
+        return BTreeSet::new();
+    };
+    let Some(run) = journal.run_at(sha) else {
+        warn!(
+            base = %sha,
+            "the journal does not remember this base commit, so nothing can be attributed to it; \
+             the window still decides the verdict"
+        );
+        return BTreeSet::new();
+    };
+    info!(base = %sha, "the base commit has a recorded run");
+    run.tests.iter().map(String::as_str).collect()
+}
+
+fn report(
+    observed: &Observed,
+    known_tests: &BTreeSet<&str>,
+    at_base: &BTreeSet<&str>,
+    new_tests: &[&String],
+    new_jobs: &[&String],
+    journal: &Journal,
+) {
+    report_known(observed, known_tests, at_base);
+    for id in new_tests {
+        warn!(test = %id, "failing here and not on the default branch");
+    }
+    for job in new_jobs {
+        warn!(job = %job, "lane failed without per-test identity, and not on the default branch");
+    }
+    info!(
+        cases = observed.cases,
+        regressed_tests = new_tests.len(),
+        regressed_jobs = new_jobs.len(),
+        attested_at_base = at_base.len(),
+        remembered_runs = journal.runs.len(),
+        "verdict"
+    );
+}
+
+fn report_known(observed: &Observed, known_tests: &BTreeSet<&str>, at_base: &BTreeSet<&str>) {
+    for id in observed
+        .tests
+        .iter()
+        .filter(|id| known_tests.contains(id.as_str()))
+    {
+        if at_base.contains(id.as_str()) {
+            warn!(test = %id, "failing, and failing at the base commit too");
+        } else {
+            warn!(test = %id, "failing, and seen failing on the default branch recently");
+        }
+    }
 }
 
 struct Observed {
@@ -294,6 +355,39 @@ mod tests {
         assert_eq!(journal.runs.len(), REMEMBERED_RUNS);
         assert!(!journal.tests().contains("suite::0"));
         assert!(journal.tests().contains("suite::5"));
+    }
+
+    #[test]
+    fn the_journal_can_answer_for_one_commit() {
+        let mut journal = Journal::default();
+        journal.record(run_of("base", &["suite::a"], &[]));
+        journal.record(run_of("later", &["suite::b"], &[]));
+        assert_eq!(
+            journal.run_at("base").map(|run| run.tests.clone()),
+            Some(BTreeSet::from(["suite::a".to_owned()]))
+        );
+        assert!(journal.run_at("absent").is_none());
+    }
+
+    #[test]
+    fn a_failure_is_attributed_to_the_base_commit_when_the_journal_has_it() {
+        let mut journal = Journal::default();
+        journal.record(run_of("base", &["suite::a"], &[]));
+        journal.record(run_of("later", &["suite::b"], &[]));
+        assert_eq!(
+            attested_at_base(&journal, Some("base")),
+            BTreeSet::from(["suite::a"])
+        );
+    }
+
+    #[test]
+    fn an_unremembered_base_attributes_nothing_and_still_lets_the_window_decide() {
+        let mut journal = Journal::default();
+        journal.record(run_of("later", &["suite::b"], &[]));
+        assert!(attested_at_base(&journal, Some("gone")).is_empty());
+        assert!(attested_at_base(&journal, None).is_empty());
+        // The window is untouched by either: it is what the verdict compares to.
+        assert_eq!(journal.tests(), BTreeSet::from(["suite::b"]));
     }
 
     #[test]

--- a/xtask/src/ci/verdict.rs
+++ b/xtask/src/ci/verdict.rs
@@ -10,6 +10,8 @@ use kithara_devtools::junit::{CaseTiming, parse_junit};
 use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 
+use super::{config::CiConfig, run::PipelineKind};
+
 /// How many `main` runs the journal keeps. One is not enough: a test that fails
 /// a quarter of the time would otherwise land in a branch's column whenever the
 /// single remembered run happened to be green, and block on its own noise.
@@ -43,9 +45,6 @@ struct Common {
     /// Directory holding this run's `JUnit` reports.
     #[arg(long, default_value = "target/junit")]
     reports: PathBuf,
-    /// Lanes that failed without per-test identity, comma separated.
-    #[arg(long, default_value = "")]
-    failed_jobs: String,
     /// Journal kept on the executor, outliving artifact expiry.
     #[arg(long, env = "KITHARA_VERDICT_JOURNAL")]
     journal: PathBuf,
@@ -120,6 +119,90 @@ impl Journal {
 /// A test's identity across runs and lanes.
 fn case_id(case: &CaseTiming) -> String {
     format!("{}::{}", case.suite, case.name)
+}
+
+/// Where the verdict expects every lane to leave what it produced. Artifacts
+/// travel between runners at their own paths, so one directory is what makes a
+/// report from the simulator and a report from a container comparable.
+pub(crate) const REPORT_DIR: &str = "target/junit";
+
+/// The report a lane writes, before it is collected. A lane that writes none
+/// still leaves a marker when it fails, which is how a browser suite or a
+/// sanitiser run — neither of which can name a test — still holds a merge
+/// request.
+pub(crate) fn produced_report(lane: &str) -> Option<&'static str> {
+    match lane {
+        "apple-test" | "linux-test" | "windows-arm64" | "windows-x64" => {
+            Some("target/nextest/ci/junit.xml")
+        }
+        "apple-test-flash-off" => Some("target-flash-off/nextest/ci/junit.xml"),
+        "apple-ios-test" => Some("target/xcresult/ios-test.junit.xml"),
+        "apple-swift-test" => Some("target/xcresult/swift-test.junit.xml"),
+        _ => None,
+    }
+}
+
+/// The build directory survives between jobs on this executor, so a report left
+/// by an earlier lane would be collected as this one's. Remove it first: a lane
+/// that produces nothing must publish nothing.
+pub(crate) fn clear(root: &Path, lane: &str) -> Result<()> {
+    let Some(report) = produced_report(lane) else {
+        return Ok(());
+    };
+    let path = root.join(report);
+    if path.exists() {
+        fs::remove_file(&path).with_context(|| format!("removing {}", path.display()))?;
+    }
+    Ok(())
+}
+
+/// Collect what this lane produced into the one directory the verdict reads,
+/// and record a bare failure for a lane that cannot name its tests.
+pub(crate) fn gather(root: &Path, lane: &str, failed: bool) -> Result<()> {
+    let directory = root.join(REPORT_DIR);
+    fs::create_dir_all(&directory).with_context(|| format!("creating {}", directory.display()))?;
+    if let Some(report) = produced_report(lane) {
+        let from = root.join(report);
+        if from.exists() {
+            let to = directory.join(format!("{lane}.xml"));
+            fs::copy(&from, &to)
+                .with_context(|| format!("copying {} to {}", from.display(), to.display()))?;
+        }
+    }
+    if failed {
+        let marker = directory.join(format!("{lane}.failed"));
+        fs::write(&marker, "").with_context(|| format!("writing {}", marker.display()))?;
+    }
+    Ok(())
+}
+
+/// The journal lives on the executor that runs this lane. The Linux container
+/// is the one with a path that outlives a job — a macOS job runs in a throwaway
+/// guest, where nothing written survives it.
+fn journal_path(config: &CiConfig) -> PathBuf {
+    config.host.cache_root_linux.join("verdict/journal.json")
+}
+
+/// `main` and the nightly chain describe the default branch, so they record.
+/// Everything else is measured against what they recorded.
+pub(crate) fn lane(root: &Path, config: &CiConfig, kind: PipelineKind) -> Result<()> {
+    let common = Common {
+        reports: root.join(REPORT_DIR),
+        journal: journal_path(config),
+        base: std::env::var("CI_MERGE_REQUEST_DIFF_BASE_SHA").ok(),
+    };
+    match kind {
+        PipelineKind::Main | PipelineKind::Nightly => {
+            let sha = std::env::var("CI_COMMIT_SHA")
+                .context("CI_COMMIT_SHA names the run being recorded")?;
+            record(&common, &sha)
+        }
+        PipelineKind::Branch
+        | PipelineKind::MergeRequest
+        | PipelineKind::Quarantine
+        | PipelineKind::Weekly
+        | PipelineKind::Release => check(&common),
+    }
 }
 
 pub(crate) fn run(args: &VerdictArgs) -> Result<()> {
@@ -265,9 +348,10 @@ struct Observed {
 /// on rather than a silence.
 fn observe(common: &Common) -> Result<Observed> {
     let cases = collect(&common.reports)?;
-    if cases.is_empty() && common.failed_jobs.trim().is_empty() {
+    let jobs = failed_markers(&common.reports)?;
+    if cases.is_empty() && jobs.is_empty() {
         bail!(
-            "no JUnit reports under {} and no failed lanes named — a verdict on nothing is not a \
+            "no `JUnit` reports and no failure markers under {} — a verdict on nothing is not a \
              verdict",
             common.reports.display()
         );
@@ -278,15 +362,29 @@ fn observe(common: &Common) -> Result<Observed> {
             .filter(|case| case.failed)
             .map(case_id)
             .collect(),
-        jobs: common
-            .failed_jobs
-            .split(',')
-            .map(str::trim)
-            .filter(|job| !job.is_empty())
-            .map(str::to_owned)
-            .collect(),
+        jobs,
         cases: cases.len(),
     })
+}
+
+/// A lane that failed leaves its name behind, whether or not it could name a
+/// test. `GitLab` hands a job no status for the jobs it needed, so the marker is
+/// what carries that across.
+fn failed_markers(root: &Path) -> Result<BTreeSet<String>> {
+    if !root.exists() {
+        return Ok(BTreeSet::new());
+    }
+    let mut jobs = BTreeSet::new();
+    let entries = fs::read_dir(root).with_context(|| format!("reading {}", root.display()))?;
+    for entry in entries {
+        let path = entry.context("reading a report directory entry")?.path();
+        if path.extension().is_some_and(|kind| kind == "failed")
+            && let Some(lane) = path.file_stem().and_then(|stem| stem.to_str())
+        {
+            jobs.insert(lane.to_owned());
+        }
+    }
+    Ok(jobs)
 }
 
 fn collect(root: &Path) -> Result<Vec<CaseTiming>> {
@@ -388,6 +486,48 @@ mod tests {
         assert!(attested_at_base(&journal, None).is_empty());
         // The window is untouched by either: it is what the verdict compares to.
         assert_eq!(journal.tests(), BTreeSet::from(["suite::b"]));
+    }
+
+    #[test]
+    fn a_lane_that_produced_nothing_publishes_nothing() {
+        let directory = tempfile::tempdir().unwrap();
+        gather(directory.path(), "apple-lint", false).unwrap();
+        assert!(directory.path().join(REPORT_DIR).exists());
+        assert!(
+            fs::read_dir(directory.path().join(REPORT_DIR))
+                .unwrap()
+                .next()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn a_failing_lane_leaves_its_name_even_without_a_report() {
+        let directory = tempfile::tempdir().unwrap();
+        gather(directory.path(), "web-chromium", true).unwrap();
+        assert_eq!(
+            failed_markers(&directory.path().join(REPORT_DIR)).unwrap(),
+            BTreeSet::from(["web-chromium".to_owned()])
+        );
+    }
+
+    #[test]
+    fn a_report_left_by_an_earlier_job_is_not_collected_as_this_ones() {
+        let directory = tempfile::tempdir().unwrap();
+        let stale = directory.path().join("target/nextest/ci/junit.xml");
+        fs::create_dir_all(stale.parent().unwrap()).unwrap();
+        fs::write(&stale, "<testsuites/>").unwrap();
+
+        clear(directory.path(), "apple-test").unwrap();
+        gather(directory.path(), "apple-test", false).unwrap();
+        assert!(
+            !directory
+                .path()
+                .join(REPORT_DIR)
+                .join("apple-test.xml")
+                .exists(),
+            "the build directory survives between jobs, so a stale report must not travel"
+        );
     }
 
     #[test]

--- a/xtask/src/ci/verdict.rs
+++ b/xtask/src/ci/verdict.rs
@@ -1,0 +1,318 @@
+use std::{
+    collections::BTreeSet,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result, bail};
+use clap::{Args, Subcommand};
+use kithara_devtools::junit::{CaseTiming, parse_junit};
+use serde::{Deserialize, Serialize};
+use tracing::{info, warn};
+
+/// How many `main` runs the journal keeps. One is not enough: a test that fails
+/// a quarter of the time would otherwise land in a branch's column whenever the
+/// single remembered run happened to be green, and block on its own noise.
+const REMEMBERED_RUNS: usize = 5;
+
+#[derive(Debug, Args)]
+pub(crate) struct VerdictArgs {
+    #[command(subcommand)]
+    command: VerdictCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum VerdictCommand {
+    /// Record what the default branch failed, for later runs to compare against.
+    Record {
+        #[command(flatten)]
+        common: Common,
+        /// Commit the recorded run belongs to.
+        #[arg(long)]
+        sha: String,
+    },
+    /// Fail when this run breaks something the default branch does not.
+    Check {
+        #[command(flatten)]
+        common: Common,
+    },
+}
+
+#[derive(Debug, Args)]
+struct Common {
+    /// Directory holding this run's `JUnit` reports.
+    #[arg(long, default_value = "target/junit")]
+    reports: PathBuf,
+    /// Lanes that failed without per-test identity, comma separated.
+    #[arg(long, default_value = "")]
+    failed_jobs: String,
+    /// Journal kept on the executor, outliving artifact expiry.
+    #[arg(long, env = "KITHARA_VERDICT_JOURNAL")]
+    journal: PathBuf,
+}
+
+/// One run of the default branch, as the journal remembers it.
+#[derive(Debug, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct Run {
+    sha: String,
+    tests: BTreeSet<String>,
+    jobs: BTreeSet<String>,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct Journal {
+    runs: Vec<Run>,
+}
+
+impl Journal {
+    fn load(path: &Path) -> Result<Self> {
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+        let text =
+            fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+        serde_json::from_str(&text).with_context(|| format!("parsing {}", path.display()))
+    }
+
+    fn store(&self, path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+        }
+        let text = serde_json::to_string_pretty(self).context("serializing the verdict journal")?;
+        fs::write(path, text + "\n").with_context(|| format!("writing {}", path.display()))
+    }
+
+    /// A run replaces its own earlier entry rather than stacking beside it, so
+    /// a retried commit does not hold two seats in the window.
+    fn record(&mut self, run: Run) {
+        self.runs.retain(|kept| kept.sha != run.sha);
+        self.runs.push(run);
+        let excess = self.runs.len().saturating_sub(REMEMBERED_RUNS);
+        self.runs.drain(..excess);
+    }
+
+    fn tests(&self) -> BTreeSet<&str> {
+        self.runs
+            .iter()
+            .flat_map(|run| run.tests.iter().map(String::as_str))
+            .collect()
+    }
+
+    fn jobs(&self) -> BTreeSet<&str> {
+        self.runs
+            .iter()
+            .flat_map(|run| run.jobs.iter().map(String::as_str))
+            .collect()
+    }
+}
+
+/// A test's identity across runs and lanes.
+fn case_id(case: &CaseTiming) -> String {
+    format!("{}::{}", case.suite, case.name)
+}
+
+pub(crate) fn run(args: &VerdictArgs) -> Result<()> {
+    match &args.command {
+        VerdictCommand::Record { common, sha } => record(common, sha),
+        VerdictCommand::Check { common } => check(common),
+    }
+}
+
+fn record(common: &Common, sha: &str) -> Result<()> {
+    let observed = observe(common)?;
+    let mut journal = Journal::load(&common.journal)?;
+    journal.record(Run {
+        sha: sha.to_owned(),
+        tests: observed.tests.clone(),
+        jobs: observed.jobs.clone(),
+    });
+    journal.store(&common.journal)?;
+    info!(
+        tests = observed.tests.len(),
+        jobs = observed.jobs.len(),
+        remembered = journal.runs.len(),
+        "recorded what the default branch is failing"
+    );
+    Ok(())
+}
+
+fn check(common: &Common) -> Result<()> {
+    let observed = observe(common)?;
+    let journal = Journal::load(&common.journal)?;
+    if journal.runs.is_empty() {
+        bail!(
+            "the journal at {} is empty; the default branch has to record a run before a \
+             regression can be told from what it already carries",
+            common.journal.display()
+        );
+    }
+    let known_tests = journal.tests();
+    let known_jobs = journal.jobs();
+
+    let new_tests: Vec<&String> = observed
+        .tests
+        .iter()
+        .filter(|id| !known_tests.contains(id.as_str()))
+        .collect();
+    let new_jobs: Vec<&String> = observed
+        .jobs
+        .iter()
+        .filter(|job| !known_jobs.contains(job.as_str()))
+        .collect();
+
+    for id in observed
+        .tests
+        .iter()
+        .filter(|id| known_tests.contains(id.as_str()))
+    {
+        warn!(test = %id, "failing, and already failing on the default branch");
+    }
+    for id in &new_tests {
+        warn!(test = %id, "failing here and not on the default branch");
+    }
+    for job in &new_jobs {
+        warn!(job = %job, "lane failed without per-test identity, and not on the default branch");
+    }
+    info!(
+        cases = observed.cases,
+        regressed_tests = new_tests.len(),
+        regressed_jobs = new_jobs.len(),
+        remembered_runs = journal.runs.len(),
+        "verdict"
+    );
+    if new_tests.is_empty() && new_jobs.is_empty() {
+        return Ok(());
+    }
+    bail!(
+        "{} test(s) and {} lane(s) fail here and not on the default branch",
+        new_tests.len(),
+        new_jobs.len()
+    )
+}
+
+struct Observed {
+    tests: BTreeSet<String>,
+    jobs: BTreeSet<String>,
+    cases: usize,
+}
+
+/// Every lane that can name its tests contributes them; a lane that cannot —
+/// the browser suites, the sanitiser runs, mutation — contributes its own name
+/// instead, so a failure there is still something a merge request can be held
+/// on rather than a silence.
+fn observe(common: &Common) -> Result<Observed> {
+    let cases = collect(&common.reports)?;
+    if cases.is_empty() && common.failed_jobs.trim().is_empty() {
+        bail!(
+            "no JUnit reports under {} and no failed lanes named — a verdict on nothing is not a \
+             verdict",
+            common.reports.display()
+        );
+    }
+    Ok(Observed {
+        tests: cases
+            .iter()
+            .filter(|case| case.failed)
+            .map(case_id)
+            .collect(),
+        jobs: common
+            .failed_jobs
+            .split(',')
+            .map(str::trim)
+            .filter(|job| !job.is_empty())
+            .map(str::to_owned)
+            .collect(),
+        cases: cases.len(),
+    })
+}
+
+fn collect(root: &Path) -> Result<Vec<CaseTiming>> {
+    if !root.exists() {
+        return Ok(Vec::new());
+    }
+    let mut cases = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(path) = stack.pop() {
+        if path.is_dir() {
+            let entries =
+                fs::read_dir(&path).with_context(|| format!("reading {}", path.display()))?;
+            for entry in entries {
+                stack.push(entry.context("reading a report directory entry")?.path());
+            }
+        } else if path.extension().is_some_and(|kind| kind == "xml") {
+            let text =
+                fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+            cases
+                .extend(parse_junit(&text).with_context(|| format!("parsing {}", path.display()))?);
+        }
+    }
+    Ok(cases)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn run_of(sha: &str, tests: &[&str], jobs: &[&str]) -> Run {
+        Run {
+            sha: sha.to_owned(),
+            tests: tests.iter().map(|id| (*id).to_owned()).collect(),
+            jobs: jobs.iter().map(|id| (*id).to_owned()).collect(),
+        }
+    }
+
+    #[test]
+    fn the_window_unions_every_run_it_remembers() {
+        let mut journal = Journal::default();
+        journal.record(run_of("one", &["suite::a"], &[]));
+        journal.record(run_of("two", &["suite::b"], &["web:firefox"]));
+        assert_eq!(journal.tests(), BTreeSet::from(["suite::a", "suite::b"]));
+        assert_eq!(journal.jobs(), BTreeSet::from(["web:firefox"]));
+    }
+
+    #[test]
+    fn a_retried_commit_does_not_hold_two_seats() {
+        let mut journal = Journal::default();
+        journal.record(run_of("one", &["suite::a"], &[]));
+        journal.record(run_of("one", &["suite::b"], &[]));
+        assert_eq!(journal.runs.len(), 1);
+        assert_eq!(journal.tests(), BTreeSet::from(["suite::b"]));
+    }
+
+    #[test]
+    fn the_window_forgets_what_falls_out_of_it() {
+        let mut journal = Journal::default();
+        for index in 0..=REMEMBERED_RUNS {
+            journal.record(run_of(
+                &index.to_string(),
+                &[&format!("suite::{index}")],
+                &[],
+            ));
+        }
+        assert_eq!(journal.runs.len(), REMEMBERED_RUNS);
+        assert!(!journal.tests().contains("suite::0"));
+        assert!(journal.tests().contains("suite::5"));
+    }
+
+    #[test]
+    fn a_journal_round_trips_through_the_executor() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("state/regressions.json");
+        let mut journal = Journal::default();
+        journal.record(run_of("one", &["suite::a"], &["deep:rtsan"]));
+        journal.store(&path).unwrap();
+
+        let loaded = Journal::load(&path).unwrap();
+        assert_eq!(loaded.tests(), BTreeSet::from(["suite::a"]));
+        assert_eq!(loaded.jobs(), BTreeSet::from(["deep:rtsan"]));
+    }
+
+    #[test]
+    fn a_missing_journal_reads_as_empty_rather_than_failing() {
+        let directory = tempfile::tempdir().unwrap();
+        let journal = Journal::load(&directory.path().join("absent.json")).unwrap();
+        assert!(journal.runs.is_empty());
+    }
+}

--- a/xtask/src/ci/xcresult.rs
+++ b/xtask/src/ci/xcresult.rs
@@ -1,0 +1,198 @@
+use std::{collections::BTreeMap, fmt::Write as _, fs, path::Path};
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+
+use super::process::Process;
+
+/// Turn the result bundle `xcodebuild` leaves behind into a `JUnit` report.
+///
+/// Xcode writes no `JUnit` of its own, so without this the simulator lane — the
+/// one carrying every iOS regression — contributes nothing to a merge request's
+/// test report, and a reviewer sees a green job with no tests behind it.
+pub(crate) fn write_junit(process: &Process, bundle: &Path, output: &Path) -> Result<()> {
+    let path = bundle.to_string_lossy().into_owned();
+    let json = process.capture(
+        "xcrun",
+        &[
+            "xcresulttool",
+            "get",
+            "test-results",
+            "tests",
+            "--path",
+            &path,
+            "--format",
+            "json",
+        ],
+        "reading the Xcode result bundle",
+    )?;
+    let parsed: Value =
+        serde_json::from_str(&json).with_context(|| format!("parsing test results from {path}"))?;
+    if let Some(parent) = output.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+    }
+    fs::write(output, junit(&parsed)?).with_context(|| format!("writing {}", output.display()))
+}
+
+#[derive(Default)]
+struct Case {
+    name: String,
+    seconds: f64,
+    failures: Vec<String>,
+    skipped: bool,
+}
+
+fn junit(results: &Value) -> Result<String> {
+    let nodes = results["testNodes"]
+        .as_array()
+        .context("xcresulttool test results have no testNodes array")?;
+    let mut suites: BTreeMap<String, Vec<Case>> = BTreeMap::new();
+    for node in nodes {
+        collect(node, "xcodebuild", &mut suites);
+    }
+
+    let total: usize = suites.values().map(Vec::len).sum();
+    let failed: usize = suites
+        .values()
+        .flatten()
+        .filter(|case| !case.failures.is_empty())
+        .count();
+    let mut report = String::from("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+    writeln!(
+        report,
+        "<testsuites tests=\"{total}\" failures=\"{failed}\">"
+    )?;
+    for (suite, cases) in &suites {
+        let suite_failed = cases
+            .iter()
+            .filter(|case| !case.failures.is_empty())
+            .count();
+        writeln!(
+            report,
+            "  <testsuite name=\"{}\" tests=\"{}\" failures=\"{suite_failed}\">",
+            escape(suite),
+            cases.len()
+        )?;
+        for case in cases {
+            writeln!(
+                report,
+                "    <testcase classname=\"{}\" name=\"{}\" time=\"{:.3}\">",
+                escape(suite),
+                escape(&case.name),
+                case.seconds
+            )?;
+            if case.skipped {
+                report.push_str("      <skipped/>\n");
+            }
+            for failure in &case.failures {
+                writeln!(report, "      <failure message=\"{}\"/>", escape(failure))?;
+            }
+            report.push_str("    </testcase>\n");
+        }
+        report.push_str("  </testsuite>\n");
+    }
+    report.push_str("</testsuites>\n");
+    Ok(report)
+}
+
+/// `suite` carries the closest enclosing suite or bundle name, which is what a
+/// `JUnit` reader shows as the class a test belongs to.
+fn collect(node: &Value, suite: &str, suites: &mut BTreeMap<String, Vec<Case>>) {
+    let name = node["name"].as_str().unwrap_or_default();
+    match node["nodeType"].as_str().unwrap_or_default() {
+        "Test Case" => {
+            let (suite, case) = split_identifier(node, suite, name);
+            suites.entry(suite).or_default().push(Case {
+                name: case,
+                seconds: node["durationInSeconds"].as_f64().unwrap_or_default(),
+                failures: failure_messages(node),
+                skipped: node["result"].as_str() == Some("Skipped"),
+            });
+        }
+        "Test Suite" | "Unit test bundle" | "UI test bundle" => {
+            for child in children(node) {
+                collect(child, name, suites);
+            }
+        }
+        _ => {
+            for child in children(node) {
+                collect(child, suite, suites);
+            }
+        }
+    }
+}
+
+/// A case identifies itself as `Suite/testName()`, which names the type that
+/// holds the test rather than the display name of the suite it was grouped
+/// under. Prefer it, and fall back to the enclosing node when it is absent.
+fn split_identifier(node: &Value, suite: &str, name: &str) -> (String, String) {
+    node["nodeIdentifier"]
+        .as_str()
+        .and_then(|id| id.split_once('/'))
+        .map_or_else(
+            || (suite.to_owned(), name.to_owned()),
+            |(class, case)| (class.to_owned(), case.to_owned()),
+        )
+}
+
+/// Only a `Failure Message` fails a case. A passing test can carry a
+/// `Runtime Warning` child, and treating every child as a failure would report
+/// green runs as red.
+fn failure_messages(node: &Value) -> Vec<String> {
+    children(node)
+        .filter(|child| child["nodeType"].as_str() == Some("Failure Message"))
+        .filter_map(|child| child["name"].as_str().map(str::to_owned))
+        .collect()
+}
+
+fn children(node: &Value) -> impl Iterator<Item = &Value> {
+    node["children"].as_array().into_iter().flatten()
+}
+
+fn escape(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture() -> Value {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/xcresult-tests.json");
+        serde_json::from_str(&fs::read_to_string(path).unwrap()).unwrap()
+    }
+
+    #[test]
+    fn every_case_reaches_the_report() {
+        let report = junit(&fixture()).unwrap();
+        assert!(report.contains("<testsuites tests=\"3\" failures=\"1\""));
+        assert_eq!(report.matches("<testcase ").count(), 3);
+    }
+
+    #[test]
+    fn a_case_is_classed_by_the_type_that_holds_it() {
+        let report = junit(&fixture()).unwrap();
+        assert!(report.contains("classname=\"LabaIOSTraps\""));
+        assert!(report.contains("name=\"laba419OfflineResume()\""));
+    }
+
+    #[test]
+    fn a_runtime_warning_on_a_passing_test_is_not_a_failure() {
+        let report = junit(&fixture()).unwrap();
+        assert!(
+            !report.contains("priority inversions"),
+            "a Runtime Warning child must not be reported as a failure"
+        );
+    }
+
+    #[test]
+    fn a_failure_message_reaches_the_report_escaped() {
+        let report = junit(&fixture()).unwrap();
+        assert!(report.contains("<failure message=\"Laba419OfflineResume.swift:68:"));
+        assert!(!report.contains("<failure message=\"\"/>"));
+    }
+}

--- a/xtask/tests/fixtures/xcresult-tests.json
+++ b/xtask/tests/fixtures/xcresult-tests.json
@@ -1,0 +1,68 @@
+{
+  "testNodes": [
+    {
+      "children": [
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "name": "Laba413CacheCommitGrows.swift:6: Thread running at User-initiated quality-of-service class waiting on a lower QoS thread running at Default quality-of-service class. Investigate ways to avoid priority inversions",
+                      "nodeType": "Runtime Warning"
+                    }
+                  ],
+                  "duration": "1 с",
+                  "durationInSeconds": 1,
+                  "name": "LABA-413 commits played audio into the configured cache",
+                  "nodeIdentifier": "LabaIOSTraps/laba413CacheCommitGrows()",
+                  "nodeIdentifierURL": "test://com.apple.xcode/KitharaDemo/KitharaDemoUnitTests_iOS/LabaIOSTraps/laba413CacheCommitGrows()",
+                  "nodeType": "Test Case",
+                  "result": "Passed"
+                },
+                {
+                  "children": [
+                    {
+                      "name": "Laba415InterruptionResume.swift:11: Thread running at User-initiated quality-of-service class waiting on a lower QoS thread running at Default quality-of-service class. Investigate ways to avoid priority inversions",
+                      "nodeType": "Runtime Warning"
+                    }
+                  ],
+                  "name": "LABA-415 pauses and resumes for an audio-session interruption",
+                  "nodeIdentifier": "LabaIOSTraps/laba415InterruptionResume()",
+                  "nodeIdentifierURL": "test://com.apple.xcode/KitharaDemo/KitharaDemoUnitTests_iOS/LabaIOSTraps/laba415InterruptionResume()",
+                  "nodeType": "Test Case",
+                  "result": "Passed"
+                },
+                {
+                  "children": [
+                    {
+                      "name": "Laba419OfflineResume.swift:68: Expectation failed: resumed: LABA-419: connectivity returned after playback starved at 47.993375s, but media time never reached 48.993375s; current=47.993375s",
+                      "nodeType": "Failure Message"
+                    }
+                  ],
+                  "duration": "1 мин 35 с",
+                  "durationInSeconds": 95,
+                  "name": "LABA-419 resumes playback after connectivity returns",
+                  "nodeIdentifier": "LabaIOSTraps/laba419OfflineResume()",
+                  "nodeIdentifierURL": "test://com.apple.xcode/KitharaDemo/KitharaDemoUnitTests_iOS/LabaIOSTraps/laba419OfflineResume()",
+                  "nodeType": "Test Case",
+                  "result": "Failed"
+                }
+              ],
+              "name": "LABA iOS traps",
+              "nodeType": "Test Suite",
+              "result": "Failed"
+            }
+          ],
+          "name": "KitharaDemoUnitTests_iOS",
+          "nodeType": "Unit test bundle",
+          "result": "Failed"
+        }
+      ],
+      "name": "KitharaDemoUnitTests_iOS",
+      "nodeType": "Test Plan",
+      "result": "Failed"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

CI could not tell a regression from what it was already failing, and it could
not show a reviewer what ran. Both are prerequisites for moving development to
GitLab while GitHub keeps accepting pull requests, and neither was true.

The JUnit reports were the first surprise. Five jobs declared
`artifacts:reports:junit`, but nextest resolves `junit.path` against its own
store directory, so every run wrote to `target/nextest/ci/target/nextest/ci/`
and GitLab matched nothing. `test_report_summary` for the last pipelines
returned 27 tests, all from `android:test`, while roughly 1800 Rust tests went
unseen — and the jobs stayed green throughout. The same `[profile.ci.junit]`
header, inserted above the profile's own keys, had also swallowed
`test-threads` and `leak-timeout`. A test now pins the path against the lanes
that collect it, and each of its three assertions was confirmed by
reintroducing the mistake it guards.

The simulator lane produced no report at all: `xcodebuild` writes no JUnit, so
the only lane running the iOS regressions contributed nothing. It now keeps its
result bundle and converts it, on a failing run as much as a passing one, and
runs on merge requests rather than only on `main` — a push stops producing
pipelines once a merge request is open, so without that the regressions would
never run where they are being reviewed.

With reports arriving, the gate itself changes shape. Waiting for the suite to
be green blocks every change behind red it did not cause, so the lanes that can
be judged no longer gate on themselves. A journal on the executor records what
the default branch fails, and a run is held only for failing something the
branch does not. Every kind of test counts, not only nextest: the simulator
suite and the Swift package emit JUnit too, and a lane that can name no test —
the browser suites, the sanitiser runs — is registered by name, so a failure
there still holds a merge request.

The rest is the bridge. It refused to publish anything unless the pipeline was
`success`, judged on the parent — and three parents on `ci/platforms-opt-in`
reported success over cancelled children, which would have published a commit
whose tests never ran. It required a GitHub App for the one operation that
needs one, check runs, where nobody can install one; that moves to commit
statuses and a token. It refused an import for touching `Cargo.toml` or
`Cargo.lock`, which are not the pipeline that judges the patch: four of the five
pull requests open on GitHub were refused, one of them on the lockfile alone.
And a rejection was permanent, with no way to say its reason had been dealt
with.

## Behavior / scope

- contract or behavior: a pipeline is green when nothing regressed against the
  default branch, not when everything passes; the bridge judges the child
  pipeline and authenticates with a token; manifests are no longer control
  paths.
- affected area: `xtask ci` (bridge, lanes, verdict), `.gitlab/ci/*`,
  `.config/nextest.toml`, `.config/just/platform.just`, `kithara-devtools`
  (JUnit reading moved to the crate root), `docs/guides/ci-host.md`.

## Validation

- `cargo nextest run -p xtask` — 228 passed
- `just check clippy` — clean
- `cargo run -q -p xtask -- format --check` — clean
- `cargo nextest run --profile ci -p kithara-net` — 116 passed, report written
  to `target/nextest/ci/junit.xml`, the path the lanes collect
- not run: the verdict end to end. Recording on `main` and checking on a branch
  needs artifacts travelling between runners, which cannot be reproduced
  locally.

## Surface impact

- Public API: changed: `kithara_devtools::junit` is now public, moved out of
  `perf`.
- Platform/runtime: changed: tooling surface, and the Apple lane gains a result
  bundle plus a JUnit conversion.
- Perf-sensitive paths: none

## Risks / follow-ups

- The verdict has never run against a real pipeline. The first check after this
  lands has no journal to read and says so; a `main` run has to record first.
- A lane that never starts leaves neither report nor marker, and the verdict
  reads that as nothing to judge rather than as missing coverage.
- Test identity is `classname::name`, so renaming a test reads as one
  disappearing and another appearing. A rename and a fix in one change will look
  like a regression.
- `apple:ios-test` moving onto merge requests lengthens the queue on a
  serialised host.
