### PR TITLE
fix(ffi): enter runtime in polling thread

### DIFF
--- a/crates/kithara-ffi/Cargo.toml
+++ b/crates/kithara-ffi/Cargo.toml
@@ -186,6 +186,10 @@ tracing-android = { workspace = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 kithara = { workspace = true, features = ["probe"] }
 kithara-net = { workspace = true, default-features = false }
+kithara-queue = { workspace = true, default-features = false, features = [
+    "backend-cpal",
+    "probe",
+] }
 kithara-test-utils = { workspace = true, features = ["mock", "probe", "hang"] }
 
 futures = { workspace = true }

--- a/crates/kithara-ffi/src/native/bridge/event_bridge.rs
+++ b/crates/kithara-ffi/src/native/bridge/event_bridge.rs
@@ -517,4 +517,72 @@ mod tests {
             }] if *id == item_id && reason == "network timeout"
         ));
     }
+
+    async fn wait_for_status(
+        events: &mut EventReceiver,
+        id: TrackId,
+        status: TrackStatus,
+        timeout_ms: u64,
+    ) -> bool {
+        let wait = async {
+            while let Ok(Envelope { event, .. }) = events.recv().await {
+                if matches!(
+                    event,
+                    Event::Queue(QueueEvent::TrackStatusChanged { id: seen, status: ref seen_status })
+                        if seen == id && *seen_status == status
+                ) {
+                    return true;
+                }
+            }
+            false
+        };
+        kithara_platform::time::timeout(Duration::from_millis(timeout_ms), wait)
+            .await
+            .unwrap_or(false)
+    }
+
+    /// The polling thread drives `Queue::tick`, and a natural EOF on a
+    /// repeat-one track makes that tick respawn the consumed track's load
+    /// — async work that panics without an ambient runtime. The thread is
+    /// a plain OS thread, so it only has one if it enters `FFI_RUNTIME`
+    /// itself.
+    #[kithara::test(tokio)]
+    async fn polling_thread_reloads_a_consumed_track_after_eof() {
+        let queue = Arc::new(Queue::new(kithara_queue::QueueConfig::default()));
+        let id = queue.register_for_test();
+        queue.mark_played_for_test(id);
+        queue.set_repeat(kithara_queue::RepeatMode::One);
+        queue.set_rate(1.0);
+
+        let mut events = queue.subscribe();
+        queue
+            .bus()
+            .publish(Event::Player(PlayerEvent::ItemDidPlayToEnd {
+                src: Arc::from(format!("test://memory/{}", id.as_u64())),
+                item_id: None,
+            }));
+
+        let cancel = CancelToken::root();
+        let observer: Arc<dyn PlayerObserver> = Arc::new(CollectingPlayerObserver::default());
+        let thread = EventBridge::spawn_time_thread(
+            Arc::clone(&queue),
+            observer,
+            Arc::new(Mutex::new(ItemRegistry::default())),
+            Arc::new(Mutex::new(None)),
+            cancel.clone(),
+        );
+
+        let reload_started = wait_for_status(&mut events, id, TrackStatus::Pending, 2000).await;
+        cancel.cancel();
+        let joined = thread.join();
+
+        assert!(
+            reload_started,
+            "tick after EOF must restart the consumed repeat-one track"
+        );
+        assert!(
+            joined.is_ok(),
+            "polling thread must survive the reload it starts"
+        );
+    }
 }

--- a/crates/kithara-ffi/src/native/bridge/event_bridge.rs
+++ b/crates/kithara-ffi/src/native/bridge/event_bridge.rs
@@ -335,6 +335,7 @@ impl EventBridge {
         cancel: CancelToken,
     ) -> JoinHandle<()> {
         spawn(move || {
+            let _rt = crate::FFI_RUNTIME.enter();
             let interval = Duration::from_millis(Self::TIME_POLL_INTERVAL_MS);
             let mut last_time: Option<f64> = None;
             let mut last_duration: Option<f64> = None;

--- a/crates/kithara-queue/src/queue/lifecycle.rs
+++ b/crates/kithara-queue/src/queue/lifecycle.rs
@@ -176,6 +176,22 @@ impl Queue {
         id
     }
 
+    /// Test helper: put `id` into the state a track reaches after natural
+    /// EOF — selected in navigation and already consumed by the player.
+    /// The next advance onto it must reload it (repeat-one) instead of
+    /// picking a pre-loaded successor.
+    #[cfg(any(test, feature = "probe"))]
+    pub fn mark_played_for_test(&self, id: TrackId) {
+        let index = {
+            let guard = self.lock_tracks();
+            guard.iter().position(|e| e.id == id)
+        };
+        if let Some(index) = index {
+            self.lock_navigation_mut().select(index);
+            self.set_status(id, TrackStatus::Consumed);
+        }
+    }
+
     /// Remove a track from the queue by id.
     ///
     /// If the removed track is currently playing:


### PR DESCRIPTION
## Summary
The native FFI polling thread called `Queue::tick` without an ambient Tokio runtime. That path can restart asynchronous playback work after natural EOF, so repeat-one playback could fail to reload the consumed item. Entering the existing shared FFI runtime once at polling-thread startup gives that work the runtime context already used by the rest of the native FFI surface.

## Behavior / scope
- contract or behavior: native polling can restart asynchronous queue work after natural EOF
- affected area: `kithara-ffi` native event bridge only

## Validation
- `just fmt check`
- `just test run -p kithara-ffi -E 'test(/event_bridge/)'` (7 passed, 5135 skipped)
- pre-commit `just lint fast`
- `cargo clippy -p kithara-ffi --lib -- -D warnings` reached the crate but was blocked by two pre-existing warnings in unchanged `crates/kithara-audio/src/lib.rs`

## Surface impact
- Public API: none
- Platform/runtime: changed: native FFI polling thread
- Perf-sensitive paths: none; the runtime guard is entered once when the thread starts

## Risks / follow-ups
- End-to-end iOS repeat-one proof remains in the separate LABA-420 product MR.
