### PR TITLE
[WIP experiment] Explore public stop lifecycle contract

### DIFF
--- a/apple/Examples/KitharaDemo/UnitTests/TrackToRadioPlaybackParity.swift
+++ b/apple/Examples/KitharaDemo/UnitTests/TrackToRadioPlaybackParity.swift
@@ -1,0 +1,191 @@
+import AVFAudio
+import AVFoundation
+import Foundation
+import Kithara
+import Testing
+
+extension IntegrationRegressionsIOS {
+    @MainActor
+    @Test("A track-to-radio transition matches AVQueuePlayer")
+    func trackToRadioTransitionMatchesAVQueuePlayer() async throws {
+        try await TestServerFixture.setNetwork(online: true)
+        defer {
+            Task {
+                _ = try? await TestServerFixture.setNetwork(online: true)
+            }
+        }
+
+        let audioSession = AVAudioSession.sharedInstance()
+        try audioSession.setCategory(.playback)
+        try audioSession.setActive(true)
+        defer {
+            try? audioSession.setActive(false, options: .notifyOthersOnDeactivation)
+        }
+
+        let trackURL = try TestServerFixture.asset("test.mp3")
+        let radioURL = try await TestServerFixture.pacedHlsMasterURL()
+        let kithara = try await observeKitharaTrackToRadio(
+            trackURL: trackURL,
+            radioURL: radioURL
+        )
+        let apple = try await observeAVQueuePlayerTrackToRadio(
+            trackURL: trackURL,
+            radioURL: radioURL
+        )
+
+        let expected = TrackToRadioTrace(
+            trackAdvanced: true,
+            queueCleared: true,
+            sessionReleased: true,
+            radioCurrent: true,
+            radioAdvanced: true
+        )
+        #expect(kithara == expected, "Kithara transition trace was \(kithara)")
+        #expect(apple == expected, "AVQueuePlayer transition trace was \(apple)")
+        #expect(kithara == apple)
+    }
+
+    @MainActor
+    private func observeKitharaTrackToRadio(
+        trackURL: URL,
+        radioURL: URL
+    ) async throws -> TrackToRadioTrace {
+        let cacheURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("track-radio-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: cacheURL,
+            withIntermediateDirectories: true
+        )
+        let player = KitharaPlayer(
+            config: .init(store: AssetStore(root: cacheURL.path))
+        )
+        defer {
+            player.stop()
+            try? FileManager.default.removeItem(at: cacheURL)
+        }
+
+        let track = KitharaPlayerItem(url: trackURL.absoluteString)
+        try player.insert(track)
+        player.play()
+        try await waitForTrackToRadioFact("Kithara track playback to advance") {
+            player.currentTime > 0.1 && player.currentAudioItem === track
+        }
+        let trackAdvanced = player.currentTime > 0.1
+
+        player.stop()
+        let queueCleared = player.itemCount == 0 && player.currentAudioItem == nil
+        try #require(
+            queueCleared,
+            "Kithara stop left the prior track in its queue"
+        )
+        let sessionReleased = try releaseAndReactivateAudioSession()
+
+        let radio = KitharaPlayerItem(url: radioURL.absoluteString)
+        try player.insert(radio)
+        player.play()
+        try await waitForTrackToRadioFact("Kithara radio playback to advance") {
+            player.currentAudioItem === radio && player.currentTime > 0.5
+        }
+
+        return TrackToRadioTrace(
+            trackAdvanced: trackAdvanced,
+            queueCleared: queueCleared,
+            sessionReleased: sessionReleased,
+            radioCurrent: player.currentAudioItem === radio,
+            radioAdvanced: player.currentTime > 0.5 && player.currentRate > 0
+        )
+    }
+
+    @MainActor
+    private func observeAVQueuePlayerTrackToRadio(
+        trackURL: URL,
+        radioURL: URL
+    ) async throws -> TrackToRadioTrace {
+        let track = AVPlayerItem(url: trackURL)
+        let player = AVQueuePlayer(items: [track])
+        defer {
+            player.pause()
+            player.removeAllItems()
+        }
+
+        player.play()
+        try await waitForTrackToRadioFact("AVQueuePlayer track playback to advance") {
+            finiteSeconds(player.currentTime()) > 0.1 && player.currentItem === track
+        }
+        let trackAdvanced = finiteSeconds(player.currentTime()) > 0.1
+
+        player.pause()
+        player.removeAllItems()
+        let queueCleared = player.items().isEmpty && player.currentItem == nil
+        try #require(
+            queueCleared,
+            "AVQueuePlayer clear left the prior track in its queue"
+        )
+        let sessionReleased = try releaseAndReactivateAudioSession()
+
+        let radio = AVPlayerItem(url: radioURL)
+        player.insert(radio, after: nil)
+        player.play()
+        try await waitForTrackToRadioFact("AVQueuePlayer radio playback to advance") {
+            player.currentItem === radio && finiteSeconds(player.currentTime()) > 0.5
+        }
+
+        return TrackToRadioTrace(
+            trackAdvanced: trackAdvanced,
+            queueCleared: queueCleared,
+            sessionReleased: sessionReleased,
+            radioCurrent: player.currentItem === radio,
+            radioAdvanced: finiteSeconds(player.currentTime()) > 0.5 && player.rate > 0
+        )
+    }
+
+    @MainActor
+    private func releaseAndReactivateAudioSession() throws -> Bool {
+        let audioSession = AVAudioSession.sharedInstance()
+        try audioSession.setActive(false, options: .notifyOthersOnDeactivation)
+        try audioSession.setActive(true)
+        return true
+    }
+
+    @MainActor
+    private func waitForTrackToRadioFact(
+        _ description: String,
+        condition: () -> Bool
+    ) async throws {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(60))
+        while !condition() {
+            guard clock.now < deadline else {
+                throw TrackToRadioTimeout(description)
+            }
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+    }
+}
+
+private struct TrackToRadioTrace: Equatable, CustomStringConvertible {
+    let trackAdvanced: Bool
+    let queueCleared: Bool
+    let sessionReleased: Bool
+    let radioCurrent: Bool
+    let radioAdvanced: Bool
+
+    var description: String {
+        "trackAdvanced=\(trackAdvanced), queueCleared=\(queueCleared), "
+            + "sessionReleased=\(sessionReleased), radioCurrent=\(radioCurrent), "
+            + "radioAdvanced=\(radioAdvanced)"
+    }
+}
+
+private struct TrackToRadioTimeout: Error, CustomStringConvertible {
+    let description: String
+
+    init(_ description: String) {
+        self.description = "Timed out waiting for \(description)"
+    }
+}
+
+private func finiteSeconds(_ time: CMTime) -> TimeInterval {
+    let seconds = time.seconds
+    return seconds.isFinite ? seconds : 0
+}

--- a/apple/Sources/Kithara/KitharaPlayer.swift
+++ b/apple/Sources/Kithara/KitharaPlayer.swift
@@ -6,6 +6,94 @@ import KitharaFFI
 import AVFoundation
 #endif
 
