### PR TITLE
fix(ci): ask the guest for its blocks back on every sweep, and let the installer read the config the bridge reads

### DIFF
--- a/docs/guides/ci-host.md
+++ b/docs/guides/ci-host.md
@@ -265,9 +265,13 @@ APFS container the volume shares with others the two are different questions,
 and reading them the old way left a 279 GB volume with 24 GB free reported as
 `Normal` while jobs were already being refused.
 
-The Linux guest's data disk is sparse and never deflates: pruning inside it
-returns nothing to this volume. Aggressive cleanup therefore discards its freed
-blocks, and only refusal recycles the guest outright.
+The Linux guest keeps its root filesystem mounted `discard`, so that image stays
+at about a gigabyte. Its data disk — the one carrying `/var/lib/docker` — is not,
+so every layer Docker deletes stays allocated in a sparse file this volume pays
+for. Every cleanup therefore trims it, whatever the pressure: the trim costs
+seconds, and one on a machine that had drifted to 44 GB free returned 63 of them.
+Recycling the guest outright reaches only what Docker still holds and the prune
+window will not take, which is why refusal is the one thing that does it.
 
 The CI volume has a 300 GB APFS quota. New work stops at 285 GB. Cleanup starts
 at 240 GB and becomes aggressive at 270 GB. Workspaces, VM overlays, logs, and

--- a/xtask/src/ci/bridge/command.rs
+++ b/xtask/src/ci/bridge/command.rs
@@ -141,6 +141,18 @@ impl BridgeConfig {
     }
 }
 
