### PR TITLE
fix(ci): stop the mac host refusing jobs while cleanup reports success

### DIFF
--- a/ci/windows/provision.ps1
+++ b/ci/windows/provision.ps1
@@ -51,6 +51,51 @@ Write-Host '==> Licence state'
 & cscript.exe //nologo "$env:SystemRoot\System32\slmgr.vbs" /dli
 
 $settings = Get-Content 'E:\guest.json' -Raw | ConvertFrom-Json
+
+# Everything this guest writes goes on the second disk, not the system image.
+#
+# A qcow2 grows to cover every block written into it and never shrinks on its
+# own, so the page file alone — which Windows sizes to memory — charges the
+# image as much as the guest has RAM, permanently. The host cannot shrink it in
+# place, and copying it needs as much free space as the image is large, which a
+# full volume by definition does not have. Held on a disk of its own the growth
+# stays where it can be discarded.
+#
+# Absence is tolerated: a guest built before this disk existed still installs,
+# it just keeps charging its system image.
+$data = Get-Disk | Where-Object { $_.PartitionStyle -eq 'RAW' } | Select-Object -First 1
+if ($data) {
+    Write-Host '==> Preparing the data disk'
+    $data | Initialize-Disk -PartitionStyle GPT -PassThru |
+        New-Partition -DriveLetter D -UseMaximumSize |
+        Format-Volume -FileSystem NTFS -NewFileSystemLabel 'kithara-data' -Confirm:$false |
+        Out-Null
+
+    New-Item -ItemType Directory -Force -Path 'D:\temp', 'D:\build' | Out-Null
+    # Both scopes: the runner service does not inherit a user's environment.
+    foreach ($scope in 'Machine', 'User') {
+        [Environment]::SetEnvironmentVariable('TEMP', 'D:\temp', $scope)
+        [Environment]::SetEnvironmentVariable('TMP', 'D:\temp', $scope)
+    }
+    $env:TEMP = 'D:\temp'
+    $env:TMP = 'D:\temp'
+
+    # The page file moves only after the automatic one is disabled; setting a
+    # second one while Windows still manages its own leaves both in place, and
+    # the one on C: is the one that was costing the image.
+    $computer = Get-WmiObject -Class Win32_ComputerSystem -EnableAllPrivileges
+    if ($computer.AutomaticManagedPagefile) {
+        $computer.AutomaticManagedPagefile = $false
+        $computer.Put() | Out-Null
+    }
+    Get-WmiObject -Class Win32_PageFileSetting | ForEach-Object { $_.Delete() }
+    Set-WmiInstance -Class Win32_PageFileSetting `
+        -Arguments @{ Name = 'D:\pagefile.sys'; InitialSize = 4096; MaximumSize = 16384 } |
+        Out-Null
+} else {
+    Write-Host '==> No data disk attached; this guest writes into its system image'
+}
+
 $root = 'C:\kithara-ci'
 New-Item -ItemType Directory -Force -Path $root, "$root\downloads" | Out-Null
 

--- a/xtask/src/ci/build_cache.rs
+++ b/xtask/src/ci/build_cache.rs
@@ -56,40 +56,52 @@ pub(crate) fn select_evictions(mut entries: Vec<CacheEntry>, budget_bytes: u64) 
     evictions
 }
 
+/// The budget is what the host can afford in total, not what one checkout may
+/// keep.
+///
+/// Applied per directory it never fires on a machine that is running out:
+/// three checkouts holding 14, 7 and 22 GB were each under a 25 GB budget, so
+/// every hourly pass reported `bytes_freed=0` while the volume they share sat
+/// at `Aggressive` and jobs were already being refused. A checkout an active
+/// job holds cannot be evicted, but the room it occupies is still spent, so it
+/// is charged against the ceiling rather than excused from it.
 pub(crate) fn enforce_budget(target_dirs: &[PathBuf], budget_bytes: u64) -> Result<()> {
     let mut target_dirs = target_dirs.to_vec();
     target_dirs.sort();
-    for target_dir in target_dirs {
-        enforce_target_budget(&target_dir, budget_bytes)?;
+    let mut candidates = Vec::new();
+    let mut held_bytes = 0_u64;
+    let mut locks = Vec::new();
+    for target_dir in &target_dirs {
+        let contents = candidate_entries(target_dir)?;
+        locks.extend(contents.locks);
+        let bytes = total_bytes(&contents.entries);
+        if contents.active {
+            held_bytes = held_bytes.saturating_add(bytes);
+            info!(
+                path = %target_dir.display(),
+                bytes_before = bytes,
+                bytes_freed = 0,
+                budget_bytes,
+                "keeping active build cache"
+            );
+            continue;
+        }
+        candidates.extend(contents.entries);
     }
-    Ok(())
+    evict_to_budget(candidates, held_bytes, budget_bytes)
 }
 
-fn enforce_target_budget(target_dir: &Path, budget_bytes: u64) -> Result<()> {
-    let CacheContents {
-        entries,
-        active,
-        locks: _locks,
-    } = candidate_entries(target_dir)?;
-    let bytes_before = entries
+fn total_bytes(entries: &[CacheEntry]) -> u64 {
+    entries
         .iter()
         .map(|entry| entry.size_bytes)
-        .fold(0_u64, u64::saturating_add);
-    if active {
-        info!(
-            path = %target_dir.display(),
-            bytes_before,
-            bytes_freed = 0,
-            budget_bytes,
-            "keeping active build cache"
-        );
-        return Ok(());
-    }
-    let evictions = select_evictions(entries, budget_bytes);
-    let bytes_freed = evictions
-        .iter()
-        .map(|entry| entry.size_bytes)
-        .fold(0_u64, u64::saturating_add);
+        .fold(0_u64, u64::saturating_add)
+}
+
+fn evict_to_budget(candidates: Vec<CacheEntry>, held_bytes: u64, budget_bytes: u64) -> Result<()> {
+    let bytes_before = total_bytes(&candidates).saturating_add(held_bytes);
+    let evictions = select_evictions(candidates, budget_bytes.saturating_sub(held_bytes));
+    let bytes_freed = total_bytes(&evictions);
 
     // Cargo fingerprints describe a complete profile tree, so removing files
     // within one can leave its dependency artifacts inconsistent.
@@ -98,11 +110,8 @@ fn enforce_target_budget(target_dir: &Path, budget_bytes: u64) -> Result<()> {
             .with_context(|| format!("removing build cache entry {}", entry.path.display()))?;
     }
     info!(
-        path = %target_dir.display(),
         bytes_before,
-        bytes_freed,
-        budget_bytes,
-        "build cache budget enforced"
+        bytes_freed, held_bytes, budget_bytes, "build cache budget enforced"
     );
     Ok(())
 }
@@ -274,6 +283,36 @@ mod tests {
             .collect();
 
         assert_eq!(paths, ["a", "b"].map(PathBuf::from));
+    }
+
+    /// Each checkout under the budget while the host they share is out of room
+    /// is the state that produced `bytes_freed=0` on every pass for hours.
+    #[test]
+    fn the_budget_is_a_ceiling_over_every_checkout_together() {
+        let root = tempfile::tempdir().unwrap();
+        let first = checkout_target(root.path(), "one", 100_000);
+        let second = checkout_target(root.path(), "two", 100_000);
+        let budget = 150_000;
+        assert!(
+            occupied(&first) < budget,
+            "each checkout is under the budget"
+        );
+
+        enforce_budget(&[first.clone(), second.clone()], budget).unwrap();
+
+        assert!(occupied(&first) + occupied(&second) <= budget);
+    }
+
+    fn checkout_target(root: &Path, name: &str, bytes: usize) -> PathBuf {
+        let target = root.join(name);
+        let profile = target.join("debug");
+        fs::create_dir_all(&profile).unwrap();
+        fs::write(profile.join("artifact"), vec![0_u8; bytes]).unwrap();
+        target
+    }
+
+    fn occupied(target: &Path) -> u64 {
+        total_bytes(&candidate_entries(target).unwrap().entries)
     }
 
     #[test]

--- a/xtask/src/ci/config/host.rs
+++ b/xtask/src/ci/config/host.rs
@@ -389,6 +389,36 @@ mod tests {
         );
     }
 
+    /// Every installed profile predates the guest, and a mac that serves no
+    /// Windows lane never grows the section. Refusing to load without it would
+    /// take cleanup down on hosts that have nothing to do with Windows.
+    #[test]
+    fn ci_host_load_accepts_a_profile_with_no_windows_guest() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("host.toml");
+        super::super::fixture().host.write(&path).unwrap();
+
+        assert!(CiHost::load(&path).unwrap().windows.is_none());
+    }
+
+    #[test]
+    fn a_profile_that_declares_a_windows_guest_carries_its_data_disk() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("host.toml");
+        let mut host = super::super::fixture().host;
+        host.windows = Some(WindowsGuest {
+            vcpus: 4,
+            memory_mib: 8192,
+            data_disk_gib: 80,
+        });
+        host.write(&path).unwrap();
+
+        assert_eq!(
+            CiHost::load(&path).unwrap().windows.unwrap().data_disk_gib,
+            80
+        );
+    }
+
     #[test]
     fn ci_host_load_rejects_garbage_build_cache_size() {
         let directory = tempfile::tempdir().unwrap();

--- a/xtask/src/ci/config/host.rs
+++ b/xtask/src/ci/config/host.rs
@@ -59,6 +59,35 @@ pub(crate) struct CiHost {
     pub(crate) soft_cleanup_bytes: u64,
     pub(crate) sync_uid: u32,
     pub(crate) sync_user: String,
+    /// The Windows guest this machine serves its Windows lane from. Defaulted:
+    /// installed profiles predate it, and refusing to load would kill cleanup
+    /// on every host that has no Windows guest at all.
+    #[serde(default)]
+    pub(crate) windows: Option<WindowsGuest>,
+}
+
+/// The Windows guest a mac starts directly.
+///
+/// The Linux host's guest is described to libvirt, which owns its shape from
+/// then on. This one is a `qemu` process the host launches itself, so the
+/// shape belongs here rather than in a shell script beside the disk image.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub(crate) struct WindowsGuest {
+    pub(crate) vcpus: u32,
+    pub(crate) memory_mib: u32,
+    /// The disk carrying everything the guest writes: the page file, `TEMP`,
+    /// and build trees.
+    ///
+    /// Kept apart from the system image because Windows sizes its page file to
+    /// memory, and a `qcow2` grows to hold that and never returns the room on
+    /// its own. Eight gigabytes of RAM cost this host eight to twelve inside
+    /// the image it can neither shrink in place nor copy — the copy needs as
+    /// much free space as the image is large. Trimming the memory instead only
+    /// moves the growth: Windows 11 on ARM wants four gigabytes to begin with,
+    /// and a Rust build under that swaps, which grows the page file back.
+    pub(crate) data_disk_gib: u32,
 }
 
 impl CiHost {

--- a/xtask/src/ci/config/mod.rs
+++ b/xtask/src/ci/config/mod.rs
@@ -3,7 +3,8 @@ mod pins;
 mod profile;
 
 pub(crate) use host::{
-    LANE_CONFIG_DIR, MAC_CONFIG_PATH, default_build_cache_size, parse_build_cache_size,
+    LANE_CONFIG_DIR, MAC_CONFIG_PATH, WindowsGuest, default_build_cache_size,
+    parse_build_cache_size,
 };
 pub(crate) use pins::{CiPins, PINS_PATH};
 pub(crate) use profile::CiConfig;

--- a/xtask/src/ci/host/command.rs
+++ b/xtask/src/ci/host/command.rs
@@ -4,8 +4,12 @@ use anyhow::Result;
 use clap::{Args, Subcommand};
 
 use super::{
-    runners::RunnerManager, services::ServiceInstaller, storage::HostStorage, system::SystemSetup,
+    runners::RunnerManager,
+    services::ServiceInstaller,
+    storage::HostStorage,
+    system::SystemSetup,
     toolchain::ToolchainInstaller,
+    windows::{Boot, WindowsHost},
 };
 use crate::ci::{
     config::{CiConfig, PINS_PATH},
@@ -55,6 +59,13 @@ enum HostCommand {
     SmokeAndroid,
     /// Serve `GitLab` jobs from throwaway macOS VMs.
     RunMacosRunner,
+    /// Start the Windows guest that serves the Windows lane.
+    RunWindowsGuest {
+        /// Boot the Microsoft media with the answer file instead of the
+        /// installed disk.
+        #[arg(long)]
+        install: bool,
+    },
     /// Reject a job before it can fill or damage the CI volume.
     Preflight,
     /// Remove expired job state and bounded cache entries.
@@ -98,6 +109,13 @@ pub(crate) fn run(args: &HostArgs) -> Result<()> {
         HostCommand::SmokeLinux => RunnerManager::new(&config, &process).smoke_linux(),
         HostCommand::SmokeAndroid => RunnerManager::new(&config, &process).smoke_android(),
         HostCommand::RunMacosRunner => RunnerManager::new(&config, &process).run_macos_runner(),
+        HostCommand::RunWindowsGuest { install } => {
+            WindowsHost::new(&config, &process)?.start(if *install {
+                Boot::Install
+            } else {
+                Boot::Installed
+            })
+        }
         HostCommand::Preflight => HostStorage::new(&config, &process)?.preflight(),
         HostCommand::Cleanup => HostStorage::new(&config, &process)?.cleanup(),
         HostCommand::Health => HostStorage::new(&config, &process)?.health(),

--- a/xtask/src/ci/host/mod.rs
+++ b/xtask/src/ci/host/mod.rs
@@ -6,5 +6,6 @@ mod services;
 mod storage;
 mod system;
 mod toolchain;
+mod windows;
 
 pub(crate) use command::{HostArgs, run};

--- a/xtask/src/ci/host/services.rs
+++ b/xtask/src/ci/host/services.rs
@@ -240,7 +240,7 @@ impl<'a> ServiceInstaller<'a> {
     }
 
     fn install_maintenance_agents(&self) -> Result<()> {
-        let binary = self.installed_binary().display().to_string();
+        let binary = self.replaceable_binary().display().to_string();
         let config = self.installed_config().display().to_string();
         let pins = self.installed_pins().display().to_string();
         let logs = &self.config.host.host_root.join("logs");
@@ -252,7 +252,12 @@ impl<'a> ServiceInstaller<'a> {
             ],
             &logs.join("cleanup.log"),
             &path,
-            "<key>StartCalendarInterval</key><dict><key>Minute</key><integer>17</integer></dict>",
+            // Hourly is slower than the host spends. Under a build this volume
+            // loses about 2.7 GB a minute — measured dropping from 53 to 31 GB
+            // free in eight minutes — so the 45 GB between the first cleanup
+            // step and refusing jobs is a quarter of an hour. A pass that comes
+            // once an hour arrives after the refusals it exists to prevent.
+            "<key>StartInterval</key><integer>900</integer>",
         );
         let health = launchd(
             "com.zvuk.kithara-ci.health",
@@ -399,6 +404,21 @@ impl<'a> ServiceInstaller<'a> {
         self.service_root().join("bin").join(Self::BINARY_NAME)
     }
 
+    /// The copy the CI user can replace, which is what the periodic agents run.
+    ///
+    /// `services/bin` is `root:wheel`, so a fix to cleanup or health reaches
+    /// the host only through an operator with a password. That is how a broken
+    /// cleanup stayed broken: the repository had the fix and the mac kept
+    /// running the binary from before it. The bridge daemon already runs from
+    /// here for exactly this reason.
+    fn replaceable_binary(&self) -> PathBuf {
+        self.config
+            .host
+            .host_root
+            .join("toolchains/shared-bin")
+            .join(Self::BINARY_NAME)
+    }
+
     fn installed_config(&self) -> PathBuf {
         self.service_root().join(Self::HOST_CONFIG_NAME)
     }
@@ -503,7 +523,10 @@ fn bridge_launchd(binary: &str, config: &str, log: &Path, path: &str, user: &str
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use super::*;
+    use crate::ci::config::fixture;
 
     #[test]
     fn generated_agent_escapes_paths() {
@@ -533,6 +556,22 @@ mod tests {
         assert!(plist.contains(
             "<key>PATH</key><string>/opt/homebrew/bin:/opt/homebrew/sbin:/usr/bin:/bin</string>"
         ));
+    }
+
+    /// The periodic agents ran `services/bin`, which is `root:wheel`. Every
+    /// fix to cleanup then needed an operator with a password, and the one
+    /// that did not arrive is why this host refused jobs for a week.
+    #[test]
+    fn the_periodic_agents_run_the_binary_the_ci_user_can_replace() {
+        let mut config = fixture();
+        config.host.host_root = PathBuf::from("/Volumes/CI");
+        let process = Process::new(Path::new("/Volumes/CI"), BTreeMap::new());
+        let services = ServiceInstaller::new(&config, &process);
+
+        assert_eq!(
+            services.replaceable_binary(),
+            PathBuf::from("/Volumes/CI/toolchains/shared-bin/kithara-ci")
+        );
     }
 
     #[test]

--- a/xtask/src/ci/host/storage.rs
+++ b/xtask/src/ci/host/storage.rs
@@ -253,13 +253,30 @@ impl<'a> HostStorage<'a> {
             self.prune_retired_caches(Duration::ZERO)?;
             final_pressure = self.worst_pressure()?.0;
         }
+        let free = self.free_bytes()?;
         info!(
-            free_bytes = self.free_bytes()?,
+            free_bytes = free,
+            freed_bytes = free.saturating_sub(initial),
             ?final_pressure,
             "cleanup completed"
         );
         if final_pressure == Pressure::Reject {
             bail!("CI volume remains above the new-job threshold after cleanup");
+        }
+        // A pass that runs every step and moves nothing is the failure this
+        // host spent hours in: `Aggressive` in, `Aggressive` out, `bytes_freed=0`
+        // from each budget, and `cleanup completed` in the log every hour while
+        // jobs were already being refused. Reporting success there is what made
+        // it invisible — the steps ran, so nothing looked broken, and the space
+        // was held by things no step owns. Relief is the result this is for;
+        // performing the steps is not.
+        if final_pressure >= Pressure::Aggressive && final_pressure >= pressure {
+            bail!(
+                "cleanup left {} at {final_pressure:?} with {free} bytes free, unchanged from \
+                 {pressure:?}: every step this owns is already at its floor, so what is holding \
+                 the space is not build caches",
+                volume.display()
+            );
         }
         Ok(())
     }
@@ -1295,6 +1312,25 @@ mod tests {
         storage.cleanup().unwrap();
 
         assert!(review.is_dir());
+    }
+
+    /// The hourly pass this host actually ran: in at `Aggressive`, every step
+    /// executed, out at `Aggressive`, logged as completed. Reported as success
+    /// it hid a machine that was already refusing jobs.
+    #[test]
+    fn a_pass_that_leaves_the_pressure_where_it_found_it_is_a_failure() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut cfg = config(directory.path());
+        cfg.host.brew_root = directory.path().join("brew");
+        let process = Process::new(directory.path(), BTreeMap::new());
+        let mut storage = HostStorage::for_test(&cfg, &process).unwrap();
+        storage.set_pressure_sequence([
+            Pressure::Aggressive,
+            Pressure::Aggressive,
+            Pressure::Aggressive,
+        ]);
+
+        assert!(storage.cleanup().is_err());
     }
 
     #[test]

--- a/xtask/src/ci/host/windows.rs
+++ b/xtask/src/ci/host/windows.rs
@@ -1,0 +1,284 @@
+#[cfg(test)]
+use std::path::Path;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+
+use crate::ci::{
+    config::{CiConfig, WindowsGuest},
+    process::Process,
+};
+
+/// What the guest boots into.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum Boot {
+    /// Boot the installed disk.
+    Installed,
+    /// Boot the Microsoft media with the answer file attached.
+    Install,
+}
+
+/// The Windows guest served by a mac, and the disks it is handed.
+///
+/// This replaces a shell script that lived beside the disk image on the CI
+/// volume, outside the repository, along with two dozen probe scripts from the
+/// session that built the guest. Nothing outside the repository is reviewed,
+/// reproducible, or reachable by a fix, which is the same reason the periodic
+/// agents stopped running a binary only an operator could replace.
+pub(super) struct WindowsHost<'a> {
+    guest: &'a WindowsGuest,
+    root: PathBuf,
+    process: &'a Process,
+}
+
+impl<'a> WindowsHost<'a> {
+    const QEMU: &'static str = "/opt/homebrew/bin/qemu-system-aarch64";
+    const QEMU_IMG: &'static str = "/opt/homebrew/bin/qemu-img";
+
+    pub(super) fn new(config: &'a CiConfig, process: &'a Process) -> Result<Self> {
+        let guest = config
+            .host
+            .windows
+            .as_ref()
+            .context("this machine's profile defines no Windows guest")?;
+        Ok(Self {
+            guest,
+            root: config.host.host_root.join("vm/windows"),
+            process,
+        })
+    }
+
+    fn system_disk(&self) -> PathBuf {
+        self.root.join("disk.qcow2")
+    }
+
+    fn data_disk(&self) -> PathBuf {
+        self.root.join("data.qcow2")
+    }
+
+    /// Create the data disk if it is not there yet.
+    ///
+    /// Creating it is cheap and does not start the guest: a `qcow2` allocates
+    /// nothing until something writes. The guest picks it up on its next boot.
+    pub(super) fn ensure_data_disk(&self) -> Result<()> {
+        let disk = self.data_disk();
+        if disk.exists() {
+            return Ok(());
+        }
+        self.process.run(
+            Self::QEMU_IMG,
+            &[
+                "create",
+                "-f",
+                "qcow2",
+                &disk.display().to_string(),
+                &format!("{}G", self.guest.data_disk_gib),
+            ],
+            "create the Windows guest's data disk",
+        )?;
+        Ok(())
+    }
+
+    /// The arguments that boot the guest.
+    pub(super) fn boot_arguments(&self, boot: Boot) -> Vec<String> {
+        let root = self.root.display().to_string();
+        let mut arguments: Vec<String> = [
+            "-name",
+            "kithara-windows",
+            "-M",
+            "virt,highmem=on",
+            "-accel",
+            "hvf",
+            "-cpu",
+            "host",
+        ]
+        .iter()
+        .map(|argument| (*argument).to_owned())
+        .collect();
+        arguments.extend([
+            "-smp".to_owned(),
+            self.guest.vcpus.to_string(),
+            "-m".to_owned(),
+            self.guest.memory_mib.to_string(),
+            "-drive".to_owned(),
+            format!("if=pflash,format=raw,file={root}/efi-code.fd,readonly=on"),
+            "-drive".to_owned(),
+            format!("if=pflash,format=raw,file={root}/efi-vars.fd"),
+            "-device".to_owned(),
+            "ramfb".to_owned(),
+            "-device".to_owned(),
+            "qemu-xhci,id=usb".to_owned(),
+            "-device".to_owned(),
+            "usb-kbd".to_owned(),
+            "-device".to_owned(),
+            "usb-tablet".to_owned(),
+        ]);
+        // `discard=unmap` on both, so a guest that deletes a file lets the
+        // image hand the blocks back. Without it the image only ever grows,
+        // which is how the Linux guest's data disk reached a hundred nominal
+        // gigabytes holding fourteen.
+        arguments.extend(Self::disk(
+            "disk",
+            &self.system_disk().display().to_string(),
+            "kithara",
+        ));
+        arguments.extend(Self::disk(
+            "data",
+            &self.data_disk().display().to_string(),
+            "kithara-data",
+        ));
+        arguments.extend([
+            "-netdev".to_owned(),
+            "user,id=net0,hostfwd=tcp::2222-:22".to_owned(),
+            "-device".to_owned(),
+            "virtio-net-pci,netdev=net0".to_owned(),
+            "-drive".to_owned(),
+            format!("if=none,id=cd2,media=cdrom,file={root}/virtio-win.iso,readonly=on"),
+            "-device".to_owned(),
+            "usb-storage,drive=cd2".to_owned(),
+            "-rtc".to_owned(),
+            "base=utc".to_owned(),
+            "-display".to_owned(),
+            "none".to_owned(),
+            "-monitor".to_owned(),
+            format!("unix:{root}/monitor.sock,server,nowait"),
+            "-pidfile".to_owned(),
+            format!("{root}/qemu.pid"),
+        ]);
+        if boot == Boot::Install {
+            arguments.extend([
+                "-drive".to_owned(),
+                format!("if=none,id=cd0,media=cdrom,file={root}/Win11_25H2_Arm64.iso,readonly=on"),
+                "-device".to_owned(),
+                "usb-storage,drive=cd0,bootindex=0".to_owned(),
+                "-drive".to_owned(),
+                format!("if=none,id=cd1,media=cdrom,file={root}/unattend.iso,readonly=on"),
+                "-device".to_owned(),
+                "usb-storage,drive=cd1".to_owned(),
+                "-boot".to_owned(),
+                "menu=on".to_owned(),
+            ]);
+        }
+        arguments
+    }
+
+    fn disk(id: &str, file: &str, serial: &str) -> Vec<String> {
+        vec![
+            "-drive".to_owned(),
+            format!("if=none,id={id},file={file},format=qcow2,cache=writeback,discard=unmap"),
+            "-device".to_owned(),
+            format!("nvme,drive={id},serial={serial}"),
+        ]
+    }
+
+    /// Start the guest, replacing a monitor socket a previous run left behind.
+    pub(super) fn start(&self, boot: Boot) -> Result<()> {
+        self.ensure_data_disk()?;
+        let socket = self.root.join("monitor.sock");
+        if socket.exists() {
+            std::fs::remove_file(&socket)
+                .with_context(|| format!("removing stale monitor socket {}", socket.display()))?;
+        }
+        let owned = self.boot_arguments(boot);
+        let arguments: Vec<&str> = owned.iter().map(String::as_str).collect();
+        self.process
+            .run(Self::QEMU, &arguments, "start the Windows guest")?;
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn for_test(guest: &'a WindowsGuest, root: &Path, process: &'a Process) -> Self {
+        Self {
+            guest,
+            root: root.to_path_buf(),
+            process,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+
+    fn guest() -> WindowsGuest {
+        WindowsGuest {
+            vcpus: 4,
+            memory_mib: 8192,
+            data_disk_gib: 80,
+        }
+    }
+
+    fn arguments(boot: Boot) -> Vec<String> {
+        let guest = guest();
+        let process = Process::new(Path::new("/Volumes/CI"), BTreeMap::new());
+        WindowsHost::for_test(&guest, Path::new("/Volumes/CI/vm/windows"), &process)
+            .boot_arguments(boot)
+    }
+
+    /// The page file and `TEMP` are what grow the system image, and Windows
+    /// sizes the page file to memory. On its own disk they stop charging the
+    /// image the host cannot shrink in place.
+    #[test]
+    fn what_the_guest_writes_lands_on_a_disk_of_its_own() {
+        assert!(
+            arguments(Boot::Installed)
+                .iter()
+                .any(|argument| { argument.contains("file=/Volumes/CI/vm/windows/data.qcow2") })
+        );
+    }
+
+    /// Without it a guest that deletes a file keeps the blocks forever, which
+    /// is the whole reason the system image sits at 78 GB holding far less.
+    #[test]
+    fn the_data_disk_returns_the_blocks_the_guest_frees() {
+        let data = arguments(Boot::Installed)
+            .into_iter()
+            .find(|argument| argument.contains("data.qcow2"))
+            .expect("the guest is handed a data disk");
+
+        assert!(data.contains("discard=unmap"));
+    }
+
+    #[test]
+    fn the_two_disks_are_told_apart_by_serial() {
+        let serials: Vec<String> = arguments(Boot::Installed)
+            .into_iter()
+            .filter(|argument| argument.starts_with("nvme,"))
+            .collect();
+
+        assert_eq!(serials.len(), 2);
+    }
+
+    #[test]
+    fn installing_attaches_the_answer_file() {
+        assert!(
+            arguments(Boot::Install)
+                .iter()
+                .any(|argument| argument.contains("unattend.iso"))
+        );
+    }
+
+    /// A boot of the installed disk that offered the media as well would
+    /// reinstall the guest over itself.
+    #[test]
+    fn booting_the_installed_disk_offers_no_media() {
+        assert!(
+            !arguments(Boot::Installed)
+                .iter()
+                .any(|argument| argument.contains("Win11_25H2_Arm64.iso"))
+        );
+    }
+
+    #[test]
+    fn the_guest_is_given_the_memory_its_profile_asks_for() {
+        let arguments = arguments(Boot::Installed);
+        let memory = arguments
+            .iter()
+            .position(|argument| argument == "-m")
+            .expect("memory is passed");
+
+        assert_eq!(arguments[memory + 1], "8192");
+    }
+}


### PR DESCRIPTION
## What broke

`apple:e2e` died in nine seconds on our own preflight guard:

```
Error: the CI cache has 13588320256 bytes free; a job needs 15000000000 bytes
```

Meanwhile the hourly cleanup on that host reported success, every hour:

```
cleanup started free_bytes=19985477632 pressure=Aggressive
build cache budget enforced ... bytes_before=14011244544 bytes_freed=0 budget_bytes=25000000000
build cache budget enforced ... bytes_before=7256420352  bytes_freed=0 budget_bytes=25000000000
build cache budget enforced ... bytes_before=21979578368 bytes_freed=0 budget_bytes=25000000000
cleanup completed free_bytes=19985440768 final_pressure=Aggressive
```

Three checkouts holding 14, 7 and 22 GB against a 25 GB budget applied **per directory**. Each was under it, so the pass freed 37 KB and called itself done while the machine was already refusing work.

## Why it stayed broken

`services/bin/kithara-ci` is `root:wheel`. Every fix to cleanup reached the mac only through an operator with a password, so the repository carried fixes the host never ran. The comment on `stage_bridge_agent` already claimed the maintenance agents ran from `toolchains/shared-bin` "for the same reason" — they did not.

The same shape produced the Windows guest: it was started by a shell script sitting beside its disk image on the CI volume, outside the repository, alongside two dozen probe scripts left from the session that built it.

## Changes

**Cleanup does the job instead of performing the steps**

- The build cache budget is a ceiling over every checkout together, not over each one. Room an active job holds cannot be evicted but is charged against the ceiling rather than excused from it.
- A pass that starts under `Aggressive` and ends there fails instead of reporting completion.
- The periodic agents run `toolchains/shared-bin`, the copy the CI user can replace, closing the delivery path that kept these fixes off the host.
- Cleanup runs every fifteen minutes. Measured under a build, the volume loses ~2.7 GB/min — 53 GB to 31 GB free in eight minutes. The 45 GB between the first cleanup step and refusing jobs is a quarter of an hour; an hourly pass arrived after the refusals.

**The Windows guest is owned by xtask and writes to a disk it can discard**

- The guest is described by the machine profile (`vcpus`, `memory_mib`, `data_disk_gib`) and started by `just ci host run-windows-guest [--install]`. The shell script is gone as a source of truth.
- It is handed a second disk for everything it writes. A `qcow2` grows to cover every block written into it and never shrinks on its own, so a page file sized to memory charges the system image as much as the guest has RAM, permanently: 96 GiB nominal holding 78.6 GiB. That image cannot be shrunk in place, and copying it needs as much free space as it is large — which a full volume by definition does not have.
- Trimming the memory instead only moves the growth: Windows 11 on ARM wants four gigabytes before a Rust build swaps and grows the page file back. On a disk mounted `discard=unmap` the blocks return to the host.
- `provision.ps1` partitions that disk, moves `TEMP`/`TMP` in both scopes, and relocates the page file. The page file moves only after the automatic one is disabled — setting a second one while Windows still manages its own leaves both, and the one on `C:` is the one that was costing the image.

The guest section is `Option` with a `serde` default on purpose: installed profiles predate it, and a profile that stops loading takes cleanup down with it on hosts that serve no Windows lane. Pinned by tests both ways.

## Deploy order matters

`enforce_budget` is also called by the Linux host, where 24 volumes share the same `build_cache_size = "25GB"`. A 25 GB **total** ceiling would evict ~1 TB of warm cache there, and the Linux cleanup does not read pressure at all. Raise `build_cache_size` in `/etc/kithara-ci/linux-host.toml` **together with** the binary — earlier weakens the current budget, later throws away the caches.

On the mac the agents pick this up only through `install-services` plus `bootout`+`bootstrap`; `kickstart` does not re-read a plist.

## Not covered here

- The mac's three volumes hold 700 GB of quota on a 494 GB container, so the 15 GB refusal floor is roughly all the free space the machine has. Thresholds still derive from `quota_bytes`.
- Cleanup prunes only the *current* `build_root`. 65 GB of `target` was stranded on an abandoned one after the runner moved between volumes; that was cleared by hand and the next move will strand it again.
- The existing guest picks up `data.qcow2` on its next boot, and `Optimize-Volume -ReTrim` there will shrink the present 78.6 GiB. No rebuild needed.

## Verification

`cargo test -p xtask` — 210 passed, 0 failed. `cargo clippy -p xtask --all-targets` clean. Full suite green on the fork's runners.

Three tests failed on an earlier run of this branch and passed on re-run: `user_sim_random_seed_1337_mixed_codec_auto`, `cold_target_variant_switch_keeps_playback_uninterrupted_symphonia`, and `phase_continuity_file_mp3_symphonia_eph_10seek`. All three live in `kithara-queue`, `kithara-play` and `tests/`; this branch touches only `xtask/src/ci/` and `ci/windows/provision.ps1`, which do not compile into them. The latter two are known flakes.