+final class KitharaPlayerIdentityState: @unchecked Sendable {
+    struct Emission {
+        fileprivate let revision: UInt64
+        fileprivate let item: KitharaPlayerItem?
+    }
+
+    private let lock = NSRecursiveLock()
+    private let publicationLock = NSRecursiveLock()
+    private var items: [KitharaFFI.TrackId: KitharaPlayerItem] = [:]
+    private var representations: [KitharaFFI.TrackId: AnyObject] = [:]
+    private var current: KitharaPlayerItem?
+    private var revision: UInt64 = 0
+
+    func withTransaction<R>(_ body: () throws -> R) rethrows -> R {
+        lock.lock()
+        defer { lock.unlock() }
+        return try body()
+    }
+
+    func register(_ item: KitharaPlayerItem) {
+        withTransaction { items[item.ffiTrackId] = item }
+    }
+
+    func remove(trackId: KitharaFFI.TrackId) {
+        withTransaction {
+            items.removeValue(forKey: trackId)
+            representations.removeValue(forKey: trackId)
+        }
+    }
+
+    func setRepresentation(_ representation: AnyObject, for trackId: KitharaFFI.TrackId) {
+        withTransaction { representations[trackId] = representation }
+    }
+
+    @discardableResult
+    func removeRepresentation(for trackId: KitharaFFI.TrackId) -> AnyObject? {
+        withTransaction { representations.removeValue(forKey: trackId) }
+    }
+
+    func item(for trackId: KitharaFFI.TrackId) -> KitharaPlayerItem? {
+        withTransaction { items[trackId] }
+    }
+
+    func representation(for trackId: KitharaFFI.TrackId) -> AnyObject? {
+        withTransaction { representations[trackId] }
+    }
+
+    func orderedItems(for trackIds: [KitharaFFI.TrackId]) -> [KitharaPlayerItem] {
+        withTransaction { trackIds.compactMap { items[$0] } }
+    }
+
+    func currentItem() -> KitharaPlayerItem? {
+        withTransaction { current }
+    }
+
+    func setCurrent(_ item: KitharaPlayerItem?) -> Emission? {
+        withTransaction { updateCurrent(item) }
+    }
+
+    func resolveCurrent(trackId: KitharaFFI.TrackId?) -> Emission? {
+        withTransaction { updateCurrent(trackId.flatMap { items[$0] }) }
+    }
+
+    func clear() -> Emission? {
+        withTransaction {
+            items.removeAll()
+            representations.removeAll()
+            return updateCurrent(nil)
+        }
+    }
+
+    func publish(_ emission: Emission?, using send: (KitharaPlayerItem?) -> Void) {
+        guard let emission else { return }
+        publicationLock.lock()
+        defer { publicationLock.unlock() }
+        let isLatest = withTransaction { revision == emission.revision }
+        guard isLatest else { return }
+        send(emission.item)
+    }
+
+    private func updateCurrent(_ item: KitharaPlayerItem?) -> Emission? {
+        guard current?.ffiTrackId != item?.ffiTrackId else { return nil }
+        current = item
+        revision &+= 1
+        return Emission(revision: revision, item: item)
+    }
+}
+
 /// A queue-based audio player with Combine-driven observation.
 ///
 /// Thin wrapper over the Rust `AudioPlayer`. All state lives in Rust —
