### PR TITLE
fix(ci): record a lane that fell over, and clean the volume by what is left

### DIFF
--- a/docs/guides/ci-host.md
+++ b/docs/guides/ci-host.md
@@ -237,6 +237,18 @@ carries.
 
 ## Storage policy
 
+Pressure is read from what is left, not from what was spent. The thresholds
+below are written as bytes used against the quota, and cleanup takes each one
+as the free space it intends to keep — a volume at the reject threshold is one
+with 15 GB to spare, which is exactly what a job's preflight requires. On an
+APFS container the volume shares with others the two are different questions,
+and reading them the old way left a 279 GB volume with 24 GB free reported as
+`Normal` while jobs were already being refused.
+
+The Linux guest's data disk is sparse and never deflates: pruning inside it
+returns nothing to this volume. Aggressive cleanup therefore discards its freed
+blocks, and only refusal recycles the guest outright.
+
 The CI volume has a 300 GB APFS quota. New work stops at 285 GB. Cleanup starts
 at 240 GB and becomes aggressive at 270 GB. Workspaces, VM overlays, logs, and
 whole inactive cache namespaces are pruned; individual Cargo, Gradle, and

--- a/xtask/src/ci/host/storage.rs
+++ b/xtask/src/ci/host/storage.rs
@@ -51,6 +51,7 @@ struct Volume {
     path: PathBuf,
     used: u64,
     total: u64,
+    available: u64,
 }
 
 impl Volume {
@@ -63,6 +64,7 @@ impl Volume {
             path: path.to_path_buf(),
             used: total.saturating_sub(available),
             total,
+            available,
         })
     }
 }
@@ -167,6 +169,7 @@ impl<'a> HostStorage<'a> {
                 self.prune_old_trees("cache/bootstrap/trusted", 7 * Self::DAY)?;
                 self.prune_old_trees("vm/tart/cache", 7 * Self::DAY)?;
                 self.prune_docker_cache("168h");
+                self.trim_linux_guest();
             }
             Pressure::Normal => {}
         }
@@ -284,34 +287,31 @@ impl<'a> HostStorage<'a> {
         Ok(worst)
     }
 
-    /// Thresholds are configured against the main volume. Any other volume is
-    /// held to the same proportions of its own capacity, so a second volume
-    /// needs no second set of numbers to go stale.
+    /// Pressure is what is left, not what was spent.
+    ///
+    /// The thresholds are written as bytes used against `quota_bytes`, and this
+    /// reads them as the free space each one intends to keep: a volume at the
+    /// reject threshold is one with `quota - reject` bytes to spare. On an APFS
+    /// container the volume shares, the two are not the same question. This one
+    /// measured 279 GB with 170 used — never within 100 GB of a 285 GB reject
+    /// threshold, so cleanup stayed `Normal` and never recycled the guest —
+    /// while jobs were already being refused for having 10 GB free where the
+    /// preflight wants 15.
+    ///
+    /// Read this way the ladder and the refusal agree by construction:
+    /// `quota - reject` is exactly the free space a job is required to find.
     fn pressure_of(&self, volume: &Volume) -> Pressure {
-        let quota = self.config.host.quota_bytes;
-        if volume.path == self.root || volume.total == 0 || quota == 0 {
-            return self.pressure(volume.used);
-        }
-        let scale = |bytes: u64| -> u64 {
-            (u128::from(bytes) * u128::from(volume.total) / u128::from(quota))
-                .try_into()
-                .unwrap_or(u64::MAX)
-        };
         pressure_for(
-            volume.used,
-            scale(self.config.host.soft_cleanup_bytes),
-            scale(self.config.host.aggressive_cleanup_bytes),
-            scale(self.config.host.reject_bytes),
+            volume.available,
+            self.floor(self.config.host.soft_cleanup_bytes),
+            self.floor(self.config.host.aggressive_cleanup_bytes),
+            self.floor(self.config.host.reject_bytes),
         )
     }
 
-    fn pressure(&self, used: u64) -> Pressure {
-        pressure_for(
-            used,
-            self.config.host.soft_cleanup_bytes,
-            self.config.host.aggressive_cleanup_bytes,
-            self.config.host.reject_bytes,
-        )
+    /// The free space a used-bytes threshold was asking for.
+    fn floor(&self, threshold: u64) -> u64 {
+        self.config.host.quota_bytes.saturating_sub(threshold)
     }
 
     /// Cache namespaces nothing writes to any more, once they have gone quiet
@@ -492,6 +492,39 @@ impl<'a> HostStorage<'a> {
         }
     }
 