+/// The secrets a bridge configuration points at, for the installer that has to
+/// check who owns them before activating the service.
+///
+/// It reads them from here rather than declaring the file's shape a second time:
+/// the copy that did went on asking for the GitHub App private key after the
+/// bridge moved to a token, so activation would have refused every correct
+/// configuration — and only at the last step of the switchover.
+pub(crate) fn secret_files(config: &Path) -> Result<[PathBuf; 2]> {
+    let config = BridgeConfig::load(config)?;
+    Ok([config.github_token_file, config.gitlab_token_file])
+}
+
 pub(crate) fn run(args: &BridgeArgs) -> Result<()> {
     match &args.command {
         BridgeCommand::Validate { config } => {
@@ -198,6 +210,34 @@ mod tests {
             toml::from_str::<BridgeConfig>(&with_ca).is_err(),
             "bridge config must reject a private CA instead of silently ignoring it"
         );
+    }
+
+    /// What the installer checks ownership of before it activates the service.
+    /// It used to read the file through a declaration of its own, which went on
+    /// asking for a GitHub App private key long after the bridge moved to a
+    /// token — so both tokens have to come back from the configuration the
+    /// bridge itself parses, and both have to be there.
+    #[test]
+    fn the_installer_is_handed_both_tokens_from_the_bridge_configuration() {
+        let directory = tempfile::tempdir().unwrap();
+        let github = directory.path().join("github.token");
+        let gitlab = directory.path().join("gitlab.token");
+        std::fs::write(&github, "token\n").unwrap();
+        std::fs::write(&gitlab, "token\n").unwrap();
+        let config = directory.path().join("config.toml");
+        std::fs::write(
+            &config,
+            example()
+                .replace("/path/to/github-token", github.to_str().unwrap())
+                .replace("/path/to/gitlab-token", gitlab.to_str().unwrap())
+                .replace(
+                    "/path/to/bridge-state",
+                    directory.path().join("state").to_str().unwrap(),
+                ),
+        )
+        .unwrap();
+
+        assert_eq!(super::secret_files(&config).unwrap(), [github, gitlab]);
     }
 
     #[test]

--- a/xtask/src/ci/bridge/mod.rs
+++ b/xtask/src/ci/bridge/mod.rs
@@ -5,4 +5,4 @@ mod ledger;
 mod model;
 mod reconcile;
 
-pub(crate) use command::{BridgeArgs, run};
+pub(crate) use command::{BridgeArgs, run, secret_files};

--- a/xtask/src/ci/host/services.rs
+++ b/xtask/src/ci/host/services.rs
@@ -4,19 +4,13 @@ use std::{
 };
 
 use anyhow::{Context, Result, bail};
-use serde::Deserialize;
 use tracing::info;
 
 use crate::ci::{
+    bridge,
     config::{CiConfig, LANE_CONFIG_DIR, MAC_CONFIG_PATH},
     process::Process,
 };
-
-#[derive(Deserialize)]
-struct BridgeSecrets {
-    github_private_key: PathBuf,
-    gitlab_token_file: PathBuf,
-}
 
 pub(super) struct ServiceInstaller<'a> {
     config: &'a CiConfig,
@@ -61,13 +55,9 @@ impl<'a> ServiceInstaller<'a> {
             bail!("missing staged bridge service: {}", pending.display());
         }
         self.require_private_sync_file(&config)?;
-        let secrets: BridgeSecrets = toml::from_str(
-            &fs::read_to_string(&config)
-                .with_context(|| format!("reading {}", config.display()))?,
-        )
-        .with_context(|| format!("parsing {}", config.display()))?;
-        self.require_private_sync_file(&secrets.github_private_key)?;
-        self.require_private_sync_file(&secrets.gitlab_token_file)?;
+        for secret in bridge::secret_files(&config)? {
+            self.require_private_sync_file(&secret)?;
+        }
         let binary = self.installed_binary();
         self.process.run(
             path_text(&binary)?,

--- a/xtask/src/ci/host/storage.rs
+++ b/xtask/src/ci/host/storage.rs
@@ -30,7 +30,10 @@ pub(super) struct HostStorage<'a> {
 
 #[derive(Serialize)]
 struct Health<'a> {
-    volume_used_bytes: u64,
+    /// What is left where there is least of it. The thresholds are free-space
+    /// floors, so this is the number `pressure` was read from — reporting bytes
+    /// spent instead described a quantity no decision uses.
+    free_bytes: u64,
     pressure: Pressure,
     /// Named so an operator can see which volume is under pressure without
     /// running `df` by hand.
@@ -42,14 +45,13 @@ struct Health<'a> {
 #[derive(Serialize)]
 struct VolumeHealth {
     path: String,
-    used_bytes: u64,
+    free_bytes: u64,
     total_bytes: u64,
     pressure: Pressure,
 }
 
 struct Volume {
     path: PathBuf,
-    used: u64,
     total: u64,
     available: u64,
 }
@@ -62,7 +64,6 @@ impl Volume {
             .with_context(|| format!("reading available space for {}", path.display()))?;
         Ok(Self {
             path: path.to_path_buf(),
-            used: total.saturating_sub(available),
             total,
             available,
         })
@@ -111,7 +112,7 @@ impl<'a> HostStorage<'a> {
     }
 
     pub(super) fn preflight(&self) -> Result<()> {
-        let used = self.used_bytes()?;
+        let free = self.free_bytes()?;
         let (pressure, volume) = self.worst_pressure()?;
         match pressure {
             Pressure::Reject => bail!("{} is full; new jobs stop here", volume.display()),
@@ -129,19 +130,19 @@ impl<'a> HostStorage<'a> {
             writable_probe(&directory)?;
         }
         self.process.require_tools(&["git", "sccache"])?;
-        info!(used_bytes = used, ?pressure, "host preflight passed");
+        info!(free_bytes = free, ?pressure, "host preflight passed");
         Ok(())
     }
 
     pub(super) fn cleanup(&self) -> Result<()> {
-        let initial = self.used_bytes()?;
+        let initial = self.free_bytes()?;
         // The worst single volume, not the sum: adding a second volume's bytes
         // to the first and comparing that against thresholds calibrated for the
         // first reads every machine with a guest volume as full, and the branch
         // it reaches for throws away the compiler caches that were never the
         // problem. `preflight` already decides this way.
         let (pressure, volume) = self.worst_pressure()?;
-        info!(used_bytes = initial, ?pressure, volume = %volume.display(), "cleanup started");
+        info!(free_bytes = initial, ?pressure, volume = %volume.display(), "cleanup started");
 
         self.prune_old_trees("workspaces/tmp", Self::DAY)?;
         self.prune_old_trees("workspaces/builds", Self::DAY)?;
@@ -169,10 +170,19 @@ impl<'a> HostStorage<'a> {
                 self.prune_old_trees("cache/bootstrap/trusted", 7 * Self::DAY)?;
                 self.prune_old_trees("vm/tart/cache", 7 * Self::DAY)?;
                 self.prune_docker_cache("168h");
-                self.trim_linux_guest();
             }
             Pressure::Normal => {}
         }
+
+        // Unconditional, and after the pruning above, because the guest frees
+        // blocks on its own schedule and holds them until asked. Its root
+        // filesystem is mounted `discard` and stays at a gigabyte, but the data
+        // disk carrying `/var/lib/docker` is not, so every layer Docker deletes
+        // stays allocated in a file this volume pays for. One trim on a machine
+        // that had drifted to 44 GB free returned 63 of them in seconds — too
+        // cheap to hold back for a threshold, and holding it back is what let
+        // the drift reach refusal five times.
+        self.trim_linux_guest();
 
         let target_dirs = persistent_target_dirs(&self.root.join("workspaces/gitlab"))?;
         build_cache::enforce_budget(&target_dirs, self.config.host.build_cache_budget_bytes()?)?;
@@ -182,13 +192,14 @@ impl<'a> HostStorage<'a> {
             // The guests are where the space is, and the caches are what the
             // steps above can reach — so taking the caches first pays for the
             // guests with the compiler output the machine exists to keep warm.
-            // Both guests only give their space back when they are thrown
-            // away: the macOS one measured 38 gibibytes in a recycle against
-            // three and a half for everything else together, and the Linux
-            // one's disk is allocated once and never deflates, so pruning
-            // inside it returns nothing to this volume. Recycling costs the
-            // job in flight and a cold image build, which is a trade worth
-            // making only once jobs are being refused anyway — this branch.
+            // The macOS one gives its space back only when it is thrown away:
+            // 38 gibibytes in a recycle against three and a half for
+            // everything else together. The Linux one has already been
+            // trimmed, so what is left in it is what Docker still holds and
+            // the prune window would not take — layers younger than a week.
+            // Only recycling reaches those, and it costs the job in flight and
+            // a cold image build, which is a trade worth making once jobs are
+            // being refused anyway — this branch.
             self.recycle_linux_guest();
             self.recycle_macos_guest();
             final_pressure = self.worst_pressure()?.0;
@@ -200,7 +211,7 @@ impl<'a> HostStorage<'a> {
             final_pressure = self.worst_pressure()?.0;
         }
         info!(
-            used_bytes = self.used_bytes()?,
+            free_bytes = self.free_bytes()?,
             ?final_pressure,
             "cleanup completed"
         );
@@ -211,13 +222,13 @@ impl<'a> HostStorage<'a> {
     }
 
     pub(super) fn health(&self) -> Result<()> {
-        let used = self.used_bytes()?;
+        let free = self.free_bytes()?;
         let volumes: Vec<VolumeHealth> = self
             .volumes()?
             .into_iter()
             .map(|volume| VolumeHealth {
                 path: volume.path.display().to_string(),
-                used_bytes: volume.used,
+                free_bytes: volume.available,
                 total_bytes: volume.total,
                 pressure: self.pressure_of(&volume),
             })
@@ -227,7 +238,7 @@ impl<'a> HostStorage<'a> {
         serde_json::to_writer(
             io::stdout().lock(),
             &Health {
-                volume_used_bytes: used,
+                free_bytes: free,
                 pressure,
                 volumes,
                 runner,
@@ -247,8 +258,19 @@ impl<'a> HostStorage<'a> {
         Ok(())
     }
 
-    fn used_bytes(&self) -> Result<u64> {
-        Ok(self.volumes()?.into_iter().map(|volume| volume.used).sum())
+    /// What is left on the volume with the least to spare — the one the pressure
+    /// verdict comes from, since every volume is judged against the same floors.
+    ///
+    /// Summing bytes spent across volumes measured neither: on a shared APFS
+    /// container a volume's used space counts what its neighbours hold, so the
+    /// total ran past the quota it was being compared with. This host reported
+    /// 470 GB spent on a 300 GB quota while it had 44 GB free.
+    fn free_bytes(&self) -> Result<u64> {
+        self.volumes()?
+            .into_iter()
+            .map(|volume| volume.available)
+            .min()
+            .context("no CI volume to measure")
     }
 
     /// Every volume CI storage sits on, in the order they should be reported.
@@ -779,7 +801,6 @@ mod tests {
         // volume half the quota's size reaches every step.
         let half = |available| Volume {
             path: PathBuf::from("/elsewhere"),
-            used: 150 - available,
             total: 150,
             available,
         };
@@ -788,6 +809,43 @@ mod tests {
         assert_eq!(storage.pressure_of(&half(60)), Pressure::Soft);
         assert_eq!(storage.pressure_of(&half(30)), Pressure::Aggressive);
         assert_eq!(storage.pressure_of(&half(15)), Pressure::Reject);
+    }
+
+    /// The blocks Docker frees inside the guest stay allocated in a file this
+    /// volume pays for until something asks for them back, and waiting for
+    /// pressure to ask is what let 63 gibibytes sit there while the volume drifted
+    /// toward refusing work. A tempdir has more than the sixty bytes this config
+    /// calls a floor, so the run below is `Normal` — the pressure that used to
+    /// skip the trim entirely.
+    #[cfg(unix)]
+    #[test]
+    fn the_guest_is_trimmed_even_with_nothing_under_pressure() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let mut cfg = config(directory.path());
+        cfg.host.brew_root = directory.path().join("brew");
+        let bin = cfg.host.brew_root.join("bin");
+        fs::create_dir_all(&bin).unwrap();
+        let asked = directory.path().join("asked");
+        fs::write(
+            bin.join("colima"),
+            format!("#!/bin/sh\necho \"$@\" > {}\n", asked.display()),
+        )
+        .unwrap();
+        fs::set_permissions(bin.join("colima"), fs::Permissions::from_mode(0o755)).unwrap();
+
+        let process = Process::new(directory.path(), BTreeMap::new());
+        let storage =
+            HostStorage::for_test(directory.path().to_path_buf(), &cfg, &process).unwrap();
+        assert_eq!(storage.worst_pressure().unwrap().0, Pressure::Normal);
+        storage.cleanup().unwrap();
+
+        let arguments = fs::read_to_string(&asked).expect("the guest was never asked for anything");
+        assert!(
+            arguments.contains("fstrim"),
+            "cleanup asked the guest for {arguments} instead of a trim"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The disk problem #174 addressed had a second half, and measuring the host
showed it. The Linux guest's data disk carries `/var/lib/docker` and is mounted
without `discard` — its root filesystem is mounted with it and sits at a
gigabyte, but the data disk keeps every block Docker deletes allocated in a
sparse file the CI volume pays for. The trim that returns those blocks ran only
once cleanup had escalated to aggressive, which is late by construction: the
volume arrives there *because* the blocks are already gone.

Measured on the Mac mini, which was at 44 GB free and refusing nothing yet: one
trim returned 63 GB in seconds, and the guest's image deflated from 100 GB
apparent to 14 GB actual, matching what the guest itself reports using. The trim
now runs on every sweep, after the pruning that frees the blocks inside the
guest. Recycling stays where it was, at refusal — what a trim cannot reach is
what Docker still holds and the prune window will not take, and only throwing
the guest away reaches that, at the cost of the job in flight.

The logs were the other side of the same mistake. Pressure is read from what is
left, but every line and the health JSON published bytes *spent*, summed across
volumes. On a shared APFS container each volume's used space counts what its
neighbours hold, so this host announced 470 GB spent against a 300 GB quota
while it had 44 GB free, and the two services disagreed with each other and with
`df` by 80 GB. They now publish what is left, which is the number the verdict
comes from — and the health JSON's per-volume array immediately named the volume
actually under pressure, which is a different one from the volume anybody was
watching.

Reading the host for that measurement turned up the second commit. The bridge
has never been configured there — the directory holds a staged service and an
example in a format two revisions old, and nothing had ever parsed a real
configuration. Which is how this survived: the installer read the config through
a declaration of its own, and that copy still asked for the GitHub App private
key the bridge stopped using when it moved to a token. A required field no
correct configuration contains, so activation would have refused every one of
them — at the last step of the switchover, after the mirror had been turned
around. The shape now has one owner: the bridge reports the secrets its own
configuration points at, and the installer checks ownership of what comes back.

## Behavior / scope

- contract or behavior: the guest is asked for its freed blocks on every
  cleanup rather than only under pressure; storage logs and the health JSON
  report free bytes instead of a sum of bytes spent.
- affected area: `xtask ci host` (storage, services), `xtask ci bridge`,
  `docs/guides/ci-host.md`.

## Validation

- `cargo nextest run -p xtask` — 257 passed
- `just check clippy` — clean for this change
- `cargo run -q -p xtask -- format --check` — clean
- new test `the_guest_is_trimmed_even_with_nothing_under_pressure` mutation-checked
  by moving the trim back inside the aggressive branch: it fails with "the guest
  was never asked for anything"
- new test `the_installer_is_handed_both_tokens_from_the_bridge_configuration`
  loads the shipped example through the bridge's own parser
- on the host: the built binary ran `ci host cleanup` and `ci host health`
  against the real profile and pinned config, and both named
  `/Volumes/KitharaVM/vm` as the volume under pressure — the first time either
  service pointed at the right one

## Surface impact

- Public API: unchanged
- Platform/runtime: changed: the health JSON's field names (`free_bytes`
  replacing `volume_used_bytes` and the per-volume `used_bytes`). Nothing reads
  them but an operator.
- Perf-sensitive paths: none

## Risks / follow-ups

- A trim on every sweep is I/O the guest did not do before. It took seconds on a
  98 GB disk with 80 GB free; a disk that is nearly full will take longer, and
  cleanup runs hourly against a serialised host.
- `/Volumes/KitharaVM/vm` is at 40 GB of 186 with a 38 GB base image, a 62 GB
  live clone and an 83 GB idle Windows guest. Nothing in cleanup touches the
  Windows image, and this change does not help that volume — the Linux guest
  lives on the other one.