@@ -28,6 +116,7 @@ open class KitharaPlayer: KitharaPlayerProtocol, @unchecked Sendable {
     public typealias Item = KitharaPlayerItem
 
     private let _inner: AudioPlayer
+    private let _identity = KitharaPlayerIdentityState()
     private let _eventSubject = PassthroughSubject<FfiPlayerEvent, Never>()
     private let _commandErrorSubject = PassthroughSubject<KitharaPlayerError, Never>()
     private let _currentItemSubject = CurrentValueSubject<KitharaPlayerItem?, Never>(nil)
@@ -105,7 +194,7 @@ open class KitharaPlayer: KitharaPlayerProtocol, @unchecked Sendable {
     }
 
     private func audioId(for ffiTrackId: KitharaFFI.TrackId) -> TrackId? {
-        _knownItems[ffiTrackId]?.audioId
+        _identity.item(for: ffiTrackId)?.audioId
     }
 
     // MARK: - Discrete publishers (KitharaPlayerProtocol)
@@ -204,7 +293,7 @@ open class KitharaPlayer: KitharaPlayerProtocol, @unchecked Sendable {
     /// Current queue item visible to iOS-style clients, or `nil` when
     /// the queue is empty.
     public var currentAudioItem: KitharaPlayerItem? {
-        _currentItemSubject.value
+        _identity.currentItem()
     }
 
     // MARK: - Repeat
@@ -479,23 +568,16 @@ open class KitharaPlayer: KitharaPlayerProtocol, @unchecked Sendable {
 
     // MARK: - Queue management (delegated to Rust)
 
-    /// Items inserted via ``insert(_:after:)``, preserving Swift identity.
-    private var _knownItems: [KitharaFFI.TrackId: KitharaPlayerItem] = [:]
-    private var _knownRepresentations: [KitharaFFI.TrackId: AnyObject] = [:]
-
     private func syncCurrentItem(with event: FfiPlayerEvent) {
         guard case let .currentItemChanged(itemId) = event else { return }
-        publishCurrentItem(itemId.flatMap { _knownItems[$0] })
-    }
-
-    private func publishCurrentItem(_ item: KitharaPlayerItem?) {
-        if _currentItemSubject.value?.ffiTrackId != item?.ffiTrackId {
-            _currentItemSubject.send(item)
+        let emission = _identity.withTransaction {
+            _identity.resolveCurrent(trackId: itemId)
         }
+        publishCurrentEmission(emission)
     }
 
-    private func publishQueueHeadAsCurrent() {
-        publishCurrentItem(items().first)
+    private func publishCurrentEmission(_ emission: KitharaPlayerIdentityState.Emission?) {
+        _identity.publish(emission) { _currentItemSubject.send($0) }
     }
 
     private func publishCommandError(_ error: KitharaError, itemId: TrackId?) {
@@ -508,17 +590,18 @@ open class KitharaPlayer: KitharaPlayerProtocol, @unchecked Sendable {
     /// preserving identity and active event publishers. Mirrors the iOS
     /// Player queue as a function, not a property.
     public func items() -> [KitharaPlayerItem] {
-        let ffiItems = _inner.items()
-        return ffiItems.compactMap { ffiItem in
-            let id = ffiItem.queueId()
-            return _knownItems[id]
+        _identity.withTransaction {
+            let trackIds = _inner.items().map { $0.queueId() }
+            return _identity.orderedItems(for: trackIds)
         }
     }
 
     /// Current item represented as a caller-owned wrapper type, when the item
     /// was inserted through ``insert(_:representing:after:)``.
     public func currentItemRepresentation<T: AnyObject>(as type: T.Type = T.self) -> T? {
-        currentAudioItem.flatMap { _knownRepresentations[$0.ffiTrackId] as? T }
+        _identity.withTransaction {
+            currentAudioItem.flatMap { _identity.representation(for: $0.ffiTrackId) as? T }
+        }
     }
 
     /// Current item representation publisher. Emits the caller-owned wrapper
@@ -529,7 +612,7 @@ open class KitharaPlayer: KitharaPlayerProtocol, @unchecked Sendable {
         _currentItemSubject
             .map { [weak self] item -> T? in
                 guard let self, let item else { return nil }
-                return self._knownRepresentations[item.ffiTrackId] as? T
+                return self._identity.representation(for: item.ffiTrackId) as? T
             }
             .eraseToAnyPublisher()
     }
@@ -537,7 +620,9 @@ open class KitharaPlayer: KitharaPlayerProtocol, @unchecked Sendable {
     /// Queue represented as caller-owned wrapper objects, preserving Rust queue
     /// order.
     public func itemRepresentations<T: AnyObject>(as type: T.Type = T.self) -> [T] {
-        items().compactMap { _knownRepresentations[$0.ffiTrackId] as? T }
+        _identity.withTransaction {
+            items().compactMap { _identity.representation(for: $0.ffiTrackId) as? T }
+        }
     }
 
     /// Insert an item into the queue.
@@ -550,19 +635,31 @@ open class KitharaPlayer: KitharaPlayerProtocol, @unchecked Sendable {
     ///     ``append(_:)`` for AVQueuePlayer-style append.
     /// - Throws: ``KitharaError`` if `after` is not in the queue.
     public func insert(_ item: KitharaPlayerItem, after: KitharaPlayerItem? = nil) throws {
-        let wasEmpty = itemCount == 0
-        _knownItems[item.ffiTrackId] = item
-        do {
-            try _inner.insert(item: item._inner, after: after?._inner)
-            if wasEmpty {
-                publishCurrentItem(item)
+        try insert(item, representation: nil, after: after)
+    }
+
+    private func insert(
+        _ item: KitharaPlayerItem,
+        representation: AnyObject?,
+        after: KitharaPlayerItem?
+    ) throws {
+        let emission = try _identity.withTransaction {
+            let wasEmpty = itemCount == 0
+            _identity.register(item)
+            if let representation {
+                _identity.setRepresentation(representation, for: item.ffiTrackId)
             }
-        } catch let ffiError as FfiError {
-            _knownItems.removeValue(forKey: item.ffiTrackId)
-            let error = KitharaError(ffi: ffiError)
-            publishCommandError(error, itemId: item.audioId)
-            throw error
+            do {
+                try _inner.insert(item: item._inner, after: after?._inner)
+                return wasEmpty ? _identity.setCurrent(item) : nil
+            } catch let ffiError as FfiError {
+                _identity.remove(trackId: item.ffiTrackId)
+                let error = KitharaError(ffi: ffiError)
+                publishCommandError(error, itemId: item.audioId)
+                throw error
+            }
         }
+        publishCurrentEmission(emission)
     }
 
     /// Insert an item while registering a caller-owned wrapper object for UI /
@@ -573,32 +670,27 @@ open class KitharaPlayer: KitharaPlayerProtocol, @unchecked Sendable {
         representing representation: T,
         after: KitharaPlayerItem? = nil
     ) throws {
-        _knownRepresentations[item.ffiTrackId] = representation
-        do {
-            try insert(item, after: after)
-        } catch {
-            _knownRepresentations.removeValue(forKey: item.ffiTrackId)
-            throw error
-        }
+        try insert(item, representation: representation, after: after)
     }
 
     /// Append an item to the tail of the queue (AVQueuePlayer-style).
     /// Counterpart of ``insert(_:after:)``, which inserts at the head
     /// when `after == nil` per the iOS protocol contract.
     public func append(_ item: KitharaPlayerItem) throws {
-        let wasEmpty = itemCount == 0
-        _knownItems[item.ffiTrackId] = item
-        do {
-            try _inner.append(item: item._inner)
-            if wasEmpty {
-                publishCurrentItem(item)
+        let emission = try _identity.withTransaction {
+            let wasEmpty = itemCount == 0
+            _identity.register(item)
+            do {
+                try _inner.append(item: item._inner)
+                return wasEmpty ? _identity.setCurrent(item) : nil
+            } catch let ffiError as FfiError {
+                _identity.remove(trackId: item.ffiTrackId)
+                let error = KitharaError(ffi: ffiError)
+                publishCommandError(error, itemId: item.audioId)
+                throw error
             }
-        } catch let ffiError as FfiError {
-            _knownItems.removeValue(forKey: item.ffiTrackId)
-            let error = KitharaError(ffi: ffiError)
-            publishCommandError(error, itemId: item.audioId)
-            throw error
         }
+        publishCurrentEmission(emission)
     }
 
     /// Remove an item from the queue.
@@ -606,26 +698,28 @@ open class KitharaPlayer: KitharaPlayerProtocol, @unchecked Sendable {
     /// - Parameter item: The item to remove.
     /// - Throws: ``KitharaError`` if the item is not in the queue.
     public func remove(_ item: KitharaPlayerItem) throws {
-        do {
-            try _inner.remove(item: item._inner)
-            _knownItems.removeValue(forKey: item.ffiTrackId)
-            _knownRepresentations.removeValue(forKey: item.ffiTrackId)
-            if _currentItemSubject.value?.ffiTrackId == item.ffiTrackId {
-                publishQueueHeadAsCurrent()
+        let emission = try _identity.withTransaction {
+            do {
+                try _inner.remove(item: item._inner)
+                let wasCurrent = currentAudioItem?.ffiTrackId == item.ffiTrackId
+                _identity.remove(trackId: item.ffiTrackId)
+                return wasCurrent ? _identity.setCurrent(items().first) : nil
+            } catch let ffiError as FfiError {
+                let error = KitharaError(ffi: ffiError)
+                publishCommandError(error, itemId: item.audioId)
+                throw error
             }
-        } catch let ffiError as FfiError {
-            let error = KitharaError(ffi: ffiError)
-            publishCommandError(error, itemId: item.audioId)
-            throw error
         }
+        publishCurrentEmission(emission)
     }
 
     /// Remove all items from the queue.
     public func removeAllItems() {
-        _inner.removeAllItems()
-        _knownItems.removeAll()
-        _knownRepresentations.removeAll()
-        publishCurrentItem(nil)
+        let emission = _identity.withTransaction {
+            _inner.removeAllItems()
+            return _identity.clear()
+        }
+        publishCurrentEmission(emission)
     }
 
     /// Number of items currently in the queue.
@@ -640,29 +734,33 @@ open class KitharaPlayer: KitharaPlayerProtocol, @unchecked Sendable {
     /// must already have a loaded resource (``KitharaPlayerItem/load()``
     /// finished).
     public func replaceItem(at index: Int, with item: KitharaPlayerItem) throws {
-        let oldItems = items()
-        let replacesCurrent = oldItems.indices.contains(index)
-            && oldItems[index].ffiTrackId == _currentItemSubject.value?.ffiTrackId
-        let oldItemId = oldItems.indices.contains(index) ? oldItems[index].ffiTrackId : nil
-        let oldRepresentation = oldItemId.flatMap { _knownRepresentations[$0] }
-        _knownItems[item.ffiTrackId] = item
-        if let oldItemId {
-            _knownRepresentations.removeValue(forKey: oldItemId)
-        }
-        do {
-            try _inner.replaceItem(index: UInt32(index), item: item._inner)
-            if replacesCurrent {
-                publishCurrentItem(item)
+        let emission = try _identity.withTransaction {
+            let oldItems = items()
+            let replacesCurrent = oldItems.indices.contains(index)
+                && oldItems[index].ffiTrackId == currentAudioItem?.ffiTrackId
+            let oldItemId = oldItems.indices.contains(index) ? oldItems[index].ffiTrackId : nil
+            let oldRepresentation = oldItemId.flatMap { _identity.representation(for: $0) }
+            _identity.register(item)
+            if let oldItemId {
+                _identity.removeRepresentation(for: oldItemId)
             }
-        } catch let ffiError as FfiError {
-            _knownItems.removeValue(forKey: item.ffiTrackId)
-            if let oldItemId, let oldRepresentation {
-                _knownRepresentations[oldItemId] = oldRepresentation
+            do {
+                try _inner.replaceItem(index: UInt32(index), item: item._inner)
+                if let oldItemId, oldItemId != item.ffiTrackId {
+                    _identity.remove(trackId: oldItemId)
+                }
+                return replacesCurrent ? _identity.setCurrent(item) : nil
+            } catch let ffiError as FfiError {
+                _identity.remove(trackId: item.ffiTrackId)
+                if let oldItemId, let oldRepresentation {
+                    _identity.setRepresentation(oldRepresentation, for: oldItemId)
+                }
+                let error = KitharaError(ffi: ffiError)
+                publishCommandError(error, itemId: item.audioId)
+                throw error
             }
-            let error = KitharaError(ffi: ffiError)
-            publishCommandError(error, itemId: item.audioId)
-            throw error
         }
+        publishCurrentEmission(emission)
     }
 
     /// Select an item at the given queue index.
@@ -727,9 +825,11 @@ open class KitharaPlayer: KitharaPlayerProtocol, @unchecked Sendable {
     /// slot. Mirrors `AVPlayer.stop` semantics — after `stop()`, the
     /// player is ready to accept a fresh queue via ``insert(_:after:)``.
     public func stop() {
-        _inner.stop()
-        _knownItems.removeAll()
-        publishCurrentItem(nil)
+        let emission = _identity.withTransaction {
+            _inner.stop()
+            return _identity.clear()
+        }
+        publishCurrentEmission(emission)
     }
 
     // MARK: - Network / DRM hooks

--- a/apple/Tests/KitharaTests/KitharaPlayerIdentityStateTests.swift
+++ b/apple/Tests/KitharaTests/KitharaPlayerIdentityStateTests.swift
@@ -1,0 +1,26 @@
+import Testing
+@testable import Kithara
+
+@Suite("KitharaPlayer identity state")
+struct KitharaPlayerIdentityStateTests {
+    @Test("stop rejects a current-item publication captured by an older observer")
+    func stopRejectsStaleObserverPublication() {
+        let state = KitharaPlayerIdentityState()
+        let item = KitharaPlayerItem(
+            url: "https://example.com/identity.mp3",
+            audioId: 42,
+            uuid: 123
+        )
+        state.register(item)
+        let observerEmission = state.resolveCurrent(trackId: item.ffiTrackId)
+
+        let stopEmission = state.clear()
+        var observed: [Int64?] = []
+        state.publish(stopEmission) { observed.append($0?.uuid) }
+        state.publish(observerEmission) { observed.append($0?.uuid) }
+
+        #expect(observed == [nil])
+        #expect(state.currentItem() == nil)
+        #expect(state.item(for: item.ffiTrackId) == nil)
+    }
+}

--- a/crates/kithara-ffi/src/native/inner.rs
+++ b/crates/kithara-ffi/src/native/inner.rs
@@ -149,6 +149,8 @@ pub(crate) type Inner = NativeInner;
 /// `AudioPlayer` facade delegates every public method here so the
 /// `UniFFI` surface stays a thin shell over this engine.
 pub(crate) struct NativeInner {
+    /// Serializes queue and item-registry mutations as one FFI transaction.
+    mutations: Mutex<()>,
     /// Swift-owned items indexed by `TrackId`. Populated by `insert`,
     /// drained by `remove` / `remove_all_items`. Lets `items` return
     /// the same `AudioPlayerItem` instances that Swift handed in (preserves
@@ -214,6 +216,7 @@ impl NativeInner {
         let (key_options, player_headers) = build_initial_key_state(key_options);
         let player_headers_map: DashMap<String, String> = player_headers.into_iter().collect();
         Self {
+            mutations: Mutex::default(),
             downloader,
             region,
             store,
@@ -242,6 +245,7 @@ impl NativeInner {
     }
 
     pub(crate) fn append(&self, item: &Arc<AudioPlayerItem>) -> Result<(), FfiError> {
+        let _mutation = self.mutations.lock();
         let _rt = crate::FFI_RUNTIME.enter();
         let source = build_source_for_item(self, item)?;
         let id = item.track_id();
@@ -274,6 +278,7 @@ impl NativeInner {
         item: &Arc<AudioPlayerItem>,
         after: Option<&Arc<AudioPlayerItem>>,
     ) -> Result<(), FfiError> {
+        let _mutation = self.mutations.lock();
         let _rt = crate::FFI_RUNTIME.enter();
         let source = build_source_for_item(self, item)?;
         let id = item.track_id();
@@ -320,6 +325,7 @@ impl NativeInner {
     }
 
     pub(crate) fn remove(&self, item: &AudioPlayerItem) -> Result<(), FfiError> {
+        let _mutation = self.mutations.lock();
         if !*item.inserted.lock() {
             return Err(FfiError::InvalidArgument {
                 reason: format!("item {} not in queue", item.audio_id()),
@@ -337,6 +343,7 @@ impl NativeInner {
     }
 
     pub(crate) fn remove_all_items(&self) {
+        let _mutation = self.mutations.lock();
         self.queue.clear();
         let mut items = self.items.lock();
         for (_, item) in items.drain() {
@@ -349,6 +356,7 @@ impl NativeInner {
         index: u32,
         item: &Arc<AudioPlayerItem>,
     ) -> Result<(), FfiError> {
+        let _mutation = self.mutations.lock();
         let _rt = crate::FFI_RUNTIME.enter();
         let idx = index as usize;
         let tracks = self.queue.tracks();
@@ -516,8 +524,7 @@ impl NativeInner {
     }
 
     pub(crate) fn stop(&self) {
-        self.queue.pause();
-        let _ = self.queue.seek(0.0);
+        self.remove_all_items();
     }
 
     pub(crate) fn update_peak_bitrate(&self, wifi_bps: f64, cellular_bps: f64) {
@@ -631,8 +638,12 @@ impl Drop for NativeInner {
 
 #[cfg(test)]
 mod tests {
+    use std::{sync::mpsc, thread};
+
+    use kithara_platform::time::Duration;
+
     use super::*;
-    use crate::observer::FfiKeyProcessor;
+    use crate::{observer::FfiKeyProcessor, types::FfiItemConfig};
 
     struct TaggedProcessor(u8);
 
@@ -650,6 +661,72 @@ mod tests {
             domains: domains.iter().map(ToString::to_string).collect(),
             salt: Some(salt.to_string()),
         }
+    }
+
+    fn test_item(url: &str) -> Arc<AudioPlayerItem> {
+        AudioPlayerItem::new(FfiItemConfig {
+            abr_mode: None,
+            audio_id: None,
+            headers: None,
+            uuid_i64: None,
+            url: url.to_string(),
+            is_live_stream: false,
+            preferred_peak_bitrate: 0.0,
+            preferred_peak_bitrate_expensive: 0.0,
+        })
+    }
+
+    #[kithara::test]
+    fn concurrent_append_and_stop_cannot_split_queue_and_registry() {
+        let inner = Arc::new(NativeInner::new(FfiPlayerConfig::default()));
+        let item = test_item("https://example.com/blocked-append.mp3");
+        let inserted = item.inserted.lock();
+
+        let appending_inner = Arc::clone(&inner);
+        let appending_item = Arc::clone(&item);
+        let append_thread = thread::spawn(move || appending_inner.append(&appending_item));
+        while inner.queue.is_empty() {
+            assert!(
+                !append_thread.is_finished(),
+                "append must reach the queue before waiting on inserted state"
+            );
+            thread::yield_now();
+        }
+
+        let (stop_started, stop_observer) = mpsc::channel();
+        let (stop_finished, stop_completion) = mpsc::channel();
+        let stopping_inner = Arc::clone(&inner);
+        let stop_thread = thread::spawn(move || {
+            stop_started.send(()).expect("stop observer must be alive");
+            stopping_inner.stop();
+            stop_finished
+                .send(())
+                .expect("stop completion observer must be alive");
+        });
+        stop_observer
+            .recv_timeout(Duration::from_secs(1))
+            .expect("stop thread must start");
+        let stop_overtook_append = stop_completion
+            .recv_timeout(Duration::from_millis(250))
+            .is_ok();
+
+        drop(inserted);
+        append_thread
+            .join()
+            .expect("append thread must finish")
+            .expect("append must succeed");
+        stop_thread.join().expect("stop thread must finish");
+
+        assert!(
+            !stop_overtook_append,
+            "stop must wait for the append transaction that already owns the queue"
+        );
+        assert_eq!(inner.queue.len(), 0, "stop must leave the queue empty");
+        assert!(
+            inner.items.lock().is_empty(),
+            "stop must drain the registry"
+        );
+        assert!(!*item.inserted.lock(), "stop must reset inserted state");
     }
 
     #[kithara::test]

--- a/crates/kithara-ffi/src/player/facade.rs
+++ b/crates/kithara-ffi/src/player/facade.rs
@@ -331,10 +331,8 @@ impl AudioPlayer {
         self.inner.snapshot()
     }
 
-    /// Stop playback: pause the engine and reset the current item's
-    /// position to the start. The queue is preserved, so a subsequent
-    /// [`play`](Self::play) resumes the same item from the beginning.
-    /// To empty the queue instead, use [`remove_all_items`](Self::remove_all_items).
+    /// Stop playback, release the output, and clear the queue. A subsequent
+    /// [`play`](Self::play) starts only after a fresh item is inserted.
     pub fn stop(&self) {
         self.inner.stop();
     }

--- a/crates/kithara-ffi/src/player/tests.rs
+++ b/crates/kithara-ffi/src/player/tests.rs
@@ -1,4 +1,6 @@
-use crate::{config::FfiPlayerConfig, player::AudioPlayer};
+use crate::{
+    config::FfiPlayerConfig, item::AudioPlayerItem, player::AudioPlayer, types::FfiItemConfig,
+};
 
 #[kithara::test]
 fn create_player() {
@@ -24,6 +26,45 @@ fn remove_all_items_on_empty_queue() {
     let player = AudioPlayer::new(FfiPlayerConfig::default());
     player.remove_all_items();
     assert!(player.items().is_empty());
+}
+
+#[kithara::test]
+fn stop_clears_queue_and_releases_inserted_items() {
+    let player = AudioPlayer::new(FfiPlayerConfig::default());
+    let item = AudioPlayerItem::new(FfiItemConfig {
+        abr_mode: None,
+        audio_id: None,
+        headers: None,
+        uuid_i64: None,
+        url: "https://example.com/song.mp3".to_string(),
+        is_live_stream: false,
+        preferred_peak_bitrate: 0.0,
+        preferred_peak_bitrate_expensive: 0.0,
+    });
+    player
+        .append(item.clone())
+        .expect("valid item must enter the queue");
+    assert_eq!(player.item_count(), 1, "setup must populate the queue");
+    assert!(*item.inserted.lock(), "setup must mark the item inserted");
+
+    player.stop();
+
+    assert_eq!(player.item_count(), 0, "stop must clear the queue");
+    assert!(
+        player.items().is_empty(),
+        "stop must drain the item registry"
+    );
+    assert!(
+        !*item.inserted.lock(),
+        "stop must release the old item for a later insertion"
+    );
+
+    player
+        .append(item.clone())
+        .expect("a stopped item must be insertable again");
+    assert_eq!(player.item_count(), 1, "restart queue must accept the item");
+    player.stop();
+    assert_eq!(player.item_count(), 0, "repeated stop must stay idempotent");
 }
 
 #[kithara::test]

--- a/crates/kithara-play/src/player/core.rs
+++ b/crates/kithara-play/src/player/core.rs
@@ -7,7 +7,7 @@ use kithara_platform::{
     CancelScope,
     sync::{Arc, Mutex},
 };
-use tracing::debug;
+use tracing::{debug, warn};
 
 use super::{
     config::PlayerConfig,
@@ -27,6 +27,8 @@ use crate::{
 /// carry worker references) drops before `engine`, and `engine` (whose
 /// `Drop` shuts the worker down) drops last.
 pub(crate) struct PlayerCore {
+    /// Serializes phase/slot transitions that may start or stop the engine.
+    pub(crate) lifecycle: Mutex<()>,
     /// Live shared cost meter of the audio engine (decode + effects).
     /// Constructed once and kept address-stable for the player's lifetime.
     pub(crate) engine_load: Arc<EngineLoad>,
@@ -96,6 +98,7 @@ impl PlayerImpl {
         // Seed the single speed source with the configured default rate.
         config.timestretch.set_speed(config.default_rate);
         let core = PlayerCore {
+            lifecycle: Mutex::default(),
             engine,
             engine_load: Arc::new(EngineLoad::default()),
             params: PlayerParams::from(&config),
@@ -174,13 +177,32 @@ impl PlayerImpl {
         self.core.engine.pcm_pool()
     }
 
-    /// Remove all items from the queue.
+    /// Remove all items, release the active slot, and stop the engine.
     pub fn remove_all_items(&self) {
+        let _lifecycle = self.core.lifecycle.lock();
         self.unarm_next();
         self.core.items.clear_all();
         self.set_status(PlayerStatus::Unknown);
+        self.core.params.set_paused_rate();
+        let slot = self.slot();
         let _ = self.send_to_slot(PlayerCmd::Clear);
+
+        if self.core.engine.is_running() {
+            if let Some(slot) = slot
+                && let Err(error) = self.core.engine.release_slot(slot)
+            {
+                warn!(?slot, ?error, "failed to release player slot during stop");
+            }
+            if let Err(error) = self.core.engine.stop() {
+                warn!(?error, "failed to stop player engine");
+            }
+        }
+
         self.enter_stopped();
+        self.core
+            .engine
+            .bus()
+            .publish(PlayerEvent::RateChanged { rate: 0.0 });
         debug!("all items removed");
     }
 
@@ -240,16 +262,86 @@ impl crate::api::Equalizer for PlayerImpl {
 
 #[cfg(test)]
 mod tests {
+    use std::{sync::mpsc, thread};
+
     use kithara_assets::AssetStore;
-    use kithara_audio::{StretchControls, generate_log_spaced_bands};
+    use kithara_audio::{ConsumerWakeMode, StretchControls, generate_log_spaced_bands};
     use kithara_bufpool::{BytePool, PcmPool};
     use kithara_decode::GaplessMode;
     use kithara_events::{Envelope, Event};
-    use kithara_platform::CancelToken;
+    use kithara_platform::{CancelToken, time::Duration};
     use kithara_test_utils::kithara;
 
     use super::*;
-    use crate::{api::SlotId, bridge::PlayerCmd, session::testing};
+    use crate::{
+        api::SlotId,
+        bridge::PlayerCmd,
+        session::{Cmd, Reply, SessionDispatcher, testing},
+    };
+
+    type SessionReply = Result<Reply, PlayError>;
+    type SessionCommand = (Cmd, mpsc::Sender<SessionReply>);
+
+    struct ThreadedTestSession {
+        commands: mpsc::Sender<SessionCommand>,
+    }
+
+    impl Default for ThreadedTestSession {
+        fn default() -> Self {
+            let (commands, receiver) = mpsc::channel::<SessionCommand>();
+            thread::spawn(move || {
+                let session = testing::test_session();
+                for (command, reply) in receiver {
+                    let _ = reply.send(session.exec(command));
+                }
+            });
+            Self { commands }
+        }
+    }
+
+    impl SessionDispatcher for ThreadedTestSession {
+        fn exec(&self, command: Cmd) -> SessionReply {
+            let (reply, receiver) = mpsc::channel();
+            self.commands
+                .send((command, reply))
+                .map_err(|_| PlayError::Internal("test session stopped".into()))?;
+            receiver
+                .recv()
+                .map_err(|_| PlayError::Internal("test session dropped its reply".into()))?
+        }
+
+        fn consumer_wake_mode(&self) -> ConsumerWakeMode {
+            ConsumerWakeMode::RealtimeDeferred
+        }
+    }
+
+    struct BlockingStopSession {
+        inner: ThreadedTestSession,
+        stop_entered: Mutex<Option<mpsc::Sender<()>>>,
+        resume_stop: Mutex<Option<mpsc::Receiver<()>>>,
+    }
+
+    impl SessionDispatcher for BlockingStopSession {
+        fn exec(&self, command: Cmd) -> SessionReply {
+            if matches!(&command, Cmd::StopPlayer { .. }) {
+                if let Some(entered) = self.stop_entered.lock().take() {
+                    entered
+                        .send(())
+                        .map_err(|_| PlayError::Internal("stop observer dropped".into()))?;
+                }
+                if let Some(release) = self.resume_stop.lock().take() {
+                    release
+                        .recv()
+                        .map_err(|_| PlayError::Internal("stop release dropped".into()))?;
+                }
+            }
+            self.inner.exec(command)
+        }
+
+        fn consumer_wake_mode(&self) -> ConsumerWakeMode {
+            self.inner.consumer_wake_mode()
+        }
+    }
 
     #[derive(Clone, Copy)]
     enum PlayerBasicScenario {
@@ -539,6 +631,98 @@ mod tests {
             ptr_before, ptr_after,
             "timestretch controls must stay address-stable across transitions"
         );
+        player.worker().shutdown();
+    }
+
+    #[kithara::test]
+    fn remove_all_items_stops_engine_and_restart_allocates_fresh_slot() {
+        let player = PlayerImpl::new(
+            PlayerConfig::test_builder()
+                .session(testing::test_session())
+                .build(),
+        );
+        player.play();
+        let first_slot = player.slot().expect("play must allocate a slot");
+        assert!(player.engine().is_running(), "setup must start the engine");
+
+        player.remove_all_items();
+
+        assert!(
+            !player.engine().is_running(),
+            "clearing must stop the engine"
+        );
+        assert!(
+            player.slot().is_none(),
+            "clearing must release slot ownership"
+        );
+
+        player.remove_all_items();
+        player.play();
+        let restarted_slot = player.slot().expect("restart must allocate a slot");
+        assert_ne!(
+            restarted_slot, first_slot,
+            "restart must not reuse the slot invalidated by engine stop"
+        );
+        player.remove_all_items();
+        player.worker().shutdown();
+    }
+
+    #[kithara::test]
+    fn play_waits_for_stop_and_restarts_with_a_fresh_slot() {
+        let (stop_entered, stop_observer) = mpsc::channel();
+        let (resume_stop, stop_release) = mpsc::channel();
+        let session: Arc<dyn SessionDispatcher> = Arc::new(BlockingStopSession {
+            inner: ThreadedTestSession::default(),
+            stop_entered: Mutex::new(Some(stop_entered)),
+            resume_stop: Mutex::new(Some(stop_release)),
+        });
+        let player = Arc::new(PlayerImpl::new(
+            PlayerConfig::test_builder().session(session).build(),
+        ));
+        player.play();
+        let first_slot = player.slot().expect("play must allocate a slot");
+
+        let stopping_player = Arc::clone(&player);
+        let stop_thread = thread::spawn(move || stopping_player.remove_all_items());
+        stop_observer
+            .recv_timeout(Duration::from_secs(1))
+            .expect("stop must reach the session boundary");
+
+        let (play_started, play_observer) = mpsc::channel();
+        let (play_finished, play_completion) = mpsc::channel();
+        let restarting_player = Arc::clone(&player);
+        let play_thread = thread::spawn(move || {
+            play_started.send(()).expect("play observer must be alive");
+            restarting_player.play();
+            play_finished
+                .send(())
+                .expect("play completion observer must be alive");
+        });
+        play_observer
+            .recv_timeout(Duration::from_secs(1))
+            .expect("play thread must start");
+        let completed_before_stop = play_completion
+            .recv_timeout(Duration::from_millis(250))
+            .is_ok();
+
+        resume_stop.send(()).expect("stop thread must be waiting");
+        stop_thread.join().expect("stop thread must finish");
+        play_thread.join().expect("play thread must finish");
+
+        assert!(
+            !completed_before_stop,
+            "play must wait until stop finishes invalidating its slot"
+        );
+        assert!(
+            player.engine().is_running(),
+            "serialized play must restart the engine"
+        );
+        assert_ne!(
+            player.slot(),
+            Some(first_slot),
+            "serialized play must allocate a fresh slot"
+        );
+        player.remove_all_items();
         player.worker().shutdown();
     }
 

--- a/crates/kithara-play/src/player/flow/transport.rs
+++ b/crates/kithara-play/src/player/flow/transport.rs
@@ -75,6 +75,7 @@ impl PlayerImpl {
 
     /// Pause playback (sets rate to 0.0).
     pub fn pause(&self) {
+        let _lifecycle = self.core.lifecycle.lock();
         self.core.params.set_paused_rate();
         let _ = self.send_to_slot(PlayerCmd::SetPaused(true));
         self.enter_paused();
@@ -87,6 +88,7 @@ impl PlayerImpl {
 
     /// Start playback at the configured default rate.
     pub fn play(&self) {
+        let _lifecycle = self.core.lifecycle.lock();
         let rate = self.default_rate().max(Self::MIN_PLAYBACK_RATE);
         self.core.params.set_rate_value(rate);
         self.core.timestretch.set_speed(rate);
@@ -197,6 +199,7 @@ impl PlayerImpl {
         index: usize,
         transition: SelectTransition,
     ) -> Result<(), PlayError> {
+        let _lifecycle = self.core.lifecycle.lock();
         let SelectTransition {
             autoplay,
             crossfade_seconds,

--- a/crates/kithara-play/src/player/state/phase.rs
+++ b/crates/kithara-play/src/player/state/phase.rs
@@ -60,11 +60,10 @@ pub(crate) enum PlayerPhaseKind {
 /// `current_slot` / `current_abr_handle` / `pending_next` mutexes into a
 /// single typed phase guarded by one `Mutex<PlayerPhase>`.
 ///
-/// A slot, once allocated, is reused for the player's lifetime: both
-/// `Playing` and `Paused` carry the same `slot`. `Loading` is the transient
-/// state between slot allocation and the first track being driven; `Idle` is
-/// the freshly-constructed state with no slot; `Stopped` follows
-/// `remove_all_items` (cleared queue, slot may still exist).
+/// A slot is reused across ordinary play/pause transitions. `Loading` is the
+/// transient state between slot allocation and the first track being driven;
+/// `Idle` is the freshly-constructed state with no slot; `Stopped` follows a
+/// full teardown and owns neither a slot nor track-local state.
 pub(crate) enum PlayerPhase {
     Idle,
     Loading {
@@ -82,10 +81,7 @@ pub(crate) enum PlayerPhase {
         abr_handle: Option<kithara_abr::AbrHandle>,
         pending: Option<PendingNext>,
     },
-    Stopped {
-        slot: Option<SlotId>,
-        abr_handle: Option<kithara_abr::AbrHandle>,
-    },
+    Stopped,
 }
 
 impl From<&PlayerPhase> for PlayerPhaseKind {
@@ -95,7 +91,7 @@ impl From<&PlayerPhase> for PlayerPhaseKind {
             PlayerPhase::Loading { .. } => Self::Loading,
             PlayerPhase::Playing { .. } => Self::Playing,
             PlayerPhase::Paused { .. } => Self::Paused,
-            PlayerPhase::Stopped { .. } => Self::Stopped,
+            PlayerPhase::Stopped => Self::Stopped,
         }
     }
 }
@@ -105,11 +101,10 @@ impl PlayerPhase {
     /// a true accessor (not a `self -> Other` conversion).
     const fn abr_handle_ref(&self) -> Option<&kithara_abr::AbrHandle> {
         match self {
-            Self::Idle => None,
+            Self::Idle | Self::Stopped => None,
             Self::Loading { abr_handle, .. }
             | Self::Playing { abr_handle, .. }
-            | Self::Paused { abr_handle, .. }
-            | Self::Stopped { abr_handle, .. } => abr_handle.as_ref(),
+            | Self::Paused { abr_handle, .. } => abr_handle.as_ref(),
         }
     }
 
@@ -130,8 +125,7 @@ impl PlayerPhase {
                 pending,
                 ..
             } => (abr_handle, pending),
-            Self::Stopped { abr_handle, .. } => (abr_handle, None),
-            Self::Idle => (None, None),
+            Self::Idle | Self::Stopped => (None, None),
         };
         *self = Self::Loading {
             slot,
@@ -161,14 +155,6 @@ impl PlayerPhase {
                 abr_handle,
                 pending,
             },
-            Self::Stopped {
-                slot: Some(slot),
-                abr_handle,
-            } => Self::Paused {
-                slot,
-                abr_handle,
-                pending: None,
-            },
             phase => phase,
         };
     }
@@ -194,33 +180,12 @@ impl PlayerPhase {
                 abr_handle,
                 pending,
             },
-            Self::Stopped {
-                slot: Some(slot),
-                abr_handle,
-            } => Self::Playing {
-                slot,
-                abr_handle,
-                pending: None,
-            },
             phase => phase,
         };
     }
 
     pub(crate) fn enter_stopped(&mut self) {
-        let (slot, abr_handle) = match std::mem::replace(self, Self::Idle) {
-            Self::Loading {
-                slot, abr_handle, ..
-            }
-            | Self::Playing {
-                slot, abr_handle, ..
-            }
-            | Self::Paused {
-                slot, abr_handle, ..
-            } => (Some(slot), abr_handle),
-            Self::Stopped { slot, abr_handle } => (slot, abr_handle),
-            Self::Idle => (None, None),
-        };
-        *self = Self::Stopped { slot, abr_handle };
+        *self = Self::Stopped;
     }
 
     /// Shared read access to the armed-next slot, if any.
@@ -229,7 +194,7 @@ impl PlayerPhase {
             Self::Loading { pending, .. }
             | Self::Playing { pending, .. }
             | Self::Paused { pending, .. } => pending.as_ref(),
-            Self::Idle | Self::Stopped { .. } => None,
+            Self::Idle | Self::Stopped => None,
         }
     }
 
@@ -239,7 +204,7 @@ impl PlayerPhase {
             Self::Loading { pending, .. }
             | Self::Playing { pending, .. }
             | Self::Paused { pending, .. } => Some(pending),
-            Self::Idle | Self::Stopped { .. } => None,
+            Self::Idle | Self::Stopped => None,
         }
     }
 
@@ -248,9 +213,8 @@ impl PlayerPhase {
         match self {
             Self::Loading { abr_handle, .. }
             | Self::Playing { abr_handle, .. }
-            | Self::Paused { abr_handle, .. }
-            | Self::Stopped { abr_handle, .. } => *abr_handle = handle,
-            Self::Idle => {}
+            | Self::Paused { abr_handle, .. } => *abr_handle = handle,
+            Self::Idle | Self::Stopped => {}
         }
     }
 
@@ -258,11 +222,10 @@ impl PlayerPhase {
     /// accessor (not a `self -> Other` conversion).
     const fn slot_ref(&self) -> Option<&SlotId> {
         match self {
-            Self::Idle => None,
+            Self::Idle | Self::Stopped => None,
             Self::Loading { slot, .. } | Self::Playing { slot, .. } | Self::Paused { slot, .. } => {
                 Some(slot)
             }
-            Self::Stopped { slot, .. } => slot.as_ref(),
         }
     }
 
@@ -303,7 +266,7 @@ impl PlayerImpl {
         self.publish_time_control_status(TimeControlStatus::Playing, None);
     }
 
-    /// Move the player into `Stopped`, preserving the slot/ABR handle.
+    /// Move the player into `Stopped`, dropping slot and track-local state.
     pub(crate) fn enter_stopped(&self) {
         self.phase.lock().enter_stopped();
         self.publish_time_control_status(TimeControlStatus::Paused, None);
@@ -392,14 +355,7 @@ mod tests {
             .kind(),
             PlayerPhaseKind::Paused
         );
-        assert_eq!(
-            PlayerPhase::Stopped {
-                slot: None,
-                abr_handle: None,
-            }
-            .kind(),
-            PlayerPhaseKind::Stopped
-        );
+        assert_eq!(PlayerPhase::Stopped.kind(), PlayerPhaseKind::Stopped);
     }
 
     #[kithara::test]

--- a/crates/kithara-play/src/session/graph.rs
+++ b/crates/kithara-play/src/session/graph.rs
@@ -752,6 +752,33 @@ mod tests {
         }
     }
 
+    fn stop(state: &mut SessionState<TestBackend>, player_id: PlayerId) {
+        match run_cmd(state, Cmd::StopPlayer { player_id }) {
+            Reply::Ok => {}
+            Reply::Err(err) => panic!("player {player_id} failed to stop: {err}"),
+            _ => panic!("player stop returned unexpected reply"),
+        }
+    }
+
+    /// Stopping is the verb a host reaches for when playback ends, and it must
+    /// release the output on its own — the existing coverage reaches this only
+    /// through unregister, which a host that stops without dropping its player
+    /// never performs. Naming the two separately is what tells a caller that
+    /// kept its player whether the device is free, which is the difference
+    /// between an audio session that can be deactivated and one that reports
+    /// itself busy.
+    #[kithara::test]
+    fn stopping_the_last_player_releases_the_output() {
+        device(|dev| *dev = AudioDevice::default());
+        let mut state = SessionState::<TestBackend>::new(start_test_stream);
+        let player_id = register(&mut state);
+        start(&mut state, player_id);
+
+        stop(&mut state, player_id);
+
+        assert!(state.ctx.is_none());
+    }
+
     #[kithara::test]
     fn a_running_player_replaces_its_eq_layout_without_releasing_slots() {
         device(|dev| *dev = AudioDevice::default());

--- a/crates/kithara-queue/src/queue/lifecycle.rs
+++ b/crates/kithara-queue/src/queue/lifecycle.rs
@@ -1,4 +1,3 @@
-#[cfg(any(test, feature = "probe"))]
 use std::sync::PoisonError;
 
 #[cfg(any(test, feature = "probe"))]
@@ -7,11 +6,12 @@ use kithara_events::{AdvanceReason, QueueEvent, TrackId};
 
 use super::{
     Queue,
-    types::{Placement, Transition, extract_track_name},
+    types::{CachedPosition, CrossfadeArm, Placement, SelectPhase, Transition, extract_track_name},
 };
 use crate::{
     attempts::LoadClass,
     error::QueueError,
+    navigation::NavigationState,
     track::{TrackRecord, TrackSource},
 };
 
@@ -37,12 +37,31 @@ impl Queue {
     /// their in-flight loads.
     pub fn clear(&self) {
         let ids: Vec<TrackId> = {
+            let _apply = self.lock_select_apply();
             let mut guard = self.lock_tracks_mut();
             let ids = guard.iter().map(|r| r.id).collect();
             guard.clear();
+            drop(guard);
+
+            *self.lock_pending_select_mut() = SelectPhase::Idle;
+            let mut navigation = self.lock_navigation_mut();
+            let repeat = navigation.repeat_mode();
+            let shuffle = navigation.is_shuffle_enabled();
+            *navigation = NavigationState::new();
+            navigation.set_repeat(repeat);
+            navigation.set_shuffle(shuffle);
+            drop(navigation);
+            self.write_armed_for(CrossfadeArm::Disarmed);
+            self.write_cached_position(CachedPosition::Unknown);
+            #[cfg(any(test, feature = "probe"))]
+            self.autoplay_target.store(CrossfadeArm::Disarmed);
+            self.player.remove_all_items();
             ids
         };
-        self.player.remove_all_items();
+        *self
+            .player_rx
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner) = self.player.subscribe();
         for id in ids {
             self.bus.publish(QueueEvent::TrackRemoved { id });
         }
@@ -252,7 +271,8 @@ impl Queue {
 
 #[cfg(test)]
 mod tests {
-    use kithara_events::QueueEvent;
+    use kithara_events::{PlayerEvent, QueueEvent};
+    use kithara_platform::sync::Arc;
     use kithara_test_utils::kithara;
 
     use super::*;
@@ -320,6 +340,32 @@ mod tests {
         assert_eq!(queue.len(), 2);
         queue.clear();
         assert_eq!(queue.len(), 0);
+    }
+
+    #[kithara::test(tokio)]
+    async fn clear_discards_old_eof_before_reinsert() {
+        let queue = make_queue();
+        let old = queue.register_for_test();
+        queue.lock_navigation_mut().select(0);
+        queue.player.bus().publish(PlayerEvent::ItemDidPlayToEnd {
+            src: Arc::from(format!("test://memory/{}", old.as_u64())),
+            item_id: None,
+        });
+
+        queue.clear();
+        let replacement = queue.register_for_test();
+        queue.lock_navigation_mut().select(0);
+        queue.player.set_rate(1.0);
+
+        queue
+            .tick()
+            .expect("tick must accept a freshly reinserted queue");
+
+        assert_eq!(
+            queue.current().map(|entry| entry.id),
+            Some(replacement),
+            "an EOF queued before clear must not end the replacement queue"
+        );
     }
 
     #[kithara::test(tokio)]


### PR DESCRIPTION
## Summary
This draft preserves the broad LABA-427 stop-lifecycle experiment for independent review. It explores making public Swift `stop()` a full teardown boundary that clears the old queue and identity state, releases the native output slot, stops the engine, and lets a later radio item start from fresh state. This is intentionally wider than the product MR and is not proposed as the final narrow fix.

## Behavior / scope
- contract or behavior: `KitharaPlayer.stop()` clears Swift identity and Rust queue state; the native player serializes queue/registry mutations; the play owner tears down the active slot and engine; queue clear discards stale player events before reuse.
- affected area: `apple/Sources/Kithara/KitharaPlayer.swift`; native FFI owner/facade/tests; `kithara-play` core, transport, phase, and session graph contract test; `kithara-queue` clear lifecycle; Swift identity and track-to-radio parity tests.
- experiment boundary: 11 paths total in the PR range (the 10 preserved dirty paths plus the existing LABA-427 session-graph regression commit).

## Validation
- `git diff --check`
- `cargo fmt -p kithara-ffi -p kithara-play -p kithara-queue -- --check`
- `xcrun swiftc -parse apple/Sources/Kithara/KitharaPlayer.swift apple/Examples/KitharaDemo/UnitTests/TrackToRadioPlaybackParity.swift apple/Tests/KitharaTests/KitharaPlayerIdentityStateTests.swift`
- `cargo clippy -p kithara-ffi -p kithara-play -p kithara-queue --all-targets -- -D warnings`
- pre-commit `lint-fast`
- not completed: five filtered Rust tests; the harness began compiling the full integration target graph, so it was stopped before test execution
- not run: Apple framework build or Swift/iOS runtime tests

## Surface impact
- Public API: no signature changes; observable public `stop()` behavior changes from pause/seek to queue and output teardown
- Platform/runtime: changed: Apple wrapper and native player/queue lifecycle
- Perf-sensitive paths: changed: queue/registry and engine phase transitions gain serialization locks

## Risks / follow-ups
- WIP experiment only; lock ordering, output teardown ownership, and stale-event handling need architecture review before any subset is promoted.
- The broad Swift identity/publication redesign and concurrency serialization should stay separate from the narrow LABA-427 product fix unless proven necessary.
- Apple track-to-radio parity and output-release behavior remain unexecuted locally.