+    /// Hand the guest's freed blocks back to the volume.
+    ///
+    /// Pruning inside the guest returns nothing here on its own: the data disk
+    /// is a sparse file that grows to its high-water mark and keeps every block
+    /// it has ever written. Measured on 2026-08-11 it held 77 GB for 25 GB of
+    /// images and build cache — fifty gigabytes of blocks the guest had already
+    /// released. A discard is what tells the host they are free, and it is the
+    /// step between pruning, which frees nothing here, and recycling, which
+    /// costs a cold image build.
+    fn trim_linux_guest(&self) {
+        let colima = self.config.host.brew_tool("colima");
+        if !colima.is_file() {
+            return;
+        }
+        let home = self.root.join("home").join(&self.config.host.ci_user);
+        let mut command = self.process.command(colima);
+        command.env("COLIMA_HOME", home.join(".colima")).args([
+            "ssh",
+            "--profile",
+            Self::COLIMA_PROFILE,
+            "--",
+            "sudo",
+            "fstrim",
+            "-a",
+        ]);
+        if let Err(error) = self
+            .process
+            .run_command(&mut command, "return the Linux guest's freed blocks")
+        {
+            warn!(%error, "could not trim the Linux guest's disk");
+        }
+    }
+
     /// Delete the Linux guest and the disk it kept, so the space is allocated
     /// again from nothing.
     ///
@@ -605,12 +638,14 @@ impl<'a> HostStorage<'a> {
     }
 }
 
