### PR TITLE
feat(play): expose session transport coordinates

### DIFF
--- a/crates/kithara-audio/CONTEXT.md
+++ b/crates/kithara-audio/CONTEXT.md
@@ -14,6 +14,13 @@ calls inside the node's step, never separate nodes with rings between them.
 handle captured in `Audio::new`. **Downloader** — owned by `kithara-stream`; this
 crate never spawns it and never reconstructs HLS/file protocol policy.
 
+### Session coordinates
+
+`SessionAnchor` is the canonical relation between a continuous `SessionBeat`
+and an absolute `SessionFrame`. It carries the committed beat-rate slope and
+sample rate, and owns both `beat_at` and its inverse `frame_at`; consumers do
+not rebuild that arithmetic from a tempo scalar.
+
 Transport (`runtime/ports.rs`): SPSC `ringbuf::HeapRb` plus a one-slot overflow
 (`Outlet`/`Inlet`).
 

--- a/crates/kithara-audio/src/lib.rs
+++ b/crates/kithara-audio/src/lib.rs
@@ -36,7 +36,10 @@ pub use exports::*;
 pub use kithara_resampler::{
     NoResamplerBackend, ResamplerBackend, ResamplerOptions, ResamplerQuality,
 };
-pub use musical::{BeatMapError, CoordinateError, SourceFrame, TrackBeat, TrackBeatMap};
+pub use musical::{
+    BeatMapError, CoordinateError, SessionAnchor, SessionBeat, SessionFrame, SourceFrame,
+    TrackBeat, TrackBeatMap,
+};
 pub use pipeline::{
     config::{AudioConfig, AudioDecoderConfig, ConsumerWakeMode, DecoderResamplerSettings},
     fetch::{EpochValidator, Fetch},

--- a/crates/kithara-audio/src/musical/anchor.rs
+++ b/crates/kithara-audio/src/musical/anchor.rs
@@ -1,0 +1,190 @@
+use std::num::NonZeroU32;
+
+use num_traits::cast::ToPrimitive;
+
+use super::CoordinateError;
+
+/// A continuous beat coordinate on the session transport.
+#[derive(Clone, Copy, Debug, Default, PartialEq, PartialOrd, derive_more::Into)]
+pub struct SessionBeat(f64);
+
+impl SessionBeat {
+    /// Creates a finite session-beat coordinate. Negative beats are valid.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoordinateError`] when `value` is not finite.
+    pub const fn new(value: f64) -> Result<Self, CoordinateError> {
+        if value.is_finite() {
+            Ok(Self(value))
+        } else {
+            Err(CoordinateError::NonFinite)
+        }
+    }
+}
+
+impl TryFrom<f64> for SessionBeat {
+    type Error = CoordinateError;
+
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+/// A frame on the session clock, counted from the master ring's origin.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, derive_more::Into)]
+#[repr(transparent)]
+pub struct SessionFrame(i64);
+
+impl SessionFrame {
+    #[must_use]
+    pub const fn new(value: i64) -> Self {
+        Self(value)
+    }
+}
+
+/// The canonical session-beat <-> session-frame relation, valid from one
+/// committed render frame. The transport replaces it on every tempo commit.
+#[derive(Clone, Copy, Debug, PartialEq, fieldwork::Fieldwork)]
+#[fieldwork(get)]
+#[non_exhaustive]
+pub struct SessionAnchor {
+    /// Returns the frame this anchor was established on.
+    #[field(get, copy)]
+    frame: SessionFrame,
+    /// Returns the session beat playing at [`Self::frame`].
+    #[field(get, copy)]
+    beat: SessionBeat,
+    /// Returns the committed tempo in beats per second.
+    #[field(get, copy)]
+    beats_per_second: f64,
+    /// Returns the session sample rate this anchor counts frames in.
+    #[field(get, copy)]
+    sample_rate: NonZeroU32,
+}
+
+impl SessionAnchor {
+    /// Pins `beat` to `frame` at `beats_per_second`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoordinateError::NonInvertibleRate`] unless the tempo advances
+    /// by a finite, positive amount per output frame.
+    pub fn new(
+        frame: SessionFrame,
+        beat: SessionBeat,
+        beats_per_second: f64,
+        sample_rate: NonZeroU32,
+    ) -> Result<Self, CoordinateError> {
+        let beats_per_frame = beats_per_second / f64::from(sample_rate.get());
+        if !beats_per_second.is_finite()
+            || beats_per_second <= 0.0
+            || !beats_per_frame.is_finite()
+            || beats_per_frame <= 0.0
+        {
+            return Err(CoordinateError::NonInvertibleRate);
+        }
+        Ok(Self {
+            frame,
+            beat,
+            beats_per_second,
+            sample_rate,
+        })
+    }
+
+    /// The session beat playing at `frame`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoordinateError`] when the frame is so far from the anchor
+    /// that the beat is not representable.
+    pub fn beat_at(self, frame: SessionFrame) -> Result<SessionBeat, CoordinateError> {
+        let frames = i64::from(frame)
+            .checked_sub(i64::from(self.frame))
+            .and_then(|value| value.to_f64())
+            .ok_or(CoordinateError::NonFinite)?;
+        SessionBeat::new(f64::from(self.beat) + frames * self.beats_per_frame())
+    }
+
+    /// Inverse of [`Self::beat_at`], rounded to the nearest frame.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoordinateError`] when the frame is not representable.
+    pub fn frame_at(self, beat: SessionBeat) -> Result<SessionFrame, CoordinateError> {
+        let beats = f64::from(beat) - f64::from(self.beat);
+        let frames = (beats / self.beats_per_frame())
+            .round()
+            .to_i64()
+            .ok_or(CoordinateError::NonFinite)?;
+        i64::from(self.frame)
+            .checked_add(frames)
+            .map(SessionFrame::new)
+            .ok_or(CoordinateError::NonFinite)
+    }
+
+    /// Session beats one output frame advances at this tempo.
+    #[must_use]
+    pub fn beats_per_frame(self) -> f64 {
+        self.beats_per_second / f64::from(self.sample_rate.get())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU32;
+
+    use kithara_test_utils::kithara;
+
+    use super::{CoordinateError, SessionAnchor, SessionBeat, SessionFrame};
+
+    struct Consts;
+
+    impl Consts {
+        const BEATS_PER_SECOND: f64 = 2.0;
+        const FRAMES_PER_BEAT: i64 = 24_000;
+        const RATE: u32 = 48_000;
+    }
+
+    fn rate() -> NonZeroU32 {
+        NonZeroU32::new(Consts::RATE).expect("invariant: the fixture rate is non-zero")
+    }
+
+    fn beat(value: f64) -> SessionBeat {
+        SessionBeat::new(value).expect("invariant: the fixture beat is finite")
+    }
+
+    fn anchor_at(frame: i64, at_beat: f64) -> SessionAnchor {
+        SessionAnchor::new(
+            SessionFrame::new(frame),
+            beat(at_beat),
+            Consts::BEATS_PER_SECOND,
+            rate(),
+        )
+        .expect("invariant: the fixture tempo is a positive rate")
+    }
+
+    #[kithara::test]
+    fn frame_at_inverts_beat_at_exactly() {
+        let anchor = anchor_at(1_024, 2.5);
+        let frame = SessionFrame::new(1_024 + Consts::FRAMES_PER_BEAT * 3);
+
+        let round_tripped = anchor
+            .beat_at(frame)
+            .and_then(|beat| anchor.frame_at(beat))
+            .expect("invariant: the round trip stays representable");
+
+        assert_eq!(round_tripped, frame);
+    }
+
+    #[kithara::test]
+    fn a_tempo_that_is_not_a_positive_rate_is_refused() {
+        for refused in [0.0, -2.0, f64::from_bits(1), f64::NAN, f64::INFINITY] {
+            assert_eq!(
+                SessionAnchor::new(SessionFrame::new(0), beat(0.0), refused, rate()),
+                Err(CoordinateError::NonInvertibleRate),
+                "tempo {refused} is not an invertible slope",
+            );
+        }
+    }
+}

--- a/crates/kithara-audio/src/musical/map.rs
+++ b/crates/kithara-audio/src/musical/map.rs
@@ -4,13 +4,16 @@ use num_traits::cast::ToPrimitive;
 
 use crate::{analysis::TrackAnalysis, waveform::BeatGrid};
 
-/// An invalid musical or source-frame coordinate.
+/// An invalid musical coordinate, source-frame coordinate, or coordinate rate.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
 #[non_exhaustive]
 pub enum CoordinateError {
     /// The supplied coordinate is `NaN` or infinite.
     #[error("coordinate must be finite")]
     NonFinite,
+    /// A coordinate rate cannot define an invertible frame relation.
+    #[error("coordinate rate must advance by a finite, positive amount per frame")]
+    NonInvertibleRate,
     /// A source-frame coordinate was below the start of the source.
     #[error("source-frame coordinate must not be negative")]
     NegativeSourceFrame,

--- a/crates/kithara-audio/src/musical/mod.rs
+++ b/crates/kithara-audio/src/musical/mod.rs
@@ -1,3 +1,5 @@
+mod anchor;
 mod map;
 
+pub use anchor::{SessionAnchor, SessionBeat, SessionFrame};
 pub use map::{BeatMapError, CoordinateError, SourceFrame, TrackBeat, TrackBeatMap};

--- a/crates/kithara-play/CONTEXT.md
+++ b/crates/kithara-play/CONTEXT.md
@@ -260,6 +260,15 @@ capability through an internal, builder-skipped `ResourceConfig` field into
 `AudioConfig`. There is no public resource setter and therefore no second
 source of session wake policy.
 
+### Session transport anchor
+
+`TransportCommitState` is the only owner of when the session beat-to-frame
+relation changes. Every applied transport commit creates one `SessionAnchor`
+at that exact render boundary and stores it in `SessionTransportSnapshot`. A
+stream restart removes the snapshot because the session frame axis restarted;
+the first block on the new axis reanchors the preserved beat before publishing
+another snapshot.
+
 ## Session Mixing
 
 Session-input gain has two distinct owners. Each `EngineImpl` owns its *desired* input level

--- a/crates/kithara-play/src/api/mod.rs
+++ b/crates/kithara-play/src/api/mod.rs
@@ -6,10 +6,9 @@ pub mod types;
 
 pub use binding::{SyncUnavailable, TrackBinding};
 pub use equalizer::Equalizer;
+pub use kithara_audio::SessionBeat;
 pub use mix::{CrossfaderBus, crossfader_gain};
-pub use transport::{
-    SessionBeat, SessionBeatError, SessionTransportSnapshot, Tempo, TempoError, TransportRevision,
-};
+pub use transport::{SessionTransportSnapshot, Tempo, TempoError, TransportRevision};
 pub use types::{
     DjEvent, EngineEvent, InterruptionKind, ItemEvent, ItemStatus, PlaybackDirection, PlayerEvent,
     PlayerStatus, RouteChangeReason, SessionDuckingMode, SessionEvent, SlotId, TimeControlStatus,

--- a/crates/kithara-play/src/api/transport.rs
+++ b/crates/kithara-play/src/api/transport.rs
@@ -1,5 +1,7 @@
 use std::num::NonZeroU64;
 
+use kithara_audio::{SessionAnchor, SessionBeat};
+
 const SECONDS_PER_MINUTE: f64 = 60.0;
 
 /// A musical tempo in beats per minute, inside the range the session clock can
@@ -56,37 +58,6 @@ pub struct TempoError {
     beats_per_minute: f64,
 }
 
-/// A continuous beat coordinate on the session transport.
-#[derive(Clone, Copy, Debug, Default, PartialEq, PartialOrd, derive_more::Into)]
-pub struct SessionBeat(f64);
-
-impl SessionBeat {
-    /// Creates a finite session-beat coordinate. Negative beats are valid.
-    pub const fn new(value: f64) -> Result<Self, SessionBeatError> {
-        if value.is_finite() {
-            Ok(Self(value))
-        } else {
-            Err(SessionBeatError { value })
-        }
-    }
-}
-
-impl TryFrom<f64> for SessionBeat {
-    type Error = SessionBeatError;
-
-    fn try_from(value: f64) -> Result<Self, Self::Error> {
-        Self::new(value)
-    }
-}
-
-/// The value supplied for a session-beat coordinate was invalid.
-#[derive(Clone, Copy, Debug, PartialEq, thiserror::Error)]
-#[error("session beat must be finite, got {value}")]
-#[non_exhaustive]
-pub struct SessionBeatError {
-    value: f64,
-}
-
 /// Monotonic generation of a committed session transport configuration.
 #[derive(
     Clone,
@@ -122,6 +93,9 @@ impl TransportRevision {
 #[fieldwork(get)]
 #[non_exhaustive]
 pub struct SessionTransportSnapshot {
+    /// Returns the session-clock relation used by this observation.
+    #[field(get, copy)]
+    anchor: SessionAnchor,
     /// Returns the processed position on the session beat grid.
     #[field(get, copy)]
     position: SessionBeat,
@@ -142,8 +116,10 @@ impl SessionTransportSnapshot {
         playing: bool,
         tempo: Tempo,
         revision: TransportRevision,
+        anchor: SessionAnchor,
     ) -> Self {
         Self {
+            anchor,
             position,
             tempo,
             revision,
@@ -154,9 +130,39 @@ impl SessionTransportSnapshot {
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroU32;
+
+    use kithara_audio::{SessionAnchor, SessionBeat, SessionFrame};
     use kithara_test_utils::kithara;
 
-    use super::SessionBeat;
+    use super::{SessionTransportSnapshot, Tempo, TransportRevision};
+
+    #[kithara::test]
+    fn snapshot_carries_the_anchor_that_places_a_target_on_the_session_clock() {
+        let anchor = SessionAnchor::new(
+            SessionFrame::new(192_000),
+            SessionBeat::new(8.0).expect("invariant: fixture beat is finite"),
+            2.0,
+            NonZeroU32::new(48_000).expect("invariant: fixture rate is non-zero"),
+        )
+        .expect("invariant: fixture anchor is valid");
+        let snapshot = SessionTransportSnapshot::new(
+            SessionBeat::new(8.0).expect("invariant: fixture position is finite"),
+            true,
+            Tempo::new(120.0).expect("invariant: fixture tempo is in range"),
+            TransportRevision::FIRST,
+            anchor,
+        );
+        let target = SessionBeat::new(11.0).expect("invariant: fixture target is finite");
+
+        assert_eq!(
+            snapshot
+                .anchor()
+                .frame_at(target)
+                .expect("invariant: fixture target is representable"),
+            SessionFrame::new(264_000)
+        );
+    }
 
     #[kithara::test]
     fn accepts_negative_and_zero_coordinates() {

--- a/crates/kithara-play/src/lib.rs
+++ b/crates/kithara-play/src/lib.rs
@@ -22,7 +22,7 @@ pub mod mock;
 
 pub use api::{
     CrossfaderBus, DjEvent, EngineEvent, Equalizer, InterruptionKind, ItemEvent, ItemStatus,
-    PlaybackDirection, PlayerEvent, PlayerStatus, RouteChangeReason, SessionBeat, SessionBeatError,
+    PlaybackDirection, PlayerEvent, PlayerStatus, RouteChangeReason, SessionBeat,
     SessionDuckingMode, SessionEvent, SessionTransportSnapshot, SlotId, SyncUnavailable, Tempo,
     TempoError, TimeControlStatus, TimeRange, TrackBinding, TransportEvent, TransportRevision,
     WaitingReason, crossfader_gain,
@@ -37,7 +37,8 @@ pub use engine::{EngineConfig, EngineImpl, apply_mix};
 pub use error::PlayError;
 pub use kithara_assets::{AssetLayout, DefaultLayout};
 pub use kithara_audio::{
-    AudioWorkerHandle, EngineLoadSnapshot, EqBandConfig, SeekOutcome, ServiceClass, StretchControls,
+    AudioWorkerHandle, CoordinateError, EngineLoadSnapshot, EqBandConfig, SeekOutcome,
+    ServiceClass, StretchControls,
 };
 pub use kithara_net::Headers;
 pub use player::{PlayerConfig, PlayerImpl, SelectTransition};

--- a/crates/kithara-play/src/session/transport/commit.rs
+++ b/crates/kithara-play/src/session/transport/commit.rs
@@ -1,5 +1,7 @@
 use std::num::NonZeroU32;
 
+use kithara_audio::SessionFrame;
+
 use crate::api::{SessionBeat, SessionTransportSnapshot, Tempo, TransportRevision};
 
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
@@ -47,15 +49,6 @@ impl SessionTransportCommit {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd, derive_more::Into)]
-pub(crate) struct RenderFrame(i64);
-
-impl RenderFrame {
-    pub(crate) const fn new(value: i64) -> Self {
-        Self(value)
-    }
-}
-
 #[derive(Clone, Copy, Debug, PartialEq, fieldwork::Fieldwork)]
 #[fieldwork(get, vis = "pub(crate)")]
 pub(crate) struct TransportCommitStamp {
@@ -64,7 +57,7 @@ pub(crate) struct TransportCommitStamp {
     #[field(get, copy)]
     previous: Option<SessionTransportCommit>,
     #[field(get, copy)]
-    target_frame: RenderFrame,
+    target_frame: SessionFrame,
     #[field(get, copy)]
     next: SessionTransportCommit,
 }
@@ -73,7 +66,7 @@ impl TransportCommitStamp {
     pub(crate) const fn new(
         previous: Option<SessionTransportCommit>,
         next: SessionTransportCommit,
-        target_frame: RenderFrame,
+        target_frame: SessionFrame,
         sample_rate: NonZeroU32,
     ) -> Self {
         Self {

--- a/crates/kithara-play/src/session/transport/control.rs
+++ b/crates/kithara-play/src/session/transport/control.rs
@@ -1,11 +1,12 @@
 use std::num::NonZeroU32;
 
 use firewheel::{FirewheelCtx, backend::AudioBackend, error::UpdateError};
+use kithara_audio::SessionFrame;
 use kithara_events::TransportEvent;
 
 use super::commit::{
-    RenderFrame, SessionTransportCommit, TransportBoundary, TransportCommitResult,
-    TransportCommitStamp, TransportObservation,
+    SessionTransportCommit, TransportBoundary, TransportCommitResult, TransportCommitStamp,
+    TransportObservation,
 };
 use crate::{
     api::{SessionBeat, SessionTransportSnapshot, Tempo, TransportRevision},
@@ -200,7 +201,7 @@ fn schedule_commit<B: AudioBackend>(
 
 fn commit_boundary<B: AudioBackend>(
     state: &SessionState<B>,
-) -> Result<(RenderFrame, NonZeroU32), SessionError> {
+) -> Result<(SessionFrame, NonZeroU32), SessionError> {
     let ctx = state.ctx.as_ref().ok_or(SessionError::NoContext)?;
     let stream_info = ctx.stream_info().ok_or(SessionError::NoContext)?;
     let lead_frames = state
@@ -213,7 +214,7 @@ fn commit_boundary<B: AudioBackend>(
         .0
         .checked_add(lead_frames)
         .ok_or(SessionError::TransportFrameExhausted)?;
-    Ok((RenderFrame::new(target_frame), stream_info.sample_rate))
+    Ok((SessionFrame::new(target_frame), stream_info.sample_rate))
 }
 
 fn queue_stamp<B: AudioBackend>(

--- a/crates/kithara-play/src/session/transport/process.rs
+++ b/crates/kithara-play/src/session/transport/process.rs
@@ -4,44 +4,24 @@ use firewheel::{
     event::ProcEvents,
     node::{ProcInfo, ProcStore},
 };
-use num_traits::ToPrimitive;
+use kithara_audio::{SessionAnchor, SessionBeat, SessionFrame};
 use triple_buffer::Input;
 
 use super::commit::{
-    RenderFrame, SessionTransportCommit, TransportBoundary, TransportCommitEvent,
-    TransportCommitResult, TransportCommitStamp, TransportObservation, TransportProcessError,
+    SessionTransportCommit, TransportBoundary, TransportCommitEvent, TransportCommitResult,
+    TransportCommitStamp, TransportObservation, TransportProcessError,
 };
-use crate::api::{SessionBeat, SessionTransportSnapshot, TransportRevision};
-
-#[derive(Clone, Copy, Debug)]
-struct TransportAnchor {
-    sample_rate: NonZeroU32,
-    frame: RenderFrame,
-    beat: SessionBeat,
-    commit: SessionTransportCommit,
-}
-
-impl TransportAnchor {
-    fn beat_at(self, frame: RenderFrame) -> Result<SessionBeat, TransportProcessError> {
-        let frames = i64::from(frame)
-            .checked_sub(i64::from(self.frame))
-            .and_then(|value| value.to_f64())
-            .ok_or(TransportProcessError::InvalidBeatRange)?;
-        let beats = f64::from(self.beat)
-            + frames * self.commit.tempo().beats_per_second() / f64::from(self.sample_rate.get());
-        SessionBeat::new(beats).map_err(|_| TransportProcessError::InvalidBeatRange)
-    }
-}
+use crate::api::{SessionTransportSnapshot, Tempo, TransportRevision};
 
 #[derive(Clone, Copy, Debug)]
 struct RenderBoundary {
-    frame: RenderFrame,
+    frame: SessionFrame,
 }
 
 #[derive(Debug, Default)]
 pub(crate) struct TransportCommitState {
     active: Option<SessionTransportCommit>,
-    anchor: Option<TransportAnchor>,
+    anchor: Option<SessionAnchor>,
     boundary: Option<RenderBoundary>,
     completion: Option<TransportCommitResult>,
     ignored_through_revision: Option<TransportRevision>,
@@ -165,9 +145,11 @@ impl TransportCommitState {
             (TransportBoundary::Continuous, Some(previous)) => {
                 let anchor = self.anchor.ok_or(TransportProcessError::InvalidBeatRange)?;
                 if previous.is_playing() {
-                    anchor.beat_at(stamp.target_frame())?
+                    anchor
+                        .beat_at(stamp.target_frame())
+                        .map_err(|_| TransportProcessError::InvalidBeatRange)?
                 } else {
-                    anchor.beat
+                    anchor.beat()
                 }
             }
             (TransportBoundary::Continuous, None) => {
@@ -175,12 +157,12 @@ impl TransportCommitState {
             }
         };
         self.active = Some(stamp.next());
-        self.anchor = Some(TransportAnchor {
+        self.set_anchor(
+            stamp.target_frame(),
             beat,
-            commit: stamp.next(),
-            frame: stamp.target_frame(),
-            sample_rate: stamp.sample_rate(),
-        });
+            stamp.next().tempo(),
+            stamp.sample_rate(),
+        )?;
         self.pending = None;
         self.completion = Some(TransportCommitResult::Applied(revision));
         Ok(())
@@ -259,7 +241,7 @@ impl TransportCommitState {
             .checked_add(frames)
             .ok_or(TransportProcessError::InvalidBeatRange)?;
         Ok(Some(RenderBoundary {
-            frame: RenderFrame::new(frame),
+            frame: SessionFrame::new(frame),
         }))
     }
 
@@ -270,20 +252,20 @@ impl TransportCommitState {
         let Some(commit) = self.active else {
             return Ok(self.snapshot);
         };
+        let anchor = self.anchor.ok_or(TransportProcessError::InvalidBeatRange)?;
         let position = if commit.is_playing() {
             session_beats
                 .ok_or(TransportProcessError::InvalidBeatRange)?
                 .end
         } else {
-            self.anchor
-                .ok_or(TransportProcessError::InvalidBeatRange)?
-                .beat
+            anchor.beat()
         };
         Ok(Some(SessionTransportSnapshot::new(
             position,
             commit.is_playing(),
             commit.tempo(),
             commit.revision(),
+            anchor,
         )))
     }
 
@@ -306,12 +288,12 @@ impl TransportCommitState {
             return Ok(());
         };
         let commit = self.active.ok_or(TransportProcessError::InvalidBeatRange)?;
-        self.anchor = Some(TransportAnchor {
+        self.set_anchor(
+            SessionFrame::new(info.clock_samples.0),
             beat,
-            commit,
-            frame: RenderFrame::new(info.clock_samples.0),
-            sample_rate: info.sample_rate,
-        });
+            commit.tempo(),
+            info.sample_rate,
+        )?;
         self.boundary = None;
         Ok(())
     }
@@ -338,7 +320,9 @@ impl TransportCommitState {
 
     fn restart(&mut self) {
         self.reject_pending();
-        self.reanchor_beat = self.snapshot.map(|snapshot| snapshot.position());
+        if let Some(snapshot) = self.snapshot.take() {
+            self.reanchor_beat = Some(snapshot.position());
+        }
         self.anchor = None;
         self.boundary = None;
     }
@@ -356,14 +340,39 @@ impl TransportCommitState {
         let anchor = self.anchor.ok_or(TransportProcessError::InvalidBeatRange)?;
         let frames =
             i64::try_from(info.frames).map_err(|_| TransportProcessError::InvalidBeatRange)?;
-        let start = RenderFrame::new(info.clock_samples.0);
-        let end = RenderFrame::new(
+        let start = SessionFrame::new(info.clock_samples.0);
+        let end = SessionFrame::new(
             info.clock_samples
                 .0
                 .checked_add(frames)
                 .ok_or(TransportProcessError::InvalidBeatRange)?,
         );
-        Ok(Some(anchor.beat_at(start)?..anchor.beat_at(end)?))
+        let at = |frame| {
+            anchor
+                .beat_at(frame)
+                .map_err(|_| TransportProcessError::InvalidBeatRange)
+        };
+        Ok(Some(at(start)?..at(end)?))
+    }
+
+    fn set_anchor(
+        &mut self,
+        frame: SessionFrame,
+        beat: SessionBeat,
+        tempo: Tempo,
+        sample_rate: NonZeroU32,
+    ) -> Result<(), TransportProcessError> {
+        let anchor = SessionAnchor::new(frame, beat, tempo.beats_per_second(), sample_rate)
+            .map_err(|_| TransportProcessError::InvalidBeatRange)?;
+        if anchor
+            .frame_at(beat)
+            .map_err(|_| TransportProcessError::InvalidBeatRange)?
+            != frame
+        {
+            return Err(TransportProcessError::InvalidBeatRange);
+        }
+        self.anchor = Some(anchor);
+        Ok(())
     }
 
     fn set_once<T>(slot: &mut Option<T>, value: T) -> Result<(), TransportProcessError> {
@@ -375,7 +384,7 @@ impl TransportCommitState {
 
     fn validate_frame(&self, info: &ProcInfo) -> Result<(), TransportProcessError> {
         if let Some(anchor) = self.anchor
-            && anchor.sample_rate != info.sample_rate
+            && anchor.sample_rate() != info.sample_rate
         {
             return Err(TransportProcessError::FrameDiscontinuity);
         }

--- a/crates/kithara-play/src/session/transport/tests.rs
+++ b/crates/kithara-play/src/session/transport/tests.rs
@@ -11,14 +11,15 @@ use firewheel::{
         ProcStore, ProcStreamCtx, ProcessStatus, StreamStatus,
     },
 };
+use kithara_audio::SessionFrame;
 use kithara_platform::time::Duration;
 use kithara_test_utils::kithara;
 use triple_buffer::{Output, triple_buffer};
 
 use super::{
     commit::{
-        RenderFrame, SessionTransportCommit, TransportCommitEvent, TransportCommitResult,
-        TransportCommitStamp, TransportObservation, TransportProcessError,
+        SessionTransportCommit, TransportCommitEvent, TransportCommitResult, TransportCommitStamp,
+        TransportObservation, TransportProcessError,
     },
     node::SessionTransportProcessor,
     process::{TransportCommitState, TransportObservationInput, process_transport},
@@ -175,7 +176,7 @@ fn active_harness() -> (
     let (mut extra, mut output) = proc_extra();
     let mut processor = SessionTransportProcessor;
     let active = commit(120.0, true, TransportRevision::FIRST);
-    let stamp = TransportCommitStamp::new(None, active, RenderFrame::new(0), sample_rate());
+    let stamp = TransportCommitStamp::new(None, active, SessionFrame::new(0), sample_rate());
     process_node(
         &mut processor,
         &proc_info_at(0),
@@ -197,7 +198,7 @@ fn tempo_commit_waits_for_the_matching_render_boundary() {
     let stamp = TransportCommitStamp::new(
         Some(active),
         next,
-        RenderFrame::new(block_frame(2)),
+        SessionFrame::new(block_frame(2)),
         sample_rate(),
     );
 
@@ -231,6 +232,14 @@ fn tempo_commit_waits_for_the_matching_render_boundary() {
     assert_eq!(applied.revision(), second_revision());
     assert_eq!(applied.tempo(), next.tempo());
     assert!((f64::from(applied.position()) - 0.05).abs() <= f64::EPSILON);
+    let transition = SessionBeat::new(0.04).expect("invariant: transition beat is finite");
+    assert_eq!(
+        applied
+            .anchor()
+            .frame_at(transition)
+            .expect("invariant: transition beat is representable on its observed anchor"),
+        SessionFrame::new(block_frame(2))
+    );
 }
 
 #[kithara::test]
@@ -241,7 +250,7 @@ fn relocation_commit_reanchors_the_exact_target_beat() {
     let stamp = TransportCommitStamp::new(
         Some(active),
         next,
-        RenderFrame::new(block_frame(2)),
+        SessionFrame::new(block_frame(2)),
         sample_rate(),
     );
     process_node(
@@ -262,6 +271,13 @@ fn relocation_commit_reanchors_the_exact_target_beat() {
     let relocated = snapshot(&mut output);
     assert_eq!(relocated.revision(), second_revision());
     assert!((f64::from(relocated.position()) - 3.27).abs() <= f64::EPSILON);
+    assert_eq!(
+        relocated
+            .anchor()
+            .frame_at(target)
+            .expect("invariant: relocation target is representable on its observed anchor"),
+        SessionFrame::new(block_frame(2))
+    );
 }
 
 #[kithara::test]
@@ -271,7 +287,7 @@ fn inactive_transport_publishes_a_frozen_position() {
     let stamp = TransportCommitStamp::new(
         Some(active),
         paused,
-        RenderFrame::new(block_frame(2)),
+        SessionFrame::new(block_frame(2)),
         sample_rate(),
     );
     process_node(
@@ -307,7 +323,7 @@ fn late_transport_commit_is_rejected_without_changing_the_active_commit() {
     let stamp = TransportCommitStamp::new(
         Some(active),
         next,
-        RenderFrame::new(block_frame(2)),
+        SessionFrame::new(block_frame(2)),
         sample_rate(),
     );
     process_node(
@@ -352,7 +368,7 @@ fn stale_transport_commit_is_rejected_without_breaking_the_clock() {
     let stamp = TransportCommitStamp::new(
         Some(stale),
         next,
-        RenderFrame::new(block_frame(2)),
+        SessionFrame::new(block_frame(2)),
         sample_rate(),
     );
     process_node(
@@ -387,7 +403,7 @@ fn transport_abort_is_idempotent() {
     let stamp = TransportCommitStamp::new(
         Some(active),
         next,
-        RenderFrame::new(block_frame(2)),
+        SessionFrame::new(block_frame(2)),
         sample_rate(),
     );
     process_node(
@@ -426,7 +442,7 @@ fn route_reset_rejects_pending_commit_and_reanchors_the_active_beat() {
     let stamp = TransportCommitStamp::new(
         Some(active),
         next,
-        RenderFrame::new(block_frame(2)),
+        SessionFrame::new(block_frame(2)),
         sample_rate(),
     );
     process_node(
@@ -452,10 +468,73 @@ fn route_reset_rejects_pending_commit_and_reanchors_the_active_beat() {
 }
 
 #[kithara::test]
+fn route_reset_withdraws_snapshot_until_new_axis_is_reanchored() {
+    let (mut processor, mut extra, mut output, _active) = active_harness();
+    process_node(
+        &mut processor,
+        &proc_info_at(block_frame(1)),
+        &mut extra,
+        None,
+        None,
+    );
+    let before_restart = snapshot(&mut output);
+    let preserved = before_restart.position();
+    assert!((f64::from(preserved) - 0.04).abs() <= f64::EPSILON);
+
+    processor.stream_stopped(&mut ProcStreamCtx {
+        store: &mut extra.store,
+        logger: &mut extra.logger,
+    });
+    assert_eq!(observation(&mut output).snapshot(), None);
+
+    process_node(&mut processor, &proc_info_at(0), &mut extra, None, None);
+    let restarted = snapshot(&mut output);
+    assert_eq!(
+        restarted
+            .anchor()
+            .frame_at(preserved)
+            .expect("invariant: preserved beat is representable on the new axis"),
+        SessionFrame::new(0)
+    );
+    assert!((f64::from(restarted.position()) - 0.06).abs() <= f64::EPSILON);
+}
+
+#[kithara::test]
+fn repeated_route_reset_preserves_the_beat_until_the_new_axis_renders() {
+    let (mut processor, mut extra, mut output, _active) = active_harness();
+    process_node(
+        &mut processor,
+        &proc_info_at(block_frame(1)),
+        &mut extra,
+        None,
+        None,
+    );
+    let preserved = snapshot(&mut output).position();
+
+    for _ in 0..2 {
+        processor.stream_stopped(&mut ProcStreamCtx {
+            store: &mut extra.store,
+            logger: &mut extra.logger,
+        });
+        assert_eq!(observation(&mut output).snapshot(), None);
+    }
+
+    process_node(&mut processor, &proc_info_at(0), &mut extra, None, None);
+    let restarted = snapshot(&mut output);
+    assert_eq!(
+        restarted
+            .anchor()
+            .frame_at(preserved)
+            .expect("invariant: preserved beat is representable on the new axis"),
+        SessionFrame::new(0)
+    );
+}
+
+#[kithara::test]
 fn duplicate_stage_in_one_block_is_rejected() {
     let (mut extra, _output) = proc_extra();
     let active = commit(120.0, true, TransportRevision::FIRST);
-    let stamp = TransportCommitStamp::new(None, active, RenderFrame::new(0), sample_rate());
+    let stamp = TransportCommitStamp::new(None, active, SessionFrame::new(0), sample_rate());
     assert_eq!(
         process_result(
             &proc_info_at(0),
@@ -498,7 +577,7 @@ fn stage_for_another_sample_rate_is_rejected() {
     let stamp = TransportCommitStamp::new(
         Some(active),
         commit(60.0, true, second_revision()),
-        RenderFrame::new(block_frame(2)),
+        SessionFrame::new(block_frame(2)),
         foreign_rate,
     );
 
@@ -526,7 +605,7 @@ fn apply_for_another_sample_rate_is_rejected() {
     let stamp = TransportCommitStamp::new(
         Some(active),
         next,
-        RenderFrame::new(block_frame(2)),
+        SessionFrame::new(block_frame(2)),
         sample_rate(),
     );
     process_node(
@@ -562,7 +641,7 @@ fn a_failing_block_rejects_the_pending_stamp_and_still_publishes() {
     let stamp = TransportCommitStamp::new(
         Some(active),
         commit(60.0, true, second_revision()),
-        RenderFrame::new(block_frame(2)),
+        SessionFrame::new(block_frame(2)),
         sample_rate(),
     );
     process_node(


### PR DESCRIPTION
## Summary

This foundation PR gives the session transport one canonical beat-to-frame coordinate. Each processed transport snapshot now carries the exact anchor established at its render commit, and a stream restart withdraws that snapshot until the preserved beat is reanchored to the new frame axis. This is the coordinate contract required by the resident tempo renderer; it does not claim audible deck synchronization yet.

Prerequisite #177 is **merged** (`51bdc8937`). This branch is no longer stacked: it is exactly **one commit** on top of current `main`.

## Base

- Rebased onto `main` at `9008650caf13f3ca0ebd3207a97df0ef3e788f52`.
- Head `1c72ed1a089643000a8bf0240c29c004f16fc2da`; `git rev-list --count main..HEAD` is `1`.
- `git range-diff` against the pre-rebase head reports `1: 680ef0fc8 = 1: 1c72ed1a0` — the patch is byte-identical, so the rebase carried no conflict adaptations and the reviewed contract is unchanged.

## Behavior / scope
- contract or behavior: move `SessionBeat` and `SessionFrame` to `kithara-audio`, add the invertible `SessionAnchor`, and attach it to `SessionTransportSnapshot`
- contract or behavior: publish the anchor at the exact applied tempo/relocation frame and withdraw the snapshot across stream restart until reanchoring
- affected area: `kithara-audio::musical` and `kithara-play::session::transport`
- excluded: renderer, `TempoSlot`, Queue, app controls, FFI, and audible SYNC behavior

## Validation
- `just fmt check` on the rebased head — green
- Full fork CI on the rebased head `1c72ed1a0` — see the run linked from the checks tab; the earlier green run `31810428257` was on the pre-rebase base and is **not** merge proof for this head
- `cargo test -p kithara-audio --lib --no-default-features --features symphonia,resample-rubato,client-reqwest,tls-rustls musical::anchor::tests` — 2 passed
- `cargo test -p kithara-play --lib --no-default-features --features backend-cpal,symphonia,client-reqwest,tls-rustls session::transport::` — 15 passed
- `cargo clippy -p kithara-audio -p kithara-play -- -D warnings`
- `just lint ast-grep`, `just lint arch`, pre-commit `lint-fast`

## Surface impact
- Public API: changed: `SessionBeat` now has canonical ownership in `kithara-audio`; `SessionBeatError` is replaced by `CoordinateError`; `SessionTransportSnapshot` exposes its `SessionAnchor`
- Platform/runtime: changed: shared session transport snapshot semantics on native audio graphs
- Perf-sensitive paths: changed: transport commit/restart bookkeeping only; no per-sample or resident renderer work is added

## Risks / follow-ups
- The successor #187 (resident presentation/tempo renderer) is rebased on this head. Merging this PR invalidates #187's CI, so #187 must be re-cut onto the post-merge `main` and re-run before it becomes ready.
- This PR intentionally has no standalone audible SYNC behavior; the durable Queue-owned sync plan and the real app `ToggleSync` land in later PRs.