-pub(super) fn pressure_for(used: u64, soft: u64, aggressive: u64, reject: u64) -> Pressure {
-    if used >= reject {
+/// Floors are free-space limits, so a smaller number is a tighter one: at or
+/// below `reject` the volume refuses work.
+pub(super) fn pressure_for(available: u64, soft: u64, aggressive: u64, reject: u64) -> Pressure {
+    if available <= reject {
         Pressure::Reject
-    } else if used >= aggressive {
+    } else if available <= aggressive {
         Pressure::Aggressive
-    } else if used >= soft {
+    } else if available <= soft {
         Pressure::Soft
     } else {
         Pressure::Normal
@@ -722,31 +757,37 @@ mod tests {
 
     #[test]
     fn pressure_thresholds_are_exact() {
-        assert_eq!(pressure_for(239, 240, 270, 285), Pressure::Normal);
-        assert_eq!(pressure_for(240, 240, 270, 285), Pressure::Soft);
-        assert_eq!(pressure_for(270, 240, 270, 285), Pressure::Aggressive);
-        assert_eq!(pressure_for(285, 240, 270, 285), Pressure::Reject);
+        // 300 GB quota with 240/270/285 used-byte thresholds keeps 60/30/15
+        // free.
+        assert_eq!(pressure_for(61, 60, 30, 15), Pressure::Normal);
+        assert_eq!(pressure_for(60, 60, 30, 15), Pressure::Soft);
+        assert_eq!(pressure_for(30, 60, 30, 15), Pressure::Aggressive);
+        assert_eq!(pressure_for(15, 60, 30, 15), Pressure::Reject);
     }
 
     #[test]
-    fn a_second_volume_is_held_to_the_same_proportions_of_its_own_size() {
+    fn a_volume_smaller_than_the_quota_still_reaches_reject() {
         let directory = tempfile::tempdir().unwrap();
         let cfg = config(directory.path());
         let process = Process::new(directory.path(), BTreeMap::new());
         let storage =
             HostStorage::for_test(directory.path().to_path_buf(), &cfg, &process).unwrap();
-        // Thresholds are 240/270/285 against a 300-byte main volume, so a
-        // volume half that size refuses at 142 and is content at 119.
-        let half = |used| Volume {
+        // The volume this replaces a proportional rule for: 279 GB total with
+        // 170 used never came within a hundred of a 285 reject threshold, so
+        // cleanup stayed `Normal` and never recycled the guest, while jobs were
+        // already being refused for free space. Judged by what is left, a
+        // volume half the quota's size reaches every step.
+        let half = |available| Volume {
             path: PathBuf::from("/elsewhere"),
-            used,
+            used: 150 - available,
             total: 150,
+            available,
         };
 
-        assert_eq!(storage.pressure_of(&half(119)), Pressure::Normal);
-        assert_eq!(storage.pressure_of(&half(120)), Pressure::Soft);
-        assert_eq!(storage.pressure_of(&half(135)), Pressure::Aggressive);
-        assert_eq!(storage.pressure_of(&half(143)), Pressure::Reject);
+        assert_eq!(storage.pressure_of(&half(61)), Pressure::Normal);
+        assert_eq!(storage.pressure_of(&half(60)), Pressure::Soft);
+        assert_eq!(storage.pressure_of(&half(30)), Pressure::Aggressive);
+        assert_eq!(storage.pressure_of(&half(15)), Pressure::Reject);
     }
 
     #[test]

--- a/xtask/src/ci/run.rs
+++ b/xtask/src/ci/run.rs
@@ -145,6 +145,23 @@ pub(crate) struct RunArgs {
 }
 
 pub(crate) fn run(args: &RunArgs, ctx: &Ctx) -> Result<()> {
+    let lane_name = args
+        .lane
+        .to_possible_value()
+        .map_or_else(|| "lane".to_owned(), |value| value.get_name().to_owned());
+    verdict::clear(&ctx.root, &lane_name)?;
+    let outcome = execute(args, ctx);
+    // A lane that fell over before it reached its own work — no host profile,
+    // no room on the cache volume — is still a lane that failed, and the
+    // verdict has to hear about it. Collecting only after a dispatched lane
+    // let exactly that go unrecorded on the first live run.
+    if let Err(error) = verdict::gather(&ctx.root, &lane_name, outcome.is_err()) {
+        warn!(%error, lane = %lane_name, "could not collect this lane's test report");
+    }
+    outcome
+}
+
+fn execute(args: &RunArgs, ctx: &Ctx) -> Result<()> {
     let ext = KitharaExt::from_ctx(ctx)?;
     ext.ci.validate()?;
     let host_config = env::var_os("KITHARA_CI_HOST_CONFIG")
@@ -171,12 +188,6 @@ pub(crate) fn run(args: &RunArgs, ctx: &Ctx) -> Result<()> {
     // exited 254. Retire the server so it restarts with what this job asked
     // for; the cache on disk is untouched.
     process.ensure("sccache", &["--stop-server"], "retire the compiler cache");
-
-    let lane_name = args
-        .lane
-        .to_possible_value()
-        .map_or_else(|| "lane".to_owned(), |value| value.get_name().to_owned());
-    verdict::clear(&ctx.root, &lane_name)?;
 
     let result = match args.lane {
         Lane::AppleLint => lane::apple::lint(&process, &ci_config),
@@ -228,12 +239,6 @@ pub(crate) fn run(args: &RunArgs, ctx: &Ctx) -> Result<()> {
         Lane::Verdict => verdict::lane(&ctx.root, &ci_config, args.kind),
     };
     process.best_effort("sccache", &["--show-stats"], "sccache statistics");
-    // The verdict reads what every lane leaves here, so collection cannot be
-    // conditional on the lane passing — a failing lane is the one whose report
-    // decides whether a merge request is held.
-    if let Err(error) = verdict::gather(&ctx.root, &lane_name, result.is_err()) {
-        warn!(%error, lane = %lane_name, "could not collect this lane's test report");
-    }
     result
 }
 


### PR DESCRIPTION
## Summary

Two failures the first live run of the verdict surfaced, both in the same
place: what CI notices about itself.

The verdict landed in #173 and its first `main` run found the hole that PR
listed as a risk. Collection sat after the lane dispatch, but the host profile
is read and the cache volume checked before it: `apple:swift-test` was refused
for having 10.1 GB free where the preflight wants 15, returned early, and left
neither a report nor a marker. The journal recorded the two lanes that reached
their own work and never heard about the third, so a merge request would have
been measured against a baseline missing a lane that was in fact failing.
Clearing and collecting now bracket the whole run.

Chasing why the volume was full turned up the second one, and it is the reason
this keeps coming back. The ladder that decides when to clean compares bytes
*used* against thresholds written for a 300 GB quota — but the volume is 279 GB
on an APFS container it shares. 170 used never approaches a 285 reject
threshold, so pressure has been reporting `Normal` throughout, aggressive
cleanup never ran, and `recycle_linux_guest` — which already exists, and whose
comment describes this exact disk — was never reached. The machine was refusing
jobs for free space while its own cleaner saw nothing wrong.

The thresholds are now read as the free space each intends to keep, so the
ladder and the refusal agree by construction: `quota - reject` is exactly what
a job's preflight requires. That alone would still only swing the hammer once
jobs are already being refused, and the hammer costs a cold image build. The
rung between them was missing: the Linux guest's data disk is sparse, grows to
its high-water mark and keeps every block it has ever written, so `docker
prune` frees space inside it and returns nothing to the volume. Measured today
it held 77 GB for 25 GB of images and build cache. Aggressive cleanup now
issues a discard, which is what hands those blocks back.

## Behavior / scope

- contract or behavior: a lane that fails before dispatch is registered in the
  verdict's journal; volume pressure is read from free space rather than from
  used-against-quota; aggressive cleanup discards the Linux guest's freed
  blocks.
- affected area: `xtask/src/ci/run.rs`, `xtask/src/ci/host/storage.rs`,
  `docs/guides/ci-host.md`.

## Validation

- `cargo nextest run -p xtask` — 228 passed
- `just check clippy` — clean
- `cargo run -q -p xtask -- format --check` — clean
- evidence for the diagnosis, from the host: volume 279 GB total / 170 used /
  24 free; `~/.colima/_lima/_disks/colima-kithara/datadisk` allocated 77 GB
  against 100 declared; `docker system df` reporting 14.4 GB of images and
  10.25 GB of build cache.
- not run: the discard itself. A job was in flight on the shared host, so
  nothing was executed against it.

## Surface impact

- Public API: none
- Platform/runtime: changed: tooling surface
- Perf-sensitive paths: none

## Risks / follow-ups

- The discard is best-effort and unverified on this host. If lima passes no
  discard through to the sparse file it will free nothing, and recycling at
  refusal stays the only reclaim — worth confirming with a measured run once
  the host is idle.
- Dropping the proportional rule for a second volume is deliberate: a job needs
  its 15 GB whatever the volume's size, and scaling the requirement by capacity
  was how a smaller volume avoided every threshold.
- The marker fix is not pinned by a test; the regression is where the call sits
  rather than what it does.