### PR TITLE
feat(audio,play): add resident presentation renderer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4952,7 +4952,6 @@ dependencies = [
  "signalsmith-stretch",
  "smallvec",
  "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]

--- a/crates/kithara-audio/CONTEXT.md
+++ b/crates/kithara-audio/CONTEXT.md
@@ -404,6 +404,11 @@ the exact offset in per-channel frames. Seek clears pending proof, and a
 same-epoch decoder replacement starts a new presentation generation only after
 the ordered barrier reaches the late stage.
 
+Within one seek epoch and sample rate, the source endpoint advances by admitted
+PCM frames after its first decoder anchor. Decoder timestamp or head-strip gaps
+and same-rate replacement cannot jump it; seek/reset or a sample-rate change
+establishes a new decoder anchor.
+
 **Sample guard.** `sanitize_sample` (`kithara-decode`, which owns it) runs on the
 *input* of every stage taking untrusted samples: `IsolatorEq::process_sample`
 before it branches, `PeakLimiter::process_planar` before it takes the frame peak.

--- a/crates/kithara-audio/CONTEXT.md
+++ b/crates/kithara-audio/CONTEXT.md
@@ -8,8 +8,10 @@ Four contexts touch one track. **Consumer thread** — `Audio<S>` (`PcmRead` +
 `PcmSession` + `PcmControl`, umbrella `PcmReader`), normally the host audio
 callback: never allocates, frees, or locks. **Renderer worker** — one shared OS
 thread per `AudioWorkerHandle` running `runtime::Scheduler` over `Box<dyn Node>`
-slots; a track is exactly one node (`DecoderNode`), and effects are `AudioEffect`
-calls inside the node's step, never separate nodes with rings between them.
+slots; a track is exactly one node (`DecoderNode`). The node owns the decode
+FSM and one late `Presentation` stage: decoded PCM enters its bounded raw queue,
+then one resident tempo stage and the frame-preserving `AudioEffect`s produce
+the final PCM. Effects are never separate nodes with rings between them.
 **Off-RT rebuild** — `RebuildPort::submit` → `spawn_blocking_on` on the tokio
 handle captured in `Audio::new`. **Downloader** — owned by `kithara-stream`; this
 crate never spawns it and never reconstructs HLS/file protocol policy.
@@ -21,14 +23,16 @@ and an absolute `SessionFrame`. It carries the committed beat-rate slope and
 sample rate, and owns both `beat_at` and its inverse `frame_at`; consumers do
 not rebuild that arithmetic from a tempo scalar.
 
-Transport (`runtime/ports.rs`): SPSC `ringbuf::HeapRb` plus a one-slot overflow
-(`Outlet`/`Inlet`).
+Transport (`runtime/ports.rs`) uses two SPSC shapes. Final PCM crosses a
+`StrictOutlet<Fetch<PresentedPcm>>` with capacity two and no overflow slot.
+Retired PCM crosses an `Outlet<PcmChunk>` with a one-slot overflow so its
+buffers can be reclaimed off the consumer thread.
 
-- **Backpressure.** `Outlet::try_push` parks one item in the overflow slot when
-  the ring is full, so a producer emitting ≤1 chunk per tick treats it as
-  infallible. Each tick starts with `Outlet::flush()`; if still full the node
-  returns `TickResult::Backpressured` *without* ticking the FSM — every internal
-  transition, seeks included, pauses until the consumer drains.
+- **Backpressure.** `Presentation::step` checks final-ring capacity before it
+  mutates tempo, effect, or coordinate state. A full ring returns
+  `TickResult::Backpressured`; the consumer can only release capacity, so the
+  subsequent single strict push cannot be displaced by another producer.
+  Decoder admission is bounded independently by `pcm_buffer_chunks`.
 - **Wake.** A producer→reader ring push arms a coalesced atomic wake;
   empty-to-non-empty also enqueues `on_data_available`. The produce core never
   calls `ThreadWake::wake` or enters the kernel. The scheduler shell delivers
@@ -113,9 +117,16 @@ mutator of track state through `update_state`. Sub-owners never take
 - `SharedStream<T>` — byte-space ground truth (position, len, phase, byte map,
   anchors, init range). No other owner clones byte-range policy.
 - `ActiveDecode` — the authoritative active `DecoderGeneration`, the optional
-  `IncomingDecode`, the always-on `PcmBlender`, the effect chain, the EOF drain.
+  `IncomingDecode`, the always-on `PcmBlender`, decoder staging, and gapless
+  transition. It does not own tempo, frame-preserving effects, or their EOF
+  drain.
   Each `DecoderGeneration` owns its decoder facts, base offset, install epoch,
   per-generation `GaplessStage`, and staged chunks.
+- `Presentation` - the sole owner of duration-changing tempo, the ordered
+  frame-preserving effect chain, fixed 512-frame final quanta, exact source
+  admission, decoder-replacement barriers, and final EOF drain. It attaches one
+  immutable `PresentationPoint` to each committed final block before making the
+  block visible to the consumer.
 - `ReadinessGate` — the only owner of byte-range readiness calculations; gate and
   wait paths must resolve the same range for the same phase.
 - `SeekEngine` — `resume_target`, and the only writer of the producer decode
@@ -376,19 +387,22 @@ a concurrent play-then-seek is applied by the post-construction seek path — a
 `VariantChange` surfacing here is a stream-layer state bug. Pinned by
 `tests/tests/kithara_hls/probe_not_ready_at_creation.rs`.
 
-## Effect chain and coordinate space
+## Presentation chain and coordinate space
 
-`create_effects` builds `[TimeStretchProcessor?, ..custom]`. There is no
-resampler stage in the chain — fixed-ratio conversion is decoder-owned — and the
-stretch slot exists only when a stretch backend is compiled in and
-`AudioConfig::stretch` is set; without one, including wasm, no speed DSP is
-inserted and PCM output is pinned to 1.0.
+`create_presentation_chain` builds `{ tempo: TimeStretchProcessor?, effects:
+custom }`. The optional resident tempo stage is the only duration-changing
+owner; every `AudioEffect` receives `AudioBlockMut` and must preserve the block
+shape. Fixed-ratio sample-rate conversion remains decoder-owned. Without a
+compiled/configured stretch backend, including wasm, there is no tempo stage
+and PCM stays at unity.
 
-**Coordinate space.** The whole pipeline runs in decoder/song time
-(`PcmMeta.timestamp` / `end_timestamp` / `frame_offset`, the seek target, the UI
-playhead). A duration-changing `AudioEffect` is the sole timeline authority: it
-restamps only `spec` + `frames` and carries the consumed input's song-time meta
-forward, so there is no translation layer and no parallel frame counter.
+Decoder/song coordinates remain in `PcmMeta` and the seek contract. The late
+stage separately tracks admitted source endpoints and final output ordinals.
+Every committed final block carries one `PresentationPoint`; the consumer emits
+a `PresentationAdvance` only after the complete block boundary is crossed, with
+the exact offset in per-channel frames. Seek clears pending proof, and a
+same-epoch decoder replacement starts a new presentation generation only after
+the ordered barrier reaches the late stage.
 
 **Sample guard.** `sanitize_sample` (`kithara-decode`, which owns it) runs on the
 *input* of every stage taking untrusted samples: `IsolatorEq::process_sample`
@@ -402,11 +416,10 @@ biquad section flushes state and returns exact zero once **both** its input and
 output fall below `f32::MIN_POSITIVE`; the input half keeps a live signal through
 a deep cut from losing its history.
 
-**EOF drain.** At true EOF `EofDrain` drains the chain incrementally, one emitted
-chunk per FSM step: each stage is flushed to exhaustion only after the upstream
-stage's outputs pass through it, so a buffering effect's multi-pull tail survives
-and the produce core allocates no drain queue. `AudioEvent::EndOfStream` fires
-once, when the drain completes — not at source exhaustion.
+**EOF drain.** At true EOF `Presentation` drains the resident tempo stage under
+the same fixed output credit before publishing the terminal marker. Fixed-shape
+effects have no independent buffered tail. `AudioEvent::EndOfStream` fires once
+when the final presentation drain completes, not at decoder exhaustion.
 
 ## Sample-rate conversion
 
@@ -431,22 +444,25 @@ in the ceil frame domain and the decoder adapter sizes buffers from that.
 
 ## Time-stretch (speed and key-lock)
 
-Playback speed lives in the source-domain `TimeStretchProcessor`; the resampler
-plan is strictly fixed-ratio (source rate → host rate) and never carries speed.
-`StretchControls` is the single source of truth, shared (`Arc`) between the
-consumer/UI and the slot, and read **every chunk** — speed, key-lock, backend,
-and region plan all apply live, mid-track, with no reload:
+Playback speed lives in the resident late-presentation
+`TimeStretchProcessor`; the resampler plan is strictly fixed-ratio (source rate
+-> host rate) and never carries speed. `StretchControls` is the single source of
+truth, shared (`Arc`) between the consumer/UI and the stage. The unchecked
+worker shell snapshots controls and prepares replacement DSP cores; the RT
+stage only moves prepared state at an ordered presentation boundary. Speed,
+key-lock, backend, and region plan all apply live, mid-track, with no reload:
 
 | key-lock | slot behaviour |
 |---|---|
 | on | `set_ratio(1/speed)`, `set_pitch(1.0)` — tempo moves, pitch held |
 | off | `set_ratio(1/speed)`, `set_pitch(speed)` — vinyl-style speed and pitch |
 
-Speed is floored at `MIN_SPEED` = 0.05. At speed 1.0 with no region plan the slot
-is a byte-identical passthrough and the backend is reset; `flush` is skipped in
-that state so its latency buffer is not emitted as trailing zeros. A live backend
-change, or a source `PcmSpec` change, rebuilds the backend in place. Key-lock
-defaults to **off** (`StretchControls::new`).
+Speed is floored at `MIN_SPEED` = 0.05. At speed 1.0 with no region plan the
+stage is a byte-identical passthrough; crossing back to unity retires buffered
+backend state before the new source quantum is presented. A live backend change
+or source `PcmSpec` change prepares a replacement core off the RT path, drains
+the old boundary, and swaps ownership without allocating or dropping on RT.
+Key-lock defaults to **off** (`StretchControls::new`).
 
 **Backend seam.** `kithara-stretch` is the optional DSP backend crate, behind
 `stretch-signalsmith` / `stretch-bungee` (native only); it owns `StretchBackend`
@@ -467,20 +483,20 @@ non-overlapping `[start_frame, end_frame)` segments in **source frames**
 `ratio_correction`, validated in `RegionPlan::new`. The processor maps each
 chunk's `frame_offset` to its region (cached cursor, binary search on a miss
 after seek/swap), splits chunks at boundaries, and drives the backend at
-`1/speed * ratio_correction`. It `flush`es (tail drained at the old ratio) and
-`reset`s **only** when a boundary moves the effective ratio beyond `RATIO_EPS`
-(1e-4); equal-ratio boundaries and gaps between segments (correction 1.0) cost
-nothing, and live speed moves inside one region glide via `set_ratio` alone. An
-empty or absent plan is exactly the planless path. Prefer `signalsmith` for
-region work — `bungee`'s `flush` is a no-op and drops the tail at every real
-ratio boundary.
+`1/speed * ratio_correction`. A boundary that changes the effective ratio
+beyond `RATIO_EPS` (1e-4) drains the old core and swaps in a same-spec core
+prepared off RT. Equal-ratio boundaries and gaps between segments (correction
+1.0) cost nothing, and live speed moves inside one region glide via
+`set_ratio` alone. An empty or absent plan is exactly the planless path. Prefer
+`signalsmith` for region work; `bungee` has no true tail drain and explicitly
+retires its held debt at a real ratio boundary.
 
-**Timeline.** A stretch changes the output frame *count*, not the rate: each
-emitted chunk recomputes `meta.frames` and forces `meta.spec` to the live source
-spec, but preserves `timestamp`/`end_timestamp` verbatim, so the playhead stays
-in source-track time. A non-empty flush chunk must never carry the
-`PcmMeta::default()` sentinel spec (0 channels): downstream stages divide by
-`spec.channels`.
+**Timeline.** A stretch changes how admitted source frames fill fixed 512-frame
+presentation credits, not the declared PCM rate. The tempo stage can retain at
+most one admitted source quantum and reports its exact held-source count; the
+presentation owner subtracts only that count when publishing the source
+endpoint. A non-empty drain block must never carry the `PcmMeta::default()`
+sentinel spec (0 channels): downstream stages divide by `spec.channels`.
 
 ## Engine load
 

--- a/crates/kithara-audio/src/audio/build.rs
+++ b/crates/kithara-audio/src/audio/build.rs
@@ -23,17 +23,20 @@ use portable_atomic::AtomicF32;
 use tracing::{debug, info, warn};
 
 use super::{
-    AtomicServiceClass, AudioConfig, AudioDecoderConfig, AudioEffect, AudioWorkerHandle,
-    DecodeError, DecodeInit, EngineLoad, Fetch, PcmSession, RebuildRuntime, ServiceClass,
-    SharedStream, SourceParts, StreamAudioSource, StreamDecoderFactory, ThreadWake,
-    TrackRegistration, WorkerWakeBridge,
+    AtomicServiceClass, AudioConfig, AudioDecoderConfig, AudioWorkerHandle, DecodeError,
+    DecodeInit, EngineLoad, Fetch, PcmSession, RebuildRuntime, ServiceClass, SharedStream,
+    SourceParts, StreamAudioSource, StreamDecoderFactory, ThreadWake, TrackRegistration,
+    WorkerWakeBridge,
     core::{Audio, AudioParts, Controls, Session, WorkerLease},
-    create_effects,
     event::{
         AudioEvents, DecoderChangedEventData, decoder_changed_event, decoder_gapless_event,
         decoder_resampler_event, playback_resampler_event,
     },
     ring::{RingConsumer, RingParts, create_channels, create_trash_channel},
+};
+use crate::{
+    pipeline::config::{PresentationChain, create_presentation_chain},
+    renderer::{PRESENTATION_RING_BLOCKS, PresentationFrontier, PresentedPcm, presentation_cell},
 };
 
 const WARM_DECODE_FRAMES: usize = 4608;
@@ -119,12 +122,14 @@ struct StreamSourceRegistration<'a, T: StreamType> {
     preload_chunks: NonZeroUsize,
     engine_load: Option<Arc<EngineLoad>>,
     initial_media_info: Option<MediaInfo>,
+    initial_spec: PcmSpec,
     variant_control: Option<Arc<dyn VariantControl>>,
     worker: Option<AudioWorkerHandle>,
     runtime_handle: RuntimeHandle,
     shared_stream: SharedStream<T>,
     decoder_factory: StreamDecoderFactory,
-    effects: Vec<Box<dyn AudioEffect>>,
+    chain: PresentationChain,
+    pcm_pool: PcmPool,
     recreate_on_host_rate_change: bool,
     pcm_buffer_chunks: usize,
 }
@@ -136,10 +141,11 @@ struct RegisteredStreamSource {
     reader_wake: Arc<ThreadWake>,
     service_class: Arc<AtomicServiceClass>,
     worker: AudioWorkerHandle,
-    data_rx: super::Inlet<Fetch<PcmChunk>>,
+    data_rx: super::Inlet<Fetch<PresentedPcm>>,
     trash_tx: super::Outlet<PcmChunk>,
     track_id: super::TrackId,
     is_standalone_worker: bool,
+    presentation_frontier: PresentationFrontier,
 }
 
 impl<T> Audio<Stream<T>>
@@ -194,12 +200,6 @@ where
         let variant_control = stream.variant_control();
         let shared_stream = SharedStream::new(stream);
         let host_sample_rate = Arc::new(AtomicU32::new(config_host_sr.map_or(0, NonZeroU32::get)));
-        warm_pcm_pool(
-            &pcm_pool,
-            warm_channels(initial_media_info.as_ref()),
-            pcm_buffer_chunks,
-        );
-
         let gapless_mode = decoder.gapless_mode();
         let deps = DecoderDeps::new(
             decoder,
@@ -219,7 +219,13 @@ where
         let metadata = decoder.metadata();
         let epoch = Arc::new(AtomicU64::new(0));
         let playback_rate = config_playback_rate.unwrap_or_else(|| Arc::new(AtomicF32::new(1.0)));
-        let effects = create_effects(initial_spec, stretch.as_ref(), &pcm_pool, custom_effects);
+        let chain =
+            create_presentation_chain(initial_spec, stretch.as_ref(), &pcm_pool, custom_effects);
+        warm_pcm_pool(
+            &pcm_pool,
+            usize::from(initial_spec.channels),
+            pcm_buffer_chunks,
+        );
         log_pipeline_ready(initial_spec, &host_sample_rate);
 
         let abr_handle = shared_stream.abr_handle();
@@ -228,7 +234,8 @@ where
         let emit = AudioEvents::deferred(&bus);
         let registered = register_stream_audio_source(StreamSourceRegistration {
             decoder,
-            effects,
+            chain,
+            pcm_pool: pcm_pool.clone(),
             engine_load,
             gapless_mode,
             pcm_buffer_chunks,
@@ -243,6 +250,7 @@ where
             epoch: Arc::clone(&epoch),
             host_sample_rate: Arc::clone(&host_sample_rate),
             initial_media_info: initial_media_info.clone(),
+            initial_spec,
             playback_resampler_backend: deps.playback_resampler_backend(),
             // A requested host rate always resolves to a resampler plan, so a
             // route change is decided by `ResumeCursor`'s rate guards alone.
@@ -286,6 +294,7 @@ where
                 peer_wake,
                 seek_prepare,
                 preload_gate: registered.preload_gate,
+                presentation_frontier: registered.presentation_frontier,
             },
             controls: Controls {
                 playback_rate,
@@ -371,7 +380,7 @@ where
     let preload_gate = Arc::new(super::PreloadGate::default());
     let reader_wake = Arc::new(ThreadWake::default());
     let (data_tx, data_rx) = create_channels(
-        registration.pcm_buffer_chunks,
+        PRESENTATION_RING_BLOCKS,
         Arc::clone(&registration.emit),
         &reader_wake,
     );
@@ -396,10 +405,9 @@ where
         playback_resampler_backend: registration.playback_resampler_backend,
         recreate_on_host_rate_change: registration.recreate_on_host_rate_change,
     }
-    .into_parts(
-        registration.effects,
-        registration.shared_stream.seek_observe().epoch(),
-    );
+    .into_parts(registration.shared_stream.seek_observe().epoch());
+    let presentation_epoch = registration.shared_stream.seek_observe().epoch();
+    let (presentation, presentation_frontier) = presentation_cell(presentation_epoch);
     let parts = SourceParts::new(
         &registration.shared_stream,
         decode,
@@ -424,6 +432,11 @@ where
         emit: registration.emit,
         service_class: service_class.clone(),
         engine_load: registration.engine_load,
+        chain: registration.chain,
+        initial_spec: registration.initial_spec,
+        pcm_pool: registration.pcm_pool,
+        presentation,
+        raw_buffer_chunks: registration.pcm_buffer_chunks,
     });
     wake_stream.set_worker_wake(worker_wake);
 
@@ -438,6 +451,7 @@ where
         worker,
         epoch: registration.epoch,
         host_sample_rate: registration.host_sample_rate,
+        presentation_frontier,
     }
 }
 
@@ -580,16 +594,10 @@ where
         .unwrap_or_default()
 }
 
-fn warm_channels(info: Option<&MediaInfo>) -> usize {
-    info.and_then(|info| info.channels).map_or(2, usize::from)
-}
-
 fn warm_pcm_pool(pool: &PcmPool, channels: usize, chunks: usize) {
-    if pool.allocated_bytes() != 0 {
-        return;
-    }
     let capacity = WARM_DECODE_FRAMES * channels.max(1);
-    pool.pre_warm(chunks.saturating_mul(2).max(1), |buffer| {
+    let buffers = chunks.max(1).saturating_add(PRESENTATION_RING_BLOCKS + 1);
+    pool.pre_warm(buffers, |buffer| {
         buffer.clear();
         buffer.resize(capacity, 0.0);
     });

--- a/crates/kithara-audio/src/audio/build.rs
+++ b/crates/kithara-audio/src/audio/build.rs
@@ -7,7 +7,7 @@ use std::{
 
 use kithara_bufpool::{BytePool, PcmPool};
 use kithara_decode::{
-    Decoder, DecoderConfig, DecoderFactory, DecoderResamplerConfig, GaplessMode, PcmChunk, PcmSpec,
+    Decoder, DecoderConfig, DecoderFactory, DecoderResamplerConfig, GaplessMode, PcmSpec,
 };
 use kithara_events::{DecoderChangeCause, Event, EventBus, FrameDomain};
 use kithara_platform::{
@@ -36,7 +36,10 @@ use super::{
 };
 use crate::{
     pipeline::config::{PresentationChain, create_presentation_chain},
-    renderer::{PRESENTATION_RING_BLOCKS, PresentationFrontier, PresentedPcm, presentation_cell},
+    renderer::{
+        OutputDisposition, PRESENTATION_RING_BLOCKS, PresentationFrontier, PresentedPcm,
+        presentation_cell,
+    },
 };
 
 const WARM_DECODE_FRAMES: usize = 4608;
@@ -142,7 +145,7 @@ struct RegisteredStreamSource {
     service_class: Arc<AtomicServiceClass>,
     worker: AudioWorkerHandle,
     data_rx: super::Inlet<Fetch<PresentedPcm>>,
-    trash_tx: super::Outlet<PcmChunk>,
+    trash_tx: super::Outlet<OutputDisposition>,
     track_id: super::TrackId,
     is_standalone_worker: bool,
     presentation_frontier: PresentationFrontier,

--- a/crates/kithara-audio/src/audio/core.rs
+++ b/crates/kithara-audio/src/audio/core.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use kithara_bufpool::PcmPool;
-use kithara_decode::{PcmChunk, PcmSpec, TrackMetadata};
+use kithara_decode::{PcmSpec, TrackMetadata};
 use kithara_events::EventBus;
 use kithara_platform::{CancelToken, sync::Arc, time::Duration};
 use kithara_stream::{
@@ -131,6 +131,7 @@ impl<S> Audio<S> {
         let recv = recv_ctx(&self.session, &self.lease);
         let was_playing = self.ring.phase == super::ConsumerPhase::Playing;
         let filled = self.ring.fill(&mut self.cursor, recv);
+        self.wake_worker_after_progress();
         self.events.fill_result(
             filled,
             was_playing,
@@ -186,7 +187,9 @@ impl<S> Audio<S> {
             self.session.playhead.as_ref(),
             recv,
             buf,
-        )?;
+        );
+        self.wake_worker_after_progress();
+        let read = read?;
         Ok(self
             .events
             .commit_read(&self.session, self.ring.validator.epoch, read))
@@ -232,8 +235,14 @@ impl<S> Audio<S> {
             return;
         }
         self.events.reset_underrun();
-        let popped = self.ring.begin_seek_epoch(begun, &mut self.cursor);
-        if popped {
+        let worker_progress = self.ring.begin_seek_epoch(begun, &mut self.cursor);
+        if worker_progress {
+            self.ring.wake_worker(self.lease.worker.as_ref());
+        }
+    }
+
+    fn wake_worker_after_progress(&mut self) {
+        if self.ring.take_worker_progress() {
             self.ring.wake_worker(self.lease.worker.as_ref());
         }
     }
@@ -285,10 +294,13 @@ impl<S: kithara_platform::maybe_send::MaybeSend> PcmRead for Audio<S> {
             chunk
         };
         let Some(presented) = chunk else {
+            self.wake_worker_after_progress();
             return chunk_outcome(self.ring.phase, self.position());
         };
         let point = presented.point();
-        let chunk: PcmChunk = presented.into();
+        let chunk = self.ring.detach(presented);
+        self.wake_worker_after_progress();
+        let chunk = chunk?;
         self.cursor.begin_chunk(&chunk);
         self.ring.promote_playing();
         self.session
@@ -318,7 +330,9 @@ impl<S: kithara_platform::maybe_send::MaybeSend> PcmRead for Audio<S> {
             self.session.playhead.as_ref(),
             recv_ctx(&self.session, &self.lease),
             output,
-        )?;
+        );
+        self.wake_worker_after_progress();
+        let read = read?;
         Ok(self
             .events
             .commit_read(&self.session, self.ring.validator.epoch, read))
@@ -430,35 +444,62 @@ fn chunk_outcome(
 #[cfg(test)]
 mod tests {
     use std::{
+        collections::VecDeque,
         num::NonZeroU32,
         sync::atomic::{AtomicU32, AtomicU64},
     };
 
     use kithara_bufpool::PcmPool;
     use kithara_decode::{PcmChunk, PcmMeta, PcmSpec};
-    use kithara_platform::sync::Arc;
-    use kithara_stream::{PlayheadState, SeekState};
+    use kithara_platform::{CancelToken, sync::Arc};
+    use kithara_stream::{PlayheadRead, PlayheadState, SeekState};
     use kithara_test_utils::kithara;
 
     use super::*;
     use crate::{
         ConsumerWakeMode,
-        audio::{Fetch, ThreadWake, connect, ring::RingParts},
-        renderer::{PresentedPcm, presentation_cell},
+        audio::{
+            Fetch, ThreadWake, connect,
+            ring::{RingParts, create_channels, create_trash_channel},
+        },
+        pipeline::{config::PresentationChain, track::TrackStep},
+        renderer::{
+            AudioWorkerSource, OutputDisposition, PresentedPcm, TrackRegistration,
+            presentation_cell,
+        },
         runtime::Outlet,
         traits::PresentationPoint,
     };
 
+    struct FinitePcmSource {
+        chunks: VecDeque<PcmChunk>,
+        seek: Arc<SeekState>,
+    }
+
+    impl AudioWorkerSource for FinitePcmSource {
+        type Chunk = PcmChunk;
+
+        fn seek_observe(&self) -> Arc<dyn SeekObserve> {
+            Arc::clone(&self.seek) as Arc<dyn SeekObserve>
+        }
+
+        fn step_track(&mut self) -> TrackStep<Self::Chunk> {
+            self.chunks.pop_front().map_or(TrackStep::Eof, |chunk| {
+                TrackStep::Produced(Fetch::data(chunk, 0))
+            })
+        }
+    }
+
     struct AudioFixture {
         audio: Audio<()>,
         data_tx: Outlet<Fetch<PresentedPcm>>,
-        _trash_rx: crate::runtime::Inlet<PcmChunk>,
+        _trash_rx: crate::runtime::Inlet<OutputDisposition>,
     }
 
     impl Default for AudioFixture {
         fn default() -> Self {
             let (data_tx, data_rx) = connect::<Fetch<PresentedPcm>>(4, None);
-            let (trash_tx, trash_rx) = connect::<PcmChunk>(8, None);
+            let (trash_tx, trash_rx) = connect::<OutputDisposition>(8, None);
             let epoch = Arc::new(AtomicU64::new(0));
             let ring = RingConsumer::new(RingParts {
                 trash_tx,
@@ -516,6 +557,10 @@ mod tests {
     impl AudioFixture {
         fn push(&mut self, frames: u32, point: PresentationPoint) {
             let spec = self.audio.spec();
+            self.push_with_spec(frames, spec, point);
+        }
+
+        fn push_with_spec(&mut self, frames: u32, spec: PcmSpec, point: PresentationPoint) {
             let channels = usize::from(spec.channels);
             let frame_count = usize::try_from(frames).expect("test frame count fits usize");
             let chunk = PcmChunk::new(
@@ -533,6 +578,94 @@ mod tests {
                 ))
                 .expect("presented PCM reaches the final ring");
         }
+    }
+
+    fn blocking_audio(chunk_count: usize) -> Audio<()> {
+        let spec = PcmSpec::new(2, NonZeroU32::new(48_000).expect("test sample rate"));
+        let pcm_pool = PcmPool::default();
+        let chunks = (0..chunk_count)
+            .map(|_| {
+                PcmChunk::new(
+                    PcmMeta {
+                        spec,
+                        frames: 512,
+                        ..Default::default()
+                    },
+                    pcm_pool.attach(vec![0.5; 512 * usize::from(spec.channels)]),
+                )
+            })
+            .collect();
+        let seek_state = Arc::new(SeekState::new());
+        let source = FinitePcmSource {
+            chunks,
+            seek: Arc::clone(&seek_state),
+        };
+        let playhead = Arc::new(PlayheadState::new());
+        let bus = EventBus::default();
+        let emit = AudioEvents::deferred(&bus);
+        let reader_wake = Arc::new(ThreadWake::default());
+        let (data_tx, data_rx) = create_channels(2, Arc::clone(&emit), &reader_wake);
+        let (trash_tx, trash_inlet) = create_trash_channel(4);
+        let preload_gate = Arc::new(PreloadGate::default());
+        let (presentation, presentation_frontier) = presentation_cell(0);
+        let worker = AudioWorkerHandle::with_cancel(CancelToken::never());
+        let track_id = worker.register_track(TrackRegistration {
+            emit: Arc::clone(&emit),
+            playhead: Arc::clone(&playhead) as Arc<dyn PlayheadRead>,
+            preload_gate: Arc::clone(&preload_gate),
+            service_class: Arc::new(AtomicServiceClass::new(ServiceClass::default())),
+            source: Box::new(source),
+            trash_inlet,
+            engine_load: None,
+            chain: PresentationChain::identity(Vec::new()),
+            initial_spec: spec,
+            outlet: data_tx,
+            pcm_pool: pcm_pool.clone(),
+            preload_chunks: 1,
+            presentation,
+            raw_buffer_chunks: 4,
+        });
+        let ring = RingConsumer::new(RingParts {
+            trash_tx,
+            epoch: Arc::new(AtomicU64::new(0)),
+            pcm_rx: data_rx,
+            reader_wake,
+            block_on_underrun: true,
+            consumer_wake_mode: ConsumerWakeMode::RealtimeDeferred,
+        });
+        let seek: Arc<dyn SeekControl> = seek_state.clone();
+        let seek_obs: Arc<dyn SeekObserve> = seek_state;
+        let playhead: Arc<dyn PlayheadWrite> = playhead;
+        Audio::from(AudioParts {
+            ring,
+            pcm_pool,
+            emit,
+            lease: WorkerLease {
+                cancel: None,
+                track_id: Some(track_id),
+                worker: Some(worker),
+                is_standalone: true,
+            },
+            session: Session {
+                playhead,
+                seek,
+                seek_obs,
+                preload_gate,
+                metadata: TrackMetadata::default(),
+                abr_handle: None,
+                peer_wake: None,
+                seek_prepare: None,
+                presentation_frontier,
+            },
+            controls: Controls {
+                host_sample_rate: Arc::new(AtomicU32::new(0)),
+                playback_rate: Arc::new(AtomicF32::new(1.0)),
+                stretch: None,
+                service_class: Arc::new(AtomicServiceClass::new(ServiceClass::default())),
+            },
+            spec,
+            marker: PhantomData,
+        })
     }
 
     fn point(source_frame: u64, generation: u64, output_end: u64) -> PresentationPoint {
@@ -555,6 +688,23 @@ mod tests {
             .seek(Duration::from_millis(250))
             .expect("seek should arm epoch");
         assert!(!fixture.audio.session.preload_gate.is_ready());
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[kithara::test(env(KITHARA_HANG_TIMEOUT_SECS = "1"))]
+    fn next_chunk_replenishes_detached_presentation_buffers() {
+        let mut audio = blocking_audio(8);
+        let mut retained = Vec::with_capacity(8);
+
+        for _ in 0..8 {
+            let ChunkOutcome::Chunk(chunk) = audio.next_chunk().expect("chunk read succeeds")
+            else {
+                panic!("finite source must yield eight PCM chunks");
+            };
+            retained.push(chunk);
+        }
+
+        assert_eq!(retained.len(), 8);
     }
 
     #[kithara::test]
@@ -583,6 +733,35 @@ mod tests {
             .expect("completed boundary becomes observable");
         assert_eq!(advance.point(), expected);
         assert_eq!(advance.read_offset_frames(), 2);
+    }
+
+    #[kithara::test]
+    fn exact_boundary_old_spec_return_is_woken_after_read() {
+        let mut fixture = AudioFixture::default();
+        let old_spec = PcmSpec::new(1, NonZeroU32::new(44_100).expect("test old rate"));
+        let point =
+            PresentationPoint::new(0, 4, 0, 4, NonZeroU32::new(44_100).expect("test old rate"));
+        fixture.push_with_spec(4, old_spec, point);
+        fixture.audio.preload().expect("old-spec PCM preloads");
+
+        let mut output = [0.0; 4];
+        let read = fixture
+            .audio
+            .read(&mut output)
+            .expect("exact-boundary old-spec read succeeds");
+
+        assert!(matches!(
+            read,
+            ReadOutcome::Frames { count, .. } if count.get() == output.len()
+        ));
+        assert!(
+            !fixture.audio.ring.take_worker_progress(),
+            "Audio owner must consume the coalesced progress flag after cursor.read"
+        );
+        let Some(OutputDisposition::Returned(returned)) = fixture._trash_rx.try_pop() else {
+            panic!("old-spec output must be returned before the owner wake");
+        };
+        assert_eq!(returned.spec(), old_spec);
     }
 
     #[kithara::test]

--- a/crates/kithara-audio/src/audio/core.rs
+++ b/crates/kithara-audio/src/audio/core.rs
@@ -691,7 +691,7 @@ mod tests {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    #[kithara::test(env(KITHARA_HANG_TIMEOUT_SECS = "1"))]
+    #[kithara::test(flash(false), env(KITHARA_HANG_TIMEOUT_SECS = "1"))]
     fn next_chunk_replenishes_detached_presentation_buffers() {
         let mut audio = blocking_audio(8);
         let mut retained = Vec::with_capacity(8);

--- a/crates/kithara-audio/src/audio/core.rs
+++ b/crates/kithara-audio/src/audio/core.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use kithara_bufpool::PcmPool;
-use kithara_decode::{PcmSpec, TrackMetadata};
+use kithara_decode::{PcmChunk, PcmSpec, TrackMetadata};
 use kithara_events::EventBus;
 use kithara_platform::{CancelToken, sync::Arc, time::Duration};
 use kithara_stream::{
@@ -22,7 +22,10 @@ use super::{
     ring::{RecvCtx, RingConsumer},
     seek::{SeekHandle, SeekHandleParts},
 };
-use crate::traits::SeekBegin;
+use crate::{
+    renderer::PresentationFrontier,
+    traits::{PresentationAdvance, PresentationPoint, SeekBegin},
+};
 
 /// Pull-based PCM facade backed by a shared renderer worker.
 pub struct Audio<S> {
@@ -55,6 +58,7 @@ pub(super) struct Session {
     pub(super) peer_wake: Option<Arc<DeferredWake>>,
     pub(super) seek_prepare: Option<Arc<dyn SeekPrepare>>,
     pub(super) metadata: TrackMetadata,
+    pub(super) presentation_frontier: PresentationFrontier,
 }
 
 pub(super) struct Controls {
@@ -250,6 +254,17 @@ impl<S: kithara_platform::maybe_send::MaybeSend> PcmRead for Audio<S> {
         }
     }
 
+    fn presentation_point(&self) -> Option<PresentationPoint> {
+        self.session
+            .presentation_frontier
+            .point(self.session.seek_obs.epoch())
+    }
+
+    fn take_presentation_advance(&mut self) -> Option<PresentationAdvance> {
+        self.sync_seek();
+        self.ring.take_presentation_advance()
+    }
+
     fn next_chunk(&mut self) -> Result<ChunkOutcome, DecodeError> {
         self.sync_seek();
         self.ring.preloaded = true;
@@ -269,14 +284,17 @@ impl<S: kithara_platform::maybe_send::MaybeSend> PcmRead for Audio<S> {
             );
             chunk
         };
-        let Some(chunk) = chunk else {
+        let Some(presented) = chunk else {
             return chunk_outcome(self.ring.phase, self.position());
         };
+        let point = presented.point();
+        let chunk: PcmChunk = presented.into();
         self.cursor.begin_chunk(&chunk);
         self.ring.promote_playing();
         self.session
             .playhead
             .advance(&ChunkPosition::from(&chunk.meta));
+        self.ring.record_presentation_advance(point, chunk.frames());
         Ok(ChunkOutcome::Chunk(chunk))
     }
 
@@ -363,6 +381,7 @@ impl<S: kithara_platform::maybe_send::MaybeSend> PcmControl for Audio<S> {
     fn set_playback_rate(&self, rate: f32) {
         if let Some(controls) = &self.controls.stretch {
             controls.set_speed(rate);
+            defer_worker_wake(self.lease.worker.as_ref());
         } else {
             self.controls.playback_rate.store(rate, Ordering::Relaxed);
         }
@@ -410,10 +429,13 @@ fn chunk_outcome(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicU32, AtomicU64};
+    use std::{
+        num::NonZeroU32,
+        sync::atomic::{AtomicU32, AtomicU64},
+    };
 
     use kithara_bufpool::PcmPool;
-    use kithara_decode::{PcmChunk, PcmMeta};
+    use kithara_decode::{PcmChunk, PcmMeta, PcmSpec};
     use kithara_platform::sync::Arc;
     use kithara_stream::{PlayheadState, SeekState};
     use kithara_test_utils::kithara;
@@ -422,16 +444,21 @@ mod tests {
     use crate::{
         ConsumerWakeMode,
         audio::{Fetch, ThreadWake, connect, ring::RingParts},
+        renderer::{PresentedPcm, presentation_cell},
+        runtime::Outlet,
+        traits::PresentationPoint,
     };
 
     struct AudioFixture {
         audio: Audio<()>,
+        data_tx: Outlet<Fetch<PresentedPcm>>,
+        _trash_rx: crate::runtime::Inlet<PcmChunk>,
     }
 
     impl Default for AudioFixture {
         fn default() -> Self {
-            let (_data_tx, data_rx) = connect::<Fetch<PcmChunk>>(1, None);
-            let (trash_tx, _trash_rx) = connect::<PcmChunk>(8, None);
+            let (data_tx, data_rx) = connect::<Fetch<PresentedPcm>>(4, None);
+            let (trash_tx, trash_rx) = connect::<PcmChunk>(8, None);
             let epoch = Arc::new(AtomicU64::new(0));
             let ring = RingConsumer::new(RingParts {
                 trash_tx,
@@ -448,6 +475,7 @@ mod tests {
             let pcm_pool = PcmPool::default();
             let bus = EventBus::default();
             let emit = AudioEvents::deferred(&bus);
+            let spec = PcmSpec::new(2, NonZeroU32::new(48_000).expect("test sample rate"));
             Self {
                 audio: Audio::from(AudioParts {
                     ring,
@@ -468,6 +496,7 @@ mod tests {
                         abr_handle: None,
                         peer_wake: None,
                         seek_prepare: None,
+                        presentation_frontier: presentation_cell(0).1,
                     },
                     controls: Controls {
                         host_sample_rate: Arc::new(AtomicU32::new(0)),
@@ -475,11 +504,45 @@ mod tests {
                         stretch: None,
                         service_class: Arc::new(AtomicServiceClass::new(ServiceClass::default())),
                     },
-                    spec: PcmMeta::default().spec,
+                    spec,
                     marker: PhantomData,
                 }),
+                data_tx,
+                _trash_rx: trash_rx,
             }
         }
+    }
+
+    impl AudioFixture {
+        fn push(&mut self, frames: u32, point: PresentationPoint) {
+            let spec = self.audio.spec();
+            let channels = usize::from(spec.channels);
+            let frame_count = usize::try_from(frames).expect("test frame count fits usize");
+            let chunk = PcmChunk::new(
+                PcmMeta {
+                    spec,
+                    frames,
+                    ..Default::default()
+                },
+                PcmPool::default().attach(vec![0.5; frame_count * channels]),
+            );
+            self.data_tx
+                .try_push(Fetch::data(
+                    PresentedPcm::new(chunk, point),
+                    point.seek_epoch(),
+                ))
+                .expect("presented PCM reaches the final ring");
+        }
+    }
+
+    fn point(source_frame: u64, generation: u64, output_end: u64) -> PresentationPoint {
+        PresentationPoint::new(
+            0,
+            source_frame,
+            generation,
+            output_end,
+            NonZeroU32::new(48_000).expect("test sample rate"),
+        )
     }
 
     #[kithara::test]
@@ -492,5 +555,48 @@ mod tests {
             .seek(Duration::from_millis(250))
             .expect("seek should arm epoch");
         assert!(!fixture.audio.session.preload_gate.is_ready());
+    }
+
+    #[kithara::test]
+    fn presentation_advance_is_hidden_until_chunk_boundary_is_consumed() {
+        let mut fixture = AudioFixture::default();
+        let expected = point(4, 2, 4);
+        fixture.push(4, expected);
+        fixture.audio.preload().expect("test PCM preloads");
+
+        assert!(fixture.audio.take_presentation_advance().is_none());
+        let mut first_half = [0.0; 4];
+        let _ = fixture
+            .audio
+            .read(&mut first_half)
+            .expect("partial PCM read succeeds");
+        assert!(fixture.audio.take_presentation_advance().is_none());
+
+        let mut second_half = [0.0; 4];
+        let _ = fixture
+            .audio
+            .read(&mut second_half)
+            .expect("boundary PCM read succeeds");
+        let advance = fixture
+            .audio
+            .take_presentation_advance()
+            .expect("completed boundary becomes observable");
+        assert_eq!(advance.point(), expected);
+        assert_eq!(advance.read_offset_frames(), 2);
+    }
+
+    #[kithara::test]
+    fn seek_clears_unclaimed_presentation_advance() {
+        let mut fixture = AudioFixture::default();
+        fixture.push(2, point(2, 4, 2));
+        fixture.audio.preload().expect("test PCM preloads");
+        let mut output = [0.0; 4];
+        let _ = fixture
+            .audio
+            .read(&mut output)
+            .expect("boundary PCM read succeeds");
+
+        let _ = fixture.audio.seek_handle().begin(Duration::from_millis(10));
+        assert!(fixture.audio.take_presentation_advance().is_none());
     }
 }

--- a/crates/kithara-audio/src/audio/cursor.rs
+++ b/crates/kithara-audio/src/audio/cursor.rs
@@ -152,7 +152,7 @@ impl ChunkCursor {
                 }
                 if copied.finished {
                     ring.record_presentation_advance(point, written_frames);
-                    ring.recycle_current();
+                    let _ = ring.recycle_current();
                 } else if copied.samples == 0 {
                     break;
                 }
@@ -297,7 +297,7 @@ mod tests {
     use crate::{
         ConsumerWakeMode,
         audio::{Fetch, ThreadWake, connect, ring::RingParts},
-        renderer::PresentedPcm,
+        renderer::{OutputDisposition, PresentedPcm},
         traits::PresentationPoint,
     };
 
@@ -312,7 +312,7 @@ mod tests {
             duration.saturating_add(Duration::from_millis(2)),
         );
         let (mut data_tx, data_rx) = connect::<Fetch<PresentedPcm>>(4, None);
-        let (trash_tx, _trash_rx) = connect::<PcmChunk>(8, None);
+        let (trash_tx, _trash_rx) = connect::<OutputDisposition>(8, None);
         let mut ring = RingConsumer::new(RingParts {
             trash_tx,
             pcm_rx: data_rx,
@@ -357,7 +357,7 @@ mod tests {
     fn read_buffer_shorter_than_frame_preserves_current_chunk() {
         let spec = PcmSpec::new(2, NonZeroU32::new(48_000).expect("test rate"));
         let (mut data_tx, data_rx) = connect::<Fetch<PresentedPcm>>(1, None);
-        let (trash_tx, mut trash_rx) = connect::<PcmChunk>(3, None);
+        let (trash_tx, mut trash_rx) = connect::<OutputDisposition>(3, None);
         let mut ring = RingConsumer::new(RingParts {
             trash_tx,
             pcm_rx: data_rx,
@@ -398,6 +398,60 @@ mod tests {
         assert!(matches!(read.outcome, ReadOutcome::Pending { .. }));
         assert!(ring.current_chunk.is_some());
         assert!(trash_rx.try_pop().is_none());
+    }
+
+    #[kithara::test]
+    fn exact_boundary_old_spec_return_arms_worker_progress() {
+        let old_spec = PcmSpec::new(1, NonZeroU32::new(44_100).expect("test old rate"));
+        let new_spec = PcmSpec::new(2, NonZeroU32::new(48_000).expect("test new rate"));
+        let (mut data_tx, data_rx) = connect::<Fetch<PresentedPcm>>(1, None);
+        let (trash_tx, mut trash_rx) = connect::<OutputDisposition>(3, None);
+        let mut ring = RingConsumer::new(RingParts {
+            trash_tx,
+            pcm_rx: data_rx,
+            reader_wake: Arc::new(ThreadWake::default()),
+            epoch: Arc::new(AtomicU64::new(0)),
+            block_on_underrun: false,
+            consumer_wake_mode: ConsumerWakeMode::RealtimeDeferred,
+        });
+        ring.preloaded = true;
+        data_tx
+            .try_push(Fetch::data(
+                presented(
+                    timed_chunk(old_spec, 4, Duration::ZERO, Duration::from_millis(1)),
+                    0,
+                ),
+                0,
+            ))
+            .expect("old-spec chunk reaches test ring");
+
+        let mut cursor = ChunkCursor::new(&PcmPool::default(), new_spec);
+        let mut events = AudioEvents::test();
+        let mut output = [0.0; 4];
+        let read = cursor
+            .read(
+                &mut ring,
+                &mut events,
+                &PlayheadState::new(),
+                RecvCtx {
+                    cancel: None,
+                    worker: None,
+                    abr: None,
+                },
+                &mut output,
+            )
+            .expect("exact-boundary read succeeds");
+
+        assert!(matches!(
+            read.outcome,
+            ReadOutcome::Frames { count, .. } if count.get() == output.len()
+        ));
+        assert!(ring.take_worker_progress());
+        assert!(!ring.take_worker_progress());
+        let Some(OutputDisposition::Returned(returned)) = trash_rx.try_pop() else {
+            panic!("old-spec output must be returned to the worker");
+        };
+        assert_eq!(returned.spec(), old_spec);
     }
 
     fn timed_chunk(spec: PcmSpec, frames: u32, start: Duration, end: Duration) -> PcmChunk {

--- a/crates/kithara-audio/src/audio/cursor.rs
+++ b/crates/kithara-audio/src/audio/cursor.rs
@@ -67,6 +67,7 @@ impl ChunkCursor {
         let consumed = self.current_chunk_consumed_frames;
         if consumed >= total_frames {
             return Ok(CopyOutcome {
+                frames: 0,
                 samples: 0,
                 finished: true,
             });
@@ -77,6 +78,7 @@ impl ChunkCursor {
         let take_frames = remaining_frames.min(output_frames);
         if take_frames == 0 {
             return Ok(CopyOutcome {
+                frames: 0,
                 samples: 0,
                 finished: false,
             });
@@ -84,6 +86,11 @@ impl ChunkCursor {
 
         let start_sample = frames_to_samples(consumed, channels)?;
         let samples = frames_to_samples(take_frames, channels)?;
+        let frames =
+            usize::try_from(take_frames).map_err(|_| DecodeError::SampleCountOverflow {
+                frames: take_frames,
+                channels,
+            })?;
         output[..samples].copy_from_slice(&chunk.samples[start_sample..start_sample + samples]);
         let consumed_total = consumed + take_frames;
         self.current_chunk_consumed_frames = consumed_total;
@@ -93,7 +100,11 @@ impl ChunkCursor {
         } else {
             playhead.advance_partial(interpolated_position(chunk.meta, consumed_total));
         }
-        Ok(CopyOutcome { finished, samples })
+        Ok(CopyOutcome {
+            finished,
+            frames,
+            samples,
+        })
     }
 
     #[cfg_attr(feature = "perf", hotpath::measure)]
@@ -120,18 +131,27 @@ impl ChunkCursor {
         }
 
         let mut written = 0;
+        let mut written_frames = 0_usize;
         let mut last_output_meta = None;
         while written < buf.len() {
             hang_tick!();
 
-            if let Some(chunk) = ring.current_chunk.as_ref() {
+            if let Some(presented) = ring.current_chunk.as_ref() {
+                let point = presented.point();
+                let chunk = presented.chunk();
                 let copied = self.copy_into(chunk, &mut buf[written..], playhead)?;
                 if copied.samples > 0 {
                     hang_reset!();
                     last_output_meta = Some(chunk.meta);
                     written += copied.samples;
+                    written_frames = written_frames.checked_add(copied.frames).ok_or(
+                        DecodeError::InvalidData {
+                            detail: "presentation read-frame offset overflow",
+                        },
+                    )?;
                 }
                 if copied.finished {
+                    ring.record_presentation_advance(point, written_frames);
                     ring.recycle_current();
                 } else if copied.samples == 0 {
                     break;
@@ -225,6 +245,7 @@ impl ChunkCursor {
 
 struct CopyOutcome {
     finished: bool,
+    frames: usize,
     samples: usize,
 }
 
@@ -276,6 +297,8 @@ mod tests {
     use crate::{
         ConsumerWakeMode,
         audio::{Fetch, ThreadWake, connect, ring::RingParts},
+        renderer::PresentedPcm,
+        traits::PresentationPoint,
     };
 
     #[kithara::test]
@@ -288,7 +311,7 @@ mod tests {
             duration.saturating_sub(Duration::from_millis(2)),
             duration.saturating_add(Duration::from_millis(2)),
         );
-        let (mut data_tx, data_rx) = connect::<Fetch<PcmChunk>>(4, None);
+        let (mut data_tx, data_rx) = connect::<Fetch<PresentedPcm>>(4, None);
         let (trash_tx, _trash_rx) = connect::<PcmChunk>(8, None);
         let mut ring = RingConsumer::new(RingParts {
             trash_tx,
@@ -300,7 +323,7 @@ mod tests {
         });
         ring.preloaded = true;
         data_tx
-            .try_push(Fetch::data(chunk, 0))
+            .try_push(Fetch::data(presented(chunk, 0), 0))
             .expect("chunk reaches test ring");
 
         let playhead = PlayheadState::new();
@@ -333,7 +356,7 @@ mod tests {
     #[kithara::test]
     fn read_buffer_shorter_than_frame_preserves_current_chunk() {
         let spec = PcmSpec::new(2, NonZeroU32::new(48_000).expect("test rate"));
-        let (mut data_tx, data_rx) = connect::<Fetch<PcmChunk>>(1, None);
+        let (mut data_tx, data_rx) = connect::<Fetch<PresentedPcm>>(1, None);
         let (trash_tx, mut trash_rx) = connect::<PcmChunk>(3, None);
         let mut ring = RingConsumer::new(RingParts {
             trash_tx,
@@ -346,7 +369,10 @@ mod tests {
         ring.preloaded = true;
         data_tx
             .try_push(Fetch::data(
-                timed_chunk(spec, 1, Duration::ZERO, Duration::from_millis(1)),
+                presented(
+                    timed_chunk(spec, 1, Duration::ZERO, Duration::from_millis(1)),
+                    0,
+                ),
                 0,
             ))
             .expect("chunk reaches test ring");
@@ -388,5 +414,17 @@ mod tests {
             },
             PcmPool::default().attach(samples),
         )
+    }
+
+    fn presented(chunk: PcmChunk, epoch: u64) -> PresentedPcm {
+        let source_end = chunk.meta.frame_offset + u64::from(chunk.meta.frames);
+        let point = PresentationPoint::new(
+            epoch,
+            source_end,
+            0,
+            u64::from(chunk.meta.frames),
+            chunk.spec().sample_rate,
+        );
+        PresentedPcm::new(chunk, point)
     }
 }

--- a/crates/kithara-audio/src/audio/event.rs
+++ b/crates/kithara-audio/src/audio/event.rs
@@ -394,6 +394,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroU32;
+
     use kithara_bufpool::PcmPool;
     use kithara_decode::{PcmChunk, PcmMeta};
     use kithara_events::{AudioEvent, Event, EventBus};
@@ -402,10 +404,22 @@ mod tests {
     use kithara_test_utils::kithara;
 
     use super::*;
-    use crate::audio::{Fetch, ring::create_channels};
+    use crate::{
+        PresentationPoint,
+        audio::{Fetch, ring::create_channels},
+        renderer::PresentedPcm,
+    };
 
-    fn empty_chunk() -> PcmChunk {
-        PcmChunk::new(PcmMeta::default(), PcmPool::default().attach(Vec::new()))
+    fn empty_presented() -> PresentedPcm {
+        let chunk = PcmChunk::new(PcmMeta::default(), PcmPool::default().attach(Vec::new()));
+        let point = PresentationPoint::new(
+            0,
+            0,
+            0,
+            0,
+            NonZeroU32::new(48_000).expect("fixture rate is non-zero"),
+        );
+        PresentedPcm::new(chunk, point)
     }
 
     #[kithara::test]
@@ -463,7 +477,7 @@ mod tests {
         let emit = AudioEvents::deferred(&bus);
         let (mut tx, mut rx) = create_channels(2, emit, &reader_wake);
 
-        tx.try_push(Fetch::data(empty_chunk(), 0))
+        tx.try_push(Fetch::data(empty_presented(), 0))
             .expect("first push reaches ring");
         assert!(events.try_recv().is_err());
         tx.flush_wake_signals();
@@ -472,7 +486,7 @@ mod tests {
             Ok(Event::Audio(AudioEvent::OutputAvailable))
         ));
 
-        tx.try_push(Fetch::data(empty_chunk(), 0))
+        tx.try_push(Fetch::data(empty_presented(), 0))
             .expect("second push reaches ring");
         tx.flush_wake_signals();
         assert!(events.try_recv().is_err());
@@ -480,7 +494,7 @@ mod tests {
         assert!(rx.try_pop().is_some());
         assert!(rx.try_pop().is_some());
 
-        tx.try_push(Fetch::data(empty_chunk(), 0))
+        tx.try_push(Fetch::data(empty_presented(), 0))
             .expect("third push reaches empty ring");
         tx.flush_wake_signals();
         assert!(matches!(

--- a/crates/kithara-audio/src/audio/mod.rs
+++ b/crates/kithara-audio/src/audio/mod.rs
@@ -11,11 +11,10 @@ pub use core::Audio;
 pub use seek::SeekHandle;
 
 pub(crate) use crate::{
-    AudioConfig, AudioDecoderConfig, AudioEffect, AudioWorkerHandle, ChunkOutcome,
-    ConsumerWakeMode, DecodeError, EngineLoad, Fetch, PcmControl, PcmRead, PcmSession,
-    PendingReason, PreloadGate, ReadOutcome, SeekOutcome, ServiceClass, StretchControls,
+    AudioConfig, AudioDecoderConfig, AudioWorkerHandle, ChunkOutcome, ConsumerWakeMode,
+    DecodeError, EngineLoad, Fetch, PcmControl, PcmRead, PcmSession, PendingReason, PreloadGate,
+    ReadOutcome, SeekOutcome, ServiceClass, StretchControls,
     pipeline::{
-        config::create_effects,
         consumer::{ConsumerPhase, FailureSource},
         fetch::EpochValidator,
         parts::SourceParts,

--- a/crates/kithara-audio/src/audio/ring.rs
+++ b/crates/kithara-audio/src/audio/ring.rs
@@ -11,16 +11,21 @@ use super::{
     Inlet, Outlet, ThreadWake, WakeSignal, connect, cursor::ChunkCursor, event::ReaderOutputWake,
     park::receive_is_nonblocking,
 };
+use crate::{
+    renderer::PresentedPcm,
+    runtime::{StrictOutlet, connect_strict},
+    traits::{PresentationAdvance, PresentationPoint},
+};
 
 enum FetchOutcome {
     Continue,
-    Return(Option<PcmChunk>),
+    Return(Option<PresentedPcm>),
 }
 
 pub(super) enum RecvOutcome {
     Closed,
     Empty,
-    Item(Fetch<PcmChunk>),
+    Item(Fetch<PresentedPcm>),
 }
 
 #[derive(Clone, Copy)]
@@ -33,11 +38,12 @@ pub(super) struct RecvCtx<'a> {
 pub(super) struct RingConsumer {
     pub(super) phase: ConsumerPhase,
     pub(super) validator: EpochValidator,
-    pub(super) current_chunk: Option<PcmChunk>,
+    pub(super) current_chunk: Option<PresentedPcm>,
     pub(super) preloaded: bool,
+    presentation_advance: Option<PresentationAdvance>,
     _epoch: Arc<AtomicU64>,
     reader_wake: Arc<ThreadWake>,
-    pcm_rx: Inlet<Fetch<PcmChunk>>,
+    pcm_rx: Inlet<Fetch<PresentedPcm>>,
     trash_tx: Outlet<PcmChunk>,
     block_on_underrun: bool,
     consumer_wake_mode: ConsumerWakeMode,
@@ -46,7 +52,7 @@ pub(super) struct RingConsumer {
 pub(super) struct RingParts {
     pub(super) epoch: Arc<AtomicU64>,
     pub(super) reader_wake: Arc<ThreadWake>,
-    pub(super) pcm_rx: Inlet<Fetch<PcmChunk>>,
+    pub(super) pcm_rx: Inlet<Fetch<PresentedPcm>>,
     pub(super) trash_tx: Outlet<PcmChunk>,
     pub(super) block_on_underrun: bool,
     pub(super) consumer_wake_mode: ConsumerWakeMode,
@@ -64,6 +70,7 @@ impl RingConsumer {
             validator: EpochValidator::default(),
             phase: ConsumerPhase::Buffering,
             current_chunk: None,
+            presentation_advance: None,
             trash_tx: parts.trash_tx,
             reader_wake: parts.reader_wake,
             _epoch: parts.epoch,
@@ -77,6 +84,7 @@ impl RingConsumer {
     #[must_use]
     pub(super) fn begin_seek_epoch(&mut self, epoch: u64, cursor: &mut ChunkCursor) -> bool {
         self.validator.epoch = epoch;
+        self.presentation_advance = None;
         self.recycle_current();
         cursor.clear();
         self.phase = ConsumerPhase::SeekPending { epoch };
@@ -117,8 +125,8 @@ impl RingConsumer {
         }
     }
 
-    pub(super) fn discard(&mut self, chunk: PcmChunk) {
-        if let Err(_overflow) = self.trash_tx.try_push(chunk) {
+    pub(super) fn discard(&mut self, presented: PresentedPcm) {
+        if let Err(_overflow) = self.trash_tx.try_push(presented.into()) {
             debug_assert!(
                 false,
                 "PCM trash ring overflow - spent buffer freed on the audio thread"
@@ -130,13 +138,13 @@ impl RingConsumer {
         let Some(chunk) = self.recv_valid_chunk(ctx) else {
             return false;
         };
-        cursor.begin_chunk(&chunk);
+        cursor.begin_chunk(chunk.chunk());
         self.current_chunk = Some(chunk);
         self.promote_playing();
         true
     }
 
-    fn process_fetch(&mut self, fetch: Fetch<PcmChunk>) -> FetchOutcome {
+    fn process_fetch(&mut self, fetch: Fetch<PresentedPcm>) -> FetchOutcome {
         if !self.validator.is_valid(&fetch) {
             if let Fetch::Data { data, .. } = fetch {
                 self.discard(data);
@@ -155,7 +163,17 @@ impl RingConsumer {
                 };
                 FetchOutcome::Return(None)
             }
-            Fetch::Data { data, .. } => FetchOutcome::Return(Some(data)),
+            Fetch::Data { data, epoch } => {
+                if data.point().seek_epoch() != epoch {
+                    self.discard(data);
+                    self.phase = ConsumerPhase::Failed {
+                        source: FailureSource::Producer,
+                    };
+                    FetchOutcome::Return(None)
+                } else {
+                    FetchOutcome::Return(Some(data))
+                }
+            }
         }
     }
 
@@ -216,7 +234,7 @@ impl RingConsumer {
     }
 
     #[kithara::hang_watchdog]
-    pub(super) fn recv_valid_chunk(&mut self, ctx: RecvCtx<'_>) -> Option<PcmChunk> {
+    pub(super) fn recv_valid_chunk(&mut self, ctx: RecvCtx<'_>) -> Option<PresentedPcm> {
         if self.phase.is_terminal() {
             return None;
         }
@@ -250,9 +268,21 @@ impl RingConsumer {
         }
     }
 
+    pub(super) fn record_presentation_advance(
+        &mut self,
+        point: PresentationPoint,
+        read_offset_frames: usize,
+    ) {
+        self.presentation_advance = Some(PresentationAdvance::new(point, read_offset_frames));
+    }
+
+    pub(super) fn take_presentation_advance(&mut self) -> Option<PresentationAdvance> {
+        self.presentation_advance.take()
+    }
+
     fn stage_post_seek_fetch(
         &mut self,
-        fetch: Fetch<PcmChunk>,
+        fetch: Fetch<PresentedPcm>,
         epoch: u64,
         cursor: &mut ChunkCursor,
     ) {
@@ -263,9 +293,16 @@ impl RingConsumer {
         );
         match fetch {
             Fetch::Data { data, .. } => {
-                cursor.begin_chunk(&data);
-                self.current_chunk = Some(data);
-                self.phase = ConsumerPhase::Playing;
+                if data.point().seek_epoch() != epoch {
+                    self.discard(data);
+                    self.phase = ConsumerPhase::Failed {
+                        source: FailureSource::ProducerAfterSeek,
+                    };
+                } else {
+                    cursor.begin_chunk(data.chunk());
+                    self.current_chunk = Some(data);
+                    self.phase = ConsumerPhase::Playing;
+                }
             }
             Fetch::NaturalEof { .. } => {
                 self.phase = ConsumerPhase::AtEof;
@@ -280,12 +317,15 @@ impl RingConsumer {
 }
 
 pub(super) fn create_channels(
-    pcm_buffer_chunks: usize,
+    capacity: usize,
     emit: Arc<DeferredBus<Event>>,
     reader_wake: &Arc<ThreadWake>,
-) -> (Outlet<Fetch<PcmChunk>>, Inlet<Fetch<PcmChunk>>) {
+) -> (
+    StrictOutlet<Fetch<PresentedPcm>>,
+    Inlet<Fetch<PresentedPcm>>,
+) {
     let wake: Arc<dyn WakeSignal> = Arc::new(ReaderOutputWake::new(Arc::clone(reader_wake), emit));
-    connect::<Fetch<PcmChunk>>(pcm_buffer_chunks.max(1), Some(wake))
+    connect_strict::<Fetch<PresentedPcm>>(capacity.max(1), Some(wake))
 }
 
 pub(super) fn create_trash_channel(
@@ -307,10 +347,10 @@ struct ConsumerHangCtx {
 }
 
 fn try_pop_and_wake(
-    pcm_rx: &mut Inlet<Fetch<PcmChunk>>,
+    pcm_rx: &mut Inlet<Fetch<PresentedPcm>>,
     worker: Option<&AudioWorkerHandle>,
     mode: ConsumerWakeMode,
-) -> Option<Fetch<PcmChunk>> {
+) -> Option<Fetch<PresentedPcm>> {
     let fetch = pcm_rx.try_pop()?;
     wake_worker(worker, mode);
     Some(fetch)
@@ -344,7 +384,7 @@ mod tests {
         events: crate::audio::event::AudioEvents,
         cursor: ChunkCursor,
         _trash_rx: Inlet<PcmChunk>,
-        data_tx: Outlet<Fetch<PcmChunk>>,
+        data_tx: Outlet<Fetch<PresentedPcm>>,
         ring: RingConsumer,
     }
 
@@ -358,7 +398,7 @@ mod tests {
             block_on_underrun: bool,
             consumer_wake_mode: ConsumerWakeMode,
         ) -> Self {
-            let (data_tx, pcm_rx) = connect::<Fetch<PcmChunk>>(4, None);
+            let (data_tx, pcm_rx) = connect::<Fetch<PresentedPcm>>(4, None);
             let (trash_tx, trash_rx) = connect::<PcmChunk>(8, None);
             let pool = PcmPool::default();
             let mut ring = RingConsumer::new(RingParts {
@@ -381,7 +421,7 @@ mod tests {
         }
 
         fn recv(&mut self) -> Option<PcmChunk> {
-            self.ring.recv_valid_chunk(empty_ctx())
+            self.ring.recv_valid_chunk(empty_ctx()).map(PcmChunk::from)
         }
     }
 
@@ -393,11 +433,16 @@ mod tests {
         }
     }
 
-    fn make_chunk(samples: &[f32]) -> PcmChunk {
+    fn make_presented(samples: &[f32], epoch: u64) -> PresentedPcm {
         let mut meta = PcmMeta::default();
         meta.spec.channels = 1;
         meta.frames = u32::try_from(samples.len()).unwrap_or(u32::MAX);
-        PcmChunk::new(meta, PcmPool::default().attach(samples.to_vec()))
+        let frame = u64::from(meta.frames);
+        let rate = meta.spec.sample_rate;
+        PresentedPcm::new(
+            PcmChunk::new(meta, PcmPool::default().attach(samples.to_vec())),
+            PresentationPoint::new(epoch, frame, 0, frame, rate),
+        )
     }
 
     #[kithara::test]
@@ -425,11 +470,11 @@ mod tests {
         let mut drained = RingFixture::new(true);
         drained
             .data_tx
-            .try_push(Fetch::data(make_chunk(&[0.1]), 0))
+            .try_push(Fetch::data(make_presented(&[0.1], 0), 0))
             .expect("first stale chunk reaches ring");
         drained
             .data_tx
-            .try_push(Fetch::data(make_chunk(&[0.2]), 0))
+            .try_push(Fetch::data(make_presented(&[0.2], 0), 0))
             .expect("second stale chunk reaches ring");
         drained
             .data_tx
@@ -486,7 +531,7 @@ mod tests {
         let mut fixture = RingFixture::new(true);
         fixture
             .data_tx
-            .try_push(Fetch::data(make_chunk(&[0.1, 0.2]), 0))
+            .try_push(Fetch::data(make_presented(&[0.1, 0.2], 0), 0))
             .expect("chunk reaches ring");
         assert!(fixture.ring.fill(&mut fixture.cursor, empty_ctx()));
         assert_eq!(fixture.ring.phase, ConsumerPhase::Playing);
@@ -508,7 +553,7 @@ mod tests {
         let _ = fixture.ring.begin_seek_epoch(1, &mut fixture.cursor);
         fixture
             .data_tx
-            .try_push(Fetch::data(make_chunk(&[0.1, 0.2]), 1))
+            .try_push(Fetch::data(make_presented(&[0.1, 0.2], 1), 1))
             .expect("post-seek chunk reaches ring");
         assert!(fixture.ring.fill(&mut fixture.cursor, empty_ctx()));
         assert_eq!(fixture.ring.phase, ConsumerPhase::Playing);
@@ -519,11 +564,11 @@ mod tests {
         let mut fixture = RingFixture::new(true);
         fixture
             .data_tx
-            .try_push(Fetch::data(make_chunk(&[0.1, 0.2]), 0))
+            .try_push(Fetch::data(make_presented(&[0.1, 0.2], 0), 0))
             .expect("stale chunk reaches ring");
         fixture
             .data_tx
-            .try_push(Fetch::data(make_chunk(&[0.7, 0.8]), 1))
+            .try_push(Fetch::data(make_presented(&[0.7, 0.8], 1), 1))
             .expect("fresh chunk reaches ring");
         let _ = fixture.ring.begin_seek_epoch(1, &mut fixture.cursor);
         let mut buf = [0.0; 2];
@@ -549,7 +594,7 @@ mod tests {
         let mut fixture = RingFixture::new(true);
         fixture
             .data_tx
-            .try_push(Fetch::data(make_chunk(&[0.1, 0.2]), 0))
+            .try_push(Fetch::data(make_presented(&[0.1, 0.2], 0), 0))
             .expect("stale chunk reaches ring");
         fixture
             .data_tx

--- a/crates/kithara-audio/src/audio/ring.rs
+++ b/crates/kithara-audio/src/audio/ring.rs
@@ -457,12 +457,17 @@ mod tests {
 
     #[kithara::test]
     fn explicit_off_rt_mode_is_immediate_without_blocking_reads() {
-        let fixture = RingFixture::with_wake_mode(true, false, ConsumerWakeMode::ImmediateOffRt);
+        let mut fixture =
+            RingFixture::with_wake_mode(true, false, ConsumerWakeMode::ImmediateOffRt);
 
         assert_eq!(
             fixture.ring.consumer_wake_mode,
             ConsumerWakeMode::ImmediateOffRt
         );
+        assert!(matches!(
+            fixture.ring.recv_outcome(empty_ctx()),
+            RecvOutcome::Empty
+        ));
     }
 
     #[kithara::test]

--- a/crates/kithara-audio/src/audio/ring.rs
+++ b/crates/kithara-audio/src/audio/ring.rs
@@ -12,7 +12,7 @@ use super::{
     park::receive_is_nonblocking,
 };
 use crate::{
-    renderer::PresentedPcm,
+    renderer::{OutputDisposition, PresentedPcm},
     runtime::{StrictOutlet, connect_strict},
     traits::{PresentationAdvance, PresentationPoint},
 };
@@ -44,7 +44,9 @@ pub(super) struct RingConsumer {
     _epoch: Arc<AtomicU64>,
     reader_wake: Arc<ThreadWake>,
     pcm_rx: Inlet<Fetch<PresentedPcm>>,
-    trash_tx: Outlet<PcmChunk>,
+    trash_tx: Outlet<OutputDisposition>,
+    trash_rejected: Option<OutputDisposition>,
+    worker_progress_pending: bool,
     block_on_underrun: bool,
     consumer_wake_mode: ConsumerWakeMode,
 }
@@ -53,7 +55,7 @@ pub(super) struct RingParts {
     pub(super) epoch: Arc<AtomicU64>,
     pub(super) reader_wake: Arc<ThreadWake>,
     pub(super) pcm_rx: Inlet<Fetch<PresentedPcm>>,
-    pub(super) trash_tx: Outlet<PcmChunk>,
+    pub(super) trash_tx: Outlet<OutputDisposition>,
     pub(super) block_on_underrun: bool,
     pub(super) consumer_wake_mode: ConsumerWakeMode,
 }
@@ -72,6 +74,8 @@ impl RingConsumer {
             current_chunk: None,
             presentation_advance: None,
             trash_tx: parts.trash_tx,
+            trash_rejected: None,
+            worker_progress_pending: false,
             reader_wake: parts.reader_wake,
             _epoch: parts.epoch,
             preloaded: false,
@@ -80,13 +84,18 @@ impl RingConsumer {
         }
     }
 
+    /// Returns whether the worker can progress after the complete seek drain.
     #[kithara::hang_watchdog]
     #[must_use]
     pub(super) fn begin_seek_epoch(&mut self, epoch: u64, cursor: &mut ChunkCursor) -> bool {
         self.validator.epoch = epoch;
         self.presentation_advance = None;
-        self.recycle_current();
+        let mut published = self.recycle_current();
         cursor.clear();
+        if self.trash_rejected.is_some() {
+            let pending = self.take_worker_progress();
+            return published || pending;
+        }
         self.phase = ConsumerPhase::SeekPending { epoch };
 
         let mut popped = false;
@@ -94,15 +103,20 @@ impl RingConsumer {
             popped = true;
             if fetch.epoch() < epoch {
                 if let Fetch::Data { data, .. } = fetch {
-                    self.discard(data);
+                    let discarded = self.discard(data);
+                    published |= discarded;
+                    if !discarded {
+                        break;
+                    }
                 }
                 hang_tick!();
                 continue;
             }
-            self.stage_post_seek_fetch(fetch, epoch, cursor);
+            published |= self.stage_post_seek_fetch(fetch, epoch, cursor);
             break;
         }
-        popped
+        let pending = self.take_worker_progress();
+        popped || published || pending
     }
 
     pub(super) fn wake_worker(&self, worker: Option<&AudioWorkerHandle>) {
@@ -125,13 +139,57 @@ impl RingConsumer {
         }
     }
 
-    pub(super) fn discard(&mut self, presented: PresentedPcm) {
-        if let Err(_overflow) = self.trash_tx.try_push(presented.into()) {
-            debug_assert!(
-                false,
-                "PCM trash ring overflow - spent buffer freed on the audio thread"
-            );
+    fn discard(&mut self, presented: PresentedPcm) -> bool {
+        if self.trash_rejected.is_some() {
+            debug_assert!(self.current_chunk.is_none());
+            self.current_chunk = Some(presented);
+            self.fail_output_return();
+            return false;
         }
+        if let Some(rejected) = self.push_output(presented.returned()) {
+            self.trash_rejected = Some(rejected);
+            self.fail_output_return();
+            return false;
+        }
+        self.worker_progress_pending = true;
+        true
+    }
+
+    pub(super) fn detach(
+        &mut self,
+        presented: PresentedPcm,
+    ) -> Result<PcmChunk, super::DecodeError> {
+        if self.trash_rejected.is_some() {
+            self.current_chunk = Some(presented);
+            self.fail_output_return();
+            return Err(output_return_error());
+        }
+        let point = presented.point();
+        let (chunk, disposition) = presented.detach();
+        if self.push_output(disposition).is_some() {
+            self.current_chunk = Some(PresentedPcm::new(chunk, point));
+            self.fail_output_return();
+            return Err(output_return_error());
+        }
+        self.worker_progress_pending = true;
+        Ok(chunk)
+    }
+
+    fn push_output(&mut self, disposition: OutputDisposition) -> Option<OutputDisposition> {
+        self.trash_tx.try_push(disposition).err()
+    }
+
+    fn fail_output_return(&mut self) {
+        self.phase = ConsumerPhase::Failed {
+            source: FailureSource::Producer,
+        };
+    }
+
+    /// Takes the coalesced final-output publication signal.
+    pub(super) fn take_worker_progress(&mut self) -> bool {
+        let pending = self.worker_progress_pending;
+        self.worker_progress_pending = false;
+        pending
     }
 
     pub(super) fn fill(&mut self, cursor: &mut ChunkCursor, ctx: RecvCtx<'_>) -> bool {
@@ -146,8 +204,10 @@ impl RingConsumer {
 
     fn process_fetch(&mut self, fetch: Fetch<PresentedPcm>) -> FetchOutcome {
         if !self.validator.is_valid(&fetch) {
-            if let Fetch::Data { data, .. } = fetch {
-                self.discard(data);
+            if let Fetch::Data { data, .. } = fetch
+                && !self.discard(data)
+            {
+                return FetchOutcome::Return(None);
             }
             return FetchOutcome::Continue;
         }
@@ -262,10 +322,12 @@ impl RingConsumer {
         }
     }
 
-    pub(super) fn recycle_current(&mut self) {
+    #[must_use]
+    pub(super) fn recycle_current(&mut self) -> bool {
         if let Some(chunk) = self.current_chunk.take() {
-            self.discard(chunk);
+            return self.discard(chunk);
         }
+        false
     }
 
     pub(super) fn record_presentation_advance(
@@ -285,7 +347,7 @@ impl RingConsumer {
         fetch: Fetch<PresentedPcm>,
         epoch: u64,
         cursor: &mut ChunkCursor,
-    ) {
+    ) -> bool {
         debug_assert_eq!(
             fetch.epoch(),
             epoch,
@@ -294,23 +356,27 @@ impl RingConsumer {
         match fetch {
             Fetch::Data { data, .. } => {
                 if data.point().seek_epoch() != epoch {
-                    self.discard(data);
+                    let published = self.discard(data);
                     self.phase = ConsumerPhase::Failed {
                         source: FailureSource::ProducerAfterSeek,
                     };
+                    published
                 } else {
                     cursor.begin_chunk(data.chunk());
                     self.current_chunk = Some(data);
                     self.phase = ConsumerPhase::Playing;
+                    false
                 }
             }
             Fetch::NaturalEof { .. } => {
                 self.phase = ConsumerPhase::AtEof;
+                false
             }
             Fetch::Failure { .. } => {
                 self.phase = ConsumerPhase::Failed {
                     source: FailureSource::ProducerAfterSeek,
                 };
+                false
             }
         }
     }
@@ -330,8 +396,8 @@ pub(super) fn create_channels(
 
 pub(super) fn create_trash_channel(
     pcm_buffer_chunks: usize,
-) -> (Outlet<PcmChunk>, Inlet<PcmChunk>) {
-    connect::<PcmChunk>(pcm_buffer_chunks.max(1) + 2, None)
+) -> (Outlet<OutputDisposition>, Inlet<OutputDisposition>) {
+    connect::<OutputDisposition>(pcm_buffer_chunks.max(1) + 2, None)
 }
 
 #[derive(serde::Serialize)]
@@ -366,6 +432,12 @@ fn wake_worker(worker: Option<&AudioWorkerHandle>, mode: ConsumerWakeMode) {
     }
 }
 
+const fn output_return_error() -> super::DecodeError {
+    super::DecodeError::InvalidData {
+        detail: "bounded presentation output return ring is full",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::AtomicU64;
@@ -383,7 +455,7 @@ mod tests {
         playhead: Arc<PlayheadState>,
         events: crate::audio::event::AudioEvents,
         cursor: ChunkCursor,
-        _trash_rx: Inlet<PcmChunk>,
+        _trash_rx: Inlet<OutputDisposition>,
         data_tx: Outlet<Fetch<PresentedPcm>>,
         ring: RingConsumer,
     }
@@ -399,7 +471,7 @@ mod tests {
             consumer_wake_mode: ConsumerWakeMode,
         ) -> Self {
             let (data_tx, pcm_rx) = connect::<Fetch<PresentedPcm>>(4, None);
-            let (trash_tx, trash_rx) = connect::<PcmChunk>(8, None);
+            let (trash_tx, trash_rx) = connect::<OutputDisposition>(8, None);
             let pool = PcmPool::default();
             let mut ring = RingConsumer::new(RingParts {
                 pcm_rx,
@@ -471,6 +543,41 @@ mod tests {
     }
 
     #[kithara::test]
+    fn saturated_return_ring_retains_every_output() {
+        let mut fixture = RingFixture::new(true);
+        let (trash_tx, trash_rx) = connect::<OutputDisposition>(1, None);
+        fixture.ring.trash_tx = trash_tx;
+        fixture._trash_rx = trash_rx;
+
+        assert!(fixture.ring.discard(make_presented(&[0.1], 0)));
+        assert!(fixture.ring.discard(make_presented(&[0.2], 0)));
+        assert!(!fixture.ring.discard(make_presented(&[0.3], 0)));
+        assert!(!fixture.ring.discard(make_presented(&[0.4], 0)));
+
+        assert!(matches!(
+            fixture._trash_rx.try_pop(),
+            Some(OutputDisposition::Returned(_))
+        ));
+        assert!(fixture.ring.trash_tx.flush());
+        assert!(matches!(
+            fixture._trash_rx.try_pop(),
+            Some(OutputDisposition::Returned(_))
+        ));
+        assert!(fixture._trash_rx.try_pop().is_none());
+        assert!(matches!(
+            fixture.ring.trash_rejected.as_ref(),
+            Some(OutputDisposition::Returned(_))
+        ));
+        assert!(fixture.ring.current_chunk.is_some());
+        assert!(matches!(
+            fixture.ring.phase,
+            ConsumerPhase::Failed {
+                source: FailureSource::Producer
+            }
+        ));
+    }
+
+    #[kithara::test]
     fn seek_drain_reports_whether_it_popped_any_item() {
         let mut drained = RingFixture::new(true);
         drained
@@ -490,6 +597,19 @@ mod tests {
 
         let mut empty = RingFixture::new(true);
         assert!(!empty.ring.begin_seek_epoch(1, &mut empty.cursor));
+    }
+
+    #[kithara::test]
+    fn current_only_seek_reports_return_progress() {
+        let mut fixture = RingFixture::new(true);
+        fixture.ring.current_chunk = Some(make_presented(&[0.1, 0.2], 0));
+
+        assert!(fixture.ring.begin_seek_epoch(1, &mut fixture.cursor));
+        assert!(fixture.ring.current_chunk.is_none());
+        assert!(matches!(
+            fixture._trash_rx.try_pop(),
+            Some(OutputDisposition::Returned(_))
+        ));
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/crates/kithara-audio/src/effects/eq/effect.rs
+++ b/crates/kithara-audio/src/effects/eq/effect.rs
@@ -1,7 +1,7 @@
-use kithara_decode::PcmChunk;
+use kithara_decode::DecodeResult;
 
 use super::{EqBandConfig, IsolatorEq};
-use crate::AudioEffect;
+use crate::{AudioBlockMut, AudioEffect};
 
 pub struct EqEffect {
     eq_l: IsolatorEq,
@@ -57,26 +57,20 @@ impl EqEffect {
 }
 
 impl AudioEffect for EqEffect {
-    fn flush(&mut self) -> Option<PcmChunk> {
-        None
-    }
-
-    fn process(&mut self, mut chunk: PcmChunk) -> Option<PcmChunk> {
+    fn process(&mut self, mut block: AudioBlockMut<'_>) -> DecodeResult<()> {
         let channels = self.channels as usize;
         if channels == 0 {
-            return Some(chunk);
+            return Ok(());
         }
 
-        let samples = &mut chunk.samples;
-
-        for frame in samples.chunks_exact_mut(channels) {
+        for frame in block.samples_mut().chunks_exact_mut(channels) {
             frame[0] = self.eq_l.process_sample(frame[0]);
             if channels >= 2 {
                 frame[1] = self.eq_r.process_sample(frame[1]);
             }
         }
 
-        Some(chunk)
+        Ok(())
     }
 
     fn reset(&mut self) {
@@ -90,7 +84,7 @@ mod tests {
     use std::{f32::consts::PI, num::NonZeroU32};
 
     use kithara_bufpool::PcmPool;
-    use kithara_decode::{PcmMeta, PcmSpec};
+    use kithara_decode::{PcmChunk, PcmMeta, PcmSpec};
     use kithara_test_utils::kithara;
 
     use super::{super::*, *};
@@ -113,6 +107,10 @@ mod tests {
         )
     }
 
+    fn process_chunk(effect: &mut EqEffect, chunk: &mut PcmChunk) -> DecodeResult<()> {
+        effect.process(AudioBlockMut::new(&chunk.meta, &mut chunk.samples))
+    }
+
     #[kithara::test]
     fn eq_flat_gain_preserves_magnitude() {
         let bands = generate_log_spaced_bands(10);
@@ -120,7 +118,8 @@ mod tests {
         let mut eq = EqEffect::new(bands, spec.sample_rate.get(), spec.channels);
 
         let warmup = vec![0.0f32; 4096];
-        let _ = eq.process(test_chunk(spec, warmup));
+        let mut warmup = test_chunk(spec, warmup);
+        process_chunk(&mut eq, &mut warmup).expect("EQ warmup succeeds");
 
         let num_frames: u16 = 44100;
         let pcm: Vec<f32> = (0..num_frames)
@@ -130,8 +129,8 @@ mod tests {
         let input_rms: f32 =
             (pcm.iter().map(|s| s * s).sum::<f32>() / f32::from(num_frames)).sqrt();
 
-        let chunk = test_chunk(spec, pcm);
-        let output = eq.process(chunk).unwrap();
+        let mut output = test_chunk(spec, pcm);
+        process_chunk(&mut eq, &mut output).expect("EQ processing must succeed");
         let out = &output.samples[..];
 
         let steady = &out[4096..];
@@ -179,8 +178,8 @@ mod tests {
         eq.set_gain(0, 6.0);
         let spec = EqFixture::spec(2, 44100);
         let pcm = vec![0.5f32; 256];
-        let chunk = test_chunk(spec, pcm);
-        let _ = eq.process(chunk);
+        let mut chunk = test_chunk(spec, pcm);
+        process_chunk(&mut eq, &mut chunk).expect("EQ setup succeeds");
 
         eq.reset();
 
@@ -327,16 +326,16 @@ mod tests {
         let warmup: Vec<f32> = (0u16..4096)
             .map(|i| (2.0 * PI * 1000.0 * f32::from(i) / 44100.0).sin())
             .collect();
-        let chunk = test_chunk(spec, warmup);
-        let _ = eq.process(chunk);
+        let mut chunk = test_chunk(spec, warmup);
+        process_chunk(&mut eq, &mut chunk).expect("EQ warmup succeeds");
 
         eq.set_gain(0, MAX_GAIN_DB);
 
         let signal: Vec<f32> = (0u16..4096)
             .map(|i| (2.0 * PI * 1000.0 * f32::from(i + 4096) / 44100.0).sin())
             .collect();
-        let chunk = test_chunk(spec, signal);
-        let output = eq.process(chunk).unwrap();
+        let mut output = test_chunk(spec, signal);
+        process_chunk(&mut eq, &mut output).expect("EQ processing must succeed");
         let out = &output.samples[..];
 
         let max_diff = out
@@ -366,17 +365,9 @@ mod tests {
         }
 
         let pcm = vec![0.5f32; sample_len];
-        let chunk = test_chunk(spec, pcm);
-        let result = eq.process(chunk);
-        assert!(result.is_some());
-        assert_eq!(result.unwrap().samples.len(), sample_len);
-    }
-
-    #[kithara::test]
-    fn eq_flush_returns_none() {
-        let bands = generate_log_spaced_bands(3);
-        let mut eq = EqEffect::new(bands, 44100, 2);
-        assert!(eq.flush().is_none());
+        let mut chunk = test_chunk(spec, pcm);
+        process_chunk(&mut eq, &mut chunk).expect("EQ processing must succeed");
+        assert_eq!(chunk.samples.len(), sample_len);
     }
 
     #[kithara::test]
@@ -396,8 +387,8 @@ mod tests {
             }
 
             let pcm: Vec<f32> = (0u16..1024).map(|i| (f32::from(i) * 0.1).sin()).collect();
-            let chunk = test_chunk(spec, pcm);
-            let output = eq.process(chunk).unwrap();
+            let mut output = test_chunk(spec, pcm);
+            process_chunk(&mut eq, &mut output).expect("EQ processing must succeed");
             for (i, &s) in output.samples.iter().enumerate() {
                 assert!(s.is_finite(), "round {round} sample {i}: got {s}");
             }
@@ -416,8 +407,8 @@ mod tests {
         pcm[10] = f32::NAN;
         pcm[20] = f32::INFINITY;
         pcm[30] = f32::NEG_INFINITY;
-        let chunk = test_chunk(spec, pcm);
-        let output = eq.process(chunk).unwrap();
+        let mut output = test_chunk(spec, pcm);
+        process_chunk(&mut eq, &mut output).expect("EQ processing must succeed");
 
         for (i, &s) in output.samples.iter().enumerate() {
             assert!(s.is_finite(), "sample {i}: got {s}");
@@ -441,9 +432,10 @@ mod tests {
             eq.set_gain(2, gain);
 
             let pcm: Vec<f32> = (0u16..512).map(|i| (f32::from(i) * 0.3).sin()).collect();
-            let chunk = test_chunk(spec, pcm);
-            let output = eq.process(chunk).unwrap();
-            for &s in &output.samples[..] {
+            let mut chunk = test_chunk(spec, pcm);
+            eq.process(AudioBlockMut::new(&chunk.meta, &mut chunk.samples))
+                .expect("EQ processing must succeed");
+            for &s in &chunk.samples[..] {
                 assert!(s.is_finite());
             }
         }
@@ -573,8 +565,8 @@ mod tests {
     fn converge_smoother(eq: &mut EqEffect, spec: PcmSpec) {
         let frames = (spec.sample_rate.get() as usize) / 5;
         let pcm = vec![0.0f32; frames * spec.channels as usize];
-        let chunk = test_chunk(spec, pcm);
-        let _ = eq.process(chunk);
+        let mut chunk = test_chunk(spec, pcm);
+        process_chunk(eq, &mut chunk).expect("EQ convergence processing succeeds");
     }
 
     #[expect(
@@ -591,8 +583,8 @@ mod tests {
 
         let input_rms: f32 = (pcm.iter().map(|s| s * s).sum::<f32>() / num_frames as f32).sqrt();
 
-        let chunk = test_chunk(spec, pcm);
-        let output = eq.process(chunk).unwrap();
+        let mut output = test_chunk(spec, pcm);
+        process_chunk(eq, &mut output).expect("EQ processing must succeed");
         let out = &output.samples[..];
 
         let steady = &out[4096..];

--- a/crates/kithara-audio/src/effects/timestretch/backend.rs
+++ b/crates/kithara-audio/src/effects/timestretch/backend.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
 
 use arc_swap::ArcSwapOption;
 use kithara_platform::sync::Arc;
@@ -14,13 +14,23 @@ struct EngineControls {
     backend: AtomicU8,
 }
 
-/// Live playback-speed control shared by the caller and the effect chain.
+/// Live controls published by callers and snapshotted off RT for the resident tempo stage.
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct StretchControls {
     speed: Arc<AtomicF32>,
     region_plan: ArcSwapOption<RegionPlan>,
     engine: EngineControls,
+    revision: AtomicU64,
+}
+
+#[derive(Clone)]
+pub(crate) struct StretchSnapshot {
+    pub(crate) backend: StretchKind,
+    pub(crate) keylock: bool,
+    pub(crate) plan: Option<Arc<RegionPlan>>,
+    pub(crate) revision: u64,
+    pub(crate) speed: f32,
 }
 
 impl StretchControls {
@@ -33,7 +43,29 @@ impl StretchControls {
                 keylock: AtomicBool::new(false),
                 backend: AtomicU8::new(u8::from(StretchKind::default())),
             },
+            revision: AtomicU64::new(0),
         })
+    }
+
+    pub(crate) fn revision(&self) -> u64 {
+        self.revision.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn try_snapshot(&self) -> Option<StretchSnapshot> {
+        for _ in 0..2 {
+            let revision = self.revision.load(Ordering::Acquire);
+            let snapshot = StretchSnapshot {
+                backend: self.backend(),
+                keylock: self.keylock(),
+                plan: self.region_plan(),
+                revision,
+                speed: self.speed(),
+            };
+            if self.revision.load(Ordering::Acquire) == revision {
+                return Some(snapshot);
+            }
+        }
+        None
     }
 
     #[must_use]
@@ -46,28 +78,31 @@ impl StretchControls {
         self.engine.keylock.load(Ordering::Relaxed)
     }
 
-    delegate::delegate! {
-        to self.region_plan {
-            #[must_use]
-            #[call(load_full)]
-            pub fn region_plan(&self) -> Option<Arc<RegionPlan>>;
-            #[call(store)]
-            pub fn set_region_plan(&self, plan: Option<Arc<RegionPlan>>);
-        }
+    #[must_use]
+    pub fn region_plan(&self) -> Option<Arc<RegionPlan>> {
+        self.region_plan.load_full()
+    }
+
+    pub fn set_region_plan(&self, plan: Option<Arc<RegionPlan>>) {
+        self.region_plan.store(plan);
+        self.revision.fetch_add(1, Ordering::Release);
     }
 
     pub fn set_backend(&self, backend: StretchKind) {
         self.engine
             .backend
             .store(u8::from(backend), Ordering::Relaxed);
+        self.revision.fetch_add(1, Ordering::Release);
     }
 
     pub fn set_keylock(&self, on: bool) {
         self.engine.keylock.store(on, Ordering::Relaxed);
+        self.revision.fetch_add(1, Ordering::Release);
     }
 
     pub fn set_speed(&self, speed: f32) {
         self.speed.store(speed, Ordering::Relaxed);
+        self.revision.fetch_add(1, Ordering::Release);
     }
 
     #[must_use]

--- a/crates/kithara-audio/src/effects/timestretch/controls.rs
+++ b/crates/kithara-audio/src/effects/timestretch/controls.rs
@@ -6,7 +6,7 @@ use portable_atomic::AtomicF32;
 
 use crate::region::RegionPlan;
 
-/// Live playback-speed control shared by the caller and the effect chain.
+/// Live controls published by callers and snapshotted off RT for the resident tempo stage.
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct StretchControls {

--- a/crates/kithara-audio/src/effects/timestretch/processor.rs
+++ b/crates/kithara-audio/src/effects/timestretch/processor.rs
@@ -1,20 +1,30 @@
-#[cfg(test)]
-use std::collections::HashSet;
-
 use kithara_bufpool::PcmPool;
-use kithara_decode::{PcmChunk, PcmMeta, PcmSpec};
+use kithara_decode::{DecodeError, DecodeResult, PcmChunk, PcmMeta, PcmSpec, duration_for_frames};
 use kithara_platform::sync::Arc;
-use kithara_stretch::{StretchBackend, StretchKind, StretchOptions, build_backend};
-use tracing::warn;
+use kithara_stretch::{StretchOptions, build_backend};
 
-use super::StretchControls;
-use crate::{
-    region::{ActiveRegion, RegionPlan},
-    traits::AudioEffect,
+use super::{StretchControls, backend::StretchSnapshot};
+#[path = "render.rs"]
+mod render;
+#[path = "state.rs"]
+mod state;
+
+use state::{
+    AdmittedSource, DrainFrontier, PrepareCause, PreparedCore, RegionBoundary, RetiredCores,
+    TempoCore,
 };
 
-/// Pre-resampler time-stretch slot. Reads live key-lock, backend, and speed
-/// from the shared [`StretchControls`] each chunk:
+use crate::{
+    region::RegionPlan,
+    traits::{
+        OutputCredit, PresentationPoint, TempoBoundaryId, TempoDiscontinuityDebt,
+        TempoDiscontinuityStep, TempoEofDebt, TempoEofStep, TempoPrepareRequest, TempoStage,
+        TempoStep,
+    },
+};
+
+/// Resident late-presentation time-stretch stage driven by shared
+/// [`StretchControls`]:
 ///
 /// - key-lock **on**: drives the backend with the inverse stretch factor
 ///   (`1 / speed`) and pitch held at `1.0`;
@@ -24,36 +34,26 @@ use crate::{
 /// At unity speed with no region plan the slot is a byte-identical
 /// passthrough, so default playback keeps the old no-DSP behavior.
 ///
-/// An optional [`RegionPlan`] (also on the controls) maps
-/// `frame_offset` to per-region ratio corrections: chunks split at segment
-/// boundaries and the effective stretch is `1/speed × ratio_correction`.
-/// The backend is flushed + reset only when a boundary actually moves the
-/// ratio beyond `RATIO_EPS`; equal-ratio boundaries cost nothing.
-///
+/// An optional [`RegionPlan`] maps source positions to live ratio corrections.
+/// A real correction boundary retains future source, prepares a fresh core
+/// off-RT, and drains the old core before an allocation-free commit. Adjacent
+/// equal-ratio regions stay on the resident core without a boundary cost.
 pub struct TimeStretchProcessor {
     controls: Arc<StretchControls>,
-    backend: Box<dyn StretchBackend>,
-    /// Most recent input meta, carried onto each output chunk.
+    active: Option<TempoCore>,
+    prepared: Option<PreparedCore>,
+    retired: Option<RetiredCores>,
+    next_boundary: u64,
+    admitted: Option<AdmittedSource>,
     last_input_meta: Option<PcmMeta>,
-    /// Region plan cached from the controls; `Arc::ptr_eq` detects a live swap.
-    plan: Option<Arc<RegionPlan>>,
-    /// Region covering the playhead — the lookup cursor. `None` forces a
-    /// fresh binary search (first chunk, plan swap, region exit, seek).
-    region: Option<ActiveRegion>,
     pool: PcmPool,
-    spec: PcmSpec,
-    /// Backend kind currently built; compared against `controls.backend()` to
-    /// detect a live backend swap.
-    current_kind: StretchKind,
-    /// Interleaved output scratch, reused across calls (alloc-free steady state).
-    scratch: Vec<f32>,
-    /// Whether previous input ran through the backend. Drives a clean backend
-    /// reset when the processor returns to unity passthrough.
-    active: bool,
-    /// Last pitch factor pushed to the backend; avoids redundant updates.
-    applied_pitch: f64,
-    /// Last stretch factor pushed to the backend; avoids redundant updates.
-    applied_stretch: f64,
+    requested_spec: PcmSpec,
+    eof_offset: usize,
+    eof_pending: bool,
+    discontinuity_pending: bool,
+    drain_frontier: Option<DrainFrontier>,
+    region_boundary: Option<RegionBoundary>,
+    failed: bool,
 }
 
 impl TimeStretchProcessor {
@@ -61,616 +61,510 @@ impl TimeStretchProcessor {
     /// factor. At `speed = 0.05` the stretch is already 20x, beyond which
     /// time-stretch quality collapses, so there is no point clamping lower.
     const MIN_SPEED: f32 = 0.05;
+    const PRESENTATION_FRAMES: usize = 512;
+    const MAX_STRETCH: usize = 20;
+    const BACKEND_INPUT_FRAMES: usize = Self::PRESENTATION_FRAMES / Self::MAX_STRETCH;
     /// Re-apply the stretch ratio to the backend only when it moves this much.
     const RATIO_EPS: f64 = 1e-4;
 
     /// Build the slot at the source `spec`, driven by the shared `controls`.
     pub fn new(controls: Arc<StretchControls>, spec: PcmSpec, pool: PcmPool) -> Self {
-        let current_kind = controls.backend();
-        let options = Self::options_for(spec, &pool);
-        let backend = build_backend(current_kind, &options);
         Self {
-            backend,
-            current_kind,
+            active: None,
+            prepared: None,
+            retired: None,
+            next_boundary: 0,
+            admitted: None,
             controls,
             pool,
-            spec,
-            applied_stretch: f64::NAN,
-            applied_pitch: f64::NAN,
-            active: false,
+            requested_spec: spec,
             last_input_meta: None,
-            scratch: Vec::new(),
-            plan: None,
+            eof_offset: 0,
+            eof_pending: false,
+            discontinuity_pending: false,
+            drain_frontier: None,
+            region_boundary: None,
+            failed: false,
+        }
+    }
+
+    fn build_core(&self, snapshot: StretchSnapshot, spec: PcmSpec) -> DecodeResult<TempoCore> {
+        if spec.channels == 0 {
+            return Err(DecodeError::InvalidData {
+                detail: "tempo stage cannot adopt a zero-channel PCM spec",
+            });
+        }
+        if !snapshot.speed.is_finite() || snapshot.speed <= 0.0 {
+            return Err(DecodeError::InvalidData {
+                detail: "tempo stage cannot adopt an invalid playback speed",
+            });
+        }
+        let bypass = snapshot.plan.is_none()
+            && (snapshot.speed.max(Self::MIN_SPEED) - 1.0).abs() <= f32::EPSILON;
+        if bypass {
+            return Ok(TempoCore {
+                backend: None,
+                scratch: Vec::new(),
+                snapshot,
+                spec,
+                region: None,
+                applied_pitch: f64::NAN,
+                applied_stretch: f64::NAN,
+                source_frames_pushed: 0,
+                processing: false,
+            });
+        }
+        let options = Self::options_for(spec, &self.pool);
+        let backend = build_backend(snapshot.backend, &options)
+            .map_err(|error| DecodeError::pcm_stream("time-stretch backend construction", error))?;
+        let channels = usize::from(spec.channels);
+        let scratch_samples =
+            (Self::PRESENTATION_FRAMES * channels).max(backend.max_tail_samples());
+        Ok(TempoCore {
+            backend: Some(backend),
+            scratch: Vec::with_capacity(scratch_samples),
+            snapshot,
+            spec,
             region: None,
-        }
-    }
-
-    /// Push `pitch` to the backend when it moved beyond `RATIO_EPS`.
-    fn apply_pitch(&mut self, pitch: f64) {
-        if !self.applied_pitch.is_nan() && (pitch - self.applied_pitch).abs() <= Self::RATIO_EPS {
-            return;
-        }
-        match self.backend.set_pitch(pitch) {
-            Ok(()) => self.applied_pitch = pitch,
-            Err(e) => warn!(error = %e, "time-stretch set_pitch failed"),
-        }
-    }
-
-    /// Push `stretch` to the backend when it moved beyond `RATIO_EPS`. At a
-    /// region `boundary` the old region's tail is drained (`flush`, into
-    /// `scratch`) and the backend restarted so the new ratio starts clean;
-    /// live speed moves glide via `set_ratio` alone. Boundaries whose ratio
-    /// did not move cost nothing. `NaN` is the "never applied" sentinel; the
-    /// diff test alone would skip it (every comparison with `NaN` is false).
-    fn apply_stretch(&mut self, stretch: f64, boundary: bool) {
-        let first = self.applied_stretch.is_nan();
-        if !first && (stretch - self.applied_stretch).abs() <= Self::RATIO_EPS {
-            return;
-        }
-        if boundary && !first {
-            if let Err(e) = self.backend.flush(&mut self.scratch) {
-                warn!(error = %e, "time-stretch flush at region boundary failed");
-            }
-            self.backend.reset();
-        }
-        match self.backend.set_ratio(stretch) {
-            Ok(()) => self.applied_stretch = stretch,
-            Err(e) => warn!(error = %e, "time-stretch set_ratio failed"),
-        }
-    }
-
-    /// Assemble an output chunk from `scratch`, preserving decoder timing.
-    fn emit(&mut self) -> Option<PcmChunk> {
-        let total = self.scratch.len();
-        if total == 0 {
-            return None;
-        }
-        let channels = usize::from(self.spec.channels.max(1));
-        let mut meta = self.last_input_meta.unwrap_or_default();
-        // The output carries real audio, so its spec must be the live source
-        // spec — never the `PcmMeta::default()` sentinel (channels 0, placeholder
-        // rate) that `unwrap_or_default()` yields on a flush with no prior input
-        // meta. A stretch only retimes; it preserves channels and sample rate.
-        // Leaving the sentinel spec on a non-empty chunk breaks the downstream
-        // `spec.channels > 0` chunk invariant (the resampler divides by it).
-        meta.spec = self.spec;
-        meta.frames = u32::try_from(total / channels).unwrap_or(u32::MAX);
-        let mut pcm = self.pool.get();
-        if pcm.ensure_len(total).is_err() {
-            warn!("PCM pool budget exhausted during time-stretch");
-            return None;
-        }
-        pcm[..].copy_from_slice(&self.scratch);
-        Some(PcmChunk::new(meta, pcm))
+            applied_pitch: f64::NAN,
+            applied_stretch: f64::NAN,
+            source_frames_pushed: 0,
+            processing: false,
+        })
     }
 
     fn options_for(spec: PcmSpec, pool: &PcmPool) -> StretchOptions {
         StretchOptions::builder()
             .sample_rate(spec.sample_rate.get())
             .channels(usize::from(spec.channels.max(1)))
+            .max_input_frames(Self::BACKEND_INPUT_FRAMES)
+            .max_output_frames(Self::PRESENTATION_FRAMES)
             .pool(pool.clone())
             .build()
     }
 
-    /// Rebuild the backend for `kind` at the current `spec`, discarding any
-    /// buffered state. Used on a live backend swap and on a source-spec change.
-    fn rebuild_backend(&mut self, kind: StretchKind) {
-        let options = Self::options_for(self.spec, &self.pool);
-        self.backend = build_backend(kind, &options);
-        self.current_kind = kind;
-        self.applied_stretch = f64::NAN;
-        self.applied_pitch = f64::NAN;
-        self.active = false;
+    fn active(&self) -> DecodeResult<&TempoCore> {
+        self.active.as_ref().ok_or(DecodeError::InvalidData {
+            detail: "tempo stage has no prepared active core",
+        })
     }
 
-    /// Region covering `frame`, plus whether the playhead just crossed out
-    /// of a previously resolved region (a plan boundary or a seek).
-    fn region_for(&mut self, frame: u64) -> (ActiveRegion, bool) {
-        if let Some(r) = self.region
-            && r.contains(frame)
-        {
-            return (r, false);
-        }
-        let next = self
-            .plan
-            .as_ref()
-            .map_or(ActiveRegion::UNBOUNDED, |p| p.region_at(frame));
-        let crossed = self.region.is_some();
-        self.region = Some(next);
-        (next, crossed)
+    fn active_mut(&mut self) -> DecodeResult<&mut TempoCore> {
+        self.active.as_mut().ok_or(DecodeError::InvalidData {
+            detail: "tempo stage has no prepared active core",
+        })
     }
 
-    fn reset_for_passthrough(&mut self) {
-        if !self.active {
-            return;
-        }
-        self.backend.reset();
-        self.applied_stretch = f64::NAN;
-        self.applied_pitch = f64::NAN;
-        self.active = false;
+    fn bypass_for(snapshot: &StretchSnapshot) -> bool {
+        snapshot.plan.is_none() && (snapshot.speed.max(Self::MIN_SPEED) - 1.0).abs() <= f32::EPSILON
     }
 
-    /// Pull the live region plan handle; on a swap drop the region cursor.
-    fn sync_plan(&mut self) {
-        let want = self.controls.region_plan();
-        let same = match (&self.plan, &want) {
+    fn same_plan(left: &Option<Arc<RegionPlan>>, right: &Option<Arc<RegionPlan>>) -> bool {
+        match (left, right) {
             (None, None) => true,
-            (Some(a), Some(b)) => Arc::ptr_eq(a, b),
+            (Some(left), Some(right)) => Arc::ptr_eq(left, right),
             _ => false,
-        };
-        if !same {
-            self.plan = want;
-            self.region = None;
         }
     }
 
-    fn unity_passthrough(&self, speed: f32) -> bool {
-        self.plan.is_none() && (speed - 1.0).abs() <= f32::EPSILON
+    fn same_snapshot(left: &StretchSnapshot, right: &StretchSnapshot) -> bool {
+        left.revision == right.revision
+            && left.backend == right.backend
+            && left.keylock == right.keylock
+            && left.speed.to_bits() == right.speed.to_bits()
+            && Self::same_plan(&left.plan, &right.plan)
+    }
+
+    fn channels(&self) -> usize {
+        self.active.as_ref().map_or_else(
+            || usize::from(self.requested_spec.channels.max(1)),
+            TempoCore::channels,
+        )
+    }
+
+    fn validate_credit(&self, credit: &mut OutputCredit<'_>) -> DecodeResult<()> {
+        if credit.channels() != self.channels()
+            || credit.max_frames() == 0
+            || credit.max_frames() > Self::PRESENTATION_FRAMES
+        {
+            return Err(DecodeError::InvalidData {
+                detail: "tempo output credit has an invalid PCM shape",
+            });
+        }
+        let samples =
+            credit
+                .max_frames()
+                .checked_mul(credit.channels())
+                .ok_or(DecodeError::InvalidData {
+                    detail: "tempo output credit sample count overflow",
+                })?;
+        if credit.samples_mut().len() < samples {
+            return Err(DecodeError::InvalidData {
+                detail: "tempo output credit buffer is shorter than its frame count",
+            });
+        }
+        Ok(())
+    }
+
+    fn output_meta(
+        &self,
+        source: &PcmMeta,
+        source_offset: usize,
+        output_frames: usize,
+    ) -> DecodeResult<PcmMeta> {
+        let offset = u64::try_from(source_offset).map_err(|_| DecodeError::InvalidData {
+            detail: "tempo source offset exceeds u64",
+        })?;
+        let mut meta = *source;
+        let spec = self.active()?.spec;
+        meta.spec = spec;
+        meta.frame_offset =
+            meta.frame_offset
+                .checked_add(offset)
+                .ok_or(DecodeError::InvalidData {
+                    detail: "tempo source frame offset overflow",
+                })?;
+        meta.timestamp = meta
+            .timestamp
+            .checked_add(duration_for_frames(spec.sample_rate.get(), offset))
+            .ok_or(DecodeError::InvalidData {
+                detail: "tempo source timestamp overflow",
+            })?;
+        meta.frames = u32::try_from(output_frames).map_err(|_| DecodeError::InvalidData {
+            detail: "tempo output frame count exceeds u32",
+        })?;
+        Ok(meta)
+    }
+
+    fn admitted_source_frames(&self) -> u64 {
+        self.admitted.as_ref().map_or(0, |source| {
+            let remaining = source.chunk.frames() - source.consumed_frames;
+            u64::try_from(remaining).unwrap_or(u64::MAX)
+        })
+    }
+
+    fn active_held_source_frames(&self) -> u64 {
+        self.active.as_ref().map_or(0, |core| {
+            if !core.processing {
+                return 0;
+            }
+            core.backend.as_ref().map_or(0, |backend| {
+                u64::try_from(backend.source_latency_frames())
+                    .unwrap_or(u64::MAX)
+                    .min(core.source_frames_pushed)
+            })
+        })
+    }
+
+    fn admitted_source_frame(&self) -> DecodeResult<Option<u64>> {
+        self.admitted
+            .as_ref()
+            .map(|source| {
+                let consumed = u64::try_from(source.consumed_frames).map_err(|_| {
+                    DecodeError::InvalidData {
+                        detail: "tempo admitted source cursor exceeds u64",
+                    }
+                })?;
+                source.chunk.meta.frame_offset.checked_add(consumed).ok_or(
+                    DecodeError::InvalidData {
+                        detail: "tempo admitted source position overflow",
+                    },
+                )
+            })
+            .transpose()
+    }
+
+    fn region_boundary_ready(&self) -> DecodeResult<bool> {
+        if !self
+            .prepared
+            .as_ref()
+            .is_some_and(|prepared| prepared.cause == PrepareCause::RegionBoundary)
+        {
+            return Ok(false);
+        }
+        let boundary = self.region_boundary.ok_or(DecodeError::InvalidData {
+            detail: "tempo prepared region boundary lost its source cursor",
+        })?;
+        if self.admitted_source_frame()? != Some(boundary.source_frame) {
+            return Err(DecodeError::InvalidData {
+                detail: "tempo region boundary moved away from its retained source",
+            });
+        }
+        Ok(true)
     }
 }
 
-impl AudioEffect for TimeStretchProcessor {
-    fn flush(&mut self) -> Option<PcmChunk> {
-        // Only drain the backend when it actually processed input. In unity
-        // passthrough `process` forwards chunks untouched and never feeds the
-        // backend, so flushing it would emit its algorithmic-latency buffer as
-        // spurious trailing zeros. Nothing was buffered: skip.
-        if !self.active {
-            return None;
+impl TempoStage for TimeStretchProcessor {
+    fn release_retired_off_rt(&mut self) {
+        if let Some(retired) = self.retired.take() {
+            retired.release();
         }
-        self.scratch.clear();
-        if let Err(e) = self.backend.flush(&mut self.scratch) {
-            warn!(error = %e, "time-stretch backend flush failed");
-            return None;
-        }
-        self.emit()
     }
 
-    fn process(&mut self, chunk: PcmChunk) -> Option<PcmChunk> {
-        let spec_changed = chunk.spec() != self.spec;
-        if spec_changed {
-            self.spec = chunk.spec();
-        }
-        let want_kind = self.controls.backend();
-        if want_kind != self.current_kind || spec_changed {
-            self.rebuild_backend(want_kind);
-        }
-
-        self.sync_plan();
-        let speed = self.controls.speed().max(Self::MIN_SPEED);
-        if self.unity_passthrough(speed) {
-            self.reset_for_passthrough();
-            return Some(chunk);
-        }
-
-        self.active = true;
-        self.last_input_meta = Some(chunk.meta);
-        self.scratch.clear();
-
-        let base = 1.0 / f64::from(speed);
-        let pitch = if self.controls.keylock() {
-            1.0
-        } else {
-            f64::from(speed)
+    fn service_off_rt(&mut self, request: TempoPrepareRequest) -> DecodeResult<()> {
+        self.release_retired_off_rt();
+        let Some(snapshot) = self.controls.try_snapshot() else {
+            return Ok(());
         };
-        self.apply_pitch(pitch);
-        let channels = usize::from(self.spec.channels.max(1));
-        let frames = chunk.frames();
-        let samples = &chunk.samples;
-        let mut consumed = 0_usize;
-        let mut frame = chunk.meta.frame_offset;
-        // Walk the chunk region by region: a plan boundary mid-chunk splits
-        // it at the boundary sample, each sub-chunk at its own ratio.
-        while consumed < frames {
-            let (region, crossed) = self.region_for(frame);
-            let left = u64::try_from(frames - consumed).unwrap_or(u64::MAX);
-            let span = region.end().saturating_sub(frame).min(left).max(1);
-            let sub = usize::try_from(span).unwrap_or(frames - consumed);
-            self.apply_stretch(base * region.correction(), crossed);
-            let needed = self.scratch.len() + self.backend.max_output_samples(sub);
-            if self.scratch.capacity() < needed {
-                self.scratch.reserve(needed - self.scratch.len());
-            }
-            let part = &samples[consumed * channels..(consumed + sub) * channels];
-            if let Err(e) = self.backend.process(part, &mut self.scratch) {
-                warn!(error = %e, "time-stretch backend process failed; dropping chunk");
-                return None;
-            }
-            consumed += sub;
-            frame = frame.saturating_add(span);
+        let (requested_spec, requested_cause) = match request {
+            TempoPrepareRequest::Current { spec } => (spec, PrepareCause::Current),
+            TempoPrepareRequest::DecoderBoundary { spec } => (spec, PrepareCause::DecoderBoundary),
+        };
+        let (spec, cause) = if self.region_boundary.is_some() {
+            (self.active()?.spec, PrepareCause::RegionBoundary)
+        } else {
+            (requested_spec, requested_cause)
+        };
+        if self.prepared.as_ref().is_some_and(|prepared| {
+            prepared.cause == cause
+                && prepared.core.spec == spec
+                && Self::same_snapshot(&prepared.core.snapshot, &snapshot)
+        }) {
+            return Ok(());
         }
-        self.emit()
+
+        if cause == PrepareCause::Current
+            && let Some(active) = &self.active
+            && active.spec == spec
+            && active.snapshot.backend == snapshot.backend
+            && active.bypass() == Self::bypass_for(&snapshot)
+        {
+            drop(self.prepared.take());
+            self.update_active_snapshot(snapshot)?;
+            self.requested_spec = spec;
+            return Ok(());
+        }
+
+        let core = self.build_core(snapshot, spec)?;
+        if self.active.is_none() {
+            drop(self.prepared.take());
+            self.requested_spec = spec;
+            self.active = Some(core);
+            return Ok(());
+        }
+
+        drop(self.prepared.take());
+        self.next_boundary = self
+            .next_boundary
+            .checked_add(1)
+            .ok_or(DecodeError::InvalidData {
+                detail: "tempo prepared-boundary identity overflow",
+            })?;
+        self.prepared = Some(PreparedCore {
+            cause,
+            id: TempoBoundaryId::new(self.next_boundary),
+            core,
+        });
+        Ok(())
     }
 
-    fn reset(&mut self) {
-        self.backend.reset();
-        self.scratch.clear();
+    fn prepared_boundary(&self) -> Option<TempoBoundaryId> {
+        self.prepared.as_ref().and_then(|prepared| {
+            let admission_ready =
+                self.admitted.is_none() || prepared.cause == PrepareCause::RegionBoundary;
+            (admission_ready && prepared.core.snapshot.revision == self.controls.revision())
+                .then_some(prepared.id)
+        })
+    }
+
+    fn commit_prepared(&mut self, id: TempoBoundaryId) -> DecodeResult<()> {
+        if self.prepared.as_ref().map(|prepared| prepared.id) != Some(id) {
+            return Err(DecodeError::InvalidData {
+                detail: "tempo prepared-boundary identity is stale",
+            });
+        }
+        let retains_region_source = self.region_boundary_ready()?;
+        if (self.admitted.is_some() && !retains_region_source)
+            || self.eof_pending
+            || self.discontinuity_pending
+            || self.active_held_source_frames() != 0
+        {
+            return Err(DecodeError::InvalidData {
+                detail: "tempo core committed before the ordered drain completed",
+            });
+        }
+        if self.retired.is_some() {
+            return Err(DecodeError::InvalidData {
+                detail: "tempo core committed before prior state was retired off-RT",
+            });
+        }
+        let prepared = self.prepared.take().ok_or(DecodeError::InvalidData {
+            detail: "tempo stage lost its prepared core",
+        })?;
+        let active = self.active.take();
+        self.requested_spec = prepared.core.spec;
+        self.active = Some(prepared.core);
+        self.retired = Some(RetiredCores {
+            active,
+            prepared: None,
+        });
         self.last_input_meta = None;
-        self.applied_stretch = f64::NAN;
-        self.applied_pitch = f64::NAN;
-        self.active = false;
-        self.region = None;
+        self.eof_offset = 0;
+        self.drain_frontier = None;
+        self.region_boundary = None;
+        Ok(())
+    }
+
+    fn buffered_source_quanta(&self) -> usize {
+        usize::from(self.admitted.is_some())
+    }
+
+    fn output_spec(&self) -> PcmSpec {
+        self.active
+            .as_ref()
+            .map_or(self.requested_spec, |core| core.spec)
+    }
+
+    fn push_source(&mut self, chunk: PcmChunk) -> DecodeResult<()> {
+        if self.failed || self.eof_pending || self.discontinuity_pending {
+            return Err(DecodeError::InvalidData {
+                detail: "tempo stage is not accepting source in its current state",
+            });
+        }
+        if self.admitted.is_some() {
+            return Err(DecodeError::InvalidData {
+                detail: "tempo stage already owns one source chunk",
+            });
+        }
+        if chunk.spec() != self.output_spec() || chunk.frames() == 0 {
+            return Err(DecodeError::InvalidData {
+                detail: "tempo source chunk has an invalid PCM shape",
+            });
+        }
+        self.admitted = Some(AdmittedSource {
+            chunk,
+            consumed_frames: 0,
+        });
+        Ok(())
+    }
+
+    fn render(
+        &mut self,
+        _point: Option<PresentationPoint>,
+        credit: OutputCredit<'_>,
+        retire: &mut dyn FnMut(PcmChunk),
+    ) -> DecodeResult<TempoStep> {
+        if self.failed {
+            return Err(DecodeError::InvalidData {
+                detail: "tempo stage is terminal after a render failure",
+            });
+        }
+        if self.eof_pending || self.discontinuity_pending {
+            return Err(DecodeError::InvalidData {
+                detail: "tempo stage cannot render source while a drain debt is active",
+            });
+        }
+        if self.active.is_none()
+            || (self.admitted.is_none()
+                && self
+                    .active
+                    .as_ref()
+                    .is_none_or(|core| core.snapshot.revision != self.controls.revision()))
+        {
+            return Ok(TempoStep::Preparing);
+        }
+        self.render_admitted(credit, retire)
+    }
+
+    fn held_source_frames(&self) -> u64 {
+        let backend = self.drain_frontier.as_ref().map_or_else(
+            || self.active_held_source_frames(),
+            |frontier| frontier.remaining_source_frames,
+        );
+        self.admitted_source_frames().saturating_add(backend)
+    }
+
+    fn finish_eof(&mut self) -> DecodeResult<TempoEofDebt> {
+        if self.failed {
+            return Err(DecodeError::InvalidData {
+                detail: "tempo stage is terminal after a render failure",
+            });
+        }
+        if self.admitted.is_some() {
+            return Err(DecodeError::InvalidData {
+                detail: "true EOF was declared before admitted tempo source was rendered",
+            });
+        }
+        self.begin_tempo_drain("time-stretch EOF")?;
+        self.eof_pending = true;
+        Ok(TempoEofDebt::new())
+    }
+
+    fn render_eof(
+        &mut self,
+        _debt: &mut TempoEofDebt,
+        credit: OutputCredit<'_>,
+        _retire: &mut dyn FnMut(PcmChunk),
+    ) -> DecodeResult<TempoEofStep> {
+        if !self.eof_pending {
+            return Err(DecodeError::InvalidData {
+                detail: "tempo EOF renderer has no active debt",
+            });
+        }
+        Ok(match self.render_tempo_drain(credit)? {
+            Some((frames, meta)) => TempoEofStep::Rendered { frames, meta },
+            None => TempoEofStep::Drained,
+        })
+    }
+
+    fn begin_discontinuity(&mut self) -> DecodeResult<TempoDiscontinuityDebt> {
+        if self.failed {
+            return Err(DecodeError::InvalidData {
+                detail: "tempo stage is terminal after a render failure",
+            });
+        }
+        let retains_region_source = self.region_boundary_ready()?;
+        if self.admitted.is_some() && !retains_region_source {
+            return Err(DecodeError::InvalidData {
+                detail: "tempo discontinuity began before admitted source was rendered",
+            });
+        }
+        self.begin_tempo_drain("time-stretch discontinuity")?;
+        self.discontinuity_pending = true;
+        Ok(TempoDiscontinuityDebt::new())
+    }
+
+    fn render_discontinuity(
+        &mut self,
+        _debt: &mut TempoDiscontinuityDebt,
+        credit: OutputCredit<'_>,
+        _retire: &mut dyn FnMut(PcmChunk),
+    ) -> DecodeResult<TempoDiscontinuityStep> {
+        if !self.discontinuity_pending {
+            return Err(DecodeError::InvalidData {
+                detail: "tempo discontinuity renderer has no active debt",
+            });
+        }
+        Ok(match self.render_tempo_drain(credit)? {
+            Some((frames, meta)) => TempoDiscontinuityStep::Rendered { frames, meta },
+            None => TempoDiscontinuityStep::Drained,
+        })
+    }
+
+    fn deactivate(&mut self, retire: &mut dyn FnMut(PcmChunk)) -> DecodeResult<()> {
+        if self.retired.is_some() {
+            return Err(DecodeError::InvalidData {
+                detail: "tempo stage deactivated before prior state was retired off-RT",
+            });
+        }
+        if let Some(source) = self.admitted.take() {
+            retire(source.chunk);
+        }
+        let active = self.active.take();
+        let prepared = self.prepared.take();
+        if active.is_some() || prepared.is_some() {
+            self.retired = Some(RetiredCores { active, prepared });
+        }
+        self.last_input_meta = None;
+        self.eof_offset = 0;
+        self.eof_pending = false;
+        self.discontinuity_pending = false;
+        self.drain_frontier = None;
+        self.region_boundary = None;
+        self.failed = false;
+        Ok(())
     }
 }
 
 #[cfg(test)]
-mod tests {
-    use std::num::NonZero;
-
-    use kithara_bufpool::PcmPool;
-    use kithara_decode::{PcmMeta, PcmSpec};
-    use kithara_platform::time::Duration;
-    use kithara_test_utils::kithara;
-    use realfft::RealFftPlanner;
-
-    use super::*;
-
-    struct Consts;
-
-    impl Consts {
-        const CH: u16 = 2;
-        const F0: f64 = 440.0;
-        /// FFT length for the pitch (dominant-frequency) check.
-        const N: usize = 1 << 14;
-        const SR: u32 = 44_100;
-    }
-
-    fn f32_of(x: f64) -> f32 {
-        num_traits::cast(x).unwrap_or_default()
-    }
-
-    fn f64_of(x: usize) -> f64 {
-        num_traits::cast(x).unwrap_or_default()
-    }
-
-    /// Interleaved stereo sine at `F0`, phase-accumulated to avoid drift.
-    fn sine(frames: usize) -> Vec<f32> {
-        let inc = std::f64::consts::TAU * Consts::F0 / f64::from(Consts::SR);
-        let mut phase = 0.0_f64;
-        let mut out = Vec::with_capacity(frames * usize::from(Consts::CH));
-        for _ in 0..frames {
-            let s = f32_of(0.5 * phase.sin());
-            out.push(s);
-            out.push(s);
-            phase += inc;
-        }
-        out
-    }
-
-    fn chunk(samples: &[f32]) -> PcmChunk {
-        let frames = samples.len() / usize::from(Consts::CH);
-        PcmChunk::new(
-            PcmMeta {
-                spec: PcmSpec {
-                    channels: Consts::CH,
-                    sample_rate: NonZero::new(Consts::SR).unwrap(),
-                },
-                frames: u32::try_from(frames).unwrap_or(0),
-                timestamp: Duration::ZERO,
-                ..Default::default()
-            },
-            PcmPool::default().attach(samples.to_vec()),
-        )
-    }
-
-    /// Index of the strongest spectral bin (skipping DC) of a mono window
-    /// taken from the middle of `mono`.
-    fn dominant_bin(mono: &[f32]) -> usize {
-        let start = (mono.len().saturating_sub(Consts::N)) / 2;
-        let seg = &mono[start..start + Consts::N];
-        let mut planner = RealFftPlanner::<f32>::new();
-        let fft = planner.plan_fft_forward(Consts::N);
-        let mut input = fft.make_input_vec();
-        input.copy_from_slice(seg);
-        let mut spectrum = fft.make_output_vec();
-        fft.process(&mut input, &mut spectrum).unwrap();
-        spectrum
-            .iter()
-            .enumerate()
-            .skip(1)
-            .max_by(|a, b| a.1.norm().total_cmp(&b.1.norm()))
-            .map_or(0, |(i, _)| i)
-    }
-
-    fn expected_bin(freq: f64) -> usize {
-        num_traits::cast((freq * f64_of(Consts::N) / f64::from(Consts::SR)).round()).unwrap_or(0)
-    }
-
-    fn spec() -> PcmSpec {
-        PcmSpec {
-            channels: Consts::CH,
-            sample_rate: NonZero::new(Consts::SR).unwrap(),
-        }
-    }
-
-    fn processor(controls: Arc<StretchControls>) -> TimeStretchProcessor {
-        TimeStretchProcessor::new(controls, spec(), PcmPool::default())
-    }
-
-    fn keylocked(kind: StretchKind, speed: f32) -> TimeStretchProcessor {
-        let controls = StretchControls::new(speed);
-        controls.set_keylock(true);
-        controls.set_backend(kind);
-        processor(controls)
-    }
-
-    fn vinyl(kind: StretchKind, speed: f32) -> TimeStretchProcessor {
-        let controls = StretchControls::new(speed);
-        controls.set_keylock(false);
-        controls.set_backend(kind);
-        processor(controls)
-    }
-
-    fn render(fx: &mut TimeStretchProcessor, input: &[f32]) -> Vec<f32> {
-        let mut out: Vec<f32> = Vec::new();
-        let block = 4096 * usize::from(Consts::CH);
-        for data in input.chunks(block) {
-            if let Some(c) = fx.process(chunk(data)) {
-                assert_eq!(
-                    c.spec().sample_rate.get(),
-                    Consts::SR,
-                    "stretch preserves sample rate"
-                );
-                assert_eq!(c.spec().channels, Consts::CH);
-                out.extend_from_slice(&c.samples);
-            }
-        }
-        while let Some(c) = fx.flush() {
-            // A non-empty flush chunk carries real audio, so its spec must stay
-            // the source spec — never the `PcmMeta::default()` sentinel (0
-            // channels) that a `None` `last_input_meta` would otherwise yield.
-            assert_eq!(c.spec().channels, Consts::CH, "flush preserves channels");
-            assert_eq!(
-                c.spec().sample_rate.get(),
-                Consts::SR,
-                "flush preserves sample rate"
-            );
-            out.extend_from_slice(&c.samples);
-        }
-        out
-    }
-
-    fn run_keylocked(kind: StretchKind, speed: f32, in_frames: usize) -> Vec<f32> {
-        let input = sine(in_frames);
-        render(&mut keylocked(kind, speed), &input)
-    }
-
-    fn run_vinyl(kind: StretchKind, speed: f32, in_frames: usize) -> Vec<f32> {
-        let input = sine(in_frames);
-        render(&mut vinyl(kind, speed), &input)
-    }
-
-    /// Half playback speed -> stretch 2.0 -> ~double duration, pitch held.
-    /// Shared across every compiled-in backend.
-    fn assert_half_speed_contract(kind: StretchKind) {
-        let channels = usize::from(Consts::CH);
-        let in_frames = usize::try_from(Consts::SR).unwrap() * 2; // 2 s
-        let out = run_keylocked(kind, 0.5, in_frames);
-        let out_frames = out.len() / channels;
-
-        // Both C++ backends emit fixed-length output with leading latency-fill
-        // (and bungee drops its tail), nudging the measured duration off an
-        // exact 2x on a short clip — hence the ±10% band. Pitch is still
-        assert!(
-            out_frames * 10 >= in_frames * 18 && out_frames * 10 <= in_frames * 22,
-            "{kind:?}: expected ~2x duration, got {out_frames} from {in_frames}"
-        );
-
-        // Pitch preserved: dominant bin still at F0 (the load-bearing check —
-        // a resampler-in-disguise would shift it).
-        let mono: Vec<f32> = out.iter().step_by(channels).copied().collect();
-        assert!(
-            mono.len() >= Consts::N,
-            "{kind:?}: not enough output for the FFT window"
-        );
-        let peak = dominant_bin(&mono);
-        let want = expected_bin(Consts::F0);
-        assert!(
-            peak.abs_diff(want) <= 3,
-            "{kind:?}: pitch moved under time-stretch: peak bin {peak}, expected {want}"
-        );
-    }
-
-    fn assert_unity_contract(kind: StretchKind) {
-        let in_frames = usize::try_from(Consts::SR).unwrap() * 2;
-        let input = sine(in_frames);
-        let out = render(&mut keylocked(kind, 1.0), &input);
-        assert_eq!(out, input, "{kind:?}: unity speed must bypass byte-exact");
-    }
-
-    #[cfg(feature = "stretch-signalsmith")]
-    #[kithara::test]
-    fn signalsmith_half_speed_and_unity_contracts() {
-        assert_half_speed_contract(StretchKind::Signalsmith);
-        assert_unity_contract(StretchKind::Signalsmith);
-    }
-
-    #[cfg(feature = "stretch-bungee")]
-    #[kithara::test]
-    fn bungee_half_speed_and_unity_contracts() {
-        assert_half_speed_contract(StretchKind::Bungee);
-        assert_unity_contract(StretchKind::Bungee);
-    }
-
-    #[kithara::test]
-    fn output_meta_preserves_decoder_timeline() {
-        let channels = usize::from(Consts::CH);
-        let mut fx = keylocked(StretchKind::default(), 0.5);
-        let cf = 1024usize;
-        let block = sine(cf);
-        let mut fed_ends = HashSet::new();
-        let mut emitted = Vec::new();
-        for i in 0..40u64 {
-            let mut c = chunk(&block);
-            let end = Duration::from_millis(i * 100 + 100);
-            c.meta.timestamp = Duration::from_millis(i * 100);
-            c.meta.end_timestamp = end;
-            c.meta.frame_offset = i * u64::try_from(cf).unwrap();
-            fed_ends.insert(end);
-            if let Some(o) = fx.process(c) {
-                emitted.push(o);
-            }
-        }
-        while let Some(o) = fx.flush() {
-            emitted.push(o);
-        }
-        assert!(!emitted.is_empty(), "stretch produced no output");
-        for o in &emitted {
-            assert_eq!(
-                o.spec(),
-                PcmSpec {
-                    channels: Consts::CH,
-                    sample_rate: NonZero::new(Consts::SR).unwrap()
-                },
-                "spec (incl. sample rate) preserved verbatim"
-            );
-            assert_eq!(
-                usize::try_from(o.meta.frames).unwrap(),
-                o.samples.len() / channels,
-                "frames recomputed to the actual output count"
-            );
-            assert!(
-                fed_ends.contains(&o.meta.end_timestamp),
-                "end_timestamp carried verbatim from an input chunk (source-track time)"
-            );
-        }
-    }
-
-    /// Key-lock off is vinyl mode: speed changes duration and pitch in the
-    /// stretch slot, with no resampler-rate handoff.
-    #[kithara::test]
-    fn vinyl_speed_scales_duration_and_pitch() {
-        let channels = usize::from(Consts::CH);
-        let in_frames = usize::try_from(Consts::SR).unwrap() * 2;
-        let out = run_vinyl(StretchKind::default(), 2.0, in_frames);
-        let out_frames = out.len() / channels;
-        assert!(
-            out_frames * 10 >= in_frames * 4 && out_frames * 10 <= in_frames * 6,
-            "vinyl 2x should roughly halve duration, got {out_frames} from {in_frames}"
-        );
-        let mono: Vec<f32> = out.iter().step_by(channels).copied().collect();
-        assert!(
-            mono.len() >= Consts::N,
-            "not enough vinyl output for the FFT window"
-        );
-        let peak = dominant_bin(&mono);
-        let want = expected_bin(Consts::F0 * 2.0);
-        assert!(
-            peak.abs_diff(want) <= 4,
-            "vinyl pitch did not follow speed: peak bin {peak}, expected {want}"
-        );
-    }
-
-    #[kithara::test]
-    fn live_speed_change_updates_stretch_duration() {
-        let controls = StretchControls::new(1.0);
-        controls.set_keylock(true);
-        controls.set_backend(StretchKind::default());
-        let mut fx = processor(Arc::clone(&controls));
-        let block = sine(4096);
-        let unity = fx.process(chunk(&block)).expect("unity bypass emits");
-        assert_eq!(&unity.samples[..], &block[..], "unity phase bypasses");
-
-        controls.set_speed(0.5);
-        let mut stretched: Vec<f32> = Vec::new();
-        for _ in 0..24 {
-            if let Some(c) = fx.process(chunk(&block)) {
-                stretched.extend_from_slice(&c.samples);
-            }
-        }
-        while let Some(c) = fx.flush() {
-            stretched.extend_from_slice(&c.samples);
-        }
-        assert!(
-            stretched.len() > block.len() * 24,
-            "half-speed key-lock should lengthen output after a live speed change"
-        );
-    }
-
-    /// Flipping key-lock mid-stream switches from vinyl pitch shift to
-    /// pitch-preserving stretch — no reload.
-    #[kithara::test]
-    fn live_keylock_toggle_switches_pitch_mode() {
-        let controls = StretchControls::new(0.5);
-        controls.set_keylock(false);
-        controls.set_backend(StretchKind::default());
-        let mut fx = processor(Arc::clone(&controls));
-        let block = sine(4096);
-
-        let mut vinyl_out: Vec<f32> = Vec::new();
-        for _ in 0..24 {
-            if let Some(c) = fx.process(chunk(&block)) {
-                vinyl_out.extend_from_slice(&c.samples);
-            }
-        }
-        let vinyl_mono: Vec<f32> = vinyl_out
-            .iter()
-            .step_by(usize::from(Consts::CH))
-            .copied()
-            .collect();
-        assert!(
-            dominant_bin(&vinyl_mono).abs_diff(expected_bin(Consts::F0 * 0.5)) <= 4,
-            "off: vinyl pitch follows speed"
-        );
-
-        controls.set_keylock(true);
-        let mut stretched: Vec<f32> = Vec::new();
-        for _ in 0..24 {
-            if let Some(c) = fx.process(chunk(&block)) {
-                stretched.extend_from_slice(&c.samples);
-            }
-        }
-        while let Some(c) = fx.flush() {
-            stretched.extend_from_slice(&c.samples);
-        }
-        let mono: Vec<f32> = stretched
-            .iter()
-            .step_by(usize::from(Consts::CH))
-            .copied()
-            .collect();
-        assert!(
-            mono.len() >= Consts::N,
-            "on: not enough output for the FFT window"
-        );
-        assert!(
-            dominant_bin(&mono).abs_diff(expected_bin(Consts::F0)) <= 3,
-            "on: pitch preserved after live toggle"
-        );
-    }
-
-    /// Swapping the backend mid-stream keeps the stream flowing and pitch-locked.
-    #[cfg(all(feature = "stretch-signalsmith", feature = "stretch-bungee"))]
-    #[kithara::test]
-    fn live_backend_swap_continues_and_keeps_pitch() {
-        let controls = StretchControls::new(0.5);
-        controls.set_keylock(true);
-        controls.set_backend(StretchKind::Bungee);
-        let mut fx = processor(Arc::clone(&controls));
-        let block = sine(4096);
-        let mut out: Vec<f32> = Vec::new();
-        for i in 0..24 {
-            if i == 6 {
-                controls.set_backend(StretchKind::Signalsmith);
-            }
-            if let Some(c) = fx.process(chunk(&block)) {
-                out.extend_from_slice(&c.samples);
-            }
-        }
-        while let Some(c) = fx.flush() {
-            out.extend_from_slice(&c.samples);
-        }
-        let mono: Vec<f32> = out
-            .iter()
-            .step_by(usize::from(Consts::CH))
-            .copied()
-            .collect();
-        assert!(
-            mono.len() >= Consts::N,
-            "not enough output after swap for the FFT window"
-        );
-        assert!(
-            dominant_bin(&mono).abs_diff(expected_bin(Consts::F0)) <= 3,
-            "pitch preserved after live backend swap"
-        );
-    }
-}
+pub(in crate::effects::timestretch) mod tests;

--- a/crates/kithara-audio/src/effects/timestretch/processor/tests/audio.rs
+++ b/crates/kithara-audio/src/effects/timestretch/processor/tests/audio.rs
@@ -1,0 +1,441 @@
+use std::{collections::HashSet, num::NonZero};
+
+use kithara_decode::{DecodeError, PcmSpec};
+use kithara_platform::{sync::Arc, time::Duration};
+use kithara_stretch::{StretchBackend, StretchBackendError, StretchKind};
+use kithara_test_utils::kithara;
+
+use super::{
+    super::*,
+    common::{
+        Consts, assert_half_speed_contract, assert_unity_contract, chunk, dominant_bin, drain_eof,
+        expected_bin, keylocked, processor, render_chunk, run_vinyl, sine,
+    },
+};
+
+#[cfg(feature = "stretch-signalsmith")]
+#[kithara::test]
+fn signalsmith_half_speed_and_unity_contracts() {
+    assert_half_speed_contract(StretchKind::Signalsmith);
+    assert_unity_contract(StretchKind::Signalsmith);
+}
+#[cfg(feature = "stretch-bungee")]
+#[kithara::test]
+fn bungee_half_speed_and_unity_contracts() {
+    assert_half_speed_contract(StretchKind::Bungee);
+    assert_unity_contract(StretchKind::Bungee);
+}
+
+#[kithara::test]
+fn output_meta_preserves_decoder_timeline() {
+    let channels = usize::from(Consts::CH);
+    let mut fx = keylocked(StretchKind::default(), 0.5);
+    let cf = 1024usize;
+    let block = sine(cf);
+    let mut fed_ends = HashSet::new();
+    let mut emitted = Vec::new();
+    for i in 0..40u64 {
+        let mut c = chunk(&block);
+        let end = Duration::from_millis(i * 100 + 100);
+        c.meta.timestamp = Duration::from_millis(i * 100);
+        c.meta.end_timestamp = end;
+        c.meta.frame_offset = i * u64::try_from(cf).unwrap();
+        fed_ends.insert(end);
+        if let Some(o) = render_chunk(&mut fx, c).expect("fixture stretch processing must succeed")
+        {
+            emitted.push(o);
+        }
+    }
+    while let Some(o) = drain_eof(&mut fx) {
+        emitted.push(o);
+    }
+    assert!(!emitted.is_empty(), "stretch produced no output");
+    for o in &emitted {
+        assert_eq!(
+            o.spec(),
+            PcmSpec {
+                channels: Consts::CH,
+                sample_rate: NonZero::new(Consts::SR).unwrap()
+            },
+            "spec (incl. sample rate) preserved verbatim"
+        );
+        assert_eq!(
+            usize::try_from(o.meta.frames).unwrap(),
+            o.samples.len() / channels,
+            "frames recomputed to the actual output count"
+        );
+        assert!(
+            fed_ends.contains(&o.meta.end_timestamp),
+            "end_timestamp carried verbatim from an input chunk (source-track time)"
+        );
+    }
+}
+
+#[kithara::test]
+fn vinyl_speed_scales_duration_and_pitch() {
+    let channels = usize::from(Consts::CH);
+    let in_frames = usize::try_from(Consts::SR).unwrap() * 2;
+    let out = run_vinyl(StretchKind::default(), 2.0, in_frames);
+    let out_frames = out.len() / channels;
+    assert!(
+        out_frames * 10 >= in_frames * 4 && out_frames * 10 <= in_frames * 6,
+        "vinyl 2x should roughly halve duration, got {out_frames} from {in_frames}"
+    );
+    let mono: Vec<f32> = out.iter().step_by(channels).copied().collect();
+    assert!(
+        mono.len() >= Consts::N,
+        "not enough vinyl output for the FFT window"
+    );
+    let peak = dominant_bin(&mono);
+    let want = expected_bin(Consts::F0 * 2.0);
+    assert!(
+        peak.abs_diff(want) <= 4,
+        "vinyl pitch did not follow speed: peak bin {peak}, expected {want}"
+    );
+}
+
+#[kithara::test]
+fn vinyl_speed_above_two_is_applied_without_clamping() {
+    let channels = usize::from(Consts::CH);
+    let in_frames = usize::try_from(Consts::SR).unwrap() * 2;
+    let out = run_vinyl(StretchKind::default(), 4.0, in_frames);
+    let out_frames = out.len() / channels;
+    assert!(
+        out_frames * 10 >= in_frames * 2 && out_frames * 10 <= in_frames * 3,
+        "vinyl 4x should roughly quarter duration, got {out_frames} from {in_frames}"
+    );
+    let mono: Vec<f32> = out.iter().step_by(channels).copied().collect();
+    assert!(
+        mono.len() >= Consts::N,
+        "not enough 4x vinyl output for the FFT window"
+    );
+    let peak = dominant_bin(&mono);
+    let want = expected_bin(Consts::F0 * 4.0);
+    assert!(
+        peak.abs_diff(want) <= 6,
+        "vinyl pitch was clamped above 2x: peak bin {peak}, expected {want}"
+    );
+}
+
+#[kithara::test]
+fn live_speed_change_updates_stretch_duration() {
+    let controls = StretchControls::new(1.0);
+    controls.set_keylock(true);
+    controls.set_backend(StretchKind::default());
+    let mut fx = processor(Arc::clone(&controls));
+    let block = sine(4096);
+    let unity = render_chunk(&mut fx, chunk(&block))
+        .expect("unity bypass processing succeeds")
+        .expect("unity bypass emits");
+    assert_eq!(&unity.samples[..], &block[..], "unity phase bypasses");
+
+    controls.set_speed(0.5);
+    let mut stretched: Vec<f32> = Vec::new();
+    for _ in 0..24 {
+        if let Some(c) =
+            render_chunk(&mut fx, chunk(&block)).expect("fixture stretch processing must succeed")
+        {
+            stretched.extend_from_slice(&c.samples);
+        }
+    }
+    while let Some(c) = drain_eof(&mut fx) {
+        stretched.extend_from_slice(&c.samples);
+    }
+    assert!(
+        stretched.len() > block.len() * 24,
+        "half-speed key-lock should lengthen output after a live speed change"
+    );
+}
+
+#[kithara::test]
+fn held_source_frames_tracks_only_active_stretch() {
+    let controls = StretchControls::new(0.5);
+    controls.set_keylock(true);
+    controls.set_backend(StretchKind::default());
+    let mut fx = processor(Arc::clone(&controls));
+    let block = sine(4096);
+
+    let _ = render_chunk(&mut fx, chunk(&block));
+    assert!(
+        TempoStage::held_source_frames(&fx) > 0,
+        "non-unity stretch must retain source input"
+    );
+
+    controls.set_speed(1.0);
+    let unity = render_chunk(&mut fx, chunk(&block))
+        .expect("unity bypass processing succeeds")
+        .expect("unity bypass emits");
+    assert!(unity.samples.len() >= block.len());
+    assert_eq!(
+        &unity.samples[unity.samples.len() - block.len()..],
+        &block[..]
+    );
+    assert_eq!(TempoStage::held_source_frames(&fx), 0);
+}
+
+struct MissingPromisedTailBackend;
+
+impl StretchBackend for MissingPromisedTailBackend {
+    fn flush(&mut self, _out: &mut Vec<f32>) -> Result<(), StretchBackendError> {
+        Ok(())
+    }
+
+    fn max_output_samples(&self, input_frames: usize) -> usize {
+        input_frames.saturating_mul(usize::from(Consts::CH))
+    }
+
+    fn max_tail_samples(&self) -> usize {
+        0
+    }
+
+    fn source_latency_frames(&self) -> usize {
+        1
+    }
+
+    fn process(&mut self, input: &[f32], out: &mut Vec<f32>) -> Result<(), StretchBackendError> {
+        out.extend_from_slice(input);
+        Ok(())
+    }
+
+    fn reset(&mut self) {}
+
+    fn set_pitch(&mut self, _scale: f64) -> Result<(), StretchBackendError> {
+        Ok(())
+    }
+
+    fn set_ratio(&mut self, _stretch: f64) -> Result<(), StretchBackendError> {
+        Ok(())
+    }
+}
+
+#[kithara::test]
+fn promised_tail_backend_missing_held_audio_fails_closed() {
+    let mut stage = keylocked(StretchKind::default(), 0.5);
+    let core = stage.active.as_mut().expect("fixture has an active core");
+    core.backend = Some(Box::new(MissingPromisedTailBackend));
+    core.processing = true;
+    core.source_frames_pushed = 1;
+
+    let Err(error) = TempoStage::finish_eof(&mut stage) else {
+        panic!("promised held audio cannot disappear at EOF");
+    };
+
+    assert!(matches!(
+        error,
+        DecodeError::InvalidData {
+            detail: "tempo backend retained source without a rendered drain tail"
+        }
+    ));
+}
+
+#[cfg(feature = "stretch-bungee")]
+fn rendered_bungee_stage() -> TimeStretchProcessor {
+    let mut stage = keylocked(StretchKind::Bungee, 0.5);
+    let source = sine(TimeStretchProcessor::PRESENTATION_FRAMES);
+    TempoStage::push_source(&mut stage, chunk(&source)).expect("one Bungee quantum is admitted");
+    while TempoStage::buffered_source_quanta(&stage) != 0 {
+        let mut output =
+            vec![0.0; TimeStretchProcessor::PRESENTATION_FRAMES * usize::from(Consts::CH)];
+        let credit = OutputCredit::new(
+            &mut output,
+            usize::from(Consts::CH),
+            TimeStretchProcessor::PRESENTATION_FRAMES,
+        );
+        TempoStage::render(&mut stage, None, credit, &mut |_| {})
+            .expect("Bungee source quantum renders before the boundary");
+    }
+    assert!(
+        TempoStage::held_source_frames(&stage) > 0,
+        "fixture must exercise Bungee's undiscoverable held tail"
+    );
+    stage
+}
+
+#[cfg(feature = "stretch-bungee")]
+#[kithara::test]
+fn bungee_eof_discards_undrainable_held_source_without_failure() {
+    let mut stage = rendered_bungee_stage();
+    let mut debt = TempoStage::finish_eof(&mut stage)
+        .expect("Bungee explicitly retires its undiscoverable tail at EOF");
+    assert_eq!(TempoStage::held_source_frames(&stage), 0);
+    let mut output = vec![0.0; TimeStretchProcessor::PRESENTATION_FRAMES * usize::from(Consts::CH)];
+    let credit = OutputCredit::new(
+        &mut output,
+        usize::from(Consts::CH),
+        TimeStretchProcessor::PRESENTATION_FRAMES,
+    );
+
+    let step = TempoStage::render_eof(&mut stage, &mut debt, credit, &mut |_| {})
+        .expect("Bungee EOF debt completes without a synthetic tail");
+
+    assert!(matches!(step, TempoEofStep::Drained));
+}
+
+#[cfg(feature = "stretch-bungee")]
+#[kithara::test]
+fn bungee_barrier_discards_undrainable_held_source_without_failure() {
+    let mut stage = rendered_bungee_stage();
+    let mut debt = TempoStage::begin_discontinuity(&mut stage)
+        .expect("Bungee explicitly retires its undiscoverable tail at a decoder barrier");
+    assert_eq!(TempoStage::held_source_frames(&stage), 0);
+    let mut output = vec![0.0; TimeStretchProcessor::PRESENTATION_FRAMES * usize::from(Consts::CH)];
+    let credit = OutputCredit::new(
+        &mut output,
+        usize::from(Consts::CH),
+        TimeStretchProcessor::PRESENTATION_FRAMES,
+    );
+
+    let step = TempoStage::render_discontinuity(&mut stage, &mut debt, credit, &mut |_| {})
+        .expect("Bungee barrier debt completes without a synthetic tail");
+
+    assert!(matches!(step, TempoDiscontinuityStep::Drained));
+}
+
+#[cfg(feature = "stretch-signalsmith")]
+#[kithara::test]
+fn signalsmith_tail_drain_releases_held_source_frames() {
+    let mut fx = keylocked(StretchKind::Signalsmith, 0.5);
+    let block = sine(4096);
+    let _ = render_chunk(&mut fx, chunk(&block));
+    assert!(TempoStage::held_source_frames(&fx) > 0);
+
+    let tail = drain_eof(&mut fx).expect("Signalsmith must emit its tail once");
+
+    assert!(!tail.samples.is_empty());
+    assert_eq!(TempoStage::held_source_frames(&fx), 0);
+}
+
+#[kithara::test]
+fn live_keylock_toggle_switches_pitch_mode() {
+    let controls = StretchControls::new(0.5);
+    controls.set_keylock(false);
+    controls.set_backend(StretchKind::default());
+    let mut fx = processor(Arc::clone(&controls));
+    let block = sine(4096);
+
+    let mut vinyl_out: Vec<f32> = Vec::new();
+    for _ in 0..24 {
+        if let Some(c) =
+            render_chunk(&mut fx, chunk(&block)).expect("fixture stretch processing must succeed")
+        {
+            vinyl_out.extend_from_slice(&c.samples);
+        }
+    }
+    let vinyl_mono: Vec<f32> = vinyl_out
+        .iter()
+        .step_by(usize::from(Consts::CH))
+        .copied()
+        .collect();
+    assert!(
+        dominant_bin(&vinyl_mono).abs_diff(expected_bin(Consts::F0 * 0.5)) <= 4,
+        "off: vinyl pitch follows speed"
+    );
+
+    controls.set_keylock(true);
+    let mut stretched: Vec<f32> = Vec::new();
+    for _ in 0..24 {
+        if let Some(c) =
+            render_chunk(&mut fx, chunk(&block)).expect("fixture stretch processing must succeed")
+        {
+            stretched.extend_from_slice(&c.samples);
+        }
+    }
+    while let Some(c) = drain_eof(&mut fx) {
+        stretched.extend_from_slice(&c.samples);
+    }
+    let mono: Vec<f32> = stretched
+        .iter()
+        .step_by(usize::from(Consts::CH))
+        .copied()
+        .collect();
+    assert!(
+        mono.len() >= Consts::N,
+        "on: not enough output for the FFT window"
+    );
+    assert!(
+        dominant_bin(&mono).abs_diff(expected_bin(Consts::F0)) <= 3,
+        "on: pitch preserved after live toggle"
+    );
+}
+
+#[cfg(all(feature = "stretch-signalsmith", feature = "stretch-bungee"))]
+#[kithara::test]
+fn live_backend_swap_continues_and_keeps_pitch() {
+    let controls = StretchControls::new(0.5);
+    controls.set_keylock(true);
+    controls.set_backend(StretchKind::Bungee);
+    let mut fx = processor(Arc::clone(&controls));
+    let block = sine(4096);
+    let mut out: Vec<f32> = Vec::new();
+    for i in 0..24 {
+        if i == 6 {
+            controls.set_backend(StretchKind::Signalsmith);
+        }
+        if let Some(c) =
+            render_chunk(&mut fx, chunk(&block)).expect("fixture stretch processing must succeed")
+        {
+            out.extend_from_slice(&c.samples);
+        }
+    }
+    while let Some(c) = drain_eof(&mut fx) {
+        out.extend_from_slice(&c.samples);
+    }
+    let mono: Vec<f32> = out
+        .iter()
+        .step_by(usize::from(Consts::CH))
+        .copied()
+        .collect();
+    assert!(
+        mono.len() >= Consts::N,
+        "not enough output after swap for the FFT window"
+    );
+    assert!(
+        dominant_bin(&mono).abs_diff(expected_bin(Consts::F0)) <= 3,
+        "pitch preserved after live backend swap"
+    );
+}
+
+#[kithara::test]
+#[case(0.05)]
+#[case(0.5)]
+#[case(1.0)]
+#[case(1.5)]
+#[case(2.0)]
+fn tempo_stage_speed_matrix_never_exceeds_one_output_credit(#[case] speed: f32) {
+    for keylock in [false, true] {
+        let controls = StretchControls::new(speed);
+        controls.set_keylock(keylock);
+        controls.set_backend(StretchKind::default());
+        let mut stage = processor(controls);
+        let source = sine(TimeStretchProcessor::PRESENTATION_FRAMES);
+        TempoStage::push_source(&mut stage, chunk(&source))
+            .expect("one source quantum is admitted");
+        let mut retired = 0;
+        let mut rendered = 0;
+        for _ in 0..64 {
+            if TempoStage::buffered_source_quanta(&stage) == 0 {
+                break;
+            }
+            let mut output =
+                vec![0.0; TimeStretchProcessor::PRESENTATION_FRAMES * usize::from(Consts::CH)];
+            let credit = OutputCredit::new(
+                &mut output,
+                usize::from(Consts::CH),
+                TimeStretchProcessor::PRESENTATION_FRAMES,
+            );
+            if let TempoStep::Rendered { frames, .. } =
+                TempoStage::render(&mut stage, None, credit, &mut |chunk| {
+                    retired += chunk.frames()
+                })
+                .expect("one credited tempo step succeeds")
+            {
+                assert!(frames <= TimeStretchProcessor::PRESENTATION_FRAMES);
+                rendered += frames;
+            }
+        }
+
+        assert_eq!(TempoStage::buffered_source_quanta(&stage), 0);
+        assert_eq!(retired, TimeStretchProcessor::PRESENTATION_FRAMES);
+        assert!(rendered > 0, "speed {speed}, keylock {keylock}");
+    }
+}

--- a/crates/kithara-audio/src/effects/timestretch/processor/tests/common.rs
+++ b/crates/kithara-audio/src/effects/timestretch/processor/tests/common.rs
@@ -1,0 +1,323 @@
+use std::num::NonZero;
+
+use kithara_bufpool::PcmPool;
+use kithara_decode::{DecodeError, DecodeResult, PcmChunk, PcmMeta, PcmSpec, duration_for_frames};
+use kithara_platform::{sync::Arc, time::Duration};
+use kithara_stretch::StretchKind;
+use realfft::RealFftPlanner;
+
+use super::super::*;
+
+pub(super) struct Consts;
+
+impl Consts {
+    pub(super) const CH: u16 = 2;
+    pub(super) const F0: f64 = 440.0;
+    pub(super) const N: usize = 1 << 14;
+    pub(super) const SR: u32 = 44_100;
+}
+
+pub(super) fn f32_of(x: f64) -> f32 {
+    num_traits::cast(x).unwrap_or_default()
+}
+
+pub(super) fn f64_of(x: usize) -> f64 {
+    num_traits::cast(x).unwrap_or_default()
+}
+
+pub(super) fn sine(frames: usize) -> Vec<f32> {
+    let inc = std::f64::consts::TAU * Consts::F0 / f64::from(Consts::SR);
+    let mut phase = 0.0_f64;
+    let mut out = Vec::with_capacity(frames * usize::from(Consts::CH));
+    for _ in 0..frames {
+        let s = f32_of(0.5 * phase.sin());
+        out.push(s);
+        out.push(s);
+        phase += inc;
+    }
+    out
+}
+
+pub(super) fn chunk(samples: &[f32]) -> PcmChunk {
+    chunk_at(spec(), samples)
+}
+
+pub(super) fn chunk_at(spec: PcmSpec, samples: &[f32]) -> PcmChunk {
+    let frames = samples.len() / usize::from(Consts::CH);
+    PcmChunk::new(
+        PcmMeta {
+            spec,
+            frames: u32::try_from(frames).unwrap_or(0),
+            timestamp: Duration::ZERO,
+            ..Default::default()
+        },
+        PcmPool::default().attach(samples.to_vec()),
+    )
+}
+
+pub(super) fn dominant_bin(mono: &[f32]) -> usize {
+    let start = (mono.len().saturating_sub(Consts::N)) / 2;
+    let seg = &mono[start..start + Consts::N];
+    let mut planner = RealFftPlanner::<f32>::new();
+    let fft = planner.plan_fft_forward(Consts::N);
+    let mut input = fft.make_input_vec();
+    input.copy_from_slice(seg);
+    let mut spectrum = fft.make_output_vec();
+    fft.process(&mut input, &mut spectrum).unwrap();
+    spectrum
+        .iter()
+        .enumerate()
+        .skip(1)
+        .max_by(|a, b| a.1.norm().total_cmp(&b.1.norm()))
+        .map_or(0, |(i, _)| i)
+}
+
+pub(super) fn expected_bin(freq: f64) -> usize {
+    num_traits::cast((freq * f64_of(Consts::N) / f64::from(Consts::SR)).round()).unwrap_or(0)
+}
+
+pub(super) fn spec() -> PcmSpec {
+    PcmSpec {
+        channels: Consts::CH,
+        sample_rate: NonZero::new(Consts::SR).unwrap(),
+    }
+}
+
+pub(super) fn processor(controls: Arc<StretchControls>) -> TimeStretchProcessor {
+    let mut processor = TimeStretchProcessor::new(controls, spec(), PcmPool::default().clone());
+    TempoStage::service_off_rt(
+        &mut processor,
+        TempoPrepareRequest::Current { spec: spec() },
+    )
+    .expect("fixture tempo core prepares off-RT");
+    processor
+}
+
+pub(in crate::effects::timestretch) fn render_chunk(
+    stage: &mut TimeStretchProcessor,
+    chunk: PcmChunk,
+) -> DecodeResult<Option<PcmChunk>> {
+    let spec = chunk.spec();
+    let mut rendered = Vec::new();
+    service_boundary(stage, spec, &mut rendered)?;
+    let source_meta = chunk.meta;
+    let channels = stage.channels();
+    for (part_index, samples) in chunk
+        .samples
+        .chunks(TimeStretchProcessor::PRESENTATION_FRAMES * channels)
+        .enumerate()
+    {
+        let source_offset = part_index
+            .checked_mul(TimeStretchProcessor::PRESENTATION_FRAMES)
+            .ok_or(DecodeError::InvalidData {
+                detail: "fixture tempo source offset overflow",
+            })?;
+        let frames = samples.len() / channels;
+        let mut meta = source_meta;
+        meta.frame_offset = meta
+            .frame_offset
+            .checked_add(
+                u64::try_from(source_offset).map_err(|_| DecodeError::InvalidData {
+                    detail: "fixture tempo source offset exceeds u64",
+                })?,
+            )
+            .ok_or(DecodeError::InvalidData {
+                detail: "fixture tempo source position overflow",
+            })?;
+        let source_offset = u64::try_from(source_offset).map_err(|_| DecodeError::InvalidData {
+            detail: "fixture tempo source offset exceeds u64",
+        })?;
+        meta.timestamp = source_meta.timestamp.saturating_add(duration_for_frames(
+            stage.output_spec().sample_rate.get(),
+            source_offset,
+        ));
+        meta.frames = u32::try_from(frames).map_err(|_| DecodeError::InvalidData {
+            detail: "fixture tempo source length exceeds u32",
+        })?;
+        let part = PcmChunk::new(meta, PcmPool::default().attach(samples.to_vec()));
+        TempoStage::push_source(stage, part)?;
+        while TempoStage::buffered_source_quanta(stage) != 0 {
+            if service_boundary(stage, spec, &mut rendered)? {
+                continue;
+            }
+            let mut output = vec![0.0; TimeStretchProcessor::PRESENTATION_FRAMES * channels];
+            let credit = OutputCredit::new(
+                &mut output,
+                channels,
+                TimeStretchProcessor::PRESENTATION_FRAMES,
+            );
+            if let TempoStep::Rendered { frames, .. } =
+                TempoStage::render(stage, None, credit, &mut |_| {})?
+            {
+                rendered.extend_from_slice(&output[..frames * channels]);
+            }
+        }
+    }
+    if rendered.is_empty() {
+        return Ok(None);
+    }
+    let mut meta = source_meta;
+    meta.frames =
+        u32::try_from(rendered.len() / channels).map_err(|_| DecodeError::InvalidData {
+            detail: "fixture tempo output length exceeds u32",
+        })?;
+    Ok(Some(PcmChunk::new(meta, stage.pool.attach(rendered))))
+}
+
+fn service_boundary(
+    stage: &mut TimeStretchProcessor,
+    spec: PcmSpec,
+    rendered: &mut Vec<f32>,
+) -> DecodeResult<bool> {
+    TempoStage::service_off_rt(stage, TempoPrepareRequest::Current { spec })?;
+    if let Some(boundary) = TempoStage::prepared_boundary(stage) {
+        let mut debt = TempoStage::begin_discontinuity(stage)?;
+        loop {
+            let channels = stage.channels();
+            let mut output = vec![0.0; TimeStretchProcessor::PRESENTATION_FRAMES * channels];
+            let credit = OutputCredit::new(
+                &mut output,
+                channels,
+                TimeStretchProcessor::PRESENTATION_FRAMES,
+            );
+            match TempoStage::render_discontinuity(stage, &mut debt, credit, &mut |_| {})? {
+                TempoDiscontinuityStep::Drained => break,
+                TempoDiscontinuityStep::Rendered { frames, .. } => {
+                    rendered.extend_from_slice(&output[..frames * channels]);
+                }
+            }
+        }
+        TempoStage::commit_prepared(stage, boundary)?;
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+pub(in crate::effects::timestretch) fn drain_eof(
+    stage: &mut TimeStretchProcessor,
+) -> Option<PcmChunk> {
+    let mut debt = TempoStage::finish_eof(stage).ok()?;
+    let channels = stage.channels();
+    let mut rendered = Vec::new();
+    loop {
+        let mut output = vec![0.0; TimeStretchProcessor::PRESENTATION_FRAMES * channels];
+        let credit = OutputCredit::new(
+            &mut output,
+            channels,
+            TimeStretchProcessor::PRESENTATION_FRAMES,
+        );
+        match TempoStage::render_eof(stage, &mut debt, credit, &mut |_| {}) {
+            Ok(TempoEofStep::Drained) => break,
+            Ok(TempoEofStep::Rendered { frames, .. }) => {
+                rendered.extend_from_slice(&output[..frames * channels]);
+            }
+            Err(_) => return None,
+        }
+    }
+    if rendered.is_empty() {
+        return None;
+    }
+    let spec = stage.output_spec();
+    let mut meta = stage.last_input_meta?;
+    meta.spec = spec;
+    meta.frames = u32::try_from(rendered.len() / channels).ok()?;
+    Some(PcmChunk::new(meta, stage.pool.attach(rendered)))
+}
+
+pub(in crate::effects::timestretch) fn source_endpoint(
+    stage: &TimeStretchProcessor,
+) -> Option<u64> {
+    let meta = stage.last_input_meta?;
+    meta.frame_offset.checked_add(u64::from(meta.frames))
+}
+
+pub(super) fn keylocked(kind: StretchKind, speed: f32) -> TimeStretchProcessor {
+    let controls = StretchControls::new(speed);
+    controls.set_keylock(true);
+    controls.set_backend(kind);
+    processor(controls)
+}
+
+pub(super) fn vinyl(kind: StretchKind, speed: f32) -> TimeStretchProcessor {
+    let controls = StretchControls::new(speed);
+    controls.set_keylock(false);
+    controls.set_backend(kind);
+    processor(controls)
+}
+
+pub(super) fn render(fx: &mut TimeStretchProcessor, input: &[f32]) -> Vec<f32> {
+    let mut out: Vec<f32> = Vec::new();
+    let block = 4096 * usize::from(Consts::CH);
+    for data in input.chunks(block) {
+        if let Some(c) =
+            render_chunk(fx, chunk(data)).expect("fixture stretch processing must succeed")
+        {
+            assert_eq!(
+                c.spec().sample_rate.get(),
+                Consts::SR,
+                "stretch preserves sample rate"
+            );
+            assert_eq!(c.spec().channels, Consts::CH);
+            out.extend_from_slice(&c.samples);
+        }
+    }
+    while let Some(c) = drain_eof(fx) {
+        // A non-empty flush chunk carries real audio, so its spec must stay
+        // the source spec, never the `PcmMeta::default()` sentinel (0
+        // channels) that a `None` `last_input_meta` would otherwise yield.
+        assert_eq!(c.spec().channels, Consts::CH, "flush preserves channels");
+        assert_eq!(
+            c.spec().sample_rate.get(),
+            Consts::SR,
+            "flush preserves sample rate"
+        );
+        out.extend_from_slice(&c.samples);
+    }
+    out
+}
+
+pub(super) fn run_keylocked(kind: StretchKind, speed: f32, in_frames: usize) -> Vec<f32> {
+    let input = sine(in_frames);
+    render(&mut keylocked(kind, speed), &input)
+}
+
+pub(super) fn run_vinyl(kind: StretchKind, speed: f32, in_frames: usize) -> Vec<f32> {
+    let input = sine(in_frames);
+    render(&mut vinyl(kind, speed), &input)
+}
+
+pub(super) fn assert_half_speed_contract(kind: StretchKind) {
+    let channels = usize::from(Consts::CH);
+    let in_frames = usize::try_from(Consts::SR).unwrap() * 2; // 2 s
+    let out = run_keylocked(kind, 0.5, in_frames);
+    let out_frames = out.len() / channels;
+
+    // Both C++ backends emit fixed-length output with leading latency-fill
+    // (and bungee drops its tail), nudging the measured duration off an
+    // exact 2x on a short clip, hence the 10% band.
+    assert!(
+        out_frames * 10 >= in_frames * 18 && out_frames * 10 <= in_frames * 22,
+        "{kind:?}: expected ~2x duration, got {out_frames} from {in_frames}"
+    );
+
+    // Pitch preserved: dominant bin still at F0 (the load-bearing check;
+    // a resampler-in-disguise would shift it).
+    let mono: Vec<f32> = out.iter().step_by(channels).copied().collect();
+    assert!(
+        mono.len() >= Consts::N,
+        "{kind:?}: not enough output for the FFT window"
+    );
+    let peak = dominant_bin(&mono);
+    let want = expected_bin(Consts::F0);
+    assert!(
+        peak.abs_diff(want) <= 3,
+        "{kind:?}: pitch moved under time-stretch: peak bin {peak}, expected {want}"
+    );
+}
+
+pub(super) fn assert_unity_contract(kind: StretchKind) {
+    let in_frames = usize::try_from(Consts::SR).unwrap() * 2;
+    let input = sine(in_frames);
+    let out = render(&mut keylocked(kind, 1.0), &input);
+    assert_eq!(out, input, "{kind:?}: unity speed must bypass byte-exact");
+}

--- a/crates/kithara-audio/src/effects/timestretch/processor/tests/lifecycle.rs
+++ b/crates/kithara-audio/src/effects/timestretch/processor/tests/lifecycle.rs
@@ -1,0 +1,401 @@
+use std::num::NonZero;
+
+use kithara_bufpool::PcmPool;
+use kithara_decode::{DecodeError, PcmSpec};
+use kithara_platform::sync::Arc;
+use kithara_stretch::StretchKind;
+use kithara_test_utils::kithara;
+
+use super::{
+    super::*,
+    common::{Consts, chunk, chunk_at, keylocked, processor, sine, spec},
+};
+use crate::region::{GridSegment, RegionPlan};
+
+fn render_step(stage: &mut TimeStretchProcessor) -> TempoStep {
+    let mut output = vec![0.0; TimeStretchProcessor::PRESENTATION_FRAMES * usize::from(Consts::CH)];
+    let credit = OutputCredit::new(
+        &mut output,
+        usize::from(Consts::CH),
+        TimeStretchProcessor::PRESENTATION_FRAMES,
+    );
+    TempoStage::render(stage, None, credit, &mut |_| {}).expect("tempo source renders")
+}
+
+fn drain_discontinuity(stage: &mut TimeStretchProcessor) {
+    let mut debt =
+        TempoStage::begin_discontinuity(stage).expect("tempo discontinuity begins after admission");
+    loop {
+        let mut output =
+            vec![0.0; TimeStretchProcessor::PRESENTATION_FRAMES * usize::from(Consts::CH)];
+        let credit = OutputCredit::new(
+            &mut output,
+            usize::from(Consts::CH),
+            TimeStretchProcessor::PRESENTATION_FRAMES,
+        );
+        if matches!(
+            TempoStage::render_discontinuity(stage, &mut debt, credit, &mut |_| {})
+                .expect("tempo discontinuity drains"),
+            TempoDiscontinuityStep::Drained
+        ) {
+            break;
+        }
+    }
+}
+
+#[kithara::test]
+fn control_boundary_is_withheld_while_source_is_admitted() {
+    let controls = StretchControls::new(1.0);
+    let mut stage = processor(Arc::clone(&controls));
+    let source = sine(TimeStretchProcessor::PRESENTATION_FRAMES);
+    TempoStage::push_source(&mut stage, chunk(&source)).expect("source quantum is admitted");
+
+    controls.set_speed(0.5);
+    TempoStage::service_off_rt(&mut stage, TempoPrepareRequest::Current { spec: spec() })
+        .expect("control replacement prepares off-RT");
+    assert!(stage.prepared.is_some());
+    assert_eq!(TempoStage::prepared_boundary(&stage), None);
+
+    assert!(matches!(
+        render_step(&mut stage),
+        TempoStep::Rendered { .. }
+    ));
+    assert_eq!(TempoStage::buffered_source_quanta(&stage), 0);
+    assert!(TempoStage::prepared_boundary(&stage).is_some());
+}
+
+#[kithara::test]
+fn decoder_boundary_is_withheld_while_source_is_admitted() {
+    let controls = StretchControls::new(1.0);
+    let mut stage = processor(controls);
+    let source = sine(TimeStretchProcessor::PRESENTATION_FRAMES);
+    TempoStage::push_source(&mut stage, chunk(&source)).expect("source quantum is admitted");
+    let replacement = PcmSpec::new(
+        Consts::CH,
+        NonZero::new(48_000).expect("replacement rate is non-zero"),
+    );
+
+    TempoStage::service_off_rt(
+        &mut stage,
+        TempoPrepareRequest::DecoderBoundary { spec: replacement },
+    )
+    .expect("decoder replacement prepares off-RT");
+    assert!(matches!(
+        stage.prepared.as_ref().map(|prepared| prepared.cause),
+        Some(PrepareCause::DecoderBoundary)
+    ));
+    assert_eq!(TempoStage::prepared_boundary(&stage), None);
+
+    assert!(matches!(
+        render_step(&mut stage),
+        TempoStep::Rendered { .. }
+    ));
+    assert_eq!(TempoStage::buffered_source_quanta(&stage), 0);
+    assert!(TempoStage::prepared_boundary(&stage).is_some());
+}
+
+#[kithara::test]
+fn region_boundary_preempts_and_defers_queued_decoder_boundary() {
+    let controls = StretchControls::new(1.0);
+    controls.set_keylock(true);
+    controls.set_backend(StretchKind::default());
+    let plan = RegionPlan::new(vec![
+        GridSegment::new(0, 256, 0.9),
+        GridSegment::new(256, 512, 1.1),
+    ])
+    .expect("fixture region plan is valid");
+    controls.set_region_plan(Some(Arc::new(plan)));
+    let mut stage = processor(controls);
+    let source = sine(TimeStretchProcessor::PRESENTATION_FRAMES);
+    TempoStage::push_source(&mut stage, chunk(&source)).expect("source quantum is admitted");
+
+    let reached_boundary = (0..64).any(|_| matches!(render_step(&mut stage), TempoStep::Preparing));
+    assert!(
+        reached_boundary,
+        "fixture must retain source at a region boundary"
+    );
+    assert_eq!(TempoStage::buffered_source_quanta(&stage), 1);
+
+    let replacement = PcmSpec::new(
+        Consts::CH,
+        NonZero::new(48_000).expect("replacement rate is non-zero"),
+    );
+    TempoStage::service_off_rt(
+        &mut stage,
+        TempoPrepareRequest::DecoderBoundary { spec: replacement },
+    )
+    .expect("region replacement prepares before the decoder replacement");
+    let region = TempoStage::prepared_boundary(&stage).expect("region boundary is published");
+    assert!(matches!(
+        stage.prepared.as_ref().map(|prepared| prepared.cause),
+        Some(PrepareCause::RegionBoundary)
+    ));
+    assert_eq!(
+        stage.prepared.as_ref().map(|prepared| prepared.core.spec),
+        Some(spec())
+    );
+
+    drain_discontinuity(&mut stage);
+    TempoStage::commit_prepared(&mut stage, region).expect("region replacement commits first");
+    TempoStage::service_off_rt(
+        &mut stage,
+        TempoPrepareRequest::DecoderBoundary { spec: replacement },
+    )
+    .expect("queued decoder replacement is reissued on the next cycle");
+    assert!(matches!(
+        stage.prepared.as_ref().map(|prepared| prepared.cause),
+        Some(PrepareCause::DecoderBoundary)
+    ));
+    assert_eq!(
+        stage.prepared.as_ref().map(|prepared| prepared.core.spec),
+        Some(replacement)
+    );
+    assert_eq!(TempoStage::prepared_boundary(&stage), None);
+
+    while TempoStage::buffered_source_quanta(&stage) != 0 {
+        assert!(!matches!(render_step(&mut stage), TempoStep::Preparing));
+    }
+    let decoder = TempoStage::prepared_boundary(&stage).expect("decoder boundary follows region");
+    assert_ne!(decoder, region);
+}
+
+#[kithara::test]
+fn repeated_off_rt_service_preserves_the_exact_decoder_boundary() {
+    let controls = StretchControls::new(0.5);
+    controls.set_keylock(true);
+    controls.set_backend(StretchKind::default());
+    let mut stage = processor(Arc::clone(&controls));
+
+    TempoStage::service_off_rt(
+        &mut stage,
+        TempoPrepareRequest::DecoderBoundary { spec: spec() },
+    )
+    .expect("decoder replacement prepares off-RT");
+    let first = TempoStage::prepared_boundary(&stage).expect("boundary is published");
+
+    TempoStage::service_off_rt(
+        &mut stage,
+        TempoPrepareRequest::DecoderBoundary { spec: spec() },
+    )
+    .expect("identical service request is idempotent");
+    let second = TempoStage::prepared_boundary(&stage).expect("boundary stays published");
+
+    assert_eq!(first, second);
+}
+
+#[kithara::test]
+fn off_rt_release_allows_seek_after_a_committed_tempo_boundary() {
+    let controls = StretchControls::new(1.0);
+    let mut stage = processor(Arc::clone(&controls));
+    controls.set_speed(0.5);
+    TempoStage::service_off_rt(&mut stage, TempoPrepareRequest::Current { spec: spec() })
+        .expect("replacement core prepares off-RT");
+    let boundary = TempoStage::prepared_boundary(&stage).expect("tempo boundary is published");
+    let mut debt = TempoStage::begin_discontinuity(&mut stage)
+        .expect("idle core creates a finite discontinuity");
+    let mut output = vec![0.0; TimeStretchProcessor::PRESENTATION_FRAMES * usize::from(Consts::CH)];
+    let credit = OutputCredit::new(
+        &mut output,
+        usize::from(Consts::CH),
+        TimeStretchProcessor::PRESENTATION_FRAMES,
+    );
+    assert!(matches!(
+        TempoStage::render_discontinuity(&mut stage, &mut debt, credit, &mut |_| {})
+            .expect("idle discontinuity drains"),
+        TempoDiscontinuityStep::Drained
+    ));
+    TempoStage::commit_prepared(&mut stage, boundary).expect("replacement core commits on RT");
+
+    assert!(
+        TempoStage::deactivate(&mut stage, &mut |_| {}).is_err(),
+        "RT deactivation must not overwrite an unreleased retired core"
+    );
+    TempoStage::release_retired_off_rt(&mut stage);
+    TempoStage::deactivate(&mut stage, &mut |_| {})
+        .expect("off-RT release makes the following seek deactivation safe");
+}
+
+#[kithara::test]
+fn missing_initial_core_waits_without_consuming_admitted_source() {
+    let controls = StretchControls::new(0.5);
+    let mut stage = TimeStretchProcessor::new(controls, spec(), PcmPool::default());
+    let source = sine(TimeStretchProcessor::PRESENTATION_FRAMES);
+    TempoStage::push_source(&mut stage, chunk(&source)).expect("source admission is retained");
+    let mut output = vec![0.0; source.len()];
+    let credit = OutputCredit::new(
+        &mut output,
+        usize::from(Consts::CH),
+        TimeStretchProcessor::PRESENTATION_FRAMES,
+    );
+
+    assert!(matches!(
+        TempoStage::render(&mut stage, None, credit, &mut |_| {})
+            .expect("missing preparation is a typed wait"),
+        TempoStep::Preparing
+    ));
+    assert_eq!(TempoStage::buffered_source_quanta(&stage), 1);
+}
+
+#[kithara::test]
+fn invalid_speed_is_rejected_during_off_rt_preparation() {
+    let controls = StretchControls::new(f32::NAN);
+    let mut stage = TimeStretchProcessor::new(controls, spec(), PcmPool::default());
+
+    assert!(matches!(
+        TempoStage::service_off_rt(&mut stage, TempoPrepareRequest::Current { spec: spec() }),
+        Err(DecodeError::InvalidData {
+            detail: "tempo stage cannot adopt an invalid playback speed"
+        })
+    ));
+    assert!(stage.active.is_none());
+}
+
+#[cfg(feature = "stretch-signalsmith")]
+#[kithara::test]
+fn signalsmith_discontinuity_tail_advances_the_source_frontier_exactly() {
+    let mut stage = keylocked(StretchKind::Signalsmith, 0.5);
+    let source = sine(TimeStretchProcessor::PRESENTATION_FRAMES);
+    TempoStage::push_source(&mut stage, chunk(&source)).expect("one source quantum is admitted");
+    while TempoStage::buffered_source_quanta(&stage) != 0 {
+        let mut output =
+            vec![0.0; TimeStretchProcessor::PRESENTATION_FRAMES * usize::from(Consts::CH)];
+        let credit = OutputCredit::new(
+            &mut output,
+            usize::from(Consts::CH),
+            TimeStretchProcessor::PRESENTATION_FRAMES,
+        );
+        TempoStage::render(&mut stage, None, credit, &mut |_| {})
+            .expect("source quantum renders before the barrier");
+    }
+    let held = TempoStage::held_source_frames(&stage);
+    assert!(held > 0);
+    let expected_tail = stage
+        .active
+        .as_ref()
+        .and_then(|core| core.backend.as_ref())
+        .expect("fixture has an active Signalsmith backend")
+        .max_tail_samples()
+        / usize::from(Consts::CH);
+    assert!(
+        expected_tail > TimeStretchProcessor::PRESENTATION_FRAMES,
+        "fixture must exercise a multi-block drain tail"
+    );
+    let mut debt = TempoStage::begin_discontinuity(&mut stage)
+        .expect("ordered discontinuity creates finite debt");
+    let mut rendered_tail = 0;
+    let admitted_end = u64::try_from(TimeStretchProcessor::PRESENTATION_FRAMES).unwrap();
+    let mut previous_frontier = admitted_end - held;
+    loop {
+        let mut output =
+            vec![0.0; TimeStretchProcessor::PRESENTATION_FRAMES * usize::from(Consts::CH)];
+        let credit = OutputCredit::new(
+            &mut output,
+            usize::from(Consts::CH),
+            TimeStretchProcessor::PRESENTATION_FRAMES,
+        );
+        match TempoStage::render_discontinuity(&mut stage, &mut debt, credit, &mut |_| {})
+            .expect("discontinuity debt drains")
+        {
+            TempoDiscontinuityStep::Drained => {
+                assert_eq!(TempoStage::held_source_frames(&stage), 0);
+                break;
+            }
+            TempoDiscontinuityStep::Rendered { frames, .. } => {
+                assert!(frames <= TimeStretchProcessor::PRESENTATION_FRAMES);
+                rendered_tail += frames;
+                let released = u128::from(held) * u128::try_from(rendered_tail).unwrap()
+                    / u128::try_from(expected_tail).unwrap();
+                let expected_held = held - u64::try_from(released).unwrap();
+                let current_held = TempoStage::held_source_frames(&stage);
+                assert_eq!(current_held, expected_held);
+                let frontier = admitted_end - current_held;
+                assert!(
+                    frontier >= previous_frontier,
+                    "source frontier regressed from {previous_frontier} to {frontier}"
+                );
+                previous_frontier = frontier;
+            }
+        }
+    }
+
+    assert_eq!(rendered_tail, expected_tail);
+    assert_eq!(previous_frontier, admitted_end);
+}
+
+#[cfg(feature = "stretch-signalsmith")]
+#[kithara::test]
+fn signalsmith_reconfigure_after_discontinuity_adopts_the_replacement_spec_and_live_controls() {
+    let controls = StretchControls::new(0.5);
+    controls.set_keylock(true);
+    controls.set_backend(StretchKind::Signalsmith);
+    let mut stage = processor(Arc::clone(&controls));
+    let source = sine(TimeStretchProcessor::PRESENTATION_FRAMES);
+    TempoStage::push_source(&mut stage, chunk(&source)).expect("old source quantum is admitted");
+    while TempoStage::buffered_source_quanta(&stage) != 0 {
+        let mut output =
+            vec![0.0; TimeStretchProcessor::PRESENTATION_FRAMES * usize::from(Consts::CH)];
+        let credit = OutputCredit::new(
+            &mut output,
+            usize::from(Consts::CH),
+            TimeStretchProcessor::PRESENTATION_FRAMES,
+        );
+        TempoStage::render(&mut stage, None, credit, &mut |_| {})
+            .expect("old source quantum renders before the barrier");
+    }
+    let mut debt = TempoStage::begin_discontinuity(&mut stage)
+        .expect("ordered discontinuity creates finite debt");
+    loop {
+        let mut output =
+            vec![0.0; TimeStretchProcessor::PRESENTATION_FRAMES * usize::from(Consts::CH)];
+        let credit = OutputCredit::new(
+            &mut output,
+            usize::from(Consts::CH),
+            TimeStretchProcessor::PRESENTATION_FRAMES,
+        );
+        if matches!(
+            TempoStage::render_discontinuity(&mut stage, &mut debt, credit, &mut |_| {})
+                .expect("old tail drains before replacement"),
+            TempoDiscontinuityStep::Drained
+        ) {
+            break;
+        }
+    }
+
+    controls.set_speed(1.0);
+    controls.set_keylock(false);
+    let replacement = PcmSpec::new(
+        Consts::CH,
+        NonZero::new(48_000).expect("replacement rate is non-zero"),
+    );
+    TempoStage::service_off_rt(
+        &mut stage,
+        TempoPrepareRequest::DecoderBoundary { spec: replacement },
+    )
+    .expect("replacement core prepares off-RT");
+    let boundary = TempoStage::prepared_boundary(&stage)
+        .expect("replacement core publishes an exact boundary");
+    TempoStage::commit_prepared(&mut stage, boundary)
+        .expect("drained stage adopts replacement PCM shape");
+
+    assert_eq!(TempoStage::output_spec(&stage), replacement);
+    assert!(Arc::ptr_eq(&stage.controls, &controls));
+    assert_eq!(stage.controls.speed(), 1.0);
+    assert!(!stage.controls.keylock());
+    let replacement_source = vec![0.25; TimeStretchProcessor::PRESENTATION_FRAMES * 2];
+    TempoStage::push_source(&mut stage, chunk_at(replacement, &replacement_source))
+        .expect("first replacement source quantum is admitted");
+    let mut output = vec![0.0; replacement_source.len()];
+    let credit = OutputCredit::new(
+        &mut output,
+        usize::from(replacement.channels),
+        TimeStretchProcessor::PRESENTATION_FRAMES,
+    );
+    let TempoStep::Rendered { frames, meta } =
+        TempoStage::render(&mut stage, None, credit, &mut |_| {})
+            .expect("replacement quantum renders with live controls")
+    else {
+        panic!("unity replacement quantum must render immediately");
+    };
+    assert_eq!(frames, TimeStretchProcessor::PRESENTATION_FRAMES);
+    assert_eq!(meta.spec, replacement);
+}

--- a/crates/kithara-audio/src/effects/timestretch/processor/tests/mod.rs
+++ b/crates/kithara-audio/src/effects/timestretch/processor/tests/mod.rs
@@ -1,0 +1,5 @@
+mod audio;
+mod common;
+mod lifecycle;
+
+pub(in crate::effects::timestretch) use common::{drain_eof, render_chunk, source_endpoint};

--- a/crates/kithara-audio/src/effects/timestretch/region_tests.rs
+++ b/crates/kithara-audio/src/effects/timestretch/region_tests.rs
@@ -6,11 +6,11 @@ use kithara_platform::sync::Arc;
 use kithara_stretch::StretchKind;
 use kithara_test_utils::kithara;
 
-use super::{StretchControls, TimeStretchProcessor};
-use crate::{
-    region::{GridSegment, RegionPlan, RegionPlanError},
-    traits::AudioEffect,
+use super::{
+    StretchControls, TimeStretchProcessor,
+    processor::tests::{drain_eof, render_chunk, source_endpoint},
 };
+use crate::region::{GridSegment, RegionPlan, RegionPlanError};
 
 const SR: u32 = 44_100;
 const CH: usize = 2;
@@ -97,6 +97,10 @@ fn add_click(buf: &mut [f32], frame: usize) {
 /// Render `source` through a key-locked Signalsmith processor with `plan`,
 /// feeding 4096-frame chunks with advancing `frame_offset` (source frames).
 fn render(speed: f32, plan: Option<RegionPlan>, source: &[f32]) -> Vec<f32> {
+    render_with_endpoint(speed, plan, source).0
+}
+
+fn render_with_endpoint(speed: f32, plan: Option<RegionPlan>, source: &[f32]) -> (Vec<f32>, u64) {
     let controls = StretchControls::new(speed);
     controls.set_keylock(true);
     controls.set_backend(StretchKind::Signalsmith);
@@ -106,15 +110,18 @@ fn render(speed: f32, plan: Option<RegionPlan>, source: &[f32]) -> Vec<f32> {
     let mut offset = 0_u64;
     for data in source.chunks(4096 * CH) {
         let frames = data.len() / CH;
-        if let Some(o) = fx.process(chunk(data, offset)) {
+        if let Some(o) = render_chunk(&mut fx, chunk(data, offset))
+            .expect("fixture stretch processing must succeed")
+        {
             out.extend_from_slice(&o.samples);
         }
         offset += u64_of(frames);
     }
-    while let Some(o) = fx.flush() {
+    while let Some(o) = drain_eof(&mut fx) {
         out.extend_from_slice(&o.samples);
     }
-    out
+    let endpoint = source_endpoint(&fx).expect("rendered source has an exact endpoint");
+    (out, endpoint)
 }
 
 fn mono(samples: &[f32]) -> Vec<f32> {
@@ -228,7 +235,7 @@ fn corrections_align_drifting_clicks_to_nominal_grid() {
     ])
     .expect("valid plan");
 
-    let out = render(1.0, Some(plan), &src);
+    let (out, endpoint) = render_with_endpoint(1.0, Some(plan), &src);
     let clicks = click_positions(&mono(&out));
     assert_eq!(
         clicks.len(),
@@ -239,15 +246,13 @@ fn corrections_align_drifting_clicks_to_nominal_grid() {
     // ±5% of a bar; the drifted spacings (P1, P2) are off by 10% and must fail.
     let tol = NOMINAL / 20;
     for (i, pair) in clicks.windows(2).enumerate() {
-        if i == BARS - 1 {
-            continue; // spans the boundary reset transient
-        }
         let gap = pair[1] - pair[0];
         assert!(
             gap.abs_diff(NOMINAL) <= tol,
             "click interval {i} = {gap} frames, want ~{NOMINAL} (plan correction not applied?)"
         );
     }
+    assert_eq!(endpoint, u64_of(TOTAL), "source endpoint must stay exact");
 }
 
 /// A ratio change at a segment boundary must not click: the max sample step

--- a/crates/kithara-audio/src/effects/timestretch/render.rs
+++ b/crates/kithara-audio/src/effects/timestretch/render.rs
@@ -1,0 +1,264 @@
+use kithara_decode::{DecodeError, DecodeResult, PcmChunk};
+
+use super::{TimeStretchProcessor, state::AdmittedSource};
+use crate::traits::{OutputCredit, TempoStep};
+
+impl TimeStretchProcessor {
+    pub(super) fn render_admitted(
+        &mut self,
+        mut credit: OutputCredit<'_>,
+        retire: &mut dyn FnMut(PcmChunk),
+    ) -> DecodeResult<TempoStep> {
+        self.validate_credit(&mut credit)?;
+        let Some(mut admitted) = self.admitted.take() else {
+            return Ok(TempoStep::NeedSource);
+        };
+        match self.render_admitted_inner(&mut admitted, &mut credit) {
+            Ok((step, consumed)) => {
+                admitted.consumed_frames = admitted.consumed_frames.checked_add(consumed).ok_or(
+                    DecodeError::InvalidData {
+                        detail: "tempo admitted source cursor overflow",
+                    },
+                )?;
+                let consumed_chunk = admitted.consumed_frames == admitted.chunk.frames();
+                if consumed_chunk {
+                    retire(admitted.chunk);
+                    return Ok(step);
+                }
+                if matches!(step, TempoStep::Rendered { .. } | TempoStep::Preparing) {
+                    self.admitted = Some(admitted);
+                    return Ok(step);
+                }
+                if consumed == 0 {
+                    self.admitted = Some(admitted);
+                    self.failed = true;
+                    return Err(DecodeError::InvalidData {
+                        detail: "tempo backend made no source or output progress",
+                    });
+                }
+                self.admitted = Some(admitted);
+                Ok(TempoStep::Consumed)
+            }
+            Err(error) => {
+                self.admitted = Some(admitted);
+                self.failed = true;
+                Err(error)
+            }
+        }
+    }
+
+    fn render_unity(
+        &mut self,
+        admitted: &AdmittedSource,
+        credit: &mut OutputCredit<'_>,
+        remaining: usize,
+    ) -> DecodeResult<(TempoStep, usize)> {
+        let frames = remaining.min(credit.max_frames());
+        let channels = self.channels();
+        let start =
+            admitted
+                .consumed_frames
+                .checked_mul(channels)
+                .ok_or(DecodeError::InvalidData {
+                    detail: "tempo unity source offset overflow",
+                })?;
+        let samples = frames
+            .checked_mul(channels)
+            .ok_or(DecodeError::InvalidData {
+                detail: "tempo unity sample count overflow",
+            })?;
+        let end = start.checked_add(samples).ok_or(DecodeError::InvalidData {
+            detail: "tempo unity source range overflow",
+        })?;
+        credit.samples_mut()[..samples].copy_from_slice(
+            admitted
+                .chunk
+                .samples
+                .get(start..end)
+                .ok_or(DecodeError::InvalidData {
+                    detail: "tempo unity source range exceeds PCM",
+                })?,
+        );
+        let meta = self.output_meta(&admitted.chunk.meta, admitted.consumed_frames, frames)?;
+        self.last_input_meta = Some(admitted.chunk.meta);
+        Ok((TempoStep::Rendered { frames, meta }, frames))
+    }
+
+    fn remaining_source(&self, admitted: &AdmittedSource) -> DecodeResult<usize> {
+        if admitted.chunk.spec() != self.active()?.spec {
+            return Err(DecodeError::InvalidData {
+                detail: "tempo stage received a source with a different PCM spec",
+            });
+        }
+        admitted
+            .chunk
+            .frames()
+            .checked_sub(admitted.consumed_frames)
+            .ok_or(DecodeError::InvalidData {
+                detail: "tempo source cursor exceeds the admitted chunk",
+            })
+    }
+
+    fn fitting_source_frames(
+        &self,
+        available: usize,
+        credit_samples: usize,
+    ) -> DecodeResult<usize> {
+        let backend = self.active()?.backend()?;
+        let mut lower = 1;
+        let mut upper = available;
+        let mut best = 0;
+        while lower <= upper {
+            let middle = lower.midpoint(upper);
+            if backend.max_output_samples(middle) <= credit_samples {
+                best = middle;
+                lower = middle + 1;
+            } else {
+                upper = middle - 1;
+            }
+        }
+        Ok(best)
+    }
+    fn render_admitted_inner(
+        &mut self,
+        admitted: &mut AdmittedSource,
+        credit: &mut OutputCredit<'_>,
+    ) -> DecodeResult<(TempoStep, usize)> {
+        let remaining = self.remaining_source(admitted)?;
+        let speed = self.active()?.snapshot.speed.max(Self::MIN_SPEED);
+        if remaining == 0 {
+            return Ok((TempoStep::NeedSource, 0));
+        }
+        if self.active()?.bypass() {
+            return self.render_unity(admitted, credit, remaining);
+        }
+
+        let source_frame = admitted
+            .chunk
+            .meta
+            .frame_offset
+            .checked_add(u64::try_from(admitted.consumed_frames).map_err(|_| {
+                DecodeError::InvalidData {
+                    detail: "tempo source cursor exceeds u64",
+                }
+            })?)
+            .ok_or(DecodeError::InvalidData {
+                detail: "tempo source position overflow",
+            })?;
+        let (region, crossed) = self.region_for(source_frame)?;
+        if crossed {
+            self.request_region_boundary(source_frame)?;
+            return Ok((TempoStep::Preparing, 0));
+        }
+        let region_remaining =
+            region
+                .end()
+                .checked_sub(source_frame)
+                .ok_or(DecodeError::InvalidData {
+                    detail: "tempo region ends before the source cursor",
+                })?;
+        let remaining_u64 = u64::try_from(remaining).map_err(|_| DecodeError::InvalidData {
+            detail: "tempo admitted source length exceeds u64",
+        })?;
+        let region_frames = if region_remaining >= remaining_u64 {
+            remaining
+        } else {
+            usize::try_from(region_remaining).map_err(|_| DecodeError::InvalidData {
+                detail: "tempo region length exceeds usize",
+            })?
+        };
+        let available = remaining
+            .min(region_frames.max(1))
+            .min(Self::PRESENTATION_FRAMES);
+        let base = 1.0 / f64::from(speed);
+        let pitch = if self.active()?.snapshot.keylock {
+            1.0
+        } else {
+            f64::from(speed)
+        };
+        self.apply_pitch(pitch)?;
+        self.apply_stretch(base * region.correction())?;
+        let credit_samples =
+            credit
+                .max_frames()
+                .checked_mul(self.channels())
+                .ok_or(DecodeError::InvalidData {
+                    detail: "tempo credit sample count overflow",
+                })?;
+        let source_frames = self.fitting_source_frames(available, credit_samples)?;
+        if source_frames == 0 {
+            return Err(DecodeError::InvalidData {
+                detail: "tempo backend cannot fit one source frame in the output credit",
+            });
+        }
+        let channels = self.channels();
+        let source_range = admitted.sample_range(source_frames, channels)?;
+        let predicted = self.active()?.backend()?.max_output_samples(source_frames);
+        if predicted > self.active()?.scratch.capacity() || predicted > credit_samples {
+            return Err(DecodeError::InvalidData {
+                detail: "tempo backend output exceeds its prepared credit bound",
+            });
+        }
+        let input = admitted
+            .chunk
+            .samples
+            .get(source_range)
+            .ok_or(DecodeError::InvalidData {
+                detail: "tempo source range exceeds admitted PCM",
+            })?;
+        let core = self.active_mut()?;
+        core.scratch.clear();
+        let backend = core
+            .backend
+            .as_deref_mut()
+            .ok_or(DecodeError::InvalidData {
+                detail: "active tempo core lost its DSP backend",
+            })?;
+        backend
+            .process(input, &mut core.scratch)
+            .map_err(|_| DecodeError::InvalidData {
+                detail: "time-stretch backend failed to render",
+            })?;
+        let rendered_samples = self.active()?.scratch.len();
+        if rendered_samples > predicted
+            || rendered_samples > credit_samples
+            || rendered_samples % channels != 0
+        {
+            self.active_mut()?.scratch.clear();
+            return Err(DecodeError::InvalidData {
+                detail: "tempo backend violated its declared output bound",
+            });
+        }
+        let core = self.active_mut()?;
+        core.processing = true;
+        core.source_frames_pushed = core
+            .source_frames_pushed
+            .checked_add(
+                u64::try_from(source_frames).map_err(|_| DecodeError::InvalidData {
+                    detail: "tempo source progress exceeds u64",
+                })?,
+            )
+            .ok_or(DecodeError::InvalidData {
+                detail: "tempo source progress overflow",
+            })?;
+        let output_frames = rendered_samples / channels;
+        if output_frames == 0 {
+            return Ok((TempoStep::NeedSource, source_frames));
+        }
+        credit.samples_mut()[..rendered_samples].copy_from_slice(&self.active()?.scratch);
+        self.active_mut()?.scratch.clear();
+        let meta = self.output_meta(
+            &admitted.chunk.meta,
+            admitted.consumed_frames,
+            output_frames,
+        )?;
+        self.last_input_meta = Some(admitted.chunk.meta);
+        Ok((
+            TempoStep::Rendered {
+                frames: output_frames,
+                meta,
+            },
+            source_frames,
+        ))
+    }
+}

--- a/crates/kithara-audio/src/effects/timestretch/state.rs
+++ b/crates/kithara-audio/src/effects/timestretch/state.rs
@@ -1,0 +1,372 @@
+use std::ops::Range;
+
+use kithara_decode::{DecodeError, DecodeResult, PcmChunk, PcmMeta, PcmSpec};
+use kithara_stretch::{DrainDisposition, StretchBackend};
+
+use super::{super::backend::StretchSnapshot, TimeStretchProcessor};
+use crate::{
+    region::ActiveRegion,
+    traits::{OutputCredit, TempoBoundaryId},
+};
+
+pub(super) struct TempoCore {
+    pub(super) backend: Option<Box<dyn StretchBackend>>,
+    pub(super) scratch: Vec<f32>,
+    pub(super) snapshot: StretchSnapshot,
+    pub(super) spec: PcmSpec,
+    pub(super) region: Option<ActiveRegion>,
+    pub(super) applied_pitch: f64,
+    pub(super) applied_stretch: f64,
+    pub(super) source_frames_pushed: u64,
+    pub(super) processing: bool,
+}
+
+pub(super) struct PreparedCore {
+    pub(super) cause: PrepareCause,
+    pub(super) id: TempoBoundaryId,
+    pub(super) core: TempoCore,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub(super) enum PrepareCause {
+    Current,
+    DecoderBoundary,
+    RegionBoundary,
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct RegionBoundary {
+    pub(super) source_frame: u64,
+}
+
+pub(super) struct RetiredCores {
+    pub(super) active: Option<TempoCore>,
+    pub(super) prepared: Option<PreparedCore>,
+}
+
+impl TimeStretchProcessor {
+    pub(super) fn apply_pitch(&mut self, pitch: f64) -> DecodeResult<()> {
+        let core = self.active_mut()?;
+        if !core.applied_pitch.is_nan() && (pitch - core.applied_pitch).abs() <= Self::RATIO_EPS {
+            return Ok(());
+        }
+        core.backend_mut()?
+            .set_pitch(pitch)
+            .map_err(|_| DecodeError::InvalidData {
+                detail: "time-stretch backend rejected pitch",
+            })?;
+        core.applied_pitch = pitch;
+        Ok(())
+    }
+
+    pub(super) fn apply_stretch(&mut self, stretch: f64) -> DecodeResult<()> {
+        let core = self.active_mut()?;
+        if !core.applied_stretch.is_nan()
+            && (stretch - core.applied_stretch).abs() <= Self::RATIO_EPS
+        {
+            return Ok(());
+        }
+        core.backend_mut()?
+            .set_ratio(stretch)
+            .map_err(|_| DecodeError::InvalidData {
+                detail: "time-stretch backend rejected ratio",
+            })?;
+        core.applied_stretch = stretch;
+        Ok(())
+    }
+
+    pub(super) fn update_active_snapshot(&mut self, snapshot: StretchSnapshot) -> DecodeResult<()> {
+        let core = self.active_mut()?;
+        let plan_changed = !Self::same_plan(&core.snapshot.plan, &snapshot.plan);
+        let parameters_changed = core.snapshot.keylock != snapshot.keylock
+            || (core.snapshot.speed - snapshot.speed).abs() > f32::EPSILON;
+        core.snapshot = snapshot;
+        if plan_changed {
+            core.region = None;
+        }
+        if parameters_changed || plan_changed {
+            core.applied_pitch = f64::NAN;
+            core.applied_stretch = f64::NAN;
+        }
+        Ok(())
+    }
+
+    pub(super) fn region_for(&mut self, frame: u64) -> DecodeResult<(ActiveRegion, bool)> {
+        let core = self.active_mut()?;
+        if let Some(r) = core.region
+            && r.contains(frame)
+        {
+            return Ok((r, false));
+        }
+        let mut next = self
+            .active()?
+            .snapshot
+            .plan
+            .as_ref()
+            .map_or(ActiveRegion::UNBOUNDED, |p| p.region_at(frame));
+        if let Some(plan) = &self.active()?.snapshot.plan {
+            let correction = next.correction();
+            let mut end = next.end();
+            for _ in 0..=plan.segments.len() {
+                if end == u64::MAX {
+                    break;
+                }
+                let following = plan.region_at(end);
+                if (following.correction() - correction).abs() > Self::RATIO_EPS {
+                    break;
+                }
+                end = following.end();
+            }
+            next = ActiveRegion::new(next.start(), end, correction);
+        }
+        let core = self.active_mut()?;
+        let crossed = core.region.is_some();
+        if !crossed {
+            core.region = Some(next);
+        }
+        Ok((next, crossed))
+    }
+
+    pub(super) fn request_region_boundary(&mut self, source_frame: u64) -> DecodeResult<()> {
+        match self.region_boundary {
+            None => self.region_boundary = Some(RegionBoundary { source_frame }),
+            Some(boundary) if boundary.source_frame == source_frame => {}
+            Some(_) => {
+                return Err(DecodeError::InvalidData {
+                    detail: "tempo stage crossed a second region boundary before commit",
+                });
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn begin_tempo_drain(&mut self, context: &'static str) -> DecodeResult<()> {
+        if self.eof_pending || self.discontinuity_pending {
+            return Err(DecodeError::InvalidData {
+                detail: "tempo stage already has an active drain debt",
+            });
+        }
+        let held_source_frames = self.active_held_source_frames();
+        let core = self.active_mut()?;
+        core.scratch.clear();
+        if core.processing {
+            let bound = core.backend()?.max_tail_samples();
+            if bound > core.scratch.capacity() {
+                return Err(DecodeError::InvalidData {
+                    detail: "tempo tail exceeds prepared storage",
+                });
+            }
+            let (backend, scratch) = core
+                .backend
+                .as_deref_mut()
+                .zip(Some(&mut core.scratch))
+                .ok_or(DecodeError::InvalidData {
+                    detail: "active tempo core lost its DSP backend",
+                })?;
+            backend
+                .flush(scratch)
+                .map_err(|_| DecodeError::InvalidData { detail: context })?;
+            if core.scratch.len() > bound || core.scratch.len() % core.channels() != 0 {
+                return Err(DecodeError::InvalidData {
+                    detail: "tempo backend violated its tail bound",
+                });
+            }
+        }
+        self.eof_offset = 0;
+        let core = self.active()?;
+        let tail_frames = core.scratch.len() / core.channels();
+        let disposition = core
+            .backend
+            .as_ref()
+            .map_or(DrainDisposition::DiscardHeld, |backend| {
+                backend.drain_disposition()
+            });
+        self.drain_frontier = Some(match disposition {
+            DrainDisposition::RenderedTail => DrainFrontier::new(held_source_frames, tail_frames)?,
+            DrainDisposition::DiscardHeld if tail_frames == 0 => DrainFrontier::new(0, 0)?,
+            DrainDisposition::DiscardHeld => {
+                return Err(DecodeError::InvalidData {
+                    detail: "discarding tempo backend emitted an undeclared drain tail",
+                });
+            }
+            _ => {
+                return Err(DecodeError::InvalidData {
+                    detail: "tempo backend declared an unsupported drain disposition",
+                });
+            }
+        });
+        Ok(())
+    }
+
+    pub(super) fn render_tempo_drain(
+        &mut self,
+        mut credit: OutputCredit<'_>,
+    ) -> DecodeResult<Option<(usize, PcmMeta)>> {
+        self.validate_credit(&mut credit)?;
+        if self.eof_offset >= self.active()?.scratch.len() {
+            let core = self.active_mut()?;
+            core.scratch.clear();
+            core.processing = false;
+            core.applied_stretch = f64::NAN;
+            core.applied_pitch = f64::NAN;
+            core.source_frames_pushed = 0;
+            self.eof_offset = 0;
+            self.eof_pending = false;
+            self.discontinuity_pending = false;
+            self.drain_frontier = None;
+            return Ok(None);
+        }
+        let channels = self.channels();
+        let available_frames = (self.active()?.scratch.len() - self.eof_offset) / channels;
+        let frames = available_frames.min(credit.max_frames());
+        let samples = frames
+            .checked_mul(channels)
+            .ok_or(DecodeError::InvalidData {
+                detail: "tempo drain sample count overflow",
+            })?;
+        let end = self
+            .eof_offset
+            .checked_add(samples)
+            .ok_or(DecodeError::InvalidData {
+                detail: "tempo drain sample range overflow",
+            })?;
+        credit.samples_mut()[..samples]
+            .copy_from_slice(&self.active()?.scratch[self.eof_offset..end]);
+        self.eof_offset = end;
+        let frontier = self
+            .drain_frontier
+            .as_mut()
+            .ok_or(DecodeError::InvalidData {
+                detail: "tempo drain lost its source frontier",
+            })?;
+        frontier.advance(frames)?;
+        let spec = self.active()?.spec;
+        let mut meta = self.last_input_meta.ok_or(DecodeError::InvalidData {
+            detail: "tempo drain has no admitted source metadata",
+        })?;
+        meta.spec = spec;
+        meta.frames = u32::try_from(frames).map_err(|_| DecodeError::InvalidData {
+            detail: "tempo drain frame count exceeds u32",
+        })?;
+        Ok(Some((frames, meta)))
+    }
+}
+
+impl TempoCore {
+    pub(super) fn backend(&self) -> DecodeResult<&dyn StretchBackend> {
+        self.backend.as_deref().ok_or(DecodeError::InvalidData {
+            detail: "tempo bypass core has no DSP backend",
+        })
+    }
+
+    pub(super) fn backend_mut(&mut self) -> DecodeResult<&mut (dyn StretchBackend + 'static)> {
+        self.backend.as_deref_mut().ok_or(DecodeError::InvalidData {
+            detail: "tempo bypass core has no DSP backend",
+        })
+    }
+
+    pub(super) fn bypass(&self) -> bool {
+        self.backend.is_none()
+    }
+
+    pub(super) fn channels(&self) -> usize {
+        usize::from(self.spec.channels.max(1))
+    }
+}
+
+impl RetiredCores {
+    pub(super) fn release(self) {
+        drop(self.active);
+        drop(self.prepared);
+    }
+}
+
+pub(super) struct AdmittedSource {
+    pub(super) chunk: PcmChunk,
+    pub(super) consumed_frames: usize,
+}
+
+impl AdmittedSource {
+    pub(super) fn sample_range(
+        &self,
+        frames: usize,
+        channels: usize,
+    ) -> DecodeResult<Range<usize>> {
+        let start = self
+            .consumed_frames
+            .checked_mul(channels)
+            .ok_or(DecodeError::InvalidData {
+                detail: "tempo source sample offset overflow",
+            })?;
+        let samples = frames
+            .checked_mul(channels)
+            .ok_or(DecodeError::InvalidData {
+                detail: "tempo source sample count overflow",
+            })?;
+        let end = start.checked_add(samples).ok_or(DecodeError::InvalidData {
+            detail: "tempo source sample range overflow",
+        })?;
+        Ok(start..end)
+    }
+}
+
+pub(super) struct DrainFrontier {
+    emitted_output_frames: usize,
+    pub(super) remaining_source_frames: u64,
+    total_output_frames: usize,
+    total_source_frames: u64,
+}
+
+impl DrainFrontier {
+    pub(super) fn new(total_source_frames: u64, total_output_frames: usize) -> DecodeResult<Self> {
+        if total_source_frames != 0 && total_output_frames == 0 {
+            return Err(DecodeError::InvalidData {
+                detail: "tempo backend retained source without a rendered drain tail",
+            });
+        }
+        Ok(Self {
+            emitted_output_frames: 0,
+            remaining_source_frames: total_source_frames,
+            total_output_frames,
+            total_source_frames,
+        })
+    }
+
+    pub(super) fn advance(&mut self, output_frames: usize) -> DecodeResult<()> {
+        self.emitted_output_frames = self
+            .emitted_output_frames
+            .checked_add(output_frames)
+            .filter(|emitted| *emitted <= self.total_output_frames)
+            .ok_or(DecodeError::InvalidData {
+                detail: "tempo drain output exceeded its declared tail",
+            })?;
+        if self.total_output_frames == 0 {
+            self.remaining_source_frames = 0;
+            return Ok(());
+        }
+        let emitted =
+            u128::try_from(self.emitted_output_frames).map_err(|_| DecodeError::InvalidData {
+                detail: "tempo drain output progress exceeds u128",
+            })?;
+        let total_output =
+            u128::try_from(self.total_output_frames).map_err(|_| DecodeError::InvalidData {
+                detail: "tempo drain output length exceeds u128",
+            })?;
+        let released = u128::from(self.total_source_frames)
+            .checked_mul(emitted)
+            .ok_or(DecodeError::InvalidData {
+                detail: "tempo drain source allocation overflow",
+            })?
+            / total_output;
+        let released = u64::try_from(released).map_err(|_| DecodeError::InvalidData {
+            detail: "tempo drain released source exceeds u64",
+        })?;
+        self.remaining_source_frames =
+            self.total_source_frames
+                .checked_sub(released)
+                .ok_or(DecodeError::InvalidData {
+                    detail: "tempo drain released more source than it retained",
+                })?;
+        Ok(())
+    }
+}

--- a/crates/kithara-audio/src/lib.rs
+++ b/crates/kithara-audio/src/lib.rs
@@ -49,7 +49,8 @@ pub use renderer::{
     AudioWorkerHandle, AudioWorkerSource, EngineLoad, EngineLoadSnapshot, PreloadGate, ServiceClass,
 };
 pub use traits::{
-    AudioEffect, ChunkOutcome, DecodeError, DecodeResult, PcmControl, PcmRead, PcmReader,
-    PcmSession, PendingReason, ReadOutcome, SeekBegin, SeekOutcome,
+    AudioBlockMut, AudioEffect, ChunkOutcome, DecodeError, DecodeResult, PcmControl, PcmRead,
+    PcmReader, PcmSession, PendingReason, PresentationAdvance, PresentationCursor,
+    PresentationPoint, ReadOutcome, SeekBegin, SeekOutcome,
 };
 pub use waveform::{AnalysisParams, BeatGrid, Bucket, GridSegment, bucket::Waveform};

--- a/crates/kithara-audio/src/musical/anchor.rs
+++ b/crates/kithara-audio/src/musical/anchor.rs
@@ -41,6 +41,13 @@ impl SessionFrame {
     pub const fn new(value: i64) -> Self {
         Self(value)
     }
+
+    /// Returns this session coordinate advanced by `frames`.
+    #[must_use]
+    pub fn offset(self, frames: u64) -> Option<Self> {
+        let frames = i64::try_from(frames).ok()?;
+        i64::from(self).checked_add(frames).map(Self::new)
+    }
 }
 
 /// The canonical session-beat <-> session-frame relation, valid from one
@@ -186,5 +193,12 @@ mod tests {
                 "tempo {refused} is not an invertible slope",
             );
         }
+    }
+
+    #[kithara::test]
+    fn session_frame_offset_is_checked() {
+        assert_eq!(SessionFrame::new(41).offset(1), Some(SessionFrame::new(42)));
+        assert_eq!(SessionFrame::new(i64::MAX).offset(1), None);
+        assert_eq!(SessionFrame::new(0).offset(u64::MAX), None);
     }
 }

--- a/crates/kithara-audio/src/pipeline/config/chain.rs
+++ b/crates/kithara-audio/src/pipeline/config/chain.rs
@@ -7,54 +7,70 @@ use kithara_platform::sync::Arc;
     any(feature = "stretch-signalsmith", feature = "stretch-bungee")
 ))]
 use crate::effects::timestretch::TimeStretchProcessor;
-use crate::{effects::timestretch::StretchControls, traits::AudioEffect};
+use crate::{
+    effects::timestretch::StretchControls,
+    traits::{AudioEffect, TempoStage},
+};
 
-/// Build `[Stretch?, ..custom]`. Fixed-ratio sample-rate conversion belongs to
-/// the decoder plan.
-pub(crate) fn create_effects(
+/// The single duration-changing owner followed by frame-preserving effects.
+pub(crate) struct PresentationChain {
+    pub(crate) effects: Vec<Box<dyn AudioEffect>>,
+    pub(crate) tempo: Option<Box<dyn TempoStage>>,
+}
+
+impl PresentationChain {
+    pub(crate) fn identity(effects: Vec<Box<dyn AudioEffect>>) -> Self {
+        Self {
+            effects,
+            tempo: None,
+        }
+    }
+}
+
+/// Build `{ tempo: Stretch?, effects: custom }`. Fixed-ratio sample-rate
+/// conversion belongs to the decoder plan.
+pub(crate) fn create_presentation_chain(
     initial_spec: PcmSpec,
     stretch: Option<&Arc<StretchControls>>,
     pool: &PcmPool,
-    custom_effects: Vec<Box<dyn AudioEffect>>,
-) -> Vec<Box<dyn AudioEffect>> {
-    let mut chain: Vec<Box<dyn AudioEffect>> = Vec::new();
-
-    append_stretch_slot(stretch, &mut chain, initial_spec, pool);
-    chain.extend(custom_effects);
-    chain
+    effects: Vec<Box<dyn AudioEffect>>,
+) -> PresentationChain {
+    match create_tempo_stage(stretch, initial_spec, pool) {
+        Some(tempo) => PresentationChain {
+            effects,
+            tempo: Some(tempo),
+        },
+        None => PresentationChain::identity(effects),
+    }
 }
 
-/// Tempo mode with a compiled-in backend: prepend the stretch slot.
 #[cfg(all(
     not(target_arch = "wasm32"),
     any(feature = "stretch-signalsmith", feature = "stretch-bungee")
 ))]
-fn append_stretch_slot(
+fn create_tempo_stage(
     controls: Option<&Arc<StretchControls>>,
-    chain: &mut Vec<Box<dyn AudioEffect>>,
     initial_spec: PcmSpec,
     pool: &PcmPool,
-) {
-    let Some(controls) = controls else {
-        return;
-    };
-    chain.push(Box::new(TimeStretchProcessor::new(
-        Arc::clone(controls),
-        initial_spec,
-        pool.clone(),
-    )));
+) -> Option<Box<dyn TempoStage>> {
+    controls.map(|controls| {
+        let tempo: Box<dyn TempoStage> = Box::new(TimeStretchProcessor::new(
+            Arc::clone(controls),
+            initial_spec,
+            pool.clone(),
+        ));
+        tempo
+    })
 }
 
-/// No stretch backend compiled in: speed DSP is absent and playback is pinned
-/// to unity.
 #[cfg(not(all(
     not(target_arch = "wasm32"),
     any(feature = "stretch-signalsmith", feature = "stretch-bungee")
 )))]
-fn append_stretch_slot(
+fn create_tempo_stage(
     _controls: Option<&Arc<StretchControls>>,
-    _chain: &mut Vec<Box<dyn AudioEffect>>,
     _initial_spec: PcmSpec,
     _pool: &PcmPool,
-) {
+) -> Option<Box<dyn TempoStage>> {
+    None
 }

--- a/crates/kithara-audio/src/pipeline/config/tests.rs
+++ b/crates/kithara-audio/src/pipeline/config/tests.rs
@@ -1,21 +1,22 @@
 use std::num::NonZeroU32;
 
 use kithara_bufpool::{BytePool, PcmPool};
-use kithara_decode::{PcmChunk, PcmSpec};
+use kithara_decode::{DecodeResult, PcmSpec};
 use kithara_test_utils::kithara;
 
-use super::create_effects;
-use crate::{effects::timestretch::StretchControls, traits::AudioEffect};
+use super::create_presentation_chain;
+use crate::{
+    effects::timestretch::StretchControls,
+    traits::{AudioBlockMut, AudioEffect},
+};
 
 struct PassthroughEffect;
 
 impl AudioEffect for PassthroughEffect {
-    fn flush(&mut self) -> Option<PcmChunk> {
-        None
+    fn process(&mut self, _block: AudioBlockMut<'_>) -> DecodeResult<()> {
+        Ok(())
     }
-    fn process(&mut self, chunk: PcmChunk) -> Option<PcmChunk> {
-        Some(chunk)
-    }
+
     fn reset(&mut self) {}
 }
 
@@ -28,10 +29,11 @@ fn pool() -> PcmPool {
 }
 
 #[kithara::test]
-fn create_effects_includes_custom_effects() {
+fn create_presentation_chain_includes_custom_effects() {
     let pool = pool();
-    let effects = create_effects(spec(), None, &pool, vec![Box::new(PassthroughEffect)]);
-    assert_eq!(effects.len(), 1);
+    let chain = create_presentation_chain(spec(), None, &pool, vec![Box::new(PassthroughEffect)]);
+    assert_eq!(chain.effects.len(), 1);
+    assert!(chain.tempo.is_none());
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -93,11 +95,12 @@ mod no_stretch {
     /// Without a compiled-in stretch backend, `stretch` does not add a speed
     /// slot: playback remains at unity.
     #[kithara::test]
-    fn create_effects_stretch_without_backends_keeps_chain_empty() {
+    fn create_presentation_chain_stretch_without_backends_keeps_chain_empty() {
         let controls = StretchControls::new(1.5);
         let pool = pool();
-        let effects = create_effects(spec(), Some(&controls), &pool, Vec::new());
-        assert!(effects.is_empty());
+        let chain = create_presentation_chain(spec(), Some(&controls), &pool, Vec::new());
+        assert!(chain.effects.is_empty());
+        assert!(chain.tempo.is_none());
     }
 }
 
@@ -106,43 +109,31 @@ mod no_stretch {
     any(feature = "stretch-signalsmith", feature = "stretch-bungee")
 ))]
 mod stretch {
-    use kithara_decode::PcmMeta;
-
     use super::*;
 
     #[kithara::test]
-    fn create_effects_tempo_mode_prepends_stretch_slot() {
+    fn create_presentation_chain_tempo_mode_owns_stretch_stage() {
         let controls = StretchControls::new(1.0);
         let pool = pool();
-        let effects = create_effects(
+        let chain = create_presentation_chain(
             spec(),
             Some(&controls),
             &pool,
             vec![Box::new(PassthroughEffect)],
         );
-        assert_eq!(effects.len(), 2);
+        assert!(chain.tempo.is_some());
+        assert_eq!(chain.effects.len(), 1);
     }
 
     /// Key-lock off in tempo mode is still handled by the stretch slot.
     #[kithara::test]
-    fn create_effects_tempo_vinyl_uses_stretch_slot() {
+    fn create_presentation_chain_tempo_vinyl_builds_tempo_stage() {
         let controls = StretchControls::new(1.5);
         controls.set_keylock(false);
         let pool = pool();
-        let mut effects = create_effects(spec(), Some(&controls), &pool, Vec::new());
-        // Drive one chunk through the stretch slot (index 0).
-        let frames = 1024usize;
-        let samples = vec![0.0_f32; frames * 2];
-        let meta = PcmMeta {
-            spec: spec(),
-            frames: u32::try_from(frames).unwrap(),
-            ..Default::default()
-        };
-        let chunk = PcmChunk::new(meta, PcmPool::default().attach(samples));
-        let out = effects[0]
-            .process(chunk)
-            .expect("vinyl stretch emits a chunk");
-        assert_eq!(out.spec(), spec());
-        assert!(!out.samples.is_empty());
+        let chain = create_presentation_chain(spec(), Some(&controls), &pool, Vec::new());
+        let tempo = chain.tempo.expect("tempo mode owns one duration stage");
+        assert_eq!(tempo.output_spec(), spec());
+        assert!(chain.effects.is_empty());
     }
 }

--- a/crates/kithara-audio/src/pipeline/decode/core.rs
+++ b/crates/kithara-audio/src/pipeline/decode/core.rs
@@ -19,23 +19,19 @@ use tracing::{debug, warn};
 
 #[cfg(test)]
 use crate::pipeline::decode::transition::OutgoingFrontier;
-use crate::{
-    pipeline::{
-        blend::PcmBlender,
-        decode::{
-            drain::EofDrain,
-            generation::{DecoderGeneration, StageFailure, StageOutput, StageResult},
-            resume::ResumeCursor,
-            transition::IncomingDecode,
-        },
-        fetch::Fetch,
-        rebuild::RecreateState,
-        seek::{ResumeState, SeekEngine, emit::commit_outcome},
-        stream::shared::SharedStream,
-        track::{TrackFailure, WaitingReason},
+use crate::pipeline::{
+    blend::PcmBlender,
+    decode::{
+        drain::EofDrain,
+        generation::{DecoderGeneration, StageFailure, StageOutput, StageResult},
+        resume::ResumeCursor,
+        transition::IncomingDecode,
     },
-    renderer::{apply_effects, reset_effects},
-    traits::AudioEffect,
+    fetch::Fetch,
+    rebuild::RecreateState,
+    seek::{ResumeState, SeekEngine, emit::commit_outcome},
+    stream::shared::SharedStream,
+    track::{TrackFailure, WaitingReason},
 };
 
 type DecoderBuilder =
@@ -115,11 +111,7 @@ impl DecodeInit {
         self.host_sample_rate.load(Ordering::Acquire)
     }
 
-    pub(crate) fn into_parts(
-        self,
-        effects: Vec<Box<dyn AudioEffect>>,
-        installed_at_seek_epoch: u64,
-    ) -> DecodeParts {
+    pub(crate) fn into_parts(self, installed_at_seek_epoch: u64) -> DecodeParts {
         let decoder_host_sample_rate = self.decoder_host_sample_rate();
         let Self {
             decoder,
@@ -145,7 +137,7 @@ impl DecodeInit {
             decoder_host_sample_rate,
             decoder_backend,
             playback_resampler_backend,
-            active: ActiveDecode::new(active, gapless_mode, effects),
+            active: ActiveDecode::new(active, gapless_mode),
             factory: decoder_factory,
         }
     }
@@ -161,7 +153,6 @@ pub(crate) struct ActiveDecode {
     drain: EofDrain,
     #[field(get, vis = "pub(crate)", copy)]
     gapless_mode: GaplessMode,
-    effects: Vec<Box<dyn AudioEffect>>,
     rejected_chunk: Option<PcmChunk>,
     stage_error: Option<DecodeError>,
 }
@@ -187,18 +178,13 @@ pub(crate) enum DecodeAction {
 }
 
 impl ActiveDecode {
-    fn new(
-        active: DecoderGeneration,
-        gapless_mode: GaplessMode,
-        effects: Vec<Box<dyn AudioEffect>>,
-    ) -> Self {
-        let drain = EofDrain::new(effects.len());
+    fn new(active: DecoderGeneration, gapless_mode: GaplessMode) -> Self {
+        let drain = EofDrain::new();
         let blender = PcmBlender::new(active.blender_profile());
         Self {
             active,
             gapless_mode,
             blender,
-            effects,
             drain,
             incoming: None,
             rejected_chunk: None,
@@ -232,10 +218,6 @@ impl ActiveDecode {
         outcome
     }
 
-    pub(crate) fn next_drain(&mut self) -> Option<PcmChunk> {
-        self.drain.next(&mut self.effects)
-    }
-
     pub(crate) fn next_output(
         &mut self,
         cursor: &mut ResumeCursor,
@@ -263,24 +245,19 @@ impl ActiveDecode {
         }
         let holdback =
             allow_holdback && !self.active.is_finished() && self.outgoing_holdback_is_active();
-        loop {
-            let next = if holdback {
-                match self.active.next_with_holdback() {
-                    StageOutput::Output(chunk) => chunk,
-                    StageOutput::Invalid(failure) => return Err(self.reject_stage(failure)),
-                }
-            } else {
-                self.active.next()
-            };
-            let Some(chunk) = next else {
-                return Ok(None);
-            };
-            cursor.record(&chunk, epoch);
-            let chunk = self.blender.process_active(chunk);
-            if let Some(output) = apply_effects(&mut self.effects, chunk) {
-                return Ok(Some(output));
+        let next = if holdback {
+            match self.active.next_with_holdback() {
+                StageOutput::Output(chunk) => chunk,
+                StageOutput::Invalid(failure) => return Err(self.reject_stage(failure)),
             }
-        }
+        } else {
+            self.active.next()
+        };
+        let Some(chunk) = next else {
+            return Ok(None);
+        };
+        cursor.record(&chunk, epoch);
+        Ok(Some(self.blender.process_active(chunk)))
     }
 
     fn outgoing_holdback_is_active(&self) -> bool {
@@ -360,8 +337,6 @@ impl ActiveDecode {
     pub(crate) fn reset(&mut self) {
         self.stage_error = None;
         self.blender.reset();
-        reset_effects(&mut self.effects);
-        self.drain.reset();
     }
 
     #[kithara::rtsan_allow_blocking]
@@ -453,7 +428,7 @@ mod tests {
     #[kithara::test]
     fn steady_output_bypasses_transition_staging() {
         let spec = PcmSpec::new(2, NonZeroU32::new(44_100).expect("test rate"));
-        let mut decode = ActiveDecode::new(generation(spec), GaplessMode::Disabled, Vec::new());
+        let mut decode = ActiveDecode::new(generation(spec), GaplessMode::Disabled);
         let initial_capacity = decode.active().staged_capacity();
         let mut cursor = ResumeCursor::new(
             Arc::new(AtomicU32::new(spec.sample_rate.get())),
@@ -497,7 +472,7 @@ mod tests {
             VariantIndex::new(0),
             VariantIndex::new(1),
         );
-        let mut decode = ActiveDecode::new(active, GaplessMode::Disabled, Vec::new());
+        let mut decode = ActiveDecode::new(active, GaplessMode::Disabled);
         decode.incoming = Some(IncomingDecode::Priming {
             transition,
             generation: incoming,
@@ -565,7 +540,7 @@ mod tests {
             VariantIndex::new(0),
             VariantIndex::new(1),
         );
-        let mut decode = ActiveDecode::new(active, GaplessMode::Disabled, Vec::new());
+        let mut decode = ActiveDecode::new(active, GaplessMode::Disabled);
         decode.incoming = Some(IncomingDecode::Priming {
             transition,
             generation: incoming,
@@ -607,7 +582,7 @@ mod tests {
             VariantIndex::new(0),
             VariantIndex::new(1),
         );
-        let mut decode = ActiveDecode::new(active, GaplessMode::Disabled, Vec::new());
+        let mut decode = ActiveDecode::new(active, GaplessMode::Disabled);
         decode.incoming = Some(IncomingDecode::Priming {
             transition,
             generation: incoming,
@@ -681,7 +656,7 @@ mod tests {
                     .saturating_mul(usize::from(spec.channels))
             ]),
         ));
-        let mut decode = ActiveDecode::new(generation(spec), GaplessMode::Disabled, Vec::new());
+        let mut decode = ActiveDecode::new(generation(spec), GaplessMode::Disabled);
         decode.incoming = Some(IncomingDecode::Priming {
             transition,
             generation: incoming,
@@ -751,7 +726,7 @@ mod tests {
         active.stage(make_chunk(0));
         let mut incoming = generation(spec);
         incoming.stage(make_chunk(LANDED));
-        let mut decode = ActiveDecode::new(active, GaplessMode::Disabled, Vec::new());
+        let mut decode = ActiveDecode::new(active, GaplessMode::Disabled);
         decode.incoming = Some(IncomingDecode::Priming {
             transition,
             generation: incoming,
@@ -797,7 +772,7 @@ mod tests {
             None,
             GaplessMode::Disabled,
         );
-        let mut decode = ActiveDecode::new(generation(spec), GaplessMode::Disabled, Vec::new());
+        let mut decode = ActiveDecode::new(generation(spec), GaplessMode::Disabled);
         decode.incoming = Some(IncomingDecode::Priming {
             transition,
             generation: incoming,
@@ -831,7 +806,7 @@ mod tests {
             VariantIndex::new(0),
             VariantIndex::new(1),
         );
-        let mut decode = ActiveDecode::new(generation(spec), GaplessMode::Disabled, Vec::new());
+        let mut decode = ActiveDecode::new(generation(spec), GaplessMode::Disabled);
         let frames = u32::try_from(decode.blender.join_frame_count()).expect("test join fits u32");
         let samples = usize::try_from(frames)
             .expect("test join fits usize")
@@ -889,7 +864,7 @@ mod tests {
             VariantIndex::new(0),
             VariantIndex::new(1),
         );
-        let mut decode = ActiveDecode::new(generation(spec), GaplessMode::Disabled, Vec::new());
+        let mut decode = ActiveDecode::new(generation(spec), GaplessMode::Disabled);
         decode.active.stage(PcmChunk::new(
             PcmMeta {
                 spec,

--- a/crates/kithara-audio/src/pipeline/decode/drain.rs
+++ b/crates/kithara-audio/src/pipeline/decode/drain.rs
@@ -2,41 +2,19 @@ use kithara_decode::{PcmChunk, PcmSpec};
 use kithara_events::{AudioEvent, AudioFormat, DeferredBus, Event};
 use kithara_stream::PlayheadWrite;
 
-use crate::traits::AudioEffect;
-
 pub(crate) struct EofDrain {
     spec: Option<PcmSpec>,
-    exhausted: Vec<bool>,
-    active: bool,
     chunks: u64,
     samples: u64,
 }
 
 impl EofDrain {
-    pub(crate) fn new(effect_count: usize) -> Self {
+    pub(crate) const fn new() -> Self {
         Self {
-            exhausted: vec![false; effect_count],
-            active: false,
             chunks: 0,
             samples: 0,
             spec: None,
         }
-    }
-
-    pub(crate) fn next(&mut self, effects: &mut [Box<dyn AudioEffect>]) -> Option<PcmChunk> {
-        if effects.is_empty() {
-            return None;
-        }
-        if !self.active {
-            self.exhausted.fill(false);
-            self.active = true;
-        }
-        let last = effects.len() - 1;
-        pull(effects, &mut self.exhausted, last)
-    }
-
-    pub(crate) const fn reset(&mut self) {
-        self.active = false;
     }
 
     pub(crate) const fn stats(&self) -> (u64, u64) {
@@ -83,27 +61,5 @@ impl EofDrain {
             }
             self.spec = Some(chunk.spec());
         }
-    }
-}
-
-fn pull(
-    effects: &mut [Box<dyn AudioEffect>],
-    exhausted: &mut [bool],
-    stage: usize,
-) -> Option<PcmChunk> {
-    if stage == 0 {
-        return effects[0].flush();
-    }
-    loop {
-        if !exhausted[stage] {
-            if let Some(chunk) = pull(effects, exhausted, stage - 1) {
-                if let Some(output) = effects[stage].process(chunk) {
-                    return Some(output);
-                }
-                continue;
-            }
-            exhausted[stage] = true;
-        }
-        return effects[stage].flush();
     }
 }

--- a/crates/kithara-audio/src/pipeline/decode/step.rs
+++ b/crates/kithara-audio/src/pipeline/decode/step.rs
@@ -81,9 +81,6 @@ pub(crate) fn tick<T: StreamType>(
                 {
                     return DecodeAction::StartRecreate(recreate);
                 }
-                if let Some(chunk) = core.next_drain() {
-                    return produced(chunk, epoch, &mut ctx);
-                }
                 if let Some(emit) = ctx.emit {
                     emit.enqueue(AudioEvent::EndOfStream.into());
                 }

--- a/crates/kithara-audio/src/pipeline/source.rs
+++ b/crates/kithara-audio/src/pipeline/source.rs
@@ -1,5 +1,5 @@
 use arc_swap::ArcSwap;
-use kithara_decode::{ChunkRetire, PcmChunk};
+use kithara_decode::{ChunkRetire, DecodeError, PcmChunk, PcmSpec};
 use kithara_events::{AudioEvent, DecoderChangeCause, DeferredBus, Event, TrackFailureKind};
 use kithara_platform::sync::Arc;
 use kithara_stream::{
@@ -25,7 +25,7 @@ use crate::{
         parts::SourceParts,
         rebuild::{DecoderBuildComplete, DecoderBuildPurpose, port::RebuildPort, retire::Retired},
         seek::SeekEngine,
-        track::{self, CurrentFsm, Decoding, Track, TrackFailure, TrackStep, WaitContext},
+        track::{self, CurrentFsm, Decoding, Failed, Track, TrackFailure, TrackStep, WaitContext},
     },
     renderer::AudioWorkerSource,
 };
@@ -75,6 +75,9 @@ pub(crate) struct StreamAudioSource<T: StreamType> {
     /// frame, so the rebuilt decoder relabels its first chunk at this point. See
     /// `execute_recreation`.
     pub(crate) resume: ResumeCursor,
+    /// Ordered reset boundary emitted between PCM from two decoder generations
+    /// that share a seek epoch.
+    pub(crate) presentation_barrier: Option<(u64, PcmSpec)>,
     /// `(seek_epoch, target)` of the most recent applied seek.
     /// `committed_position` lags `target` until the seek's first
     /// (trim-aligned) chunk is consumed: the decoder lands at the
@@ -147,6 +150,7 @@ impl<T: StreamType> StreamAudioSource<T> {
             activity,
             readiness,
             resume,
+            presentation_barrier: None,
             variant_control,
             state: Track::<Decoding>::new(()).erase(),
             emit: None,
@@ -183,6 +187,14 @@ impl<T: StreamType> StreamAudioSource<T> {
         }
         self.activity.set_playing(playing_for_state(&new));
         self.state = new;
+    }
+
+    pub(crate) fn queue_presentation_barrier(&mut self, epoch: u64, spec: PcmSpec) {
+        debug_assert!(
+            self.presentation_barrier.is_none(),
+            "decoder replacement barriers must be consumed in order"
+        );
+        self.presentation_barrier = Some((epoch, spec));
     }
 }
 
@@ -581,6 +593,15 @@ impl<T: StreamType> AudioWorkerSource for StreamAudioSource<T> {
 
     fn step_track(&mut self) -> TrackStep<PcmChunk> {
         track::dispatch(self)
+    }
+
+    fn take_presentation_barrier(&mut self) -> Option<(u64, PcmSpec)> {
+        self.presentation_barrier.take()
+    }
+
+    fn presentation_failed(&mut self, error: DecodeError) {
+        warn!(?error, "presentation failed");
+        self.update_state(Track::<Failed>::new(TrackFailure::Decode(error)).erase());
     }
 
     fn warm_up(&mut self) {

--- a/crates/kithara-audio/src/pipeline/track/recreate.rs
+++ b/crates/kithara-audio/src/pipeline/track/recreate.rs
@@ -182,8 +182,14 @@ pub(super) fn finish_rebuild<T: StreamType>(
         Err(outcome) => return finish_recreate_outcome(src, recreate, outcome),
     };
     let duration = generation.decoder().duration();
+    let spec = generation.decoder().spec();
     let old = src.decode.replace_active(generation);
     src.retired.retire_generation(old);
+    if recreate.cause == RecreateCause::RouteChange
+        || matches!(&recreate.next, RecreateNext::Decode)
+    {
+        src.queue_presentation_barrier(src.seek_engine.epoch(), spec);
+    }
     debug!(
         ?duration,
         offset = recreate.offset,

--- a/crates/kithara-audio/src/pipeline/track/tests/rebuild.rs
+++ b/crates/kithara-audio/src/pipeline/track/tests/rebuild.rs
@@ -55,7 +55,6 @@ use crate::{
         },
     },
     renderer::AudioWorkerSource,
-    traits::AudioEffect,
 };
 
 pub(super) fn produced_data(fetch: Fetch<PcmChunk>) -> PcmChunk {
@@ -773,7 +772,7 @@ async fn test_source_with_mode(variant: u32, gapless_mode: GaplessMode) -> Rebui
         playback_resampler_backend: "none",
         recreate_on_host_rate_change: true,
     }
-    .into_parts(Vec::new(), shared_stream.seek_observe().epoch());
+    .into_parts(shared_stream.seek_observe().epoch());
     let parts = SourceParts::new(
         &shared_stream,
         decode,
@@ -807,25 +806,15 @@ struct RouteParams {
 }
 
 pub(super) async fn route_signal_source(initial_host_rate: u32) -> RouteFixture {
-    route_signal_source_with_effects(initial_host_rate, Vec::new()).await
-}
-
-pub(super) async fn route_signal_source_with_effects(
-    initial_host_rate: u32,
-    effects: Vec<Box<dyn AudioEffect>>,
-) -> RouteFixture {
-    route_source(
-        RouteParams {
-            chunks_before_eof: None,
-            gapless: None,
-            incoming_chunks_before_eof: None,
-            active_timeline_gap: 0,
-            incoming_timeline_gap: 0,
-            initial_host_rate,
-            segmented: false,
-        },
-        effects,
-    )
+    route_source(RouteParams {
+        chunks_before_eof: None,
+        gapless: None,
+        incoming_chunks_before_eof: None,
+        active_timeline_gap: 0,
+        incoming_timeline_gap: 0,
+        initial_host_rate,
+        segmented: false,
+    })
     .await
 }
 
@@ -833,18 +822,15 @@ pub(super) async fn route_signal_source_with_gapless(
     initial_host_rate: u32,
     gapless: GaplessInfo,
 ) -> RouteFixture {
-    route_source(
-        RouteParams {
-            chunks_before_eof: None,
-            gapless: Some(gapless),
-            incoming_chunks_before_eof: None,
-            active_timeline_gap: 0,
-            incoming_timeline_gap: 0,
-            initial_host_rate,
-            segmented: false,
-        },
-        Vec::new(),
-    )
+    route_source(RouteParams {
+        chunks_before_eof: None,
+        gapless: Some(gapless),
+        incoming_chunks_before_eof: None,
+        active_timeline_gap: 0,
+        incoming_timeline_gap: 0,
+        initial_host_rate,
+        segmented: false,
+    })
     .await
 }
 
@@ -853,18 +839,15 @@ pub(super) async fn route_signal_source_with_gapless_eof(
     gapless: GaplessInfo,
     chunks_before_eof: usize,
 ) -> RouteFixture {
-    route_source(
-        RouteParams {
-            chunks_before_eof: Some(chunks_before_eof),
-            gapless: Some(gapless),
-            incoming_chunks_before_eof: None,
-            active_timeline_gap: 0,
-            incoming_timeline_gap: 0,
-            initial_host_rate,
-            segmented: false,
-        },
-        Vec::new(),
-    )
+    route_source(RouteParams {
+        chunks_before_eof: Some(chunks_before_eof),
+        gapless: Some(gapless),
+        incoming_chunks_before_eof: None,
+        active_timeline_gap: 0,
+        incoming_timeline_gap: 0,
+        initial_host_rate,
+        segmented: false,
+    })
     .await
 }
 
@@ -872,22 +855,19 @@ pub(super) async fn route_signal_source_with_finite_incoming(
     initial_host_rate: u32,
     incoming_chunks_before_eof: usize,
 ) -> RouteFixture {
-    route_source(
-        RouteParams {
-            chunks_before_eof: None,
-            gapless: None,
-            incoming_chunks_before_eof: Some(incoming_chunks_before_eof),
-            active_timeline_gap: 0,
-            incoming_timeline_gap: 0,
-            initial_host_rate,
-            segmented: false,
-        },
-        Vec::new(),
-    )
+    route_source(RouteParams {
+        chunks_before_eof: None,
+        gapless: None,
+        incoming_chunks_before_eof: Some(incoming_chunks_before_eof),
+        active_timeline_gap: 0,
+        incoming_timeline_gap: 0,
+        initial_host_rate,
+        segmented: false,
+    })
     .await
 }
 
-async fn route_source(params: RouteParams, effects: Vec<Box<dyn AudioEffect>>) -> RouteFixture {
+async fn route_source(params: RouteParams) -> RouteFixture {
     let control = Arc::new(TestControl::new(media_info(0)));
     let drops = Arc::new(Mutex::new(Vec::new()));
     let host_sample_rate = Arc::new(AtomicU32::new(params.initial_host_rate));
@@ -961,7 +941,7 @@ async fn route_source(params: RouteParams, effects: Vec<Box<dyn AudioEffect>>) -
         playback_resampler_backend: "none",
         recreate_on_host_rate_change: true,
     }
-    .into_parts(effects, shared_stream.seek_observe().epoch());
+    .into_parts(shared_stream.seek_observe().epoch());
     let parts = SourceParts::new(
         &shared_stream,
         decode,
@@ -984,18 +964,15 @@ pub(super) async fn route_signal_source_with_gaps(
     active_timeline_gap: u64,
     incoming_timeline_gap: u64,
 ) -> RouteFixture {
-    route_source(
-        RouteParams {
-            chunks_before_eof: None,
-            gapless: None,
-            incoming_chunks_before_eof: None,
-            active_timeline_gap,
-            incoming_timeline_gap,
-            initial_host_rate: Consts::SAMPLE_RATE,
-            segmented: false,
-        },
-        Vec::new(),
-    )
+    route_source(RouteParams {
+        chunks_before_eof: None,
+        gapless: None,
+        incoming_chunks_before_eof: None,
+        active_timeline_gap,
+        incoming_timeline_gap,
+        initial_host_rate: Consts::SAMPLE_RATE,
+        segmented: false,
+    })
     .await
 }
 
@@ -1537,18 +1514,15 @@ async fn route_change_recreate_roots_the_demuxer_at_the_container_origin() {
         host_sample_rate,
         mut source,
         ..
-    } = route_source(
-        RouteParams {
-            chunks_before_eof: None,
-            gapless: None,
-            incoming_chunks_before_eof: None,
-            active_timeline_gap: 0,
-            incoming_timeline_gap: 0,
-            initial_host_rate: Consts::SAMPLE_RATE,
-            segmented: true,
-        },
-        Vec::new(),
-    )
+    } = route_source(RouteParams {
+        chunks_before_eof: None,
+        gapless: None,
+        incoming_chunks_before_eof: None,
+        active_timeline_gap: 0,
+        incoming_timeline_gap: 0,
+        initial_host_rate: Consts::SAMPLE_RATE,
+        segmented: true,
+    })
     .await;
 
     let mut route_recreated = false;

--- a/crates/kithara-audio/src/pipeline/track/tests/splice.rs
+++ b/crates/kithara-audio/src/pipeline/track/tests/splice.rs
@@ -430,11 +430,7 @@ async fn splice_source(variants: Vec<VariantLayout>) -> SpliceFixture {
         decoder_config(&shared_stream, backend, initial_byte_len),
     )
     .expect("create initial slq fMP4 decoder");
-    let initial_spec = initial_decoder.spec();
     let host_sample_rate = Arc::new(AtomicU32::new(Consts::SAMPLE_RATE));
-    let pcm_pool = PcmPool::default();
-    let effects =
-        crate::pipeline::config::create_effects(initial_spec, None, &pcm_pool, Vec::new());
     let factory_byte_len = Arc::new(AtomicU64::new(0));
     let decoder_factory = DecoderFactory::new(
         move |mut reader, info| {
@@ -467,7 +463,7 @@ async fn splice_source(variants: Vec<VariantLayout>) -> SpliceFixture {
         playback_resampler_backend: "none",
         recreate_on_host_rate_change: false,
     }
-    .into_parts(effects, shared_stream.seek_observe().epoch());
+    .into_parts(shared_stream.seek_observe().epoch());
     let parts = SourceParts::new(
         &shared_stream,
         decode,

--- a/crates/kithara-audio/src/pipeline/track/tests/transition.rs
+++ b/crates/kithara-audio/src/pipeline/track/tests/transition.rs
@@ -13,9 +13,8 @@ use kithara_test_utils::kithara;
 
 use super::rebuild::{
     Consts, RouteFixture, TestDecoder, media_info, produced_data, route_signal_source,
-    route_signal_source_with_effects, route_signal_source_with_finite_incoming,
-    route_signal_source_with_gapless, route_signal_source_with_gapless_eof,
-    route_signal_source_with_gaps,
+    route_signal_source_with_finite_incoming, route_signal_source_with_gapless,
+    route_signal_source_with_gapless_eof, route_signal_source_with_gaps,
 };
 use crate::{
     pipeline::{
@@ -24,40 +23,7 @@ use crate::{
         track::{AtEof, CurrentFsm, Failed, Track, TrackFailure, TrackStep},
     },
     renderer::AudioWorkerSource,
-    traits::AudioEffect,
 };
-
-struct BufferThenHalveFrames {
-    buffered: bool,
-}
-
-impl AudioEffect for BufferThenHalveFrames {
-    fn flush(&mut self) -> Option<PcmChunk> {
-        None
-    }
-
-    fn process(&mut self, mut chunk: PcmChunk) -> Option<PcmChunk> {
-        if !self.buffered {
-            self.buffered = true;
-            return None;
-        }
-        let frames = chunk.meta.frames / 2;
-        let samples = usize::try_from(frames)
-            .ok()?
-            .checked_mul(usize::from(chunk.meta.spec.channels))?;
-        chunk.samples.truncate(samples);
-        chunk.meta.frames = frames;
-        chunk.meta.end_timestamp = duration_for_frames(
-            chunk.meta.spec.sample_rate.get(),
-            chunk.meta.frame_offset.saturating_add(u64::from(frames)),
-        );
-        Some(chunk)
-    }
-
-    fn reset(&mut self) {
-        self.buffered = false;
-    }
-}
 
 fn incoming_plan() -> VariantReaderPlan {
     let abr = AbrState::new(AbrMode::Auto(Some(VariantIndex::new(0))));
@@ -267,40 +233,6 @@ async fn exact_incoming_build_pending_keeps_outgoing_pcm_running() {
         Some(0)
     );
     assert!(matches!(fixture.source.state, CurrentFsm::Decoding(_)));
-}
-
-#[kithara::test(tokio)]
-async fn raw_decode_head_ignores_buffering_and_frame_changing_effect_output() {
-    let effect = BufferThenHalveFrames { buffered: false };
-    let mut fixture =
-        route_signal_source_with_effects(Consts::SAMPLE_RATE, vec![Box::new(effect)]).await;
-
-    let TrackStep::Produced(fetch) = fixture.source.step_track() else {
-        panic!("the second raw chunk must pass the buffering effect");
-    };
-    let output = produced_data(fetch);
-    let epoch = fixture.source.seek_obs.epoch();
-    let raw_head = fixture
-        .source
-        .resume
-        .decode_head(epoch)
-        .expect("raw decode must advance the sole resume cursor");
-    let effect_head = output
-        .meta
-        .frame_offset
-        .saturating_add(u64::from(output.meta.frames));
-    let raw_frames =
-        u64::try_from(Consts::ROUTE_CHUNK_FRAMES.saturating_mul(2)).unwrap_or(u64::MAX);
-
-    assert_eq!(raw_head, (raw_frames, Consts::SAMPLE_RATE));
-    assert_ne!(raw_head.0, effect_head);
-    assert_eq!(
-        fixture.source.decode.landing_for(OutgoingFrontier::Exact {
-            frame: raw_head.0,
-            rate: raw_head.1,
-        }),
-        Some(duration_for_frames(Consts::SAMPLE_RATE, raw_frames))
-    );
 }
 
 #[kithara::test(tokio)]

--- a/crates/kithara-audio/src/renderer/handle.rs
+++ b/crates/kithara-audio/src/renderer/handle.rs
@@ -105,10 +105,13 @@ impl kithara_stream::WorkerWake for WorkerWakeBridge {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::{
+        num::NonZeroU32,
+        sync::atomic::{AtomicBool, Ordering},
+    };
 
     use kithara_bufpool::PcmPool;
-    use kithara_decode::{PcmChunk, PcmMeta};
+    use kithara_decode::{PcmChunk, PcmMeta, PcmSpec};
     use kithara_events::{DeferredBus, Event, EventBus};
     use kithara_platform::{
         sync::Arc,
@@ -121,15 +124,30 @@ mod tests {
     use super::*;
     use crate::{
         pipeline::{
+            config::PresentationChain,
             fetch::Fetch,
             track::{TrackStep, WaitingReason},
         },
-        renderer::{AudioWorkerSource, MockSource, PreloadGate, ServiceClass, ThreadWake},
-        runtime::{AtomicServiceClass, connect},
+        renderer::{
+            AudioWorkerSource, MockSource, PreloadGate, PresentedPcm, ServiceClass, ThreadWake,
+            presentation_cell,
+        },
+        runtime::{AtomicServiceClass, connect, connect_strict},
     };
 
     fn empty_chunk() -> PcmChunk {
-        PcmChunk::new(PcmMeta::default(), PcmPool::default().attach(Vec::new()))
+        let spec = PcmSpec::new(
+            2,
+            NonZeroU32::new(48_000).expect("fixture rate is non-zero"),
+        );
+        PcmChunk::new(
+            PcmMeta {
+                spec,
+                frames: 512,
+                ..Default::default()
+            },
+            PcmPool::default().attach(vec![0.0; 512 * usize::from(spec.channels)]),
+        )
     }
 
     struct FailingSource {
@@ -160,21 +178,26 @@ mod tests {
         source: S,
         ringbuf_capacity: usize,
         preload_chunks: usize,
-    ) -> (
-        TrackRegistration,
-        crate::runtime::Inlet<Fetch<PcmChunk>>,
-        Arc<PreloadGate>,
-    )
+    ) -> (TrackRegistration, TestConsumer, Arc<PreloadGate>)
     where
         S: AudioWorkerSource<Chunk = PcmChunk> + 'static,
     {
         let wake = Arc::new(ThreadWake::default());
-        let (outlet, inlet) = connect::<Fetch<PcmChunk>>(ringbuf_capacity, Some(wake));
-        let (_trash_outlet, trash_inlet) = connect::<PcmChunk>(ringbuf_capacity + 2, None);
+        let (outlet, inlet) = connect_strict::<Fetch<PresentedPcm>>(ringbuf_capacity, Some(wake));
+        let (trash_outlet, trash_inlet) = connect::<PcmChunk>(ringbuf_capacity + 2, None);
         let preload_gate = Arc::new(PreloadGate::default());
+        let (presentation, _frontier) = presentation_cell(0);
 
         let reg = TrackRegistration {
+            chain: PresentationChain::identity(Vec::new()),
+            initial_spec: PcmSpec::new(
+                2,
+                NonZeroU32::new(48_000).expect("fixture rate is non-zero"),
+            ),
             outlet,
+            pcm_pool: PcmPool::default(),
+            presentation,
+            raw_buffer_chunks: ringbuf_capacity,
             trash_inlet,
             preload_chunks,
             source: Box::new(source),
@@ -184,18 +207,45 @@ mod tests {
             service_class: Arc::new(AtomicServiceClass::new(ServiceClass::Audible)),
             engine_load: None,
         };
-        (reg, inlet, preload_gate)
+        (
+            reg,
+            TestConsumer {
+                inlet,
+                trash_outlet,
+            },
+            preload_gate,
+        )
+    }
+
+    struct TestConsumer {
+        inlet: crate::runtime::Inlet<Fetch<PresentedPcm>>,
+        trash_outlet: crate::runtime::Outlet<PcmChunk>,
+    }
+
+    impl TestConsumer {
+        fn try_pop(&mut self, worker: &AudioWorkerHandle) -> Option<()> {
+            let fetch = self.inlet.try_pop()?;
+            if let Fetch::Data { data, .. } = fetch {
+                assert!(
+                    self.trash_outlet.try_push(data.into()).is_ok(),
+                    "fixture PCM trash ring must accept every consumed final block"
+                );
+            }
+            worker.wake();
+            Some(())
+        }
     }
 
     fn wait_for_chunks(
-        rx: &mut crate::runtime::Inlet<Fetch<PcmChunk>>,
+        worker: &AudioWorkerHandle,
+        rx: &mut TestConsumer,
         count: usize,
         timeout: Duration,
     ) -> usize {
         let start = Instant::now();
         let mut received = 0;
         while received < count && start.elapsed() < timeout {
-            if rx.try_pop().is_some() {
+            if rx.try_pop(worker).is_some() {
                 received += 1;
             } else {
                 thread_sleep(Duration::from_millis(1));
@@ -230,7 +280,7 @@ mod tests {
 
         let _id = handle.register_track(reg);
 
-        let received = wait_for_chunks(&mut data_rx, 5, Duration::from_secs(5));
+        let received = wait_for_chunks(&handle, &mut data_rx, 5, Duration::from_secs(5));
         assert!(received >= 5, "expected >=5 chunks, got {received}");
 
         handle.shutdown();
@@ -246,8 +296,8 @@ mod tests {
         let _id_a = handle.register_track(reg_a);
         let _id_b = handle.register_track(reg_b);
 
-        let a = wait_for_chunks(&mut rx_a, 3, Duration::from_secs(5));
-        let b = wait_for_chunks(&mut rx_b, 3, Duration::from_secs(5));
+        let a = wait_for_chunks(&handle, &mut rx_a, 3, Duration::from_secs(5));
+        let b = wait_for_chunks(&handle, &mut rx_b, 3, Duration::from_secs(5));
         assert!(a >= 3, "track A: expected >=3 chunks, got {a}");
         assert!(b >= 3, "track B: expected >=3 chunks, got {b}");
 
@@ -266,8 +316,8 @@ mod tests {
 
         thread_sleep(Duration::from_millis(100));
 
-        let a = wait_for_chunks(&mut rx_a, 1, Duration::from_millis(100));
-        let b = wait_for_chunks(&mut rx_b, 1, Duration::from_millis(50));
+        let a = wait_for_chunks(&handle, &mut rx_a, 1, Duration::from_millis(100));
+        let b = wait_for_chunks(&handle, &mut rx_b, 1, Duration::from_millis(50));
         assert!(a >= 1, "track A should receive chunks");
         assert_eq!(b, 0, "track B should receive nothing (not ready)");
 
@@ -284,12 +334,12 @@ mod tests {
 
         thread_sleep(Duration::from_millis(50));
 
-        let first = rx.try_pop();
+        let first = rx.try_pop(&handle);
         assert!(first.is_some(), "should have at least one chunk");
 
         thread_sleep(Duration::from_millis(50));
 
-        let second = rx.try_pop();
+        let second = rx.try_pop(&handle);
         assert!(second.is_some(), "overflow slot should have been flushed");
 
         handle.shutdown();
@@ -305,7 +355,7 @@ mod tests {
         let _id_a = handle.register_track(reg_a);
         let _id_b = handle.register_track(reg_b);
 
-        let b = wait_for_chunks(&mut rx_b, 3, Duration::from_secs(5));
+        let b = wait_for_chunks(&handle, &mut rx_b, 3, Duration::from_secs(5));
         assert!(
             b >= 3,
             "track B should keep working after track A panics, got {b}"
@@ -324,7 +374,7 @@ mod tests {
 
         let _id = handle.register_track(reg);
 
-        let got = wait_for_chunks(&mut rx, 2, Duration::from_secs(5));
+        let got = wait_for_chunks(&handle, &mut rx, 2, Duration::from_secs(5));
         assert!(got >= 2);
 
         let _ = seek.begin(Duration::from_secs(10));
@@ -332,7 +382,7 @@ mod tests {
 
         thread_sleep(Duration::from_millis(100));
 
-        let after_seek = wait_for_chunks(&mut rx, 1, Duration::from_secs(5));
+        let after_seek = wait_for_chunks(&handle, &mut rx, 1, Duration::from_secs(5));
         assert!(after_seek >= 1, "should resume decoding after seek");
 
         handle.shutdown();
@@ -418,16 +468,16 @@ mod tests {
 
         let id = handle.register_track(reg);
 
-        let got = wait_for_chunks(&mut rx, 2, Duration::from_secs(5));
+        let got = wait_for_chunks(&handle, &mut rx, 2, Duration::from_secs(5));
         assert!(got >= 2);
 
         handle.unregister_track(id);
         thread_sleep(Duration::from_millis(50));
 
-        while rx.try_pop().is_some() {}
+        while rx.try_pop(&handle).is_some() {}
 
         thread_sleep(Duration::from_millis(50));
-        assert!(rx.try_pop().is_none(), "no chunks after unregister");
+        assert!(rx.try_pop(&handle).is_none(), "no chunks after unregister");
 
         handle.shutdown();
     }
@@ -445,10 +495,10 @@ mod tests {
     /// audio to stutter.
     ///
     /// The mock simulates a track whose `step_track()` blocks the thread
-    /// for 50ms (like a real `wait_range()` call waiting for network data).
+    /// for 10ms (like a real `wait_range()` call waiting for network data).
     /// The worker must still deliver chunks to the ready track at a
     /// rate sufficient for glitch-free playback.
-    #[kithara::test]
+    #[kithara::test(flash(false))]
     fn shared_worker_blocking_track_does_not_starve_producing_track() {
         struct BlockingSource {
             seek_obs: Arc<dyn SeekObserve>,
@@ -485,17 +535,12 @@ mod tests {
         let (reg_b, _rx_b, _) = make_registration(blocking_source, 32, 0);
         let _id_b = handle.register_track(reg_b);
 
-        thread_sleep(Duration::from_millis(500));
-
-        let mut got_a = 0;
-        while rx_a.try_pop().is_some() {
-            got_a += 1;
-        }
+        let got_a = wait_for_chunks(&handle, &mut rx_a, 11, Duration::from_millis(500));
 
         assert!(
             got_a >= 11,
             "Producing track must not be starved by blocking track: \
-             got only {got_a} chunks in 1s (expected ≥11 for glitch-free)"
+             got only {got_a} chunks in 500ms (expected at least 11 for glitch-free)"
         );
 
         blocking.store(false, Ordering::Relaxed);
@@ -505,8 +550,8 @@ mod tests {
     /// A track whose `step_track()` blocks must not set the delivery rate of
     /// every other track on the shared worker.
     ///
-    /// The worker runs one pass over all slots and calls `tick()` — hence
-    /// `step_track()` — exactly once per slot per pass, so a slot that blocks
+    /// The worker runs one pass over all slots and calls `tick()`, hence
+    /// `step_track()`, exactly once per slot per pass, so a slot that blocks
     /// for `BLOCK_MS` caps the pass rate at `1000 / BLOCK_MS` per second. With
     /// one chunk produced per tick, every other track is capped at that same
     /// rate no matter how fast its own source is. In production the blocking
@@ -515,7 +560,7 @@ mod tests {
     ///
     /// The oracle counts chunks, not wall-clock gaps: a ready track must be
     /// able to drain its whole source within a bounded number of polls. A gap
-    /// oracle cannot see this defect — at `BLOCK_MS` the gap stays near
+    /// oracle cannot see this defect; at `BLOCK_MS` the gap stays near
     /// `BLOCK_MS`, well inside any limit chosen for glitch-free playback,
     /// while the track still delivers an order of magnitude too few chunks.
     #[kithara::test]
@@ -523,7 +568,8 @@ mod tests {
         /// Chunks the fast track's source can produce before EOF.
         const SOURCE_CHUNKS: u32 = 1000;
         /// Polls the consumer is allowed before the source must be drained.
-        const POLL_BUDGET: u32 = 600;
+        /// This stays below `SOURCE_CHUNKS`, so one output per pass cannot pass.
+        const POLL_BUDGET: u32 = 800;
         /// How long the slow track holds the worker inside one step.
         const BLOCK_MS: u64 = 10;
         struct SlowDecodeSource {
@@ -564,16 +610,16 @@ mod tests {
 
         while delivered < SOURCE_CHUNKS && polls < POLL_BUDGET {
             let mut this_poll = 0u32;
-            while rx_a.try_pop().is_some() {
+            while rx_a.try_pop(&handle).is_some() {
                 delivered += 1;
                 this_poll += 1;
             }
             deepest_poll = deepest_poll.max(this_poll);
-            while rx_b.try_pop().is_some() {}
+            while rx_b.try_pop(&handle).is_some() {}
             polls += 1;
             // The budget has to bound the pipeline, not the host. A real pause
             // makes these polls a window of real seconds, and how many chunks
-            // arrive inside it is a property of the machine — which is how this
+            // arrive inside it is a property of the machine, which is how this
             // same budget passed on an idle host and failed on a loaded one.
             // `park_timeout` is on the macro's rewrite list, so the window is
             // virtual and advances only once the worker has parked.
@@ -588,7 +634,7 @@ mod tests {
             delivered >= SOURCE_CHUNKS,
             "fast track drained {delivered} of {SOURCE_CHUNKS} chunks in {polls} polls \
              (deepest single poll {deepest_poll}) while a co-scheduled track blocked \
-             {BLOCK_MS}ms per step — the blocking step sets the worker's pass rate and \
+             {BLOCK_MS}ms per step; the blocking step sets the worker's pass rate and \
              every other track is capped at one chunk per pass"
         );
     }

--- a/crates/kithara-audio/src/renderer/handle.rs
+++ b/crates/kithara-audio/src/renderer/handle.rs
@@ -129,8 +129,8 @@ mod tests {
             track::{TrackStep, WaitingReason},
         },
         renderer::{
-            AudioWorkerSource, MockSource, PreloadGate, PresentedPcm, ServiceClass, ThreadWake,
-            presentation_cell,
+            AudioWorkerSource, MockSource, OutputDisposition, PreloadGate, PresentedPcm,
+            ServiceClass, ThreadWake, presentation_cell,
         },
         runtime::{AtomicServiceClass, connect, connect_strict},
     };
@@ -184,7 +184,7 @@ mod tests {
     {
         let wake = Arc::new(ThreadWake::default());
         let (outlet, inlet) = connect_strict::<Fetch<PresentedPcm>>(ringbuf_capacity, Some(wake));
-        let (trash_outlet, trash_inlet) = connect::<PcmChunk>(ringbuf_capacity + 2, None);
+        let (trash_outlet, trash_inlet) = connect::<OutputDisposition>(ringbuf_capacity + 2, None);
         let preload_gate = Arc::new(PreloadGate::default());
         let (presentation, _frontier) = presentation_cell(0);
 
@@ -219,7 +219,7 @@ mod tests {
 
     struct TestConsumer {
         inlet: crate::runtime::Inlet<Fetch<PresentedPcm>>,
-        trash_outlet: crate::runtime::Outlet<PcmChunk>,
+        trash_outlet: crate::runtime::Outlet<OutputDisposition>,
     }
 
     impl TestConsumer {
@@ -227,7 +227,7 @@ mod tests {
             let fetch = self.inlet.try_pop()?;
             if let Fetch::Data { data, .. } = fetch {
                 assert!(
-                    self.trash_outlet.try_push(data.into()).is_ok(),
+                    self.trash_outlet.try_push(data.returned()).is_ok(),
                     "fixture PCM trash ring must accept every consumed final block"
                 );
             }

--- a/crates/kithara-audio/src/renderer/mod.rs
+++ b/crates/kithara-audio/src/renderer/mod.rs
@@ -4,6 +4,7 @@ mod gate;
 pub(crate) mod handle;
 mod load;
 mod node;
+mod presentation;
 mod source;
 #[cfg(test)]
 mod tests;
@@ -13,10 +14,13 @@ pub use handle::AudioWorkerHandle;
 pub(crate) use handle::{TrackId, WorkerWakeBridge};
 pub use load::{EngineLoad, EngineLoadSnapshot};
 pub(crate) use node::{DecoderNode, TrackRegistration};
+pub(crate) use presentation::{
+    PRESENTATION_RING_BLOCKS, PresentResult, Presentation, PresentationBarrier,
+    PresentationFrontier, PresentationPublisher, PresentedBlock, PresentedPcm, presentation_cell,
+};
 pub use source::AudioWorkerSource;
 #[cfg(test)]
 pub(crate) use source::MockAudioWorkerSource;
-pub(crate) use source::{apply_effects, reset_effects};
 #[cfg(test)]
 pub(crate) use tests::MockSource;
 

--- a/crates/kithara-audio/src/renderer/mod.rs
+++ b/crates/kithara-audio/src/renderer/mod.rs
@@ -15,7 +15,7 @@ pub(crate) use handle::{TrackId, WorkerWakeBridge};
 pub use load::{EngineLoad, EngineLoadSnapshot};
 pub(crate) use node::{DecoderNode, TrackRegistration};
 pub(crate) use presentation::{
-    PRESENTATION_RING_BLOCKS, PresentResult, Presentation, PresentationBarrier,
+    OutputDisposition, PRESENTATION_RING_BLOCKS, PresentResult, Presentation, PresentationBarrier,
     PresentationFrontier, PresentationPublisher, PresentedBlock, PresentedPcm, presentation_cell,
 };
 pub use source::AudioWorkerSource;

--- a/crates/kithara-audio/src/renderer/node.rs
+++ b/crates/kithara-audio/src/renderer/node.rs
@@ -1,4 +1,5 @@
-use kithara_decode::PcmChunk;
+use kithara_bufpool::PcmPool;
+use kithara_decode::{DecodeError, PcmChunk};
 use kithara_events::{AudioEvent, DeferredBus, Event};
 use kithara_platform::{
     sync::Arc,
@@ -6,13 +7,17 @@ use kithara_platform::{
 };
 use kithara_stream::{PlayheadRead, SeekObserve};
 
-use super::{AudioWorkerSource, EngineLoad, PreloadGate, ServiceClass};
+use super::{
+    AudioWorkerSource, EngineLoad, PreloadGate, PresentResult, Presentation, PresentationPublisher,
+    PresentedBlock, PresentedPcm, ServiceClass,
+};
 use crate::{
     pipeline::{
+        config::PresentationChain,
         fetch::Fetch,
         track::{TrackStep, WaitingReason},
     },
-    runtime::{AtomicServiceClass, Inlet, Node, Outlet, TickResult},
+    runtime::{AtomicServiceClass, Inlet, Node, StrictOutlet, TickResult},
 };
 
 /// Everything needed to register a track with the shared worker.
@@ -30,8 +35,13 @@ pub(crate) struct TrackRegistration {
     /// the audio thread. See `crates/kithara-audio/CONTEXT.md`.
     pub(crate) trash_inlet: Inlet<PcmChunk>,
     pub(crate) engine_load: Option<Arc<EngineLoad>>,
-    pub(crate) outlet: Outlet<Fetch<PcmChunk>>,
+    pub(crate) chain: PresentationChain,
+    pub(crate) initial_spec: kithara_decode::PcmSpec,
+    pub(crate) outlet: StrictOutlet<Fetch<PresentedPcm>>,
+    pub(crate) pcm_pool: PcmPool,
     pub(crate) preload_chunks: usize,
+    pub(crate) presentation: PresentationPublisher,
+    pub(crate) raw_buffer_chunks: usize,
 }
 
 /// Per-tick state of a [`DecoderNode`] — preload progress, EOF flag, and
@@ -49,13 +59,7 @@ pub(crate) struct DecoderRuntime {
     pub(crate) chunks_sent: usize,
 }
 
-/// A node that decodes audio chunks.
-///
-/// The source's FSM must be ticked every pass to make progress on
-/// non-producing transitions (e.g. completing a seek). Backpressure is
-/// absorbed by [`Outlet`]'s built-in overflow slot: each tick first tries
-/// to drain that slot before producing more, so the decoder itself is
-/// stateless with respect to parked chunks.
+/// A node that fills a deep raw queue and presents through one effect chain.
 pub(crate) struct DecoderNode {
     emit: Arc<DeferredBus<Event>>,
     playhead: Arc<dyn PlayheadRead>,
@@ -68,16 +72,16 @@ pub(crate) struct DecoderNode {
     service_class: Arc<AtomicServiceClass>,
     source: Box<dyn AudioWorkerSource<Chunk = PcmChunk>>,
     runtime: DecoderRuntime,
-    /// Spent chunks returned by the real-time consumer. Drained by
-    /// [`recycle`](DecoderNode::recycle) in the scheduler's unchecked shell
-    /// before and after the produce pass, and between burst ticks, so pooled
-    /// buffers are freed or recycled on this worker thread, never on the audio
-    /// thread.
+    /// Spent chunks returned by the real-time consumer. Drained once per pass
+    /// by [`recycle`](DecoderNode::recycle), in the scheduler's unchecked shell
+    /// before the produce core, so the pooled buffers are freed/recycled on
+    /// this worker thread, never on the audio thread.
     trash_inlet: Inlet<PcmChunk>,
     /// Live engine cost meter. When present, each produced chunk records the
     /// tick's decode+effects wall time against the audio it yielded.
     engine_load: Option<Arc<EngineLoad>>,
-    outlet: Outlet<Fetch<PcmChunk>>,
+    pending_failure: Option<DecodeError>,
+    presentation: Presentation,
     preload_chunks: usize,
 }
 
@@ -85,21 +89,16 @@ impl DecoderNode {
     const BUFFER_HEALTH_EMIT_MIN: Duration = Duration::from_millis(250);
     const ENGINE_LOAD_EMIT_MIN: Duration = Duration::from_millis(500);
 
+    fn defer_failure(&mut self, error: DecodeError) {
+        if self.pending_failure.is_none() {
+            self.pending_failure = Some(error);
+        }
+    }
+
     fn complete_preload(&mut self) {
         if !self.runtime.preloaded {
             self.preload_gate.signal_epoch(self.runtime.seek_epoch);
             self.runtime.preloaded = true;
-        }
-    }
-
-    fn mark_preload_progress(&mut self) {
-        if self.runtime.preloaded {
-            return;
-        }
-
-        self.runtime.chunks_sent += 1;
-        if self.runtime.chunks_sent >= self.preload_chunks && !self.outlet.has_pending() {
-            self.complete_preload();
         }
     }
 
@@ -158,28 +157,13 @@ impl DecoderNode {
         self.maybe_emit_engine_load(now);
     }
 
-    /// Record one produced chunk's decode+effects cost into the shared engine
-    /// meter.
-    fn record_load(&self, busy: Duration, fetch: &Fetch<PcmChunk>) {
-        if let (Some(load), Fetch::Data { data, .. }) = (self.engine_load.as_ref(), fetch) {
-            load.record(busy, data.frames(), data.spec().sample_rate.get());
+    fn record_load(&self, busy: Duration, block: PresentedBlock) {
+        if let Some(load) = self.engine_load.as_ref() {
+            load.record(busy, block.frames, block.sample_rate);
         }
     }
 
-    /// Reset preload state when a new seek epoch arrives.
-    ///
-    /// Fast path: `SeekObserve::take_decoder_seek` is a one-shot
-    /// `AtomicBool` armed by `begin`. The typical no-seek tick
-    /// reads a single bool and falls through; only the rare epoch-bump
-    /// tick goes through the `Arc<AtomicU64>` deref to refresh the
-    /// cached value. The slow path still re-reads the canonical
-    /// `seek_epoch` so a spurious latch consume costs at most one
-    /// no-op compare.
-    ///
-    /// On an actual epoch bump the preload gate is re-armed (re-closed)
-    /// so a fresh `Resource::preload().await` blocks again until the
-    /// post-seek refill re-opens it.
-    fn sync_seek_epoch(&mut self) {
+    fn service_seek_epoch(&mut self) {
         if !self.seek_obs.take_decoder_seek() {
             return;
         }
@@ -188,8 +172,13 @@ impl DecoderNode {
             return;
         }
 
-        if let Some(Fetch::Data { data, .. }) = self.outlet.take_pending() {
-            self.source.retire_chunk(data);
+        let source = &self.source;
+        if let Err(error) = self
+            .presentation
+            .reset_epoch(current, |chunk| source.retire_chunk(chunk))
+        {
+            self.source.presentation_failed(error);
+            self.presentation.finish_failed(current);
         }
         self.preload_gate.rearm();
         self.runtime = DecoderRuntime {
@@ -197,16 +186,113 @@ impl DecoderNode {
             ..Default::default()
         };
     }
+
+    fn present_once(&mut self, started: Instant) -> PresentResult {
+        let result = {
+            let source = &self.source;
+            self.presentation.step(|chunk| source.retire_chunk(chunk))
+        };
+        match result {
+            Ok(PresentResult::Produced(block)) => {
+                self.record_load(started.elapsed(), block);
+                PresentResult::Produced(block)
+            }
+            Ok(result) => result,
+            Err(error) => {
+                let epoch = self.source.decode_epoch();
+                self.defer_failure(error);
+                let source = &self.source;
+                if let Err(error) = self
+                    .presentation
+                    .abort_failed(epoch, |chunk| source.retire_chunk(chunk))
+                {
+                    self.defer_failure(error);
+                    self.presentation.finish_failed(epoch);
+                }
+                PresentResult::Advanced
+            }
+        }
+    }
+
+    fn fail_presentation(&mut self, detail: &'static str) {
+        let epoch = self.source.decode_epoch();
+        self.defer_failure(DecodeError::InvalidData { detail });
+        self.presentation.finish_failed(epoch);
+    }
+
+    fn pump_source(&mut self) -> TickResult {
+        if let Some((epoch, spec)) = self.source.take_presentation_barrier() {
+            let barrier = super::PresentationBarrier::DecoderReplaced { epoch, spec };
+            if barrier.epoch() != self.presentation.epoch() {
+                return TickResult::Progress;
+            }
+            if self.presentation.admit_barrier(barrier).is_err() {
+                self.fail_presentation("presentation barrier rejected after capacity preflight");
+            }
+            return TickResult::Progress;
+        }
+        match self.source.step_track() {
+            TrackStep::Produced(fetch) => {
+                self.runtime.eof_sent = false;
+                if fetch.epoch() != self.presentation.epoch() {
+                    if let Fetch::Data { data, .. } = fetch {
+                        self.source.retire_chunk(data);
+                    }
+                    return TickResult::Progress;
+                }
+                if let Some(rejected) = self.presentation.admit(fetch) {
+                    if let Fetch::Data { data, .. } = rejected {
+                        self.source.retire_chunk(data);
+                    }
+                    self.fail_presentation("raw PCM rejected after capacity preflight");
+                } else {
+                    self.runtime.chunks_sent = self.runtime.chunks_sent.saturating_add(1);
+                }
+                TickResult::Progress
+            }
+            TrackStep::StateChanged => {
+                self.runtime.eof_sent = false;
+                TickResult::Progress
+            }
+            TrackStep::Blocked(reason) => match reason {
+                WaitingReason::WaitingDemand => TickResult::UpstreamPending,
+                WaitingReason::Waiting | WaitingReason::WaitingMetadata => TickResult::Waiting,
+            },
+            TrackStep::Eof => {
+                let epoch = self.source.decode_epoch();
+                if epoch == self.presentation.epoch() {
+                    self.presentation.finish_eof(epoch);
+                }
+                TickResult::Progress
+            }
+            TrackStep::Failed => {
+                let epoch = self.source.decode_epoch();
+                if epoch == self.presentation.epoch() {
+                    self.presentation.finish_failed(epoch);
+                }
+                TickResult::Progress
+            }
+        }
+    }
 }
 
 impl From<TrackRegistration> for DecoderNode {
     fn from(reg: TrackRegistration) -> Self {
         let seek_obs = reg.source.seek_observe();
         let seek_epoch = seek_obs.epoch();
+        let presentation = Presentation::new(
+            reg.raw_buffer_chunks,
+            reg.chain,
+            reg.pcm_pool,
+            reg.initial_spec,
+            reg.outlet,
+            reg.presentation,
+            seek_epoch,
+        );
         Self {
             seek_obs,
             source: reg.source,
-            outlet: reg.outlet,
+            presentation,
             trash_inlet: reg.trash_inlet,
             playhead: reg.playhead,
             emit: reg.emit,
@@ -214,6 +300,7 @@ impl From<TrackRegistration> for DecoderNode {
             preload_gate: reg.preload_gate,
             preload_chunks: reg.preload_chunks,
             engine_load: reg.engine_load,
+            pending_failure: None,
             runtime: DecoderRuntime {
                 seek_epoch,
                 ..Default::default()
@@ -228,9 +315,19 @@ impl Node for DecoderNode {
     }
 
     fn recycle(&mut self) {
-        while self.trash_inlet.try_pop().is_some() {}
+        self.presentation.release_rejected_off_rt();
+        while let Some(chunk) = self.trash_inlet.try_pop() {
+            self.presentation.recycle_output(chunk);
+            self.presentation.release_rejected_off_rt();
+        }
+        self.presentation.release_retired_off_rt();
+        if let Some(error) = self.pending_failure.take() {
+            self.source.presentation_failed(error);
+        }
+        self.service_seek_epoch();
+        self.presentation.service_off_rt();
         self.source.flush_deferred();
-        self.outlet.flush_wake_signals();
+        self.presentation.flush_wake_signals();
     }
 
     fn service_class(&self) -> ServiceClass {
@@ -238,69 +335,66 @@ impl Node for DecoderNode {
     }
 
     fn tick(&mut self) -> TickResult {
-        self.sync_seek_epoch();
+        if self.seek_obs.epoch() != self.runtime.seek_epoch {
+            return TickResult::Progress;
+        }
+        let start = Instant::now();
+        let mut made_progress = false;
+        let mut source_wait = None;
+        let mut present_result = PresentResult::Idle;
+        let mut presented = false;
 
-        if !self.outlet.flush() {
-            return TickResult::Backpressured;
+        if self.runtime.preloaded || self.presentation.raw_ready_for_preload(self.preload_chunks) {
+            present_result = self.present_once(start);
+            presented = true;
+            made_progress |= matches!(
+                present_result,
+                PresentResult::Advanced | PresentResult::Produced(_) | PresentResult::Terminal
+            );
         }
 
-        if self.runtime.chunks_sent >= self.preload_chunks && !self.runtime.preloaded {
+        if !self.presentation.is_raw_full() && !self.presentation.is_terminal() {
+            let source_result = self.pump_source();
+            match source_result {
+                TickResult::Progress => made_progress = true,
+                TickResult::Waiting | TickResult::UpstreamPending => {
+                    source_wait = Some(source_result);
+                }
+                TickResult::Backpressured | TickResult::Done => {}
+            }
+        }
+
+        if !presented
+            && (self.runtime.preloaded
+                || self.presentation.raw_ready_for_preload(self.preload_chunks))
+        {
+            present_result = self.present_once(start);
+            made_progress |= matches!(
+                present_result,
+                PresentResult::Advanced | PresentResult::Produced(_) | PresentResult::Terminal
+            );
+        }
+
+        if matches!(present_result, PresentResult::Terminal) {
+            self.runtime.eof_sent = true;
+        }
+        if self.presentation.preload_ready(self.preload_chunks) {
             self.complete_preload();
         }
 
-        let start = Instant::now();
-        let result = match self.source.step_track() {
-            TrackStep::Produced(fetch) => {
-                self.record_load(start.elapsed(), &fetch);
-                self.runtime.eof_sent = false;
-                let _ = self.outlet.try_push(fetch);
-                self.mark_preload_progress();
-                TickResult::Progress
-            }
-
-            TrackStep::StateChanged => {
-                self.runtime.eof_sent = false;
-                TickResult::Progress
-            }
-
-            TrackStep::Blocked(reason) => match reason {
-                WaitingReason::WaitingDemand => TickResult::UpstreamPending,
-                WaitingReason::Waiting | WaitingReason::WaitingMetadata => TickResult::Waiting,
-            },
-
-            TrackStep::Eof if self.runtime.eof_sent => TickResult::Backpressured,
-
-            TrackStep::Eof => {
-                let epoch = self.source.decode_epoch();
-                let marker = Fetch::eof(epoch);
-                if let Ok(()) = self.outlet.try_push(marker) {
-                    self.complete_preload();
-                    self.runtime.eof_sent = true;
-                    TickResult::Progress
-                } else {
-                    debug_assert!(false, "EOF marker rejected — overflow invariant violated");
-                    TickResult::Waiting
-                }
-            }
-
-            TrackStep::Failed => {
-                let epoch = self.source.decode_epoch();
-                let marker = Fetch::failure(epoch);
-                if let Ok(()) = self.outlet.try_push(marker) {
-                    self.complete_preload();
-                    if self.outlet.has_pending() {
-                        TickResult::Progress
-                    } else {
-                        TickResult::Done
-                    }
-                } else {
-                    debug_assert!(
-                        false,
-                        "Failed marker rejected — overflow invariant violated"
-                    );
-                    TickResult::Waiting
-                }
-            }
+        let result = if self.presentation.terminal_failed() && self.presentation.terminal_sent() {
+            TickResult::Done
+        } else if made_progress {
+            TickResult::Progress
+        } else if let Some(wait) = source_wait {
+            wait
+        } else if matches!(present_result, PresentResult::Backpressured)
+            || self.presentation.is_raw_full()
+            || self.presentation.terminal_sent()
+        {
+            TickResult::Backpressured
+        } else {
+            TickResult::Waiting
         };
         self.maybe_emit_worker_telemetry(Instant::now());
         result
@@ -313,8 +407,14 @@ impl Node for DecoderNode {
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        num::NonZeroU32,
+        sync::atomic::{AtomicUsize, Ordering},
+    };
+
+    use assert_no_alloc::assert_no_alloc;
     use kithara_bufpool::PcmPool;
-    use kithara_decode::PcmMeta;
+    use kithara_decode::{PcmMeta, PcmSpec};
     use kithara_events::{AudioEvent, Event, EventBus};
     use kithara_platform::time::Duration;
     use kithara_stream::{PlayheadState, PlayheadWrite, SeekControl, SeekObserve, SeekState};
@@ -323,12 +423,86 @@ mod tests {
 
     use super::*;
     use crate::{
-        renderer::MockAudioWorkerSource,
-        runtime::{Inlet, Outlet, connect},
+        renderer::{MockAudioWorkerSource, presentation::PRESENTATION_FRAMES, presentation_cell},
+        runtime::{StrictOutlet, connect, connect_strict},
+        traits::PresentationPoint,
     };
 
-    fn empty_chunk() -> PcmChunk {
-        PcmChunk::new(PcmMeta::default(), PcmPool::default().attach(Vec::new()))
+    fn test_spec(channels: u16, sample_rate: u32) -> PcmSpec {
+        PcmSpec::new(
+            channels,
+            NonZeroU32::new(sample_rate).expect("test sample rate is non-zero"),
+        )
+    }
+
+    fn default_test_spec() -> PcmSpec {
+        test_spec(1, 48_000)
+    }
+
+    fn chunk_with_spec(spec: PcmSpec, frames: usize) -> PcmChunk {
+        let mut meta = PcmMeta::default();
+        meta.spec = spec;
+        meta.frames = u32::try_from(frames).expect("test frame count fits u32");
+        PcmChunk::new(
+            meta,
+            PcmPool::default().attach(vec![0.0; frames * usize::from(spec.channels)]),
+        )
+    }
+
+    fn single_frame_chunk() -> PcmChunk {
+        chunk_with_spec(default_test_spec(), 1)
+    }
+
+    fn presented_chunk() -> PresentedPcm {
+        let chunk = single_frame_chunk();
+        let point = PresentationPoint::new(0, 1, 0, 1, chunk.spec().sample_rate);
+        PresentedPcm::new(chunk, point)
+    }
+
+    fn presentation_block_chunk() -> PcmChunk {
+        chunk_with_spec(default_test_spec(), PRESENTATION_FRAMES)
+    }
+
+    struct ConcurrentSeekEofSource {
+        seek_state: Arc<SeekState>,
+    }
+
+    struct FailureProbeSource {
+        failures: Arc<AtomicUsize>,
+        seek_state: Arc<SeekState>,
+    }
+
+    impl AudioWorkerSource for FailureProbeSource {
+        type Chunk = PcmChunk;
+
+        fn seek_observe(&self) -> Arc<dyn SeekObserve> {
+            Arc::clone(&self.seek_state) as Arc<dyn SeekObserve>
+        }
+
+        fn step_track(&mut self) -> TrackStep<Self::Chunk> {
+            TrackStep::Blocked(WaitingReason::Waiting)
+        }
+
+        fn presentation_failed(&mut self, _error: DecodeError) {
+            self.failures.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    impl AudioWorkerSource for ConcurrentSeekEofSource {
+        type Chunk = PcmChunk;
+
+        fn decode_epoch(&self) -> u64 {
+            0
+        }
+
+        fn seek_observe(&self) -> Arc<dyn SeekObserve> {
+            Arc::clone(&self.seek_state) as Arc<dyn SeekObserve>
+        }
+
+        fn step_track(&mut self) -> TrackStep<Self::Chunk> {
+            self.seek_state.begin(Duration::from_secs(1));
+            TrackStep::Eof
+        }
     }
 
     /// Build a `DecoderNode` for tests: same defaults across the whole
@@ -336,15 +510,35 @@ mod tests {
     /// runtime), so call sites only spell out what they vary.
     fn test_node(
         source: Box<dyn AudioWorkerSource<Chunk = PcmChunk>>,
-        outlet: Outlet<Fetch<PcmChunk>>,
+        outlet: StrictOutlet<Fetch<PresentedPcm>>,
         preload_gate: Arc<PreloadGate>,
         seek_obs: Arc<dyn SeekObserve>,
     ) -> DecoderNode {
+        test_node_with_spec(source, outlet, preload_gate, seek_obs, default_test_spec())
+    }
+
+    fn test_node_with_spec(
+        source: Box<dyn AudioWorkerSource<Chunk = PcmChunk>>,
+        outlet: StrictOutlet<Fetch<PresentedPcm>>,
+        preload_gate: Arc<PreloadGate>,
+        seek_obs: Arc<dyn SeekObserve>,
+        initial_spec: PcmSpec,
+    ) -> DecoderNode {
         let (_trash_outlet, trash_inlet) = connect::<PcmChunk>(4, None);
+        let seek_epoch = seek_obs.epoch();
+        let presentation = Presentation::new(
+            4,
+            PresentationChain::identity(Vec::new()),
+            PcmPool::default(),
+            initial_spec,
+            outlet,
+            presentation_cell(seek_epoch).0,
+            seek_epoch,
+        );
         DecoderNode {
             seek_obs,
             source,
-            outlet,
+            presentation,
             trash_inlet,
             preload_gate,
             playhead: Arc::new(PlayheadState::new()) as Arc<dyn PlayheadRead>,
@@ -352,18 +546,20 @@ mod tests {
             service_class: Arc::new(AtomicServiceClass::new(ServiceClass::default())),
             preload_chunks: 1,
             engine_load: None,
-            runtime: DecoderRuntime::default(),
+            pending_failure: None,
+            runtime: DecoderRuntime {
+                seek_epoch,
+                ..Default::default()
+            },
         }
     }
 
     #[kithara::test]
     fn decoder_node_eof_under_backpressure() {
         let gate = Arc::new(PreloadGate::default());
-        let (mut outlet, _inlet) = connect::<Fetch<PcmChunk>>(1, None);
+        let (mut outlet, mut inlet) = connect_strict::<Fetch<PresentedPcm>>(1, None);
 
-        outlet.try_push(Fetch::data(empty_chunk(), 0)).unwrap();
-        outlet.try_push(Fetch::data(empty_chunk(), 0)).unwrap();
-        assert!(outlet.has_pending());
+        outlet.try_push(Fetch::data(presented_chunk(), 0)).unwrap();
 
         let source = Box::new(Unimock::new((
             MockAudioWorkerSource::step_track
@@ -381,32 +577,27 @@ mod tests {
             Arc::new(SeekState::new()) as Arc<dyn SeekObserve>,
         );
 
+        assert_eq!(node.tick(), TickResult::Progress);
         assert_eq!(node.tick(), TickResult::Backpressured);
         assert!(!node.runtime.eof_sent);
 
-        let _ = node.outlet.take_pending();
+        let _ = inlet.try_pop();
 
         assert_eq!(node.tick(), TickResult::Progress);
         assert!(node.runtime.eof_sent);
-        assert!(node.outlet.has_pending());
+        assert!(matches!(inlet.try_pop(), Some(Fetch::NaturalEof { .. })));
     }
 
     #[kithara::test]
     fn decoder_node_records_engine_load_on_produced() {
-        use std::num::NonZero;
-
-        use kithara_decode::PcmSpec;
-
         let meter = Arc::new(EngineLoad::default());
         assert!(!meter.snapshot().is_active(), "idle before any tick");
 
-        let (outlet, _inlet) = connect::<Fetch<PcmChunk>>(4, None);
+        let (outlet, mut inlet) = connect_strict::<Fetch<PresentedPcm>>(1, None);
+        let spec = test_spec(2, 44_100);
         let chunk = PcmChunk::new(
             PcmMeta {
-                spec: PcmSpec {
-                    channels: 2,
-                    sample_rate: NonZero::new(44_100).unwrap(),
-                },
+                spec,
                 frames: 4_410,
                 ..Default::default()
             },
@@ -418,32 +609,89 @@ mod tests {
                 .returns(TrackStep::Produced(Fetch::data(chunk, 0))),
         ));
 
-        let (_trash_outlet, trash_inlet) = connect::<PcmChunk>(4, None);
-        let mut node = DecoderNode {
+        let mut node = test_node_with_spec(
             source,
             outlet,
-            trash_inlet,
-            seek_obs: Arc::new(SeekState::new()) as Arc<dyn SeekObserve>,
-            preload_gate: Arc::new(PreloadGate::default()),
-            playhead: Arc::new(PlayheadState::new()) as Arc<dyn PlayheadRead>,
-            emit: Arc::new(DeferredBus::new(EventBus::new(8), 8)),
-            service_class: Arc::new(AtomicServiceClass::new(ServiceClass::default())),
-            preload_chunks: 1,
-            engine_load: Some(Arc::clone(&meter)),
-            runtime: DecoderRuntime::default(),
-        };
+            Arc::new(PreloadGate::default()),
+            Arc::new(SeekState::new()) as Arc<dyn SeekObserve>,
+            spec,
+        );
+        node.engine_load = Some(Arc::clone(&meter));
 
         assert_eq!(node.tick(), TickResult::Progress);
+        let produced = inlet
+            .try_pop()
+            .expect("presentation commits one output block");
+        let Fetch::Data { data, epoch } = produced else {
+            panic!("presentation must emit PCM data");
+        };
+        assert_eq!(epoch, 0);
+        assert_eq!(data.chunk().spec(), spec);
+        assert_eq!(data.chunk().frames(), PRESENTATION_FRAMES);
         assert!(
             meter.snapshot().is_active(),
-            "engine meter records on a Produced tick: {:?}",
+            "engine meter records the committed presentation block: {:?}",
             meter.snapshot()
         );
     }
 
     #[kithara::test]
+    fn presentation_failure_is_reported_only_from_the_unchecked_recycle_shell() {
+        let failures = Arc::new(AtomicUsize::new(0));
+        let seek_state = Arc::new(SeekState::new());
+        let source = Box::new(FailureProbeSource {
+            failures: Arc::clone(&failures),
+            seek_state: Arc::clone(&seek_state),
+        });
+        let (outlet, _inlet) = connect_strict::<Fetch<PresentedPcm>>(1, None);
+        let mut node = test_node(
+            source,
+            outlet,
+            Arc::new(PreloadGate::default()),
+            seek_state as Arc<dyn SeekObserve>,
+        );
+
+        node.fail_presentation("fixture presentation failure");
+        assert_eq!(failures.load(Ordering::Relaxed), 0);
+        assert!(node.pending_failure.is_some());
+
+        node.recycle();
+        assert_eq!(failures.load(Ordering::Relaxed), 1);
+        assert!(node.pending_failure.is_none());
+    }
+
+    #[kithara::test]
+    fn rejected_output_is_released_only_from_the_unchecked_recycle_shell() {
+        let (outlet, _inlet) = connect_strict::<Fetch<PresentedPcm>>(1, None);
+        let mut node = test_node(
+            Box::new(Unimock::new(())),
+            outlet,
+            Arc::new(PreloadGate::default()),
+            Arc::new(SeekState::new()) as Arc<dyn SeekObserve>,
+        );
+        let reject_pool = PcmPool::new(1, 0);
+        reject_pool.pre_warm(1, |buffer| buffer.resize(PRESENTATION_FRAMES, 0.0));
+        let rejected = PcmChunk::new(
+            PcmMeta {
+                spec: default_test_spec(),
+                frames: u32::try_from(PRESENTATION_FRAMES)
+                    .expect("presentation frame count fits u32"),
+                ..Default::default()
+            },
+            reject_pool.attach(vec![0.0; PRESENTATION_FRAMES]),
+        );
+
+        assert_no_alloc(|| node.presentation.recycle_output(rejected));
+        assert_eq!(reject_pool.stats().put_drops, 0);
+
+        node.recycle();
+
+        assert_eq!(reject_pool.stats().put_drops, 1);
+    }
+
+    #[kithara::test]
     fn worker_telemetry_throttles_immediate_repeats() {
-        let (outlet, _inlet) = connect::<Fetch<PcmChunk>>(4, None);
+        let (outlet, _inlet) = connect_strict::<Fetch<PresentedPcm>>(1, None);
         let source = Box::new(Unimock::new(()));
         let gate = Arc::new(PreloadGate::default());
         let seek = Arc::new(SeekState::new());
@@ -456,19 +704,15 @@ mod tests {
         let meter = Arc::new(EngineLoad::default());
         meter.record(Duration::from_millis(5), 4_410, 44_100);
 
-        let mut node = DecoderNode {
+        let mut node = test_node(
             source,
             outlet,
-            seek_obs: Arc::clone(&seek) as Arc<dyn SeekObserve>,
-            trash_inlet: connect::<PcmChunk>(4, None).1,
-            preload_gate: gate,
-            playhead: Arc::clone(&playhead) as Arc<dyn PlayheadRead>,
-            emit: Arc::clone(&emit),
-            service_class: Arc::new(AtomicServiceClass::new(ServiceClass::default())),
-            preload_chunks: 1,
-            engine_load: Some(meter),
-            runtime: DecoderRuntime::default(),
-        };
+            gate,
+            Arc::clone(&seek) as Arc<dyn SeekObserve>,
+        );
+        node.playhead = Arc::clone(&playhead) as Arc<dyn PlayheadRead>;
+        node.emit = Arc::clone(&emit);
+        node.engine_load = Some(meter);
 
         let now = Instant::now();
         node.maybe_emit_worker_telemetry(now);
@@ -500,14 +744,13 @@ mod tests {
         /// `TrackStep::Failed`) must materialise as distinct variants on
         /// the wire so the consumer can finalise the track only on
         /// natural EOF.
-        fn drain_marker<T>(outlet: &mut Outlet<Fetch<T>>, inlet: &mut Inlet<Fetch<T>>) -> Fetch<T> {
-            outlet.flush();
+        fn drain_marker<T>(inlet: &mut Inlet<Fetch<T>>) -> Fetch<T> {
             inlet.try_pop().expect("producer pushed a terminal marker")
         }
 
         let gate = Arc::new(PreloadGate::default());
 
-        let (eof_outlet, mut eof_inlet) = connect::<Fetch<PcmChunk>>(1, None);
+        let (eof_outlet, mut eof_inlet) = connect_strict::<Fetch<PresentedPcm>>(1, None);
         let eof_source = Box::new(Unimock::new((
             MockAudioWorkerSource::step_track
                 .next_call(matching!())
@@ -523,9 +766,9 @@ mod tests {
             Arc::new(SeekState::new()) as Arc<dyn SeekObserve>,
         );
         assert_eq!(eof_node.tick(), TickResult::Progress);
-        let eof_marker = drain_marker(&mut eof_node.outlet, &mut eof_inlet);
+        let eof_marker = drain_marker(&mut eof_inlet);
 
-        let (failed_outlet, mut failed_inlet) = connect::<Fetch<PcmChunk>>(1, None);
+        let (failed_outlet, mut failed_inlet) = connect_strict::<Fetch<PresentedPcm>>(1, None);
         let failed_source = Box::new(Unimock::new((
             MockAudioWorkerSource::step_track
                 .next_call(matching!())
@@ -541,7 +784,7 @@ mod tests {
             Arc::new(SeekState::new()) as Arc<dyn SeekObserve>,
         );
         let _ = failed_node.tick();
-        let failed_marker = drain_marker(&mut failed_node.outlet, &mut failed_inlet);
+        let failed_marker = drain_marker(&mut failed_inlet);
 
         assert!(matches!(eof_marker, Fetch::NaturalEof { .. }));
         assert!(matches!(failed_marker, Fetch::Failure { .. }));
@@ -559,28 +802,21 @@ mod tests {
         // consumer's epoch validator as the *new* seek's terminal, surfacing a
         // false `ReadOutcome::Eof` for an in-range seek.
         let gate = Arc::new(PreloadGate::default());
-        let (outlet, mut inlet) = connect::<Fetch<PcmChunk>>(1, None);
+        let (outlet, mut inlet) = connect_strict::<Fetch<PresentedPcm>>(1, None);
 
-        // Consumer already requested the next seek: the seek epoch is now 1,
-        // ahead of the decode epoch (0) the pending EOF belongs to.
-        let seek_state = SeekState::new();
-        let live_epoch = seek_state.begin(Duration::from_secs(1));
-        assert_eq!(live_epoch, 1, "begin bumps the seek epoch to 1");
-        let seek_obs = Arc::new(seek_state) as Arc<dyn SeekObserve>;
-
-        let source = Box::new(Unimock::new((
-            MockAudioWorkerSource::step_track
-                .next_call(matching!())
-                .returns(TrackStep::Eof),
-            MockAudioWorkerSource::decode_epoch
-                .next_call(matching!())
-                .returns(0u64),
-        )));
+        // The worker has already sampled the current seek epoch when the
+        // consumer requests the next seek concurrently with the source step.
+        // The pending EOF still belongs to decode epoch 0.
+        let seek_state = Arc::new(SeekState::new());
+        let seek_obs = Arc::clone(&seek_state) as Arc<dyn SeekObserve>;
+        let source = Box::new(ConcurrentSeekEofSource {
+            seek_state: Arc::clone(&seek_state),
+        });
 
         let mut node = test_node(source, outlet, gate, seek_obs);
         assert_eq!(node.tick(), TickResult::Progress);
+        assert_eq!(seek_state.epoch(), 1, "source step raced with a new seek");
 
-        node.outlet.flush();
         let marker = inlet.try_pop().expect("producer pushed an EOF marker");
         assert!(matches!(&marker, Fetch::NaturalEof { .. }));
         assert_eq!(
@@ -594,14 +830,21 @@ mod tests {
     #[kithara::test]
     fn decoder_node_preload_gate_waits_for_ring() {
         let gate = Arc::new(PreloadGate::default());
-        let (mut outlet, mut inlet) = connect::<Fetch<PcmChunk>>(1, None);
+        let (mut outlet, mut inlet) = connect_strict::<Fetch<PresentedPcm>>(2, None);
 
-        outlet.try_push(Fetch::data(empty_chunk(), 0)).unwrap();
+        outlet.try_push(Fetch::data(presented_chunk(), 0)).unwrap();
+        outlet.try_push(Fetch::data(presented_chunk(), 0)).unwrap();
 
         let source = Box::new(Unimock::new((
             MockAudioWorkerSource::step_track
                 .next_call(matching!())
-                .returns(TrackStep::Produced(Fetch::data(empty_chunk(), 0))),
+                .returns(TrackStep::Produced(Fetch::data(
+                    presentation_block_chunk(),
+                    0,
+                ))),
+            MockAudioWorkerSource::step_track
+                .next_call(matching!())
+                .returns(TrackStep::Blocked(WaitingReason::Waiting)),
             MockAudioWorkerSource::step_track
                 .next_call(matching!())
                 .returns(TrackStep::Blocked(WaitingReason::Waiting)),
@@ -619,21 +862,31 @@ mod tests {
         assert!(!node.runtime.preloaded);
         assert!(!gate.is_ready());
 
-        assert_eq!(node.tick(), TickResult::Backpressured);
+        assert_eq!(node.tick(), TickResult::Waiting);
         assert!(!node.runtime.preloaded);
         assert!(!gate.is_ready());
 
         let _ = inlet.try_pop();
 
-        assert_eq!(node.tick(), TickResult::Waiting);
+        assert_eq!(node.tick(), TickResult::Progress);
         assert!(node.runtime.preloaded);
         assert!(gate.is_ready());
+        assert!(matches!(
+            inlet.try_pop(),
+            Some(Fetch::Data { data, epoch: 0 }) if data.chunk().frames() == 1
+        ));
+        assert!(matches!(
+            inlet.try_pop(),
+            Some(Fetch::Data { data, epoch: 0 })
+                if data.chunk().frames() == PRESENTATION_FRAMES
+                    && data.chunk().spec() == default_test_spec()
+        ));
     }
 
     #[kithara::test]
     fn decoder_node_live_upstream_demand_does_not_tick_hang_wait() {
         let gate = Arc::new(PreloadGate::default());
-        let (outlet, _inlet) = connect::<Fetch<PcmChunk>>(2, None);
+        let (outlet, _inlet) = connect_strict::<Fetch<PresentedPcm>>(1, None);
 
         let source = Box::new(Unimock::new(
             MockAudioWorkerSource::step_track
@@ -654,19 +907,25 @@ mod tests {
     #[kithara::test]
     fn decoder_node_seek_rearms_preload_gate() {
         let gate = Arc::new(PreloadGate::default());
-        let (outlet, mut inlet) = connect::<Fetch<PcmChunk>>(2, None);
+        let (outlet, mut inlet) = connect_strict::<Fetch<PresentedPcm>>(1, None);
 
         let seek_state = Arc::new(SeekState::new());
         let source = Box::new(Unimock::new((
             MockAudioWorkerSource::step_track
                 .next_call(matching!())
-                .returns(TrackStep::Produced(Fetch::data(empty_chunk(), 0))),
+                .returns(TrackStep::Produced(Fetch::data(
+                    presentation_block_chunk(),
+                    0,
+                ))),
             MockAudioWorkerSource::step_track
                 .next_call(matching!())
                 .returns(TrackStep::StateChanged),
             MockAudioWorkerSource::step_track
                 .next_call(matching!())
-                .returns(TrackStep::Produced(Fetch::data(empty_chunk(), 0))),
+                .returns(TrackStep::Produced(Fetch::data(
+                    presentation_block_chunk(),
+                    1,
+                ))),
         )));
 
         // Pass a seek_obs handle derived from `seek_state` so begin()
@@ -684,11 +943,16 @@ mod tests {
 
         let epoch = SeekControl::begin(&*seek_state, Duration::from_secs(1));
 
+        node.recycle();
         assert_eq!(node.tick(), TickResult::Progress);
         assert!(!node.runtime.preloaded, "seek resets the preload runtime");
         assert!(!gate.is_ready(), "sync_seek_epoch re-closes the gate");
 
-        let _ = inlet.try_pop();
+        assert!(matches!(
+            inlet.try_pop(),
+            Some(Fetch::Data { data, epoch: 0 })
+                if data.chunk().frames() == PRESENTATION_FRAMES
+        ));
 
         assert_eq!(node.tick(), TickResult::Progress);
         assert!(node.runtime.preloaded);
@@ -697,5 +961,10 @@ mod tests {
             gate.is_ready_for_epoch(epoch),
             "post-seek refill must open the new seek epoch",
         );
+        assert!(matches!(
+            inlet.try_pop(),
+            Some(Fetch::Data { data, epoch: 1 })
+                if data.chunk().frames() == PRESENTATION_FRAMES
+        ));
     }
 }

--- a/crates/kithara-audio/src/renderer/node.rs
+++ b/crates/kithara-audio/src/renderer/node.rs
@@ -220,6 +220,12 @@ impl DecoderNode {
         self.presentation.finish_failed(epoch);
     }
 
+    fn should_present(&self) -> bool {
+        self.runtime.preloaded
+            || self.presentation.raw_ready_for_preload(self.preload_chunks)
+            || self.presentation.is_raw_full()
+    }
+
     fn pump_source(&mut self) -> TickResult {
         if let Some((epoch, spec)) = self.source.take_presentation_barrier() {
             let barrier = super::PresentationBarrier::DecoderReplaced { epoch, spec };
@@ -344,7 +350,7 @@ impl Node for DecoderNode {
         let mut present_result = PresentResult::Idle;
         let mut presented = false;
 
-        if self.runtime.preloaded || self.presentation.raw_ready_for_preload(self.preload_chunks) {
+        if self.should_present() {
             present_result = self.present_once(start);
             presented = true;
             made_progress |= matches!(
@@ -364,10 +370,7 @@ impl Node for DecoderNode {
             }
         }
 
-        if !presented
-            && (self.runtime.preloaded
-                || self.presentation.raw_ready_for_preload(self.preload_chunks))
-        {
+        if !presented && self.should_present() {
             present_result = self.present_once(start);
             made_progress |= matches!(
                 present_result,
@@ -524,10 +527,22 @@ mod tests {
         seek_obs: Arc<dyn SeekObserve>,
         initial_spec: PcmSpec,
     ) -> DecoderNode {
+        test_node_with_limits(source, outlet, preload_gate, seek_obs, initial_spec, 4, 1)
+    }
+
+    fn test_node_with_limits(
+        source: Box<dyn AudioWorkerSource<Chunk = PcmChunk>>,
+        outlet: StrictOutlet<Fetch<PresentedPcm>>,
+        preload_gate: Arc<PreloadGate>,
+        seek_obs: Arc<dyn SeekObserve>,
+        initial_spec: PcmSpec,
+        raw_buffer_chunks: usize,
+        preload_chunks: usize,
+    ) -> DecoderNode {
         let (_trash_outlet, trash_inlet) = connect::<PcmChunk>(4, None);
         let seek_epoch = seek_obs.epoch();
         let presentation = Presentation::new(
-            4,
+            raw_buffer_chunks,
             PresentationChain::identity(Vec::new()),
             PcmPool::default(),
             initial_spec,
@@ -544,13 +559,60 @@ mod tests {
             playhead: Arc::new(PlayheadState::new()) as Arc<dyn PlayheadRead>,
             emit: Arc::new(DeferredBus::new(EventBus::new(8), 8)),
             service_class: Arc::new(AtomicServiceClass::new(ServiceClass::default())),
-            preload_chunks: 1,
+            preload_chunks,
             engine_load: None,
             pending_failure: None,
             runtime: DecoderRuntime {
                 seek_epoch,
                 ..Default::default()
             },
+        }
+    }
+
+    #[kithara::test]
+    fn decoder_node_preload_progresses_when_raw_capacity_is_below_target() {
+        let gate = Arc::new(PreloadGate::default());
+        let (outlet, mut inlet) = connect_strict::<Fetch<PresentedPcm>>(3, None);
+        let source = Box::new(Unimock::new((
+            MockAudioWorkerSource::step_track
+                .next_call(matching!())
+                .returns(TrackStep::Produced(Fetch::data(
+                    presentation_block_chunk(),
+                    0,
+                ))),
+            MockAudioWorkerSource::step_track
+                .next_call(matching!())
+                .returns(TrackStep::Produced(Fetch::data(
+                    presentation_block_chunk(),
+                    0,
+                ))),
+            MockAudioWorkerSource::step_track
+                .next_call(matching!())
+                .returns(TrackStep::Produced(Fetch::data(
+                    presentation_block_chunk(),
+                    0,
+                ))),
+        )));
+        let mut node = test_node_with_limits(
+            source,
+            outlet,
+            Arc::clone(&gate),
+            Arc::new(SeekState::new()) as Arc<dyn SeekObserve>,
+            default_test_spec(),
+            1,
+            3,
+        );
+
+        for admitted in 1..=3 {
+            assert_eq!(node.tick(), TickResult::Progress);
+            assert_eq!(node.runtime.chunks_sent, admitted);
+            assert!(matches!(
+                inlet.try_pop(),
+                Some(Fetch::Data { data, epoch: 0 })
+                    if data.chunk().frames() == PRESENTATION_FRAMES
+            ));
+            assert_eq!(node.runtime.preloaded, admitted == 3);
+            assert_eq!(gate.is_ready(), admitted == 3);
         }
     }
 

--- a/crates/kithara-audio/src/renderer/node.rs
+++ b/crates/kithara-audio/src/renderer/node.rs
@@ -8,8 +8,8 @@ use kithara_platform::{
 use kithara_stream::{PlayheadRead, SeekObserve};
 
 use super::{
-    AudioWorkerSource, EngineLoad, PreloadGate, PresentResult, Presentation, PresentationPublisher,
-    PresentedBlock, PresentedPcm, ServiceClass,
+    AudioWorkerSource, EngineLoad, OutputDisposition, PreloadGate, PresentResult, Presentation,
+    PresentationPublisher, PresentedBlock, PresentedPcm, ServiceClass,
 };
 use crate::{
     pipeline::{
@@ -29,11 +29,10 @@ pub(crate) struct TrackRegistration {
     /// (`Audio::set_service_class`); the worker scheduler reads it each pass.
     pub(crate) service_class: Arc<AtomicServiceClass>,
     pub(crate) source: Box<dyn AudioWorkerSource<Chunk = PcmChunk>>,
-    /// Spent-chunk return ring: the real-time consumer ([`crate::Audio`])
-    /// hands every consumed `PcmChunk` here instead of dropping it, so the
-    /// pooled buffer is freed/recycled on the worker thread rather than on
-    /// the audio thread. See `crates/kithara-audio/CONTEXT.md`.
-    pub(crate) trash_inlet: Inlet<PcmChunk>,
+    /// Final-output return ring: the real-time consumer ([`crate::Audio`])
+    /// reports whether each output was returned or detached, so replacement
+    /// allocation and pooled-buffer recycling stay on the worker thread.
+    pub(crate) trash_inlet: Inlet<OutputDisposition>,
     pub(crate) engine_load: Option<Arc<EngineLoad>>,
     pub(crate) chain: PresentationChain,
     pub(crate) initial_spec: kithara_decode::PcmSpec,
@@ -72,11 +71,10 @@ pub(crate) struct DecoderNode {
     service_class: Arc<AtomicServiceClass>,
     source: Box<dyn AudioWorkerSource<Chunk = PcmChunk>>,
     runtime: DecoderRuntime,
-    /// Spent chunks returned by the real-time consumer. Drained once per pass
-    /// by [`recycle`](DecoderNode::recycle), in the scheduler's unchecked shell
-    /// before the produce core, so the pooled buffers are freed/recycled on
-    /// this worker thread, never on the audio thread.
-    trash_inlet: Inlet<PcmChunk>,
+    /// Final-output dispositions from the real-time consumer. Drained once per
+    /// pass by [`recycle`](DecoderNode::recycle), in the scheduler's unchecked
+    /// shell before the produce core.
+    trash_inlet: Inlet<OutputDisposition>,
     /// Live engine cost meter. When present, each produced chunk records the
     /// tick's decode+effects wall time against the audio it yielded.
     engine_load: Option<Arc<EngineLoad>>,
@@ -322,8 +320,8 @@ impl Node for DecoderNode {
 
     fn recycle(&mut self) {
         self.presentation.release_rejected_off_rt();
-        while let Some(chunk) = self.trash_inlet.try_pop() {
-            self.presentation.recycle_output(chunk);
+        while let Some(disposition) = self.trash_inlet.try_pop() {
+            self.presentation.restore_output(disposition);
             self.presentation.release_rejected_off_rt();
         }
         self.presentation.release_retired_off_rt();
@@ -539,7 +537,7 @@ mod tests {
         raw_buffer_chunks: usize,
         preload_chunks: usize,
     ) -> DecoderNode {
-        let (_trash_outlet, trash_inlet) = connect::<PcmChunk>(4, None);
+        let (_trash_outlet, trash_inlet) = connect::<OutputDisposition>(4, None);
         let seek_epoch = seek_obs.epoch();
         let presentation = Presentation::new(
             raw_buffer_chunks,

--- a/crates/kithara-audio/src/renderer/presentation/boundary.rs
+++ b/crates/kithara-audio/src/renderer/presentation/boundary.rs
@@ -224,7 +224,6 @@ impl Presentation {
             .emitted(0)
             .map(|source_end| (source_end.frame, source_end.rate));
         self.reset_effects();
-        self.window.clear();
         self.epoch = epoch;
         self.publisher.restart(epoch, source_end);
         PresentResult::Advanced

--- a/crates/kithara-audio/src/renderer/presentation/boundary.rs
+++ b/crates/kithara-audio/src/renderer/presentation/boundary.rs
@@ -1,0 +1,232 @@
+use kithara_decode::{DecodeError, DecodeResult, PcmChunk};
+
+use super::{
+    PRESENTATION_FRAMES,
+    coordinator::Presentation,
+    frontier::PresentationBarrier,
+    output::PresentResult,
+    state::{DiscontinuityPhase, RawItem, Terminal},
+};
+use crate::{
+    pipeline::fetch::Fetch,
+    traits::{OutputCredit, TempoDiscontinuityStep, TempoEofStep, TempoStage},
+};
+
+impl Presentation {
+    pub(super) fn render_tempo_eof<F>(
+        &mut self,
+        tempo: &mut dyn TempoStage,
+        epoch: u64,
+        retire: &mut F,
+    ) -> DecodeResult<PresentResult>
+    where
+        F: FnMut(PcmChunk),
+    {
+        let spec = tempo.output_spec();
+        let Some((mut pcm, channels)) = self.output_buffer(spec)? else {
+            return Ok(PresentResult::Backpressured);
+        };
+        let debt = self.eof_debt.as_mut().ok_or(DecodeError::InvalidData {
+            detail: "tempo EOF drain lost its debt token",
+        })?;
+        let step = match tempo.render_eof(
+            debt,
+            OutputCredit::new(&mut pcm, channels, PRESENTATION_FRAMES),
+            retire,
+        ) {
+            Ok(step) => step,
+            Err(error) => {
+                self.recycle_pcm(spec, pcm)?;
+                return Err(error);
+            }
+        };
+        match step {
+            TempoEofStep::Drained => {
+                self.recycle_pcm(spec, pcm)?;
+                self.eof_debt = None;
+                tempo.deactivate(retire)?;
+                self.push_terminal(Fetch::eof(epoch))?;
+                self.terminal_sent = true;
+                Ok(PresentResult::Terminal)
+            }
+            TempoEofStep::Rendered { frames, meta } => {
+                let chunk = self.tempo_chunk(pcm, spec, channels, frames, meta)?;
+                let output = self.process_effects(chunk)?;
+                self.commit(output, epoch, tempo.held_source_frames())
+            }
+        }
+    }
+
+    pub(super) fn render_discontinuity<F>(
+        &mut self,
+        tempo: &mut dyn TempoStage,
+        retire: &mut F,
+    ) -> DecodeResult<PresentResult>
+    where
+        F: FnMut(PcmChunk),
+    {
+        let draining = matches!(
+            self.discontinuity
+                .as_ref()
+                .map(|discontinuity| &discontinuity.phase),
+            Some(DiscontinuityPhase::Draining(_))
+        );
+        if draining {
+            let phase = {
+                let discontinuity =
+                    self.discontinuity
+                        .as_mut()
+                        .ok_or(DecodeError::InvalidData {
+                            detail: "tempo discontinuity lost its debt token",
+                        })?;
+                std::mem::replace(&mut discontinuity.phase, DiscontinuityPhase::Drained)
+            };
+            let DiscontinuityPhase::Draining(mut debt) = phase else {
+                return Err(DecodeError::InvalidData {
+                    detail: "tempo discontinuity changed phase while rendering",
+                });
+            };
+            let spec = tempo.output_spec();
+            let Some((mut pcm, channels)) = self.output_buffer(spec)? else {
+                self.discontinuity
+                    .as_mut()
+                    .ok_or(DecodeError::InvalidData {
+                        detail: "tempo discontinuity disappeared during backpressure",
+                    })?
+                    .phase = DiscontinuityPhase::Draining(debt);
+                return Ok(PresentResult::Backpressured);
+            };
+            let step = match tempo.render_discontinuity(
+                &mut debt,
+                OutputCredit::new(&mut pcm, channels, PRESENTATION_FRAMES),
+                retire,
+            ) {
+                Ok(step) => step,
+                Err(error) => {
+                    self.recycle_pcm(spec, pcm)?;
+                    return Err(error);
+                }
+            };
+            match step {
+                TempoDiscontinuityStep::Drained => {
+                    self.recycle_pcm(spec, pcm)?;
+                    if tempo.held_source_frames() != 0 && Self::checked_tempo_quanta(tempo)? == 0 {
+                        return Err(DecodeError::InvalidData {
+                            detail: "tempo discontinuity drained with unowned source remaining",
+                        });
+                    }
+                    let discontinuity =
+                        self.discontinuity
+                            .as_mut()
+                            .ok_or(DecodeError::InvalidData {
+                                detail: "tempo discontinuity disappeared before commit",
+                            })?;
+                    discontinuity.phase = DiscontinuityPhase::Drained;
+                }
+                TempoDiscontinuityStep::Rendered { frames, meta } => {
+                    let Some(discontinuity) = self.discontinuity.as_mut() else {
+                        self.recycle_pcm(spec, pcm)?;
+                        return Err(DecodeError::InvalidData {
+                            detail: "tempo discontinuity disappeared while rendering",
+                        });
+                    };
+                    discontinuity.phase = DiscontinuityPhase::Draining(debt);
+                    let chunk = self.tempo_chunk(pcm, spec, channels, frames, meta)?;
+                    let output = self.process_effects(chunk)?;
+                    return self.commit(output, self.epoch, tempo.held_source_frames());
+                }
+            }
+        }
+
+        let discontinuity = self.discontinuity.take().ok_or(DecodeError::InvalidData {
+            detail: "tempo discontinuity disappeared before commit",
+        })?;
+        let barrier = discontinuity.barrier;
+        if let Some(PresentationBarrier::DecoderReplaced {
+            spec: replacement, ..
+        }) = barrier
+            && self.buffers.spec != Some(replacement)
+        {
+            self.discontinuity = Some(discontinuity);
+            return Ok(PresentResult::Backpressured);
+        }
+        tempo.commit_prepared(discontinuity.boundary)?;
+        if let Some(barrier) = barrier {
+            let PresentationBarrier::DecoderReplaced {
+                spec: replacement, ..
+            } = barrier;
+            if tempo.output_spec() != replacement {
+                return Err(DecodeError::InvalidData {
+                    detail: "tempo stage did not adopt the replacement decoder PCM shape",
+                });
+            }
+            return Ok(self.apply_barrier(barrier));
+        }
+        Ok(PresentResult::Advanced)
+    }
+
+    pub(super) fn finish_terminal<F>(
+        &mut self,
+        tempo: Option<&mut dyn TempoStage>,
+        retire: &mut F,
+    ) -> DecodeResult<PresentResult>
+    where
+        F: FnMut(PcmChunk),
+    {
+        let Some(terminal) = self.terminal else {
+            return Ok(PresentResult::Idle);
+        };
+        if self.terminal_sent {
+            return Ok(PresentResult::Idle);
+        }
+        match terminal {
+            Terminal::Eof { epoch } => {
+                let Some(tempo) = tempo else {
+                    self.push_terminal(Fetch::eof(epoch))?;
+                    self.terminal_sent = true;
+                    return Ok(PresentResult::Terminal);
+                };
+                if self.eof_debt.is_none() {
+                    self.eof_debt = Some(tempo.finish_eof()?);
+                    return Ok(PresentResult::Advanced);
+                }
+                self.render_tempo_eof(tempo, epoch, retire)
+            }
+            Terminal::Failed { epoch } => {
+                if !self.failure_reset {
+                    if let Some(tempo) = tempo {
+                        tempo.deactivate(retire)?;
+                    }
+                    self.reset_effects();
+                    self.window.clear();
+                    self.failure_reset = true;
+                }
+                self.push_terminal(Fetch::failure(epoch))?;
+                self.terminal_sent = true;
+                Ok(PresentResult::Terminal)
+            }
+        }
+    }
+
+    pub(super) fn take_barrier(&mut self) -> DecodeResult<PresentationBarrier> {
+        let Some(RawItem::Barrier(barrier)) = self.raw.pop_front() else {
+            return Err(DecodeError::InvalidData {
+                detail: "presentation decoder barrier disappeared",
+            });
+        };
+        Ok(barrier)
+    }
+
+    pub(super) fn apply_barrier(&mut self, barrier: PresentationBarrier) -> PresentResult {
+        let PresentationBarrier::DecoderReplaced { epoch, .. } = barrier;
+        let source_end = self
+            .window
+            .emitted(0)
+            .map(|source_end| (source_end.frame, source_end.rate));
+        self.reset_effects();
+        self.window.clear();
+        self.epoch = epoch;
+        self.publisher.restart(epoch, source_end);
+        PresentResult::Advanced
+    }
+}

--- a/crates/kithara-audio/src/renderer/presentation/commit.rs
+++ b/crates/kithara-audio/src/renderer/presentation/commit.rs
@@ -60,7 +60,7 @@ impl Presentation {
         // of this tick therefore reserves this one slot.
         if let Err(rejected) = self.output.try_push(fetch) {
             if let Fetch::Data { data, .. } = rejected {
-                self.recycle_output(data.into());
+                self.recycle_output(data.into_inner());
             }
             return Err(DecodeError::InvalidData {
                 detail: "strict presentation reservation was lost",

--- a/crates/kithara-audio/src/renderer/presentation/commit.rs
+++ b/crates/kithara-audio/src/renderer/presentation/commit.rs
@@ -1,0 +1,225 @@
+use kithara_bufpool::PcmBuf;
+use kithara_decode::{DecodeError, DecodeResult, PcmChunk, PcmMeta, PcmSpec};
+
+use super::{
+    PRESENTATION_FRAMES,
+    coordinator::Presentation,
+    output::{
+        PresentResult, PresentedBlock, PresentedPcm, RecycleFailure, RecycleOutcome, split_meta,
+        tempo_chunk,
+    },
+    state::RawItem,
+};
+use crate::{pipeline::fetch::Fetch, traits::AudioBlockMut};
+
+impl Presentation {
+    pub(crate) fn recycle_output(&mut self, chunk: PcmChunk) {
+        if let RecycleOutcome::Rejected(failure) = self.buffers.recycle(chunk) {
+            let error = self.defer_recycle_failure(failure);
+            self.buffer_error = Some(error);
+        }
+    }
+
+    fn defer_recycle_failure(&mut self, failure: RecycleFailure) -> DecodeError {
+        let RecycleFailure { chunk, error } = failure;
+        debug_assert!(self.rejected_output.is_none());
+        self.rejected_output = Some(chunk);
+        error
+    }
+
+    pub(super) fn commit(
+        &mut self,
+        output: PcmChunk,
+        epoch: u64,
+        held_source_frames: u64,
+    ) -> DecodeResult<PresentResult> {
+        if output.frames() > PRESENTATION_FRAMES {
+            self.recycle_output(output);
+            return Err(DecodeError::InvalidData {
+                detail: "presentation stage exceeded its output credit",
+            });
+        }
+        let metrics = PresentedBlock {
+            frames: output.frames(),
+            sample_rate: output.spec().sample_rate.get(),
+        };
+        let source_end = self.window.emitted(held_source_frames);
+        let point = match self.publisher.prepare_commit(
+            epoch,
+            output.frames(),
+            source_end.map(|source_end| (source_end.frame, source_end.rate)),
+        ) {
+            Ok(point) => point,
+            Err(error) => {
+                self.recycle_output(output);
+                return Err(error);
+            }
+        };
+        let fetch = Fetch::data(PresentedPcm::new(output, point), epoch);
+        // The SPSC consumer can only free capacity. The preflight at the start
+        // of this tick therefore reserves this one slot.
+        if let Err(rejected) = self.output.try_push(fetch) {
+            if let Fetch::Data { data, .. } = rejected {
+                self.recycle_output(data.into());
+            }
+            return Err(DecodeError::InvalidData {
+                detail: "strict presentation reservation was lost",
+            });
+        }
+        self.publisher.commit(point);
+        self.final_committed = true;
+        Ok(PresentResult::Produced(metrics))
+    }
+
+    pub(super) fn next_block<F>(&mut self, retire: &mut F) -> DecodeResult<Option<(PcmChunk, u64)>>
+    where
+        F: FnMut(PcmChunk),
+    {
+        let Some(RawItem::Data(raw)) = self.raw.front() else {
+            return Err(DecodeError::InvalidData {
+                detail: "presentation raw queue lost its data head",
+            });
+        };
+        let channels = usize::from(raw.chunk.spec().channels);
+        if channels == 0 {
+            return Err(DecodeError::InvalidData {
+                detail: "presentation received PCM with zero channels",
+            });
+        }
+        let total_frames = raw.chunk.frames();
+        let remaining =
+            total_frames
+                .checked_sub(raw.consumed_frames)
+                .ok_or(DecodeError::InvalidData {
+                    detail: "presentation consumed beyond the raw chunk",
+                })?;
+        let frames = remaining.min(PRESENTATION_FRAMES);
+        if frames == 0 {
+            let Some(RawItem::Data(raw)) = self.raw.pop_front() else {
+                return Err(DecodeError::InvalidData {
+                    detail: "presentation raw queue changed while retiring",
+                });
+            };
+            retire(raw.chunk);
+            return Err(DecodeError::InvalidData {
+                detail: "presentation received an empty raw PCM chunk",
+            });
+        }
+        let consumed_frames = raw.consumed_frames;
+        let start_sample =
+            consumed_frames
+                .checked_mul(channels)
+                .ok_or(DecodeError::InvalidData {
+                    detail: "presentation sample offset overflow",
+                })?;
+        let samples = frames
+            .checked_mul(channels)
+            .ok_or(DecodeError::InvalidData {
+                detail: "presentation block sample count overflow",
+            })?;
+        let end_sample = start_sample
+            .checked_add(samples)
+            .ok_or(DecodeError::InvalidData {
+                detail: "presentation sample range overflow",
+            })?;
+        if raw.chunk.samples.get(start_sample..end_sample).is_none() {
+            return Err(DecodeError::InvalidData {
+                detail: "presentation PCM metadata exceeds its sample buffer",
+            });
+        }
+        let next_consumed =
+            consumed_frames
+                .checked_add(frames)
+                .ok_or(DecodeError::InvalidData {
+                    detail: "presentation consumed-frame counter overflow",
+                })?;
+        let meta = split_meta(&raw.chunk.meta, consumed_frames, frames, total_frames)?;
+        let epoch = raw.epoch;
+        let spec = raw.chunk.spec();
+        let Some(mut pcm) = self.buffers.take(spec)? else {
+            return Ok(None);
+        };
+        let Some(RawItem::Data(raw)) = self.raw.front_mut() else {
+            self.recycle_pcm(spec, pcm)?;
+            return Err(DecodeError::InvalidData {
+                detail: "presentation raw queue changed before slicing",
+            });
+        };
+        let source = &raw.chunk.samples[start_sample..end_sample];
+        pcm[..samples].copy_from_slice(source);
+        pcm.truncate(samples);
+        raw.consumed_frames = next_consumed;
+        if next_consumed >= total_frames {
+            let Some(RawItem::Data(raw)) = self.raw.pop_front() else {
+                self.recycle_pcm(spec, pcm)?;
+                return Err(DecodeError::InvalidData {
+                    detail: "presentation raw queue changed after slicing",
+                });
+            };
+            retire(raw.chunk);
+        }
+        Ok(Some((PcmChunk::new(meta, pcm), epoch)))
+    }
+
+    pub(super) fn output_buffer(&mut self, spec: PcmSpec) -> DecodeResult<Option<(PcmBuf, usize)>> {
+        let channels = usize::from(spec.channels);
+        if channels == 0 {
+            return Err(DecodeError::InvalidData {
+                detail: "tempo stage reported zero output channels",
+            });
+        }
+        Ok(self.buffers.take(spec)?.map(|buffer| (buffer, channels)))
+    }
+
+    pub(super) fn process_effects(&mut self, mut chunk: PcmChunk) -> DecodeResult<PcmChunk> {
+        let error = self.effects.iter_mut().find_map(|effect| {
+            effect
+                .process(AudioBlockMut::new(&chunk.meta, &mut chunk.samples))
+                .err()
+        });
+        if let Some(error) = error {
+            self.recycle_output(chunk);
+            return Err(error);
+        }
+        Ok(chunk)
+    }
+
+    pub(super) fn recycle_pcm(&mut self, spec: PcmSpec, pcm: PcmBuf) -> DecodeResult<()> {
+        let chunk = PcmChunk::new(
+            PcmMeta {
+                spec,
+                ..Default::default()
+            },
+            pcm,
+        );
+        match self.buffers.recycle(chunk) {
+            RecycleOutcome::Recycled => Ok(()),
+            RecycleOutcome::Rejected(failure) => Err(self.defer_recycle_failure(failure)),
+        }
+    }
+
+    pub(super) fn tempo_chunk(
+        &mut self,
+        pcm: PcmBuf,
+        spec: PcmSpec,
+        channels: usize,
+        frames: usize,
+        meta: PcmMeta,
+    ) -> DecodeResult<PcmChunk> {
+        match tempo_chunk(pcm, spec, channels, frames, meta) {
+            Ok(chunk) => Ok(chunk),
+            Err((error, pcm)) => {
+                self.recycle_pcm(spec, pcm)?;
+                Err(error)
+            }
+        }
+    }
+
+    pub(super) fn push_terminal(&mut self, marker: Fetch<PresentedPcm>) -> DecodeResult<()> {
+        self.output
+            .try_push(marker)
+            .map_err(|_| DecodeError::InvalidData {
+                detail: "strict presentation reservation was lost before terminal",
+            })
+    }
+}

--- a/crates/kithara-audio/src/renderer/presentation/coordinator.rs
+++ b/crates/kithara-audio/src/renderer/presentation/coordinator.rs
@@ -1,0 +1,98 @@
+use std::collections::VecDeque;
+
+use kithara_bufpool::PcmPool;
+use kithara_decode::{DecodeError, PcmChunk, PcmSpec};
+
+use super::{
+    frontier::PresentationPublisher,
+    output::{OutputBuffers, PresentedPcm},
+    state::{Discontinuity, RawItem, SourceWindow, Terminal},
+};
+use crate::{
+    pipeline::fetch::Fetch,
+    runtime::StrictOutlet,
+    traits::{AudioEffect, TempoEofDebt, TempoStage},
+};
+
+#[derive(fieldwork::Fieldwork)]
+#[fieldwork(opt_in, get)]
+pub(crate) struct Presentation {
+    pub(super) buffer_error: Option<DecodeError>,
+    pub(super) buffers: OutputBuffers,
+    pub(super) effects: Vec<Box<dyn AudioEffect>>,
+    pub(super) discontinuity: Option<Discontinuity>,
+    pub(super) eof_debt: Option<TempoEofDebt>,
+    #[field(get, vis = "pub(crate)", copy)]
+    pub(super) epoch: u64,
+    pub(super) failure_reset: bool,
+    pub(super) final_committed: bool,
+    pub(super) output: StrictOutlet<Fetch<PresentedPcm>>,
+    pub(super) publisher: PresentationPublisher,
+    pub(super) raw: VecDeque<RawItem>,
+    pub(super) raw_admitted: usize,
+    pub(super) raw_capacity: usize,
+    pub(super) rejected_output: Option<PcmChunk>,
+    pub(super) tempo: Option<Box<dyn TempoStage>>,
+    pub(super) terminal: Option<Terminal>,
+    #[field(get, vis = "pub(crate)", copy)]
+    pub(super) terminal_sent: bool,
+    pub(super) window: SourceWindow,
+}
+
+impl Presentation {
+    pub(crate) fn new(
+        raw_capacity: usize,
+        chain: crate::pipeline::config::PresentationChain,
+        pool: PcmPool,
+        initial_spec: PcmSpec,
+        output: StrictOutlet<Fetch<PresentedPcm>>,
+        publisher: PresentationPublisher,
+        epoch: u64,
+    ) -> Self {
+        let raw_capacity = raw_capacity.max(1);
+        let mut buffers = OutputBuffers::new(pool);
+        let buffer_error = buffers.prepare(initial_spec).err();
+        Self {
+            buffer_error,
+            buffers,
+            effects: chain.effects,
+            discontinuity: None,
+            eof_debt: None,
+            epoch,
+            failure_reset: false,
+            final_committed: false,
+            output,
+            publisher,
+            raw: VecDeque::with_capacity(raw_capacity),
+            raw_admitted: 0,
+            raw_capacity,
+            rejected_output: None,
+            tempo: chain.tempo,
+            terminal: None,
+            terminal_sent: false,
+            window: SourceWindow::default(),
+        }
+    }
+
+    pub(crate) fn is_raw_full(&self) -> bool {
+        let has_capacity = self.has_raw_capacity();
+        !has_capacity
+    }
+
+    pub(crate) const fn is_terminal(&self) -> bool {
+        self.terminal.is_some()
+    }
+
+    pub(crate) fn preload_ready(&self, target: usize) -> bool {
+        let raw_ready = self.raw_ready_for_preload(target);
+        raw_ready && (self.final_committed || self.terminal_sent)
+    }
+
+    pub(crate) fn raw_ready_for_preload(&self, target: usize) -> bool {
+        self.raw_admitted >= target || self.terminal.is_some()
+    }
+
+    pub(crate) const fn terminal_failed(&self) -> bool {
+        matches!(self.terminal, Some(Terminal::Failed { .. }))
+    }
+}

--- a/crates/kithara-audio/src/renderer/presentation/frontier.rs
+++ b/crates/kithara-audio/src/renderer/presentation/frontier.rs
@@ -1,0 +1,188 @@
+use std::{
+    num::NonZeroU32,
+    sync::atomic::{AtomicU32, AtomicU64, Ordering, fence},
+};
+
+use kithara_decode::{DecodeError, DecodeResult, PcmSpec};
+use kithara_platform::sync::Arc;
+
+use crate::traits::PresentationPoint;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub(crate) enum PresentationBarrier {
+    DecoderReplaced { epoch: u64, spec: PcmSpec },
+}
+
+impl PresentationBarrier {
+    pub(crate) const fn epoch(self) -> u64 {
+        match self {
+            Self::DecoderReplaced { epoch, .. } => epoch,
+        }
+    }
+}
+
+struct FrontierInner {
+    epoch: AtomicU64,
+    frame: AtomicU64,
+    generation: AtomicU64,
+    output_end: AtomicU64,
+    rate: AtomicU32,
+    revision: AtomicU64,
+}
+
+/// Read-only coherent endpoint of PCM committed to final output.
+#[derive(Clone)]
+pub(crate) struct PresentationFrontier {
+    inner: Arc<FrontierInner>,
+}
+
+/// Sole writer for one resource's presentation frontier.
+pub(crate) struct PresentationPublisher {
+    frame: u64,
+    generation: u64,
+    inner: Arc<FrontierInner>,
+    output_end: u64,
+    rate: u32,
+}
+
+impl PresentationFrontier {
+    pub(crate) fn point(&self, epoch: u64) -> Option<PresentationPoint> {
+        let point = self.snapshot()?;
+        (point.seek_epoch() == epoch).then_some(point)
+    }
+
+    pub(super) fn snapshot(&self) -> Option<PresentationPoint> {
+        let before = self.inner.revision.load(Ordering::Acquire);
+        if before & 1 != 0 {
+            return None;
+        }
+        let rate = NonZeroU32::new(self.inner.rate.load(Ordering::Relaxed))?;
+        let point = PresentationPoint::new(
+            self.inner.epoch.load(Ordering::Relaxed),
+            self.inner.frame.load(Ordering::Relaxed),
+            self.inner.generation.load(Ordering::Relaxed),
+            self.inner.output_end.load(Ordering::Relaxed),
+            rate,
+        );
+        fence(Ordering::Acquire);
+        let after = self.inner.revision.load(Ordering::Acquire);
+        (before == after).then_some(point)
+    }
+}
+
+impl PresentationPublisher {
+    fn publish(&mut self, point: Option<PresentationPoint>) {
+        let start = self.inner.revision.fetch_add(1, Ordering::AcqRel);
+        debug_assert_eq!(start & 1, 0, "presentation frontier has one writer");
+        if let Some(point) = point {
+            self.inner
+                .epoch
+                .store(point.seek_epoch(), Ordering::Relaxed);
+            self.inner
+                .frame
+                .store(point.source_frame(), Ordering::Relaxed);
+            self.inner
+                .generation
+                .store(point.generation(), Ordering::Relaxed);
+            self.inner
+                .output_end
+                .store(point.output_end(), Ordering::Relaxed);
+            self.inner
+                .rate
+                .store(point.sample_rate().get(), Ordering::Relaxed);
+        } else {
+            self.inner.rate.store(0, Ordering::Relaxed);
+        }
+        self.inner
+            .revision
+            .store(start.wrapping_add(2), Ordering::Release);
+    }
+
+    pub(super) fn prepare_commit(
+        &self,
+        epoch: u64,
+        output_frames: usize,
+        source_end: Option<(u64, u32)>,
+    ) -> DecodeResult<PresentationPoint> {
+        let output_frames = u64::try_from(output_frames).map_err(|_| DecodeError::InvalidData {
+            detail: "presentation output block length exceeds u64",
+        })?;
+        let output_end =
+            self.output_end
+                .checked_add(output_frames)
+                .ok_or(DecodeError::InvalidData {
+                    detail: "presentation output ordinal overflow",
+                })?;
+        let (frame, rate) = source_end.unwrap_or((self.frame, self.rate));
+        let rate = NonZeroU32::new(rate).ok_or(DecodeError::InvalidData {
+            detail: "presentation source sample rate is unavailable",
+        })?;
+        Ok(PresentationPoint::new(
+            epoch,
+            frame,
+            self.generation,
+            output_end,
+            rate,
+        ))
+    }
+
+    pub(super) fn commit(&mut self, point: PresentationPoint) {
+        self.frame = point.source_frame();
+        self.output_end = point.output_end();
+        self.rate = point.sample_rate().get();
+        self.publish(Some(point));
+    }
+
+    pub(super) fn point(&self, epoch: u64) -> Option<PresentationPoint> {
+        let rate = NonZeroU32::new(self.rate)?;
+        Some(PresentationPoint::new(
+            epoch,
+            self.frame,
+            self.generation,
+            self.output_end,
+            rate,
+        ))
+    }
+
+    pub(super) fn reset(&mut self) {
+        self.generation = self.generation.wrapping_add(1);
+        self.frame = 0;
+        self.output_end = 0;
+        self.rate = 0;
+        self.publish(None);
+    }
+
+    pub(super) fn restart(&mut self, epoch: u64, source_end: Option<(u64, u32)>) {
+        self.generation = self.generation.wrapping_add(1);
+        if let Some((frame, rate)) = source_end {
+            self.frame = frame;
+            self.rate = rate;
+        }
+        self.output_end = 0;
+        let point = NonZeroU32::new(self.rate)
+            .map(|rate| PresentationPoint::new(epoch, self.frame, self.generation, 0, rate));
+        self.publish(point);
+    }
+}
+
+pub(crate) fn presentation_cell(epoch: u64) -> (PresentationPublisher, PresentationFrontier) {
+    let inner = Arc::new(FrontierInner {
+        epoch: AtomicU64::new(epoch),
+        frame: AtomicU64::new(0),
+        generation: AtomicU64::new(0),
+        output_end: AtomicU64::new(0),
+        rate: AtomicU32::new(0),
+        revision: AtomicU64::new(0),
+    });
+    (
+        PresentationPublisher {
+            frame: 0,
+            generation: 0,
+            inner: Arc::clone(&inner),
+            output_end: 0,
+            rate: 0,
+        },
+        PresentationFrontier { inner },
+    )
+}

--- a/crates/kithara-audio/src/renderer/presentation/intake.rs
+++ b/crates/kithara-audio/src/renderer/presentation/intake.rs
@@ -1,0 +1,100 @@
+use kithara_decode::{DecodeError, DecodeResult, PcmChunk, PcmSpec};
+
+use super::{
+    coordinator::Presentation,
+    frontier::PresentationBarrier,
+    state::{RawChunk, RawItem},
+};
+use crate::{pipeline::fetch::Fetch, traits::TempoStage};
+
+impl Presentation {
+    #[must_use]
+    pub(crate) fn admit(&mut self, fetch: Fetch<PcmChunk>) -> Option<Fetch<PcmChunk>> {
+        if self.terminal.is_some() || !self.has_raw_capacity() {
+            return Some(fetch);
+        }
+        let Fetch::Data { data, epoch } = fetch else {
+            return Some(fetch);
+        };
+        let Some(raw_admitted) = self.raw_admitted.checked_add(1) else {
+            return Some(Fetch::data(data, epoch));
+        };
+        self.raw.push_back(RawItem::Data(RawChunk {
+            chunk: data,
+            consumed_frames: 0,
+            epoch,
+        }));
+        self.raw_admitted = raw_admitted;
+        None
+    }
+
+    pub(crate) fn admit_barrier(
+        &mut self,
+        barrier: PresentationBarrier,
+    ) -> Result<(), PresentationBarrier> {
+        if barrier.epoch() != self.epoch || self.terminal.is_some() || !self.has_raw_capacity() {
+            return Err(barrier);
+        }
+        self.raw.push_back(RawItem::Barrier(barrier));
+        Ok(())
+    }
+
+    fn charged_source_quanta(&self) -> Option<usize> {
+        let tempo = self
+            .tempo
+            .as_ref()
+            .map_or(0, |tempo| tempo.buffered_source_quanta());
+        self.raw
+            .len()
+            .checked_add(tempo)?
+            .checked_add(usize::from(self.discontinuity.is_some()))
+    }
+
+    pub(super) fn has_raw_capacity(&self) -> bool {
+        matches!(self.charged_source_quanta(), Some(charged) if charged < self.raw_capacity)
+    }
+
+    pub(super) fn checked_tempo_quanta(tempo: &dyn TempoStage) -> DecodeResult<usize> {
+        let buffered = tempo.buffered_source_quanta();
+        if buffered > 1 {
+            return Err(DecodeError::InvalidData {
+                detail: "tempo stage buffered more than one source chunk",
+            });
+        }
+        Ok(buffered)
+    }
+
+    pub(super) fn pending_buffer_spec(&self) -> Option<PcmSpec> {
+        if let Some(PresentationBarrier::DecoderReplaced { spec, .. }) = self
+            .discontinuity
+            .as_ref()
+            .and_then(|discontinuity| discontinuity.barrier)
+        {
+            return Some(spec);
+        }
+        if let Some(RawItem::Barrier(PresentationBarrier::DecoderReplaced { spec, .. })) =
+            self.raw.front()
+        {
+            return Some(*spec);
+        }
+        None
+    }
+
+    pub(super) fn take_source_chunk<F>(&mut self, retire: &mut F) -> DecodeResult<PcmChunk>
+    where
+        F: FnMut(PcmChunk),
+    {
+        let Some(RawItem::Data(raw)) = self.raw.pop_front() else {
+            return Err(DecodeError::InvalidData {
+                detail: "presentation raw queue lost its tempo source",
+            });
+        };
+        if raw.consumed_frames != 0 || raw.chunk.frames() == 0 {
+            retire(raw.chunk);
+            return Err(DecodeError::InvalidData {
+                detail: "presentation received an invalid tempo source chunk",
+            });
+        }
+        Ok(raw.chunk)
+    }
+}

--- a/crates/kithara-audio/src/renderer/presentation/lifecycle.rs
+++ b/crates/kithara-audio/src/renderer/presentation/lifecycle.rs
@@ -1,0 +1,146 @@
+use kithara_decode::{DecodeResult, PcmChunk};
+
+use super::{
+    coordinator::Presentation,
+    state::{DiscontinuityPhase, RawItem, Terminal},
+};
+use crate::traits::TempoPrepareRequest;
+
+impl Presentation {
+    pub(crate) fn service_off_rt(&mut self) {
+        if let Some(tempo) = &mut self.tempo {
+            tempo.release_retired_off_rt();
+        }
+        if self.buffer_error.is_some()
+            || self.terminal_sent
+            || matches!(self.terminal, Some(Terminal::Failed { .. }))
+        {
+            return;
+        }
+        let pending = self.pending_buffer_spec();
+        let tempo_discontinuity_drained = matches!(
+            self.discontinuity
+                .as_ref()
+                .map(|discontinuity| &discontinuity.phase),
+            Some(DiscontinuityPhase::Drained)
+        );
+        let prepare_pending_buffers = self.tempo.is_none() || tempo_discontinuity_drained;
+        if let Some(spec) = pending
+            && prepare_pending_buffers
+            && let Err(error) = self.buffers.prepare(spec)
+        {
+            self.buffer_error = Some(error);
+            return;
+        }
+        if self.discontinuity.is_some() {
+            return;
+        }
+        let Some(tempo) = &mut self.tempo else {
+            return;
+        };
+        let request = pending.map_or_else(
+            || TempoPrepareRequest::Current {
+                spec: tempo.output_spec(),
+            },
+            |spec| TempoPrepareRequest::DecoderBoundary { spec },
+        );
+        if let Err(error) = tempo.service_off_rt(request) {
+            self.buffer_error = Some(error);
+        }
+    }
+
+    pub(crate) fn release_retired_off_rt(&mut self) {
+        if let Some(tempo) = &mut self.tempo {
+            tempo.release_retired_off_rt();
+        }
+    }
+
+    pub(crate) fn release_rejected_off_rt(&mut self) {
+        drop(self.rejected_output.take());
+    }
+
+    pub(crate) fn abort_failed<F>(&mut self, epoch: u64, mut retire: F) -> DecodeResult<()>
+    where
+        F: FnMut(PcmChunk),
+    {
+        self.retire_raw(&mut retire);
+        self.deactivate_chain(&mut retire)?;
+        self.window.clear();
+        self.discontinuity = None;
+        self.eof_debt = None;
+        self.failure_reset = true;
+        self.terminal = Some(Terminal::Failed { epoch });
+        self.terminal_sent = false;
+        Ok(())
+    }
+
+    pub(crate) fn finish_eof(&mut self, epoch: u64) {
+        self.eof_debt = None;
+        self.failure_reset = false;
+        self.terminal = Some(Terminal::Eof { epoch });
+        self.terminal_sent = false;
+    }
+
+    pub(crate) fn finish_failed(&mut self, epoch: u64) {
+        self.eof_debt = None;
+        self.failure_reset = false;
+        self.terminal = Some(Terminal::Failed { epoch });
+        self.terminal_sent = false;
+    }
+
+    pub(crate) fn flush_wake_signals(&self) {
+        self.output.flush_wake_signals();
+    }
+
+    pub(crate) fn reset_epoch<F>(&mut self, epoch: u64, mut retire: F) -> DecodeResult<()>
+    where
+        F: FnMut(PcmChunk),
+    {
+        if self.epoch == epoch {
+            return Ok(());
+        }
+        self.retire_raw(&mut retire);
+        self.deactivate_chain(&mut retire)?;
+        self.window.clear();
+        self.discontinuity = None;
+        self.eof_debt = None;
+        self.epoch = epoch;
+        self.failure_reset = false;
+        self.final_committed = false;
+        self.raw_admitted = 0;
+        self.terminal = None;
+        self.terminal_sent = false;
+        self.publisher.reset();
+        Ok(())
+    }
+
+    pub(super) fn deactivate_chain<F>(&mut self, retire: &mut F) -> DecodeResult<()>
+    where
+        F: FnMut(PcmChunk),
+    {
+        if let Some(tempo) = &mut self.tempo {
+            tempo.deactivate(retire)?;
+        }
+        self.reset_effects();
+        Ok(())
+    }
+
+    pub(super) fn reset_effects(&mut self) {
+        for effect in &mut self.effects {
+            effect.reset();
+        }
+    }
+
+    fn retire_raw<F>(&mut self, retire: &mut F)
+    where
+        F: FnMut(PcmChunk),
+    {
+        let data = self.raw.drain(..).filter_map(|item| match item {
+            RawItem::Data(raw) => Some(raw.chunk),
+            RawItem::Barrier(_) => None,
+        });
+        for chunk in data {
+            retire(chunk);
+        }
+    }
+}

--- a/crates/kithara-audio/src/renderer/presentation/mod.rs
+++ b/crates/kithara-audio/src/renderer/presentation/mod.rs
@@ -13,7 +13,8 @@ pub(crate) use frontier::{
     PresentationBarrier, PresentationFrontier, PresentationPublisher, presentation_cell,
 };
 pub(crate) use output::{
-    PRESENTATION_FRAMES, PRESENTATION_RING_BLOCKS, PresentResult, PresentedBlock, PresentedPcm,
+    OutputDisposition, PRESENTATION_FRAMES, PRESENTATION_RING_BLOCKS, PresentResult,
+    PresentedBlock, PresentedPcm,
 };
 
 #[cfg(test)]

--- a/crates/kithara-audio/src/renderer/presentation/mod.rs
+++ b/crates/kithara-audio/src/renderer/presentation/mod.rs
@@ -1,0 +1,20 @@
+mod boundary;
+mod commit;
+mod coordinator;
+mod frontier;
+mod intake;
+mod lifecycle;
+mod output;
+mod render;
+mod state;
+
+pub(crate) use coordinator::Presentation;
+pub(crate) use frontier::{
+    PresentationBarrier, PresentationFrontier, PresentationPublisher, presentation_cell,
+};
+pub(crate) use output::{
+    PRESENTATION_FRAMES, PRESENTATION_RING_BLOCKS, PresentResult, PresentedBlock, PresentedPcm,
+};
+
+#[cfg(test)]
+mod tests;

--- a/crates/kithara-audio/src/renderer/presentation/output.rs
+++ b/crates/kithara-audio/src/renderer/presentation/output.rs
@@ -1,6 +1,7 @@
 use kithara_bufpool::{PcmBuf, PcmPool};
 use kithara_decode::{DecodeError, DecodeResult, PcmChunk, PcmMeta, PcmSpec, duration_for_frames};
 
+use super::coordinator::Presentation;
 use crate::traits::PresentationPoint;
 
 /// Fixed output quantum produced by the late presentation stage.
@@ -39,12 +40,32 @@ impl PresentedPcm {
     pub(crate) fn new(chunk: PcmChunk, point: PresentationPoint) -> Self {
         Self { chunk, point }
     }
+
+    pub(crate) fn returned(self) -> OutputDisposition {
+        OutputDisposition::Returned(self.chunk)
+    }
+
+    pub(crate) fn detach(self) -> (PcmChunk, OutputDisposition) {
+        let spec = self.chunk.spec();
+        (self.chunk, OutputDisposition::Detached(spec))
+    }
+
+    pub(crate) fn into_inner(self) -> PcmChunk {
+        self.chunk
+    }
 }
 
+#[cfg(test)]
 impl From<PresentedPcm> for PcmChunk {
     fn from(presented: PresentedPcm) -> Self {
-        presented.chunk
+        presented.into_inner()
     }
+}
+
+#[derive(Debug)]
+pub(crate) enum OutputDisposition {
+    Returned(PcmChunk),
+    Detached(PcmSpec),
 }
 
 pub(super) struct OutputBuffers {
@@ -62,6 +83,17 @@ pub(super) struct RecycleFailure {
 pub(super) enum RecycleOutcome {
     Recycled,
     Rejected(RecycleFailure),
+}
+
+pub(super) struct RestoreFailure {
+    pub(super) disposition: OutputDisposition,
+    pub(super) error: DecodeError,
+}
+
+#[must_use]
+pub(super) enum RestoreOutcome {
+    Restored,
+    Rejected(RestoreFailure),
 }
 
 impl OutputBuffers {
@@ -155,6 +187,64 @@ impl OutputBuffers {
         buffer.clear();
         self.free.push(buffer);
         RecycleOutcome::Recycled
+    }
+
+    pub(super) fn restore(&mut self, disposition: OutputDisposition) -> RestoreOutcome {
+        match disposition {
+            OutputDisposition::Returned(chunk) => match self.recycle(chunk) {
+                RecycleOutcome::Recycled => RestoreOutcome::Restored,
+                RecycleOutcome::Rejected(RecycleFailure { chunk, error }) => {
+                    RestoreOutcome::Rejected(RestoreFailure {
+                        disposition: OutputDisposition::Returned(chunk),
+                        error,
+                    })
+                }
+            },
+            OutputDisposition::Detached(spec) => self.replace_detached(spec).map_or_else(
+                |error| {
+                    RestoreOutcome::Rejected(RestoreFailure {
+                        disposition: OutputDisposition::Detached(spec),
+                        error,
+                    })
+                },
+                |()| RestoreOutcome::Restored,
+            ),
+        }
+    }
+
+    fn replace_detached(&mut self, spec: PcmSpec) -> DecodeResult<()> {
+        if self.free.len() >= PRESENTATION_OUTPUT_BUFFERS {
+            return Err(DecodeError::InvalidData {
+                detail: "presentation output reserve received an extra detachment",
+            });
+        }
+        if self.spec != Some(spec) {
+            return Err(DecodeError::InvalidData {
+                detail: "presentation output reserve received a stale detached PCM shape",
+            });
+        }
+        let samples = output_samples(spec)?;
+        let mut buffer = self.pool.get();
+        buffer
+            .ensure_len(samples)
+            .map_err(|error| DecodeError::pcm_stream("detached presentation replacement", error))?;
+        buffer.clear();
+        self.free.push(buffer);
+        Ok(())
+    }
+}
+
+impl Presentation {
+    pub(crate) fn restore_output(&mut self, disposition: OutputDisposition) {
+        let RestoreOutcome::Rejected(failure) = self.buffers.restore(disposition) else {
+            return;
+        };
+        let RestoreFailure { disposition, error } = failure;
+        if let OutputDisposition::Returned(chunk) = disposition {
+            debug_assert!(self.rejected_output.is_none());
+            self.rejected_output = Some(chunk);
+        }
+        self.buffer_error = Some(error);
     }
 }
 
@@ -294,4 +384,104 @@ pub(super) fn split_meta(
         };
     }
     Ok(split)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU32;
+
+    use kithara_test_utils::kithara;
+
+    use super::*;
+
+    fn test_spec() -> PcmSpec {
+        PcmSpec::new(
+            2,
+            NonZeroU32::new(48_000).expect("test sample rate is non-zero"),
+        )
+    }
+
+    fn output_chunk(spec: PcmSpec, samples: PcmBuf) -> PcmChunk {
+        PcmChunk::new(
+            PcmMeta {
+                spec,
+                frames: u32::try_from(PRESENTATION_FRAMES)
+                    .expect("presentation frame count fits u32"),
+                ..Default::default()
+            },
+            samples,
+        )
+    }
+
+    #[kithara::test]
+    fn mixed_returned_and_detached_outputs_restore_the_bounded_reserve() {
+        let spec = test_spec();
+        let mut buffers = OutputBuffers::new(PcmPool::default());
+        assert!(
+            buffers
+                .prepare(spec)
+                .expect("initial output reserve prepares")
+        );
+        let returned_first = buffers
+            .take(spec)
+            .expect("prepared reserve is valid")
+            .expect("first resident buffer is available");
+        let detached = buffers
+            .take(spec)
+            .expect("prepared reserve is valid")
+            .expect("second resident buffer is available");
+        let returned_last = buffers
+            .take(spec)
+            .expect("prepared reserve is valid")
+            .expect("third resident buffer is available");
+        assert!(
+            buffers
+                .prepare(spec)
+                .expect("same-spec preparation remains valid")
+        );
+        assert!(
+            buffers
+                .take(spec)
+                .expect("same-spec reserve remains valid")
+                .is_none(),
+            "same-spec preparation must not top up in-flight outputs"
+        );
+
+        assert!(matches!(
+            buffers.restore(OutputDisposition::Returned(output_chunk(
+                spec,
+                returned_first
+            ))),
+            RestoreOutcome::Restored
+        ));
+        assert!(matches!(
+            buffers.restore(OutputDisposition::Detached(spec)),
+            RestoreOutcome::Restored
+        ));
+        assert!(matches!(
+            buffers.restore(OutputDisposition::Returned(output_chunk(
+                spec,
+                returned_last
+            ))),
+            RestoreOutcome::Restored
+        ));
+
+        for _ in 0..PRESENTATION_OUTPUT_BUFFERS {
+            assert!(
+                buffers
+                    .take(spec)
+                    .expect("restored reserve is valid")
+                    .is_some(),
+                "each disposition must restore one resident output"
+            );
+        }
+        assert!(
+            buffers
+                .take(spec)
+                .expect("restored reserve remains valid")
+                .is_none(),
+            "the output reserve remains bounded"
+        );
+        drop(detached);
+    }
 }

--- a/crates/kithara-audio/src/renderer/presentation/output.rs
+++ b/crates/kithara-audio/src/renderer/presentation/output.rs
@@ -1,0 +1,297 @@
+use kithara_bufpool::{PcmBuf, PcmPool};
+use kithara_decode::{DecodeError, DecodeResult, PcmChunk, PcmMeta, PcmSpec, duration_for_frames};
+
+use crate::traits::PresentationPoint;
+
+/// Fixed output quantum produced by the late presentation stage.
+pub(crate) const PRESENTATION_FRAMES: usize = 512;
+
+/// Two blocks can wait in the strict final ring while one is owned by the
+/// consumer's current-chunk cursor.
+pub(crate) const PRESENTATION_RING_BLOCKS: usize = 2;
+const PRESENTATION_OUTPUT_BUFFERS: usize = PRESENTATION_RING_BLOCKS + 1;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct PresentedBlock {
+    pub(crate) frames: usize,
+    pub(crate) sample_rate: u32,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum PresentResult {
+    Advanced,
+    Backpressured,
+    Idle,
+    Produced(PresentedBlock),
+    Terminal,
+}
+
+#[derive(Debug, fieldwork::Fieldwork)]
+#[fieldwork(opt_in, get)]
+pub(crate) struct PresentedPcm {
+    #[field(get, vis = "pub(crate)")]
+    chunk: PcmChunk,
+    #[field(get, vis = "pub(crate)", copy)]
+    point: PresentationPoint,
+}
+
+impl PresentedPcm {
+    pub(crate) fn new(chunk: PcmChunk, point: PresentationPoint) -> Self {
+        Self { chunk, point }
+    }
+}
+
+impl From<PresentedPcm> for PcmChunk {
+    fn from(presented: PresentedPcm) -> Self {
+        presented.chunk
+    }
+}
+
+pub(super) struct OutputBuffers {
+    free: Vec<PcmBuf>,
+    pool: PcmPool,
+    pub(super) spec: Option<PcmSpec>,
+}
+
+pub(super) struct RecycleFailure {
+    pub(super) chunk: PcmChunk,
+    pub(super) error: DecodeError,
+}
+
+#[must_use]
+pub(super) enum RecycleOutcome {
+    Recycled,
+    Rejected(RecycleFailure),
+}
+
+impl OutputBuffers {
+    pub(super) fn new(pool: PcmPool) -> Self {
+        Self {
+            free: Vec::with_capacity(PRESENTATION_OUTPUT_BUFFERS),
+            pool,
+            spec: None,
+        }
+    }
+
+    pub(super) fn prepare(&mut self, spec: PcmSpec) -> DecodeResult<bool> {
+        if self.spec == Some(spec) {
+            return Ok(true);
+        }
+        if self.spec.is_some() && self.free.len() != PRESENTATION_OUTPUT_BUFFERS {
+            return Ok(false);
+        }
+        let samples = output_samples(spec)?;
+        while self.free.len() < PRESENTATION_OUTPUT_BUFFERS {
+            self.free.push(self.pool.get());
+        }
+        for buffer in &mut self.free {
+            buffer
+                .ensure_len(samples)
+                .map_err(|error| DecodeError::pcm_stream("presentation buffer reserve", error))?;
+            buffer.clear();
+        }
+        self.spec = Some(spec);
+        Ok(true)
+    }
+
+    pub(super) fn take(&mut self, spec: PcmSpec) -> DecodeResult<Option<PcmBuf>> {
+        if self.spec != Some(spec) {
+            return Ok(None);
+        }
+        let Some(mut buffer) = self.free.pop() else {
+            return Ok(None);
+        };
+        let samples = output_samples(spec)?;
+        if buffer.capacity() < samples {
+            self.free.push(buffer);
+            return Err(DecodeError::InvalidData {
+                detail: "presentation output reserve is smaller than its prepared PCM shape",
+            });
+        }
+        buffer.clear();
+        if buffer.ensure_len(samples).is_err() {
+            self.free.push(buffer);
+            return Err(DecodeError::InvalidData {
+                detail: "presentation output reserve grew on the real-time path",
+            });
+        }
+        Ok(Some(buffer))
+    }
+
+    pub(super) fn recycle(&mut self, chunk: PcmChunk) -> RecycleOutcome {
+        if self.free.len() >= PRESENTATION_OUTPUT_BUFFERS {
+            return RecycleOutcome::Rejected(RecycleFailure {
+                chunk,
+                error: DecodeError::InvalidData {
+                    detail: "presentation output reserve received an extra buffer",
+                },
+            });
+        }
+        let spec = chunk.spec();
+        if self.spec != Some(spec) {
+            return RecycleOutcome::Rejected(RecycleFailure {
+                chunk,
+                error: DecodeError::InvalidData {
+                    detail: "presentation output reserve received a stale PCM shape",
+                },
+            });
+        }
+        let samples = match output_samples(spec) {
+            Ok(samples) => samples,
+            Err(error) => return RecycleOutcome::Rejected(RecycleFailure { chunk, error }),
+        };
+        if chunk.samples.capacity() < samples {
+            return RecycleOutcome::Rejected(RecycleFailure {
+                chunk,
+                error: DecodeError::InvalidData {
+                    detail: "presentation output reserve received a short buffer",
+                },
+            });
+        }
+        let PcmChunk {
+            samples: mut buffer,
+            ..
+        } = chunk;
+        buffer.clear();
+        self.free.push(buffer);
+        RecycleOutcome::Recycled
+    }
+}
+
+pub(super) fn tempo_chunk(
+    mut pcm: PcmBuf,
+    spec: PcmSpec,
+    channels: usize,
+    frames: usize,
+    mut meta: PcmMeta,
+) -> Result<PcmChunk, (DecodeError, PcmBuf)> {
+    if frames == 0 || frames > PRESENTATION_FRAMES {
+        return Err((
+            DecodeError::InvalidData {
+                detail: "tempo stage violated its output frame credit",
+            },
+            pcm,
+        ));
+    }
+    if meta.spec != spec {
+        return Err((
+            DecodeError::InvalidData {
+                detail: "tempo stage output spec disagrees with its declared spec",
+            },
+            pcm,
+        ));
+    }
+    let Some(samples) = frames.checked_mul(channels) else {
+        return Err((
+            DecodeError::InvalidData {
+                detail: "tempo output sample count overflow",
+            },
+            pcm,
+        ));
+    };
+    if samples > pcm.len() {
+        return Err((
+            DecodeError::InvalidData {
+                detail: "tempo stage wrote beyond its output credit",
+            },
+            pcm,
+        ));
+    }
+    pcm.truncate(samples);
+    let Ok(meta_frames) = u32::try_from(frames) else {
+        return Err((
+            DecodeError::InvalidData {
+                detail: "tempo output frame count exceeds u32",
+            },
+            pcm,
+        ));
+    };
+    meta.frames = meta_frames;
+    Ok(PcmChunk::new(meta, pcm))
+}
+
+fn output_samples(spec: PcmSpec) -> DecodeResult<usize> {
+    let channels = usize::from(spec.channels);
+    if channels == 0 {
+        return Err(DecodeError::InvalidData {
+            detail: "presentation output has zero channels",
+        });
+    }
+    PRESENTATION_FRAMES
+        .checked_mul(channels)
+        .ok_or(DecodeError::InvalidData {
+            detail: "presentation output sample capacity overflow",
+        })
+}
+
+pub(super) fn split_meta(
+    meta: &PcmMeta,
+    offset: usize,
+    frames: usize,
+    total: usize,
+) -> DecodeResult<PcmMeta> {
+    let mut split = *meta;
+    let rate = meta.spec.sample_rate.get();
+    let offset_u64 = u64::try_from(offset).map_err(|_| DecodeError::InvalidData {
+        detail: "presentation frame offset exceeds u64",
+    })?;
+    let frames_u64 = u64::try_from(frames).map_err(|_| DecodeError::InvalidData {
+        detail: "presentation block length exceeds u64",
+    })?;
+    split.frame_offset =
+        meta.frame_offset
+            .checked_add(offset_u64)
+            .ok_or(DecodeError::InvalidData {
+                detail: "presentation frame offset overflow",
+            })?;
+    split.timestamp = meta
+        .timestamp
+        .checked_add(duration_for_frames(rate, offset_u64))
+        .ok_or(DecodeError::InvalidData {
+            detail: "presentation timestamp overflow",
+        })?;
+    split.end_timestamp = split
+        .timestamp
+        .checked_add(duration_for_frames(rate, frames_u64))
+        .ok_or(DecodeError::InvalidData {
+            detail: "presentation end timestamp overflow",
+        })?;
+    split.frames = u32::try_from(frames).map_err(|_| DecodeError::InvalidData {
+        detail: "presentation block length exceeds u32",
+    })?;
+    if total > 0 && meta.source_bytes > 0 {
+        let total_u128 = u128::try_from(total).map_err(|_| DecodeError::InvalidData {
+            detail: "presentation source frame count exceeds u128",
+        })?;
+        let offset_u128 = u128::try_from(offset).map_err(|_| DecodeError::InvalidData {
+            detail: "presentation source offset exceeds u128",
+        })?;
+        let source_bytes = u128::from(meta.source_bytes);
+        let start = u64::try_from(source_bytes * offset_u128 / total_u128).map_err(|_| {
+            DecodeError::InvalidData {
+                detail: "presentation source byte offset exceeds u64",
+            }
+        })?;
+        let end_offset = offset.checked_add(frames).ok_or(DecodeError::InvalidData {
+            detail: "presentation source range overflow",
+        })?;
+        let end_offset_u128 = u128::try_from(end_offset).map_err(|_| DecodeError::InvalidData {
+            detail: "presentation source end exceeds u128",
+        })?;
+        let end = u64::try_from(source_bytes * end_offset_u128 / total_u128).map_err(|_| {
+            DecodeError::InvalidData {
+                detail: "presentation source byte end exceeds u64",
+            }
+        })?;
+        split.source_bytes = end.checked_sub(start).ok_or(DecodeError::InvalidData {
+            detail: "presentation source byte range is reversed",
+        })?;
+        split.source_byte_offset = match meta.source_byte_offset {
+            Some(source) => Some(source.checked_add(start).ok_or(DecodeError::InvalidData {
+                detail: "presentation absolute source byte offset overflow",
+            })?),
+            None => None,
+        };
+    }
+    Ok(split)
+}

--- a/crates/kithara-audio/src/renderer/presentation/render.rs
+++ b/crates/kithara-audio/src/renderer/presentation/render.rs
@@ -1,0 +1,160 @@
+use kithara_decode::{DecodeError, DecodeResult, PcmChunk};
+
+use super::{
+    PRESENTATION_FRAMES,
+    coordinator::Presentation,
+    frontier::PresentationBarrier,
+    output::PresentResult,
+    state::{Discontinuity, DiscontinuityPhase, RawItem},
+};
+use crate::traits::{OutputCredit, TempoStage, TempoStep};
+
+impl Presentation {
+    pub(crate) fn step<F>(&mut self, mut retire: F) -> DecodeResult<PresentResult>
+    where
+        F: FnMut(PcmChunk),
+    {
+        if let Some(error) = self.buffer_error.take() {
+            return Err(error);
+        }
+        if self.rejected_output.is_some() {
+            return Err(DecodeError::InvalidData {
+                detail: "presentation rejected output awaits off-RT retirement",
+            });
+        }
+        if !self.output.has_capacity() {
+            return Ok(PresentResult::Backpressured);
+        }
+        let Some(mut tempo) = self.tempo.take() else {
+            return self.step_identity(&mut retire);
+        };
+        let result = self.step_tempo(tempo.as_mut(), &mut retire);
+        self.tempo = Some(tempo);
+        result
+    }
+
+    fn step_identity<F>(&mut self, retire: &mut F) -> DecodeResult<PresentResult>
+    where
+        F: FnMut(PcmChunk),
+    {
+        if let Some(RawItem::Barrier(PresentationBarrier::DecoderReplaced { spec, .. })) =
+            self.raw.front()
+            && self.buffers.spec != Some(*spec)
+        {
+            return Ok(PresentResult::Backpressured);
+        }
+        if matches!(self.raw.front(), Some(RawItem::Barrier(_))) {
+            let barrier = self.take_barrier()?;
+            return Ok(self.apply_barrier(barrier));
+        }
+        if self.raw.front().is_some() {
+            let Some((chunk, epoch)) = self.next_block(retire)? else {
+                return Ok(PresentResult::Backpressured);
+            };
+            let chunk = self.window.admit(chunk);
+            let output = self.process_effects(chunk)?;
+            return self.commit(output, epoch, 0);
+        }
+        self.finish_terminal(None, retire)
+    }
+
+    fn step_tempo<F>(
+        &mut self,
+        tempo: &mut dyn TempoStage,
+        retire: &mut F,
+    ) -> DecodeResult<PresentResult>
+    where
+        F: FnMut(PcmChunk),
+    {
+        if self.discontinuity.is_some() {
+            return self.render_discontinuity(tempo, retire);
+        }
+        let buffered = Self::checked_tempo_quanta(tempo)?;
+        if let Some(boundary) = tempo.prepared_boundary() {
+            let barrier = if buffered == 0 && matches!(self.raw.front(), Some(RawItem::Barrier(_)))
+            {
+                Some(self.take_barrier()?)
+            } else {
+                None
+            };
+            self.discontinuity = Some(Discontinuity {
+                barrier,
+                boundary,
+                phase: DiscontinuityPhase::Draining(tempo.begin_discontinuity()?),
+            });
+            return Ok(PresentResult::Advanced);
+        }
+        if buffered == 1 {
+            return self.render_tempo(tempo, retire);
+        }
+        if matches!(self.raw.front(), Some(RawItem::Barrier(_))) {
+            return Ok(PresentResult::Advanced);
+        }
+        if self.raw.front().is_some() {
+            let chunk = self.take_source_chunk(retire)?;
+            let chunk = self.window.admit(chunk);
+            tempo.push_source(chunk)?;
+            if Self::checked_tempo_quanta(tempo)? != 1 {
+                return Err(DecodeError::InvalidData {
+                    detail: "tempo stage did not retain its admitted source chunk",
+                });
+            }
+            return Ok(PresentResult::Advanced);
+        }
+        self.finish_terminal(Some(tempo), retire)
+    }
+
+    fn render_tempo<F>(
+        &mut self,
+        tempo: &mut dyn TempoStage,
+        retire: &mut F,
+    ) -> DecodeResult<PresentResult>
+    where
+        F: FnMut(PcmChunk),
+    {
+        let spec = tempo.output_spec();
+        let Some((mut pcm, channels)) = self.output_buffer(spec)? else {
+            return Ok(PresentResult::Backpressured);
+        };
+        let step = match tempo.render(
+            self.publisher.point(self.epoch),
+            OutputCredit::new(&mut pcm, channels, PRESENTATION_FRAMES),
+            retire,
+        ) {
+            Ok(step) => step,
+            Err(error) => {
+                self.recycle_pcm(spec, pcm)?;
+                return Err(error);
+            }
+        };
+        match step {
+            TempoStep::Preparing => {
+                self.recycle_pcm(spec, pcm)?;
+                Ok(PresentResult::Advanced)
+            }
+            TempoStep::Consumed => {
+                self.recycle_pcm(spec, pcm)?;
+                if Self::checked_tempo_quanta(tempo)? != 1 {
+                    return Err(DecodeError::InvalidData {
+                        detail: "tempo stage lost its partially consumed source chunk",
+                    });
+                }
+                Ok(PresentResult::Advanced)
+            }
+            TempoStep::NeedSource => {
+                self.recycle_pcm(spec, pcm)?;
+                if Self::checked_tempo_quanta(tempo)? != 0 {
+                    return Err(DecodeError::InvalidData {
+                        detail: "tempo stage requested source while retaining a chunk",
+                    });
+                }
+                Ok(PresentResult::Advanced)
+            }
+            TempoStep::Rendered { frames, meta } => {
+                let chunk = self.tempo_chunk(pcm, spec, channels, frames, meta)?;
+                let output = self.process_effects(chunk)?;
+                self.commit(output, self.epoch, tempo.held_source_frames())
+            }
+        }
+    }
+}

--- a/crates/kithara-audio/src/renderer/presentation/state.rs
+++ b/crates/kithara-audio/src/renderer/presentation/state.rs
@@ -1,0 +1,67 @@
+use kithara_decode::PcmChunk;
+
+use super::frontier::PresentationBarrier;
+use crate::traits::{TempoBoundaryId, TempoDiscontinuityDebt};
+
+pub(super) struct RawChunk {
+    pub(super) chunk: PcmChunk,
+    pub(super) consumed_frames: usize,
+    pub(super) epoch: u64,
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct SourceEnd {
+    pub(super) frame: u64,
+    pub(super) rate: u32,
+}
+
+#[derive(Default)]
+pub(super) struct SourceWindow {
+    admitted: Option<SourceEnd>,
+}
+
+impl SourceWindow {
+    pub(super) fn admit(&mut self, chunk: PcmChunk) -> PcmChunk {
+        self.admitted = Some(SourceEnd {
+            frame: chunk
+                .meta
+                .frame_offset
+                .saturating_add(u64::from(chunk.meta.frames)),
+            rate: chunk.meta.spec.sample_rate.get(),
+        });
+        chunk
+    }
+
+    pub(super) fn emitted(&self, held_source_frames: u64) -> Option<SourceEnd> {
+        self.admitted.map(|admitted| SourceEnd {
+            frame: admitted.frame.saturating_sub(held_source_frames),
+            ..admitted
+        })
+    }
+
+    pub(super) fn clear(&mut self) {
+        self.admitted = None;
+    }
+}
+
+pub(super) enum RawItem {
+    Barrier(PresentationBarrier),
+    Data(RawChunk),
+}
+
+#[derive(Clone, Copy)]
+pub(super) enum Terminal {
+    Eof { epoch: u64 },
+    Failed { epoch: u64 },
+}
+
+pub(super) struct Discontinuity {
+    pub(super) barrier: Option<PresentationBarrier>,
+    pub(super) boundary: TempoBoundaryId,
+    pub(super) phase: DiscontinuityPhase,
+}
+
+pub(super) enum DiscontinuityPhase {
+    Draining(TempoDiscontinuityDebt),
+    Drained,
+}

--- a/crates/kithara-audio/src/renderer/presentation/state.rs
+++ b/crates/kithara-audio/src/renderer/presentation/state.rs
@@ -22,12 +22,14 @@ pub(super) struct SourceWindow {
 
 impl SourceWindow {
     pub(super) fn admit(&mut self, chunk: PcmChunk) -> PcmChunk {
+        let rate = chunk.meta.spec.sample_rate.get();
+        let start = self
+            .admitted
+            .filter(|admitted| admitted.rate == rate)
+            .map_or(chunk.meta.frame_offset, |admitted| admitted.frame);
         self.admitted = Some(SourceEnd {
-            frame: chunk
-                .meta
-                .frame_offset
-                .saturating_add(u64::from(chunk.meta.frames)),
-            rate: chunk.meta.spec.sample_rate.get(),
+            frame: start.saturating_add(u64::from(chunk.meta.frames)),
+            rate,
         });
         chunk
     }

--- a/crates/kithara-audio/src/renderer/presentation/tests/identity.rs
+++ b/crates/kithara-audio/src/renderer/presentation/tests/identity.rs
@@ -247,6 +247,116 @@ fn final_payload_carries_the_exact_committed_presentation_point() {
 }
 
 #[kithara::test]
+fn source_progress_ignores_decoder_timestamp_gaps_after_the_first_chunk() {
+    let (output, mut input) = connect_strict(1, None);
+    let (publisher, _) = presentation_cell(0);
+    let mut presentation = Presentation::new(
+        2,
+        PresentationChain::identity(Vec::new()),
+        PcmPool::default(),
+        spec(44_100),
+        output,
+        publisher,
+        0,
+    );
+    admit(
+        &mut presentation,
+        Fetch::data(chunk(1.0, 0), 0),
+        "first raw chunk fits",
+    );
+    admit(
+        &mut presentation,
+        Fetch::data(chunk(2.0, 1_173), 0),
+        "timestamp-gapped raw chunk fits",
+    );
+
+    assert!(matches!(
+        step(&mut presentation),
+        PresentResult::Produced(_)
+    ));
+    let Fetch::Data { data: first, .. } = input.try_pop().expect("first output") else {
+        panic!("expected first output data");
+    };
+    assert_eq!(first.point().source_frame(), 512);
+    presentation.recycle_output(first.into());
+
+    assert!(matches!(
+        step(&mut presentation),
+        PresentResult::Produced(_)
+    ));
+    let Fetch::Data { data: second, .. } = input.try_pop().expect("second output") else {
+        panic!("expected second output data");
+    };
+    assert_eq!(
+        second.point().source_frame(),
+        1_024,
+        "presentation source progress follows admitted PCM, not decoder head-strip gaps"
+    );
+    presentation.recycle_output(second.into());
+}
+
+#[kithara::test]
+fn same_rate_decoder_barrier_preserves_cumulative_admitted_source_end() {
+    let (output, mut input) = connect_strict(1, None);
+    let (publisher, _) = presentation_cell(0);
+    let mut presentation = Presentation::new(
+        3,
+        PresentationChain::identity(Vec::new()),
+        PcmPool::default(),
+        spec(44_100),
+        output,
+        publisher,
+        0,
+    );
+    admit(
+        &mut presentation,
+        Fetch::data(chunk(1.0, 0), 0),
+        "old decoder chunk fits",
+    );
+    presentation
+        .admit_barrier(PresentationBarrier::DecoderReplaced {
+            epoch: 0,
+            spec: spec(44_100),
+        })
+        .expect("same-rate decoder barrier fits");
+    admit(
+        &mut presentation,
+        Fetch::data(chunk(2.0, 1_173), 0),
+        "replacement decoder chunk fits",
+    );
+
+    assert!(matches!(
+        step(&mut presentation),
+        PresentResult::Produced(_)
+    ));
+    let Fetch::Data { data: old, .. } = input.try_pop().expect("old decoder output") else {
+        panic!("expected old decoder data");
+    };
+    assert_eq!(old.point().generation(), 0);
+    assert_eq!(old.point().source_frame(), 512);
+    presentation.recycle_output(old.into());
+
+    assert_eq!(step(&mut presentation), PresentResult::Advanced);
+    assert!(matches!(
+        step(&mut presentation),
+        PresentResult::Produced(_)
+    ));
+    let Fetch::Data {
+        data: replacement, ..
+    } = input.try_pop().expect("replacement decoder output")
+    else {
+        panic!("expected replacement decoder data");
+    };
+    assert_eq!(replacement.point().generation(), 1);
+    assert_eq!(
+        replacement.point().source_frame(),
+        1_024,
+        "same-rate replacement continues from admitted source end instead of decoder timestamps"
+    );
+    presentation.recycle_output(replacement.into());
+}
+
+#[kithara::test]
 fn custom_effect_receives_fixed_shape_block() {
     let seen = Arc::new(AtomicUsize::new(0));
     let (mut presentation, mut input) = identity_presentation(vec![Box::new(StampEffect {

--- a/crates/kithara-audio/src/renderer/presentation/tests/identity.rs
+++ b/crates/kithara-audio/src/renderer/presentation/tests/identity.rs
@@ -1,0 +1,273 @@
+use super::*;
+
+#[kithara::test]
+fn identity_path_is_frame_preserving_without_tempo() {
+    let seen = Arc::new(AtomicUsize::new(0));
+    let (mut presentation, mut input) = identity_presentation(vec![Box::new(StampEffect {
+        resets: None,
+        seen_frames: Arc::clone(&seen),
+        value: 3.0,
+    })]);
+    admit(
+        &mut presentation,
+        Fetch::data(chunk(1.0, 0), 0),
+        "raw chunk fits",
+    );
+
+    assert!(matches!(
+        presentation.step(|_| {}),
+        Ok(PresentResult::Produced(PresentedBlock {
+            frames: PRESENTATION_FRAMES,
+            ..
+        }))
+    ));
+    let output = data(&mut presentation, input.try_pop().expect("identity output"));
+    assert_eq!(output.frames(), PRESENTATION_FRAMES);
+    assert_eq!(output.samples[0], 3.0);
+    assert_eq!(seen.load(Ordering::Acquire), PRESENTATION_FRAMES);
+}
+
+#[kithara::test]
+fn identity_path_commits_a_short_decoder_chunk_without_padding() {
+    const FRAMES: usize = 128;
+    let stereo = PcmSpec::new(
+        2,
+        NonZeroU32::new(44_100).expect("test sample rate is non-zero"),
+    );
+    let (output, mut input) = connect_strict(1, None);
+    let (publisher, _) = presentation_cell(0);
+    let mut presentation = Presentation::new(
+        1,
+        PresentationChain::identity(Vec::new()),
+        PcmPool::default(),
+        stereo,
+        output,
+        publisher,
+        0,
+    );
+    let mut meta = PcmMeta::default();
+    meta.spec = stereo;
+    meta.frames = u32::try_from(FRAMES).expect("test frame count fits u32");
+    let samples = FRAMES * usize::from(stereo.channels);
+    let chunk = PcmChunk::new(meta, PcmPool::default().attach(vec![0.25; samples]));
+    admit(
+        &mut presentation,
+        Fetch::data(chunk, 0),
+        "short raw chunk fits",
+    );
+
+    assert!(matches!(
+        presentation.step(|_| {}),
+        Ok(PresentResult::Produced(PresentedBlock {
+            frames: FRAMES,
+            ..
+        }))
+    ));
+    let output = data(
+        &mut presentation,
+        input.try_pop().expect("short output is committed"),
+    );
+    assert_eq!(output.frames(), FRAMES);
+    assert_eq!(output.samples.len(), samples);
+    assert!(output.samples.iter().all(|sample| *sample == 0.25));
+}
+
+#[kithara::test]
+fn underprovisioned_shared_pool_is_reserved_before_identity_rt_step() {
+    let pool = PcmPool::new(128, 200_000);
+    pool.pre_warm(1, |buffer| buffer.resize(1, 0.0));
+    assert_ne!(pool.allocated_bytes(), 0, "fixture pool starts non-empty");
+    let (output, mut input) = connect_strict(1, None);
+    let (publisher, _) = presentation_cell(0);
+    let mut presentation = Presentation::new(
+        1,
+        PresentationChain::identity(Vec::new()),
+        pool.clone(),
+        spec(44_100),
+        output,
+        publisher,
+        0,
+    );
+    admit(
+        &mut presentation,
+        Fetch::data(chunk(1.0, 0), 0),
+        "raw block fits",
+    );
+    let misses = pool.stats().alloc_misses;
+    let mut retired = None;
+
+    assert!(matches!(
+        guarded_step(&mut presentation, &mut retired),
+        Ok(PresentResult::Produced(_))
+    ));
+    assert_eq!(pool.stats().alloc_misses, misses);
+
+    drop(retired.take());
+    let Fetch::Data { data, .. } = input.try_pop().expect("identity output") else {
+        panic!("expected identity PCM");
+    };
+    presentation.recycle_output(data.into());
+}
+
+#[kithara::test]
+fn tempo_rt_step_uses_only_the_local_output_reserve() {
+    let pool = PcmPool::new(128, 200_000);
+    pool.pre_warm(1, |buffer| buffer.resize(8, 0.0));
+    let tempo = SlowStage::new(Arc::new(AtomicUsize::new(0)), 0);
+    let (output, mut input) = connect_strict(1, None);
+    let (publisher, _) = presentation_cell(0);
+    let mut presentation = Presentation::new(
+        1,
+        PresentationChain {
+            effects: Vec::new(),
+            tempo: Some(Box::new(tempo)),
+        },
+        pool.clone(),
+        spec(44_100),
+        output,
+        publisher,
+        0,
+    );
+    admit(
+        &mut presentation,
+        Fetch::data(chunk(1.0, 0), 0),
+        "raw block fits",
+    );
+    let misses = pool.stats().alloc_misses;
+    let mut retired = None;
+
+    assert_eq!(
+        guarded_step(&mut presentation, &mut retired).expect("tempo admit step"),
+        PresentResult::Advanced
+    );
+    assert!(matches!(
+        guarded_step(&mut presentation, &mut retired),
+        Ok(PresentResult::Produced(_))
+    ));
+    assert_eq!(pool.stats().alloc_misses, misses);
+
+    drop(retired.take());
+    let Fetch::Data { data, .. } = input.try_pop().expect("tempo output") else {
+        panic!("expected tempo PCM");
+    };
+    presentation.recycle_output(data.into());
+}
+
+#[kithara::test]
+fn exhausted_local_reserve_backpressures_until_consumer_recycle() {
+    let (output, mut input) = connect_strict(2, None);
+    let (publisher, _) = presentation_cell(0);
+    let mut presentation = Presentation::new(
+        4,
+        PresentationChain::identity(Vec::new()),
+        PcmPool::default(),
+        spec(44_100),
+        output,
+        publisher,
+        0,
+    );
+    for block in 0_u16..4 {
+        admit(
+            &mut presentation,
+            Fetch::data(chunk(f32::from(block), u64::from(block) * 512), 0),
+            "raw block fits",
+        );
+    }
+    assert!(matches!(
+        step(&mut presentation),
+        PresentResult::Produced(_)
+    ));
+    assert!(matches!(
+        step(&mut presentation),
+        PresentResult::Produced(_)
+    ));
+    let returned = input.try_pop().expect("consumer owns first current block");
+    assert!(matches!(
+        step(&mut presentation),
+        PresentResult::Produced(_)
+    ));
+    let current = input
+        .try_pop()
+        .expect("consumer advances to second current block");
+
+    assert_eq!(step(&mut presentation), PresentResult::Backpressured);
+
+    let Fetch::Data { data, .. } = returned else {
+        panic!("expected returned PCM");
+    };
+    presentation.recycle_output(data.into());
+    assert!(matches!(
+        step(&mut presentation),
+        PresentResult::Produced(_)
+    ));
+
+    let Fetch::Data { data, .. } = current else {
+        panic!("expected current PCM");
+    };
+    presentation.recycle_output(data.into());
+    while let Some(Fetch::Data { data, .. }) = input.try_pop() {
+        presentation.recycle_output(data.into());
+    }
+}
+
+#[kithara::test]
+fn final_payload_carries_the_exact_committed_presentation_point() {
+    let (output, mut input) = connect_strict(1, None);
+    let (publisher, frontier) = presentation_cell(0);
+    let mut presentation = Presentation::new(
+        1,
+        PresentationChain::identity(Vec::new()),
+        PcmPool::default(),
+        spec(44_100),
+        output,
+        publisher,
+        0,
+    );
+    admit(
+        &mut presentation,
+        Fetch::data(chunk(1.0, 256), 0),
+        "raw chunk fits",
+    );
+
+    assert!(matches!(
+        presentation.step(|_| {}),
+        Ok(PresentResult::Produced(_))
+    ));
+    let Fetch::Data { data, .. } = input.try_pop().expect("final output is committed") else {
+        panic!("expected final PCM data");
+    };
+    let payload_point = data.point();
+    let frontier_point = frontier.point(0).expect("frontier is committed");
+    assert_eq!(payload_point, frontier_point);
+    assert_eq!(payload_point.seek_epoch(), 0);
+    assert_eq!(payload_point.source_frame(), 768);
+    assert_eq!(payload_point.generation(), 0);
+    assert_eq!(payload_point.output_end(), 512);
+    assert_eq!(payload_point.sample_rate().get(), 44_100);
+}
+
+#[kithara::test]
+fn custom_effect_receives_fixed_shape_block() {
+    let seen = Arc::new(AtomicUsize::new(0));
+    let (mut presentation, mut input) = identity_presentation(vec![Box::new(StampEffect {
+        resets: None,
+        seen_frames: Arc::clone(&seen),
+        value: 4.0,
+    })]);
+    admit(
+        &mut presentation,
+        Fetch::data(chunk(0.0, 0), 0),
+        "raw chunk fits",
+    );
+    let _ = presentation.step(|_| {});
+
+    let output = data(
+        &mut presentation,
+        input.try_pop().expect("frame-preserving output"),
+    );
+    assert_eq!(seen.load(Ordering::Acquire), output.frames());
+    assert_eq!(
+        usize::try_from(output.meta.frames).expect("test frame count fits usize"),
+        output.frames()
+    );
+}

--- a/crates/kithara-audio/src/renderer/presentation/tests/lifecycle.rs
+++ b/crates/kithara-audio/src/renderer/presentation/tests/lifecycle.rs
@@ -1,0 +1,810 @@
+use super::*;
+#[cfg(feature = "stretch-signalsmith")]
+use crate::region::{GridSegment, RegionPlan};
+
+#[cfg(feature = "stretch-signalsmith")]
+fn sized_chunk(value: f32, frames: usize, frame_offset: u64, spec: PcmSpec) -> PcmChunk {
+    let mut meta = PcmMeta::default();
+    meta.spec = spec;
+    meta.frames = u32::try_from(frames).expect("test frame count fits u32");
+    meta.frame_offset = frame_offset;
+    meta.end_timestamp = duration_for_frames(
+        spec.sample_rate.get(),
+        frame_offset + u64::try_from(frames).expect("test frame count fits u64"),
+    );
+    let samples = frames * usize::from(spec.channels);
+    PcmChunk::new(meta, PcmPool::default().attach(vec![value; samples]))
+}
+
+#[cfg(feature = "stretch-signalsmith")]
+fn tempo_presentation(
+    controls: &Arc<StretchControls>,
+    initial_spec: PcmSpec,
+    epoch: u64,
+) -> (
+    Presentation,
+    crate::runtime::Inlet<Fetch<PresentedPcm>>,
+    PresentationFrontier,
+) {
+    let pool = PcmPool::new(128, 200_000);
+    let chain = create_presentation_chain(initial_spec, Some(controls), &pool, Vec::new());
+    let (output, input) = connect_strict(PRESENTATION_RING_BLOCKS, None);
+    let (publisher, frontier) = presentation_cell(epoch);
+    (
+        Presentation::new(4, chain, pool, initial_spec, output, publisher, epoch),
+        input,
+        frontier,
+    )
+}
+
+#[cfg(feature = "stretch-signalsmith")]
+fn serviced_step(presentation: &mut Presentation) -> DecodeResult<PresentResult> {
+    presentation.service_off_rt();
+    let mut retired = None;
+    let result = presentation.step(|chunk| {
+        debug_assert!(retired.is_none());
+        retired = Some(chunk);
+    });
+    drop(retired);
+    result
+}
+
+#[kithara::test]
+fn strict_output_never_parks_a_third_block() {
+    let (mut presentation, mut input) = identity_presentation(Vec::new());
+    admit(
+        &mut presentation,
+        Fetch::data(chunk(1.0, 0), 0),
+        "first raw chunk fits",
+    );
+    admit(
+        &mut presentation,
+        Fetch::data(chunk(2.0, 512), 0),
+        "second raw chunk fits",
+    );
+
+    assert!(matches!(
+        presentation.step(|_| {}),
+        Ok(PresentResult::Produced(_))
+    ));
+    assert_eq!(step(&mut presentation), PresentResult::Backpressured);
+    let current = input.try_pop().expect("consumer holds one block");
+    assert!(matches!(
+        presentation.step(|_| {}),
+        Ok(PresentResult::Produced(_))
+    ));
+    assert_eq!(data(&mut presentation, current).samples[0], 1.0);
+    assert_eq!(
+        data(
+            &mut presentation,
+            input.try_pop().expect("ring holds one block"),
+        )
+        .samples[0],
+        2.0
+    );
+}
+
+#[kithara::test]
+fn empty_terminal_opens_preload_after_marker_commit() {
+    let (mut presentation, mut input) = identity_presentation(Vec::new());
+    presentation.finish_eof(0);
+
+    assert!(!presentation.preload_ready(3));
+    assert_eq!(step(&mut presentation), PresentResult::Terminal);
+    assert!(input.try_pop().is_some());
+    assert!(presentation.preload_ready(3));
+}
+
+#[kithara::test]
+fn preload_requires_raw_target_and_one_final_commit() {
+    let (mut presentation, mut input) = identity_presentation(Vec::new());
+    for block in 0_u16..3 {
+        admit(
+            &mut presentation,
+            Fetch::data(chunk(f32::from(block), u64::from(block) * 512), 0),
+            "preload raw block fits",
+        );
+    }
+
+    assert!(!presentation.preload_ready(3));
+    assert!(matches!(
+        presentation.step(|_| {}),
+        Ok(PresentResult::Produced(_))
+    ));
+    assert!(presentation.preload_ready(3));
+    assert!(input.try_pop().is_some());
+}
+
+#[kithara::test]
+fn failure_drains_admitted_pcm_then_resets_without_eof_tail() {
+    let resets = Arc::new(AtomicUsize::new(0));
+    let (mut presentation, mut input) = identity_presentation(vec![Box::new(StampEffect {
+        resets: Some(Arc::clone(&resets)),
+        seen_frames: Arc::new(AtomicUsize::new(0)),
+        value: 6.0,
+    })]);
+    admit(
+        &mut presentation,
+        Fetch::data(chunk(1.0, 0), 0),
+        "first raw chunk fits",
+    );
+    admit(
+        &mut presentation,
+        Fetch::data(chunk(2.0, 512), 0),
+        "second raw chunk fits",
+    );
+    presentation.finish_failed(0);
+
+    assert!(matches!(
+        presentation.step(|_| {}),
+        Ok(PresentResult::Produced(_))
+    ));
+    assert_eq!(
+        data(&mut presentation, input.try_pop().expect("first prior PCM"),).samples[0],
+        6.0
+    );
+    assert!(matches!(
+        presentation.step(|_| {}),
+        Ok(PresentResult::Produced(_))
+    ));
+    assert_eq!(
+        data(
+            &mut presentation,
+            input.try_pop().expect("second prior PCM"),
+        )
+        .samples[0],
+        6.0
+    );
+    assert_eq!(step(&mut presentation), PresentResult::Terminal);
+    assert!(matches!(input.try_pop(), Some(Fetch::Failure { epoch: 0 })));
+    assert_eq!(resets.load(Ordering::Acquire), 1);
+}
+
+#[kithara::test]
+fn epoch_reset_retires_raw_and_resets_chain_once() {
+    let resets = Arc::new(AtomicUsize::new(0));
+    let (mut presentation, _input) = identity_presentation(vec![Box::new(StampEffect {
+        resets: Some(Arc::clone(&resets)),
+        seen_frames: Arc::new(AtomicUsize::new(0)),
+        value: 1.0,
+    })]);
+    admit(
+        &mut presentation,
+        Fetch::data(chunk(1.0, 0), 0),
+        "raw chunk fits",
+    );
+    let mut retired = 0;
+
+    presentation
+        .reset_epoch(3, |_| retired += 1)
+        .expect("epoch reset succeeds");
+
+    assert_eq!(retired, 1);
+    assert_eq!(resets.load(Ordering::Acquire), 1);
+    assert_eq!(presentation.epoch(), 3);
+    assert_eq!(step(&mut presentation), PresentResult::Idle);
+}
+
+#[kithara::test]
+fn stale_decoder_barrier_is_rejected_without_rewinding_epoch() {
+    let (mut presentation, _input) = identity_presentation(Vec::new());
+    let replacement = PresentationBarrier::DecoderReplaced {
+        epoch: 9,
+        spec: spec(48_000),
+    };
+
+    assert_eq!(presentation.admit_barrier(replacement), Err(replacement),);
+    assert_eq!(presentation.epoch(), 0);
+    assert_eq!(step(&mut presentation), PresentResult::Idle);
+}
+
+#[kithara::test]
+fn empty_raw_chunk_fails_before_final_output() {
+    let (mut presentation, mut input) = identity_presentation(Vec::new());
+    let mut meta = PcmMeta::default();
+    meta.spec.channels = 1;
+    let empty = PcmChunk::new(meta, PcmPool::default().attach(Vec::new()));
+    admit(
+        &mut presentation,
+        Fetch::data(empty, 0),
+        "empty raw item still enters the typed presentation boundary",
+    );
+    let mut retired = 0;
+
+    assert!(presentation.step(|_| retired += 1).is_err());
+    assert_eq!(retired, 1);
+    assert!(input.try_pop().is_none());
+}
+
+#[kithara::test]
+fn same_epoch_decoder_barrier_resets_frontier_between_ordered_blocks() {
+    let (output, mut input) = connect_strict(1, None);
+    let (publisher, frontier) = presentation_cell(4);
+    let mut presentation = Presentation::new(
+        4,
+        PresentationChain::identity(Vec::new()),
+        PcmPool::default(),
+        spec(44_100),
+        output,
+        publisher,
+        4,
+    );
+    admit(
+        &mut presentation,
+        Fetch::data(chunk(1.0, 0), 4),
+        "old decoder block fits",
+    );
+    presentation
+        .admit_barrier(PresentationBarrier::DecoderReplaced {
+            epoch: 4,
+            spec: spec(48_000),
+        })
+        .expect("barrier fits");
+    admit(
+        &mut presentation,
+        Fetch::data(chunk_with_spec(2.0, 512, spec(48_000)), 4),
+        "new decoder block fits",
+    );
+
+    assert!(matches!(
+        presentation.step(|_| {}),
+        Ok(PresentResult::Produced(_))
+    ));
+    assert_eq!(
+        data(&mut presentation, input.try_pop().expect("old output")).samples[0],
+        1.0
+    );
+    presentation.service_off_rt();
+    assert_eq!(
+        frontier
+            .snapshot()
+            .expect("frontier is available")
+            .source_frame(),
+        512
+    );
+    assert_eq!(step(&mut presentation), PresentResult::Advanced);
+    let reset = frontier.snapshot().expect("reset frontier is available");
+    assert_eq!(reset.generation(), 1);
+    assert_eq!(reset.source_frame(), 512);
+    assert!(matches!(
+        presentation.step(|_| {}),
+        Ok(PresentResult::Produced(_))
+    ));
+    assert_eq!(
+        data(&mut presentation, input.try_pop().expect("new output")).samples[0],
+        2.0
+    );
+}
+
+#[kithara::test]
+fn ordered_tempo_barrier_drains_held_source_before_reset() {
+    let begins = Arc::new(AtomicUsize::new(0));
+    let reconfigures = Arc::new(AtomicUsize::new(0));
+    let tempo = SlowStage::new(Arc::new(AtomicUsize::new(0)), 0)
+        .with_discontinuity(700, Arc::clone(&begins))
+        .with_reconfigures(Arc::clone(&reconfigures));
+    let (output, mut input) = connect_strict(1, None);
+    let (publisher, frontier) = presentation_cell(4);
+    let mut presentation = Presentation::new(
+        4,
+        PresentationChain {
+            effects: Vec::new(),
+            tempo: Some(Box::new(tempo)),
+        },
+        PcmPool::default(),
+        spec(44_100),
+        output,
+        publisher,
+        4,
+    );
+    admit(
+        &mut presentation,
+        Fetch::data(chunk(1.0, 0), 4),
+        "first old raw block fits",
+    );
+    admit(
+        &mut presentation,
+        Fetch::data(chunk(2.0, 512), 4),
+        "second old raw block fits",
+    );
+    presentation
+        .admit_barrier(PresentationBarrier::DecoderReplaced {
+            epoch: 4,
+            spec: spec(48_000),
+        })
+        .expect("ordered barrier fits");
+
+    for _ in 0..2 {
+        assert_eq!(step(&mut presentation), PresentResult::Advanced);
+        for _ in 0..2 {
+            assert!(matches!(
+                presentation.step(|_| {}),
+                Ok(PresentResult::Produced(_))
+            ));
+            let _ = data(
+                &mut presentation,
+                input.try_pop().expect("old tempo output"),
+            );
+        }
+    }
+    assert_eq!(
+        frontier
+            .snapshot()
+            .expect("frontier is available")
+            .source_frame(),
+        324
+    );
+
+    assert_eq!(step(&mut presentation), PresentResult::Advanced);
+    assert_eq!(begins.load(Ordering::Acquire), 1);
+    assert!(matches!(
+        presentation.step(|_| {}),
+        Ok(PresentResult::Produced(PresentedBlock { frames: 512, .. }))
+    ));
+    let _ = data(
+        &mut presentation,
+        input.try_pop().expect("first discontinuity slice"),
+    );
+    assert_eq!(
+        frontier
+            .snapshot()
+            .expect("frontier is available")
+            .source_frame(),
+        324
+    );
+    assert!(matches!(
+        presentation.step(|_| {}),
+        Ok(PresentResult::Produced(PresentedBlock { frames: 188, .. }))
+    ));
+    let _ = data(
+        &mut presentation,
+        input.try_pop().expect("final discontinuity slice"),
+    );
+    let final_old = frontier.snapshot().expect("frontier is available");
+    assert_eq!(final_old.source_frame(), 324);
+    assert_eq!(final_old.output_end(), 2_748);
+    assert_eq!(reconfigures.load(Ordering::Acquire), 0);
+
+    assert_eq!(step(&mut presentation), PresentResult::Backpressured);
+    assert_eq!(reconfigures.load(Ordering::Acquire), 0);
+    assert_eq!(step(&mut presentation), PresentResult::Advanced);
+    let reset = frontier.snapshot().expect("reset frontier is available");
+    assert_eq!(reset.generation(), 1);
+    assert_eq!(reset.source_frame(), 1_024);
+    assert_eq!(reset.output_end(), 0);
+    assert_eq!(reconfigures.load(Ordering::Acquire), 1);
+
+    admit(
+        &mut presentation,
+        Fetch::data(chunk_with_spec(3.0, 1_024, spec(48_000)), 4),
+        "replacement decoder block fits",
+    );
+    assert_eq!(step(&mut presentation), PresentResult::Advanced);
+}
+
+#[kithara::test]
+fn control_boundary_without_decoder_barrier_drains_and_commits() {
+    let requested = Arc::new(AtomicUsize::new(0));
+    let begins = Arc::new(AtomicUsize::new(0));
+    let reconfigures = Arc::new(AtomicUsize::new(0));
+    let tempo = SlowStage::new(Arc::new(AtomicUsize::new(0)), 0)
+        .with_control_boundary(Arc::clone(&requested))
+        .with_discontinuity(700, Arc::clone(&begins))
+        .with_reconfigures(Arc::clone(&reconfigures));
+    let (output, mut input) = connect_strict(1, None);
+    let (publisher, frontier) = presentation_cell(4);
+    let mut presentation = Presentation::new(
+        4,
+        PresentationChain {
+            effects: Vec::new(),
+            tempo: Some(Box::new(tempo)),
+        },
+        PcmPool::default(),
+        spec(44_100),
+        output,
+        publisher,
+        4,
+    );
+    admit(
+        &mut presentation,
+        Fetch::data(chunk(1.0, 0), 4),
+        "old raw block fits",
+    );
+
+    assert_eq!(step(&mut presentation), PresentResult::Advanced);
+    for _ in 0..2 {
+        assert!(matches!(
+            presentation.step(|_| {}),
+            Ok(PresentResult::Produced(_))
+        ));
+        let _ = data(
+            &mut presentation,
+            input.try_pop().expect("old tempo output"),
+        );
+    }
+
+    requested.store(1, Ordering::Release);
+    assert_eq!(step(&mut presentation), PresentResult::Advanced);
+    assert_eq!(begins.load(Ordering::Acquire), 1);
+    for expected_frames in [512, 188] {
+        assert!(matches!(
+            presentation.step(|_| {}),
+            Ok(PresentResult::Produced(PresentedBlock { frames, .. }))
+                if frames == expected_frames
+        ));
+        let _ = data(
+            &mut presentation,
+            input.try_pop().expect("control-boundary tail output"),
+        );
+    }
+    assert_eq!(reconfigures.load(Ordering::Acquire), 0);
+
+    assert_eq!(step(&mut presentation), PresentResult::Advanced);
+    assert_eq!(reconfigures.load(Ordering::Acquire), 1);
+    assert_eq!(
+        frontier
+            .snapshot()
+            .expect("frontier remains available")
+            .generation(),
+        0,
+        "control changes do not reset the decoder generation"
+    );
+
+    admit(
+        &mut presentation,
+        Fetch::data(chunk(2.0, 512), 4),
+        "next raw block fits after the control commit",
+    );
+    assert_eq!(step(&mut presentation), PresentResult::Advanced);
+    assert!(matches!(
+        presentation.step(|_| {}),
+        Ok(PresentResult::Produced(_))
+    ));
+}
+
+#[cfg(feature = "stretch-signalsmith")]
+#[kithara::test]
+fn serviced_decoder_boundary_waits_for_partially_rendered_source() {
+    const OLD_FRAMES: usize = 1_152;
+    let old_spec = PcmSpec::new(
+        2,
+        NonZeroU32::new(44_100).expect("test sample rate is non-zero"),
+    );
+    let replacement_spec = PcmSpec::new(
+        2,
+        NonZeroU32::new(48_000).expect("test sample rate is non-zero"),
+    );
+    let controls = StretchControls::new(1.0);
+    let (mut presentation, mut input, _) = tempo_presentation(&controls, old_spec, 4);
+    admit(
+        &mut presentation,
+        Fetch::data(sized_chunk(0.25, OLD_FRAMES, 0, old_spec), 4),
+        "large old-spec chunk fits",
+    );
+
+    assert_eq!(
+        serviced_step(&mut presentation).expect("old source admits"),
+        PresentResult::Advanced
+    );
+    assert!(matches!(
+        serviced_step(&mut presentation),
+        Ok(PresentResult::Produced(PresentedBlock { frames: 512, .. }))
+    ));
+    let Fetch::Data { data: first, .. } = input.try_pop().expect("first old-spec output") else {
+        panic!("expected old-spec PCM");
+    };
+    assert_eq!(first.point().generation(), 0);
+    assert_eq!(first.chunk().spec(), old_spec);
+    assert!(first.chunk().samples.iter().all(|sample| *sample == 0.25));
+    let mut old_frames = first.chunk().frames();
+    presentation.recycle_output(first.into());
+
+    presentation
+        .admit_barrier(PresentationBarrier::DecoderReplaced {
+            epoch: 4,
+            spec: replacement_spec,
+        })
+        .expect("replacement barrier fits behind admitted source");
+    admit(
+        &mut presentation,
+        Fetch::data(
+            sized_chunk(
+                0.5,
+                PRESENTATION_FRAMES,
+                u64::try_from(OLD_FRAMES).expect("test frame count fits u64"),
+                replacement_spec,
+            ),
+            4,
+        ),
+        "replacement source fits behind its barrier",
+    );
+
+    let mut saw_replacement = false;
+    let mut backpressured = 0;
+    for _ in 0..32 {
+        match serviced_step(&mut presentation).expect("serviced decoder transition succeeds") {
+            PresentResult::Produced(_) => {
+                let Fetch::Data { data, .. } = input.try_pop().expect("serviced output") else {
+                    panic!("expected serviced PCM");
+                };
+                if data.chunk().spec() == old_spec {
+                    assert!(!saw_replacement);
+                    assert_eq!(data.point().generation(), 0);
+                    assert!(data.chunk().samples.iter().all(|sample| *sample == 0.25));
+                    old_frames += data.chunk().frames();
+                } else {
+                    assert_eq!(data.chunk().spec(), replacement_spec);
+                    assert_eq!(data.point().generation(), 1);
+                    assert_eq!(old_frames, OLD_FRAMES);
+                    assert!(data.chunk().samples.iter().all(|sample| *sample == 0.5));
+                    saw_replacement = true;
+                }
+                presentation.recycle_output(data.into());
+                if saw_replacement {
+                    break;
+                }
+            }
+            PresentResult::Backpressured => backpressured += 1,
+            PresentResult::Advanced => {}
+            PresentResult::Idle | PresentResult::Terminal => {
+                panic!("serviced decoder transition stalled before replacement output")
+            }
+        }
+    }
+
+    assert_eq!(old_frames, OLD_FRAMES);
+    assert!(
+        saw_replacement,
+        "replacement PCM must follow the full old chunk"
+    );
+    assert_eq!(backpressured, 1);
+}
+
+#[cfg(feature = "stretch-signalsmith")]
+#[kithara::test]
+fn serviced_region_boundary_precedes_queued_decoder_boundary() {
+    let old_spec = PcmSpec::new(
+        2,
+        NonZeroU32::new(44_100).expect("test sample rate is non-zero"),
+    );
+    let replacement_spec = PcmSpec::new(
+        2,
+        NonZeroU32::new(48_000).expect("test sample rate is non-zero"),
+    );
+    let plan = RegionPlan::new(vec![
+        GridSegment::new(0, 256, 0.9),
+        GridSegment::new(256, 512, 1.1),
+    ])
+    .expect("test region plan is valid");
+    let controls = StretchControls::new(1.0);
+    controls.set_backend(StretchKind::Signalsmith);
+    controls.set_keylock(true);
+    controls.set_region_plan(Some(Arc::new(plan)));
+    let (mut presentation, mut input, frontier) = tempo_presentation(&controls, old_spec, 6);
+    admit(
+        &mut presentation,
+        Fetch::data(sized_chunk(0.25, PRESENTATION_FRAMES, 0, old_spec), 6),
+        "region source fits",
+    );
+    assert_eq!(
+        serviced_step(&mut presentation).expect("region source admits"),
+        PresentResult::Advanced
+    );
+    presentation
+        .admit_barrier(PresentationBarrier::DecoderReplaced {
+            epoch: 6,
+            spec: replacement_spec,
+        })
+        .expect("decoder barrier queues behind region source");
+    admit(
+        &mut presentation,
+        Fetch::data(
+            sized_chunk(0.5, PRESENTATION_FRAMES, 512, replacement_spec),
+            6,
+        ),
+        "replacement source queues behind decoder barrier",
+    );
+    presentation.finish_eof(6);
+
+    let mut saw_old = false;
+    let mut saw_replacement = false;
+    let mut terminal = false;
+    let mut backpressured = 0;
+    for _ in 0..512 {
+        match serviced_step(&mut presentation).expect("ordered region and decoder transitions") {
+            PresentResult::Produced(_) => {
+                let Fetch::Data { data, .. } = input.try_pop().expect("ordered output") else {
+                    panic!("expected ordered PCM");
+                };
+                match data.point().generation() {
+                    0 => {
+                        assert!(!saw_replacement);
+                        assert_eq!(data.chunk().spec(), old_spec);
+                        saw_old = true;
+                    }
+                    1 => {
+                        assert_eq!(data.chunk().spec(), replacement_spec);
+                        saw_replacement = true;
+                    }
+                    generation => panic!("unexpected presentation generation {generation}"),
+                }
+                presentation.recycle_output(data.into());
+            }
+            PresentResult::Terminal => {
+                terminal = true;
+                break;
+            }
+            PresentResult::Backpressured => backpressured += 1,
+            PresentResult::Advanced => {}
+            PresentResult::Idle => {
+                panic!("ordered region and decoder transitions stalled before EOF")
+            }
+        }
+    }
+
+    assert!(saw_old, "region source must produce before decoder reset");
+    assert!(
+        saw_replacement,
+        "replacement source must produce after decoder reset"
+    );
+    assert!(terminal, "ordered transitions must reach EOF");
+    assert_eq!(backpressured, 1);
+    let final_point = frontier.snapshot().expect("final replacement frontier");
+    assert_eq!(final_point.generation(), 1);
+    assert_eq!(final_point.source_frame(), 1_024);
+    assert!(matches!(
+        input.try_pop(),
+        Some(Fetch::NaturalEof { epoch: 6 })
+    ));
+}
+
+#[kithara::test]
+fn drained_decoder_boundary_waits_for_recycled_buffer_without_redraining() {
+    let begins = Arc::new(AtomicUsize::new(0));
+    let reconfigures = Arc::new(AtomicUsize::new(0));
+    let tempo = SlowStage::new(Arc::new(AtomicUsize::new(0)), 0)
+        .with_discontinuity(0, Arc::clone(&begins))
+        .with_reconfigures(Arc::clone(&reconfigures));
+    let (output, mut input) = connect_strict(2, None);
+    let (publisher, frontier) = presentation_cell(4);
+    let mut presentation = Presentation::new(
+        4,
+        PresentationChain {
+            effects: Vec::new(),
+            tempo: Some(Box::new(tempo)),
+        },
+        PcmPool::default(),
+        spec(44_100),
+        output,
+        publisher,
+        4,
+    );
+    admit(
+        &mut presentation,
+        Fetch::data(chunk(1.0, 0), 4),
+        "old raw block fits",
+    );
+    assert_eq!(step(&mut presentation), PresentResult::Advanced);
+    for _ in 0..2 {
+        assert!(matches!(
+            presentation.step(|_| {}),
+            Ok(PresentResult::Produced(_))
+        ));
+    }
+    let _ = data(
+        &mut presentation,
+        input.try_pop().expect("first old output"),
+    );
+    let held = input
+        .try_pop()
+        .expect("second old output remains checked out");
+
+    presentation
+        .admit_barrier(PresentationBarrier::DecoderReplaced {
+            epoch: 4,
+            spec: spec(48_000),
+        })
+        .expect("decoder barrier fits");
+    assert_eq!(step(&mut presentation), PresentResult::Advanced);
+    assert_eq!(begins.load(Ordering::Acquire), 1);
+    assert_eq!(step(&mut presentation), PresentResult::Backpressured);
+    assert_eq!(step(&mut presentation), PresentResult::Backpressured);
+    assert_eq!(begins.load(Ordering::Acquire), 1);
+    assert_eq!(reconfigures.load(Ordering::Acquire), 0);
+
+    let Fetch::Data { data: held, .. } = held else {
+        panic!("held output must contain PCM");
+    };
+    presentation.recycle_output(held.into());
+    assert_eq!(step(&mut presentation), PresentResult::Advanced);
+    assert_eq!(reconfigures.load(Ordering::Acquire), 1);
+    assert_eq!(
+        frontier
+            .snapshot()
+            .expect("decoder frontier is republished")
+            .generation(),
+        1
+    );
+}
+
+#[kithara::test]
+fn terminal_with_queued_decoder_barrier_is_prepared_before_eof() {
+    let reconfigures = Arc::new(AtomicUsize::new(0));
+    let tempo = SlowStage::new(Arc::new(AtomicUsize::new(0)), 0)
+        .with_reconfigures(Arc::clone(&reconfigures));
+    let (output, mut input) = connect_strict(1, None);
+    let (publisher, frontier) = presentation_cell(4);
+    let mut presentation = Presentation::new(
+        2,
+        PresentationChain {
+            effects: Vec::new(),
+            tempo: Some(Box::new(tempo)),
+        },
+        PcmPool::default(),
+        spec(44_100),
+        output,
+        publisher,
+        4,
+    );
+    presentation
+        .admit_barrier(PresentationBarrier::DecoderReplaced {
+            epoch: 4,
+            spec: spec(48_000),
+        })
+        .expect("queued decoder barrier fits");
+    presentation.finish_eof(4);
+
+    assert_eq!(step(&mut presentation), PresentResult::Advanced);
+    assert_eq!(step(&mut presentation), PresentResult::Backpressured);
+    assert_eq!(step(&mut presentation), PresentResult::Advanced);
+    assert_eq!(reconfigures.load(Ordering::Acquire), 1);
+    assert!(frontier.snapshot().is_none());
+    assert_eq!(step(&mut presentation), PresentResult::Advanced);
+    assert_eq!(step(&mut presentation), PresentResult::Terminal);
+    assert!(matches!(
+        input.try_pop(),
+        Some(Fetch::NaturalEof { epoch: 4 })
+    ));
+}
+
+#[kithara::test]
+fn failure_resets_held_tempo_source_without_discontinuity_drain() {
+    let begins = Arc::new(AtomicUsize::new(0));
+    let reconfigures = Arc::new(AtomicUsize::new(0));
+    let tempo = SlowStage::new(Arc::new(AtomicUsize::new(0)), 0)
+        .with_discontinuity(700, Arc::clone(&begins))
+        .with_reconfigures(Arc::clone(&reconfigures));
+    let (output, mut input) = connect_strict(1, None);
+    let (publisher, _) = presentation_cell(0);
+    let mut presentation = Presentation::new(
+        2,
+        PresentationChain {
+            effects: Vec::new(),
+            tempo: Some(Box::new(tempo)),
+        },
+        PcmPool::default(),
+        spec(44_100),
+        output,
+        publisher,
+        0,
+    );
+    admit(
+        &mut presentation,
+        Fetch::data(chunk(1.0, 0), 0),
+        "raw block fits",
+    );
+    presentation.finish_failed(0);
+
+    assert_eq!(step(&mut presentation), PresentResult::Advanced);
+    for _ in 0..2 {
+        assert!(matches!(
+            presentation.step(|_| {}),
+            Ok(PresentResult::Produced(_))
+        ));
+        let _ = data(&mut presentation, input.try_pop().expect("prior tempo PCM"));
+    }
+    assert_eq!(step(&mut presentation), PresentResult::Terminal);
+    assert!(matches!(input.try_pop(), Some(Fetch::Failure { epoch: 0 })));
+    assert_eq!(begins.load(Ordering::Acquire), 0);
+    assert_eq!(reconfigures.load(Ordering::Acquire), 0);
+}

--- a/crates/kithara-audio/src/renderer/presentation/tests/mod.rs
+++ b/crates/kithara-audio/src/renderer/presentation/tests/mod.rs
@@ -1,0 +1,386 @@
+use std::{
+    num::NonZeroU32,
+    sync::atomic::{AtomicU64, AtomicUsize, Ordering},
+};
+
+use assert_no_alloc::{AllocDisabler, assert_no_alloc};
+use kithara_bufpool::PcmPool;
+use kithara_decode::{DecodeError, DecodeResult, PcmChunk, PcmMeta, PcmSpec, duration_for_frames};
+use kithara_platform::sync::Arc;
+use kithara_test_utils::kithara;
+
+use super::*;
+#[cfg(feature = "stretch-signalsmith")]
+use crate::effects::timestretch::{StretchControls, StretchKind};
+#[cfg(feature = "stretch-signalsmith")]
+use crate::pipeline::config::create_presentation_chain;
+use crate::{
+    pipeline::{config::PresentationChain, fetch::Fetch},
+    runtime::connect_strict,
+    traits::{
+        AudioBlockMut, AudioEffect, OutputCredit, PresentationPoint, TempoBoundaryId,
+        TempoDiscontinuityDebt, TempoDiscontinuityStep, TempoEofDebt, TempoEofStep,
+        TempoPrepareRequest, TempoStage, TempoStep,
+    },
+};
+
+#[cfg(debug_assertions)]
+#[global_allocator]
+static ALLOCATOR: AllocDisabler = AllocDisabler;
+
+fn spec(sample_rate: u32) -> PcmSpec {
+    PcmSpec::new(
+        1,
+        NonZeroU32::new(sample_rate).expect("test sample rate is non-zero"),
+    )
+}
+
+fn chunk_with_spec(value: f32, frame_offset: u64, spec: PcmSpec) -> PcmChunk {
+    let mut meta = PcmMeta::default();
+    meta.spec = spec;
+    meta.frames = u32::try_from(PRESENTATION_FRAMES).expect("test block fits u32");
+    meta.frame_offset = frame_offset;
+    meta.end_timestamp = duration_for_frames(
+        meta.spec.sample_rate.get(),
+        frame_offset + u64::try_from(PRESENTATION_FRAMES).expect("test block fits u64"),
+    );
+    PcmChunk::new(
+        meta,
+        PcmPool::default().attach(vec![value; PRESENTATION_FRAMES]),
+    )
+}
+
+fn chunk(value: f32, frame_offset: u64) -> PcmChunk {
+    chunk_with_spec(value, frame_offset, spec(44_100))
+}
+
+fn data(presentation: &mut Presentation, fetch: Fetch<PresentedPcm>) -> PcmChunk {
+    let Fetch::Data { data, .. } = fetch else {
+        panic!("expected PCM data");
+    };
+    let chunk: PcmChunk = data.into();
+    let copy = PcmChunk::new(
+        chunk.meta,
+        PcmPool::default().attach(chunk.samples.to_vec()),
+    );
+    presentation.recycle_output(chunk);
+    copy
+}
+
+fn step(presentation: &mut Presentation) -> PresentResult {
+    presentation.service_off_rt();
+    presentation
+        .step(|_| {})
+        .expect("presentation step must succeed")
+}
+
+fn admit(presentation: &mut Presentation, fetch: Fetch<PcmChunk>, context: &str) {
+    assert!(presentation.admit(fetch).is_none(), "{context}");
+}
+
+#[kithara::rtsan_forbid_blocking]
+fn guarded_step(
+    presentation: &mut Presentation,
+    retired: &mut Option<PcmChunk>,
+) -> DecodeResult<PresentResult> {
+    assert_no_alloc(|| {
+        presentation.step(|chunk| {
+            debug_assert!(retired.is_none());
+            *retired = Some(chunk);
+        })
+    })
+}
+
+struct StampEffect {
+    resets: Option<Arc<AtomicUsize>>,
+    seen_frames: Arc<AtomicUsize>,
+    value: f32,
+}
+
+impl AudioEffect for StampEffect {
+    fn process(&mut self, mut block: AudioBlockMut<'_>) -> DecodeResult<()> {
+        self.seen_frames.store(
+            usize::try_from(block.meta().frames).expect("test frame count fits usize"),
+            Ordering::Release,
+        );
+        block.samples_mut().fill(self.value);
+        Ok(())
+    }
+
+    fn reset(&mut self) {
+        if let Some(resets) = &self.resets {
+            resets.fetch_add(1, Ordering::AcqRel);
+        }
+    }
+}
+
+struct SlowStage {
+    control_boundary: Option<Arc<AtomicUsize>>,
+    discontinuity_begins: Arc<AtomicUsize>,
+    discontinuity_remaining: usize,
+    eof_remaining: usize,
+    held_frames: u64,
+    max_credit: Arc<AtomicUsize>,
+    output_frame: u64,
+    prepared: Option<(TempoBoundaryId, PcmSpec)>,
+    prepare_id: u64,
+    reconfigures: Arc<AtomicUsize>,
+    renders_left: usize,
+    seen_presentation_output_end: Option<Arc<AtomicU64>>,
+    source: Option<PcmChunk>,
+    spec: PcmSpec,
+}
+
+impl SlowStage {
+    fn new(max_credit: Arc<AtomicUsize>, eof_remaining: usize) -> Self {
+        Self {
+            control_boundary: None,
+            discontinuity_begins: Arc::new(AtomicUsize::new(0)),
+            discontinuity_remaining: 0,
+            eof_remaining,
+            held_frames: 0,
+            max_credit,
+            output_frame: 0,
+            prepared: None,
+            prepare_id: 0,
+            reconfigures: Arc::new(AtomicUsize::new(0)),
+            renders_left: 0,
+            seen_presentation_output_end: None,
+            source: None,
+            spec: spec(44_100),
+        }
+    }
+
+    fn with_seen_presentation_output_end(mut self, seen: Arc<AtomicU64>) -> Self {
+        self.seen_presentation_output_end = Some(seen);
+        self
+    }
+
+    fn with_control_boundary(mut self, requested: Arc<AtomicUsize>) -> Self {
+        self.control_boundary = Some(requested);
+        self
+    }
+
+    fn with_reconfigures(mut self, reconfigures: Arc<AtomicUsize>) -> Self {
+        self.reconfigures = reconfigures;
+        self
+    }
+
+    fn with_discontinuity(mut self, frames: usize, begins: Arc<AtomicUsize>) -> Self {
+        self.discontinuity_begins = begins;
+        self.discontinuity_remaining = frames;
+        self
+    }
+
+    fn render_block(
+        &mut self,
+        mut credit: OutputCredit<'_>,
+        frames: usize,
+        value: f32,
+    ) -> TempoStep {
+        self.max_credit
+            .fetch_max(credit.max_frames(), Ordering::AcqRel);
+        credit.samples_mut()[..frames].fill(value);
+        let mut meta = PcmMeta::default();
+        meta.spec = self.spec;
+        meta.frame_offset = self.output_frame;
+        meta.frames = u32::try_from(frames).expect("test output fits u32");
+        self.output_frame += u64::try_from(frames).expect("test output fits u64");
+        TempoStep::Rendered { frames, meta }
+    }
+}
+
+impl TempoStage for SlowStage {
+    fn service_off_rt(&mut self, request: TempoPrepareRequest) -> DecodeResult<()> {
+        match request {
+            TempoPrepareRequest::Current { spec } => {
+                if self.prepared.is_some() {
+                    return Ok(());
+                }
+                if self
+                    .control_boundary
+                    .as_ref()
+                    .is_some_and(|requested| requested.swap(0, Ordering::AcqRel) != 0)
+                {
+                    self.prepare_id = self.prepare_id.wrapping_add(1);
+                    self.prepared = Some((TempoBoundaryId::new(self.prepare_id), spec));
+                } else {
+                    self.spec = spec;
+                }
+            }
+            TempoPrepareRequest::DecoderBoundary { spec } => {
+                if self.prepared.is_none() {
+                    self.prepare_id = self.prepare_id.wrapping_add(1);
+                    self.prepared = Some((TempoBoundaryId::new(self.prepare_id), spec));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn prepared_boundary(&self) -> Option<TempoBoundaryId> {
+        self.prepared.map(|(id, _)| id)
+    }
+
+    fn commit_prepared(&mut self, id: TempoBoundaryId) -> DecodeResult<()> {
+        let Some((prepared, spec)) = self.prepared.take() else {
+            return Err(DecodeError::InvalidData {
+                detail: "test tempo stage has no prepared boundary",
+            });
+        };
+        if prepared != id {
+            return Err(DecodeError::InvalidData {
+                detail: "test tempo stage received a stale boundary",
+            });
+        }
+        self.reconfigures.fetch_add(1, Ordering::AcqRel);
+        self.spec = spec;
+        Ok(())
+    }
+
+    fn buffered_source_quanta(&self) -> usize {
+        usize::from(self.source.is_some())
+    }
+
+    fn output_spec(&self) -> PcmSpec {
+        self.spec
+    }
+
+    fn push_source(&mut self, chunk: PcmChunk) -> DecodeResult<()> {
+        assert!(self.source.is_none());
+        if chunk.spec() != self.spec {
+            return Err(DecodeError::InvalidData {
+                detail: "test tempo stage received source before spec adoption",
+            });
+        }
+        self.source = Some(chunk);
+        self.renders_left = 2;
+        Ok(())
+    }
+
+    fn render(
+        &mut self,
+        point: Option<PresentationPoint>,
+        credit: OutputCredit<'_>,
+        retire: &mut dyn FnMut(PcmChunk),
+    ) -> DecodeResult<TempoStep> {
+        let Some(source) = self.source.as_ref() else {
+            return Ok(TempoStep::NeedSource);
+        };
+        if let Some(seen) = &self.seen_presentation_output_end {
+            seen.store(
+                point.map_or(0, PresentationPoint::output_end),
+                Ordering::Release,
+            );
+        }
+        let value = source.samples[0];
+        let frames = credit.max_frames();
+        let step = self.render_block(credit, frames, value);
+        self.renders_left -= 1;
+        if self.renders_left == 0
+            && let Some(source) = self.source.take()
+        {
+            retire(source);
+            self.held_frames = u64::try_from(self.discontinuity_remaining)
+                .expect("test discontinuity hold fits u64");
+        }
+        Ok(step)
+    }
+
+    fn held_source_frames(&self) -> u64 {
+        let source = self.source.as_ref().map_or(0, |source| {
+            u64::try_from(source.frames()).expect("test source frames fit u64")
+        });
+        source
+            .checked_add(self.held_frames)
+            .expect("test held source total fits u64")
+    }
+
+    fn finish_eof(&mut self) -> DecodeResult<TempoEofDebt> {
+        Ok(TempoEofDebt::new())
+    }
+
+    fn render_eof(
+        &mut self,
+        _debt: &mut TempoEofDebt,
+        mut credit: OutputCredit<'_>,
+        _retire: &mut dyn FnMut(PcmChunk),
+    ) -> DecodeResult<TempoEofStep> {
+        if self.eof_remaining == 0 {
+            return Ok(TempoEofStep::Drained);
+        }
+        self.max_credit
+            .fetch_max(credit.max_frames(), Ordering::AcqRel);
+        let frames = self.eof_remaining.min(credit.max_frames());
+        credit.samples_mut()[..frames].fill(9.0);
+        self.eof_remaining -= frames;
+        let mut meta = PcmMeta::default();
+        meta.spec = self.spec;
+        meta.frame_offset = self.output_frame;
+        meta.frames = u32::try_from(frames).expect("test EOF output fits u32");
+        self.output_frame += u64::try_from(frames).expect("test EOF output fits u64");
+        Ok(TempoEofStep::Rendered { frames, meta })
+    }
+
+    fn begin_discontinuity(&mut self) -> DecodeResult<TempoDiscontinuityDebt> {
+        self.discontinuity_begins.fetch_add(1, Ordering::AcqRel);
+        Ok(TempoDiscontinuityDebt::new())
+    }
+
+    fn render_discontinuity(
+        &mut self,
+        _debt: &mut TempoDiscontinuityDebt,
+        mut credit: OutputCredit<'_>,
+        _retire: &mut dyn FnMut(PcmChunk),
+    ) -> DecodeResult<TempoDiscontinuityStep> {
+        if self.discontinuity_remaining == 0 {
+            self.held_frames = 0;
+            return Ok(TempoDiscontinuityStep::Drained);
+        }
+        self.max_credit
+            .fetch_max(credit.max_frames(), Ordering::AcqRel);
+        let frames = self.discontinuity_remaining.min(credit.max_frames());
+        credit.samples_mut()[..frames].fill(8.0);
+        self.discontinuity_remaining -= frames;
+        let mut meta = PcmMeta::default();
+        meta.spec = self.spec;
+        meta.frame_offset = self.output_frame;
+        meta.frames = u32::try_from(frames).expect("test discontinuity output fits u32");
+        self.output_frame += u64::try_from(frames).expect("test discontinuity output fits u64");
+        Ok(TempoDiscontinuityStep::Rendered { frames, meta })
+    }
+
+    fn deactivate(&mut self, retire: &mut dyn FnMut(PcmChunk)) -> DecodeResult<()> {
+        if let Some(source) = self.source.take() {
+            retire(source);
+        }
+        self.renders_left = 0;
+        self.held_frames = 0;
+        self.discontinuity_remaining = 0;
+        Ok(())
+    }
+}
+
+fn identity_presentation(
+    effects: Vec<Box<dyn AudioEffect>>,
+) -> (Presentation, crate::runtime::Inlet<Fetch<PresentedPcm>>) {
+    let (output, input) = connect_strict(1, None);
+    let (publisher, _) = presentation_cell(0);
+    (
+        Presentation::new(
+            4,
+            PresentationChain::identity(effects),
+            PcmPool::default(),
+            spec(44_100),
+            output,
+            publisher,
+            0,
+        ),
+        input,
+    )
+}
+
+mod identity;
+mod lifecycle;
+mod recycle;
+mod tempo;

--- a/crates/kithara-audio/src/renderer/presentation/tests/recycle.rs
+++ b/crates/kithara-audio/src/renderer/presentation/tests/recycle.rs
@@ -1,0 +1,86 @@
+use std::num::NonZeroU32;
+
+use kithara_bufpool::PcmPool;
+use kithara_decode::{PcmChunk, PcmMeta, PcmSpec};
+use kithara_test_utils::kithara;
+
+use super::{
+    super::output::{OutputBuffers, RecycleOutcome},
+    assert_no_alloc,
+};
+
+fn recycle_spec(channels: u16, sample_rate: u32) -> PcmSpec {
+    PcmSpec::new(
+        channels,
+        NonZeroU32::new(sample_rate).expect("test sample rate is non-zero"),
+    )
+}
+
+fn prepared_buffers(spec: PcmSpec) -> OutputBuffers {
+    let mut buffers = OutputBuffers::new(PcmPool::default());
+    assert!(
+        buffers
+            .prepare(spec)
+            .expect("presentation reserve must prepare")
+    );
+    buffers
+}
+
+fn rejected_chunk(spec: PcmSpec, samples: usize) -> PcmChunk {
+    let pool = PcmPool::new(1, 0);
+    pool.pre_warm(1, |buffer| buffer.resize(samples.max(1), 0.0));
+    PcmChunk::new(
+        PcmMeta {
+            spec,
+            frames: 1,
+            ..Default::default()
+        },
+        pool.attach(vec![0.0; samples]),
+    )
+}
+
+#[kithara::test]
+fn full_recycle_failure_retains_pcm_without_allocator_calls() {
+    let spec = recycle_spec(1, 48_000);
+    let mut buffers = prepared_buffers(spec);
+    let chunk = rejected_chunk(spec, super::PRESENTATION_FRAMES);
+
+    let result = assert_no_alloc(|| buffers.recycle(chunk));
+
+    assert!(matches!(result, RecycleOutcome::Rejected(_)));
+    drop(result);
+}
+
+#[kithara::test]
+fn stale_recycle_failure_retains_pcm_without_allocator_calls() {
+    let spec = recycle_spec(1, 48_000);
+    let mut buffers = prepared_buffers(spec);
+    let held = buffers
+        .take(spec)
+        .expect("prepared reserve must be valid")
+        .expect("prepared reserve must have one buffer");
+    let stale = rejected_chunk(recycle_spec(2, 44_100), super::PRESENTATION_FRAMES * 2);
+
+    let result = assert_no_alloc(|| buffers.recycle(stale));
+
+    assert!(matches!(result, RecycleOutcome::Rejected(_)));
+    drop(result);
+    drop(held);
+}
+
+#[kithara::test]
+fn undersized_recycle_failure_retains_pcm_without_allocator_calls() {
+    let spec = recycle_spec(1, 48_000);
+    let mut buffers = prepared_buffers(spec);
+    let held = buffers
+        .take(spec)
+        .expect("prepared reserve must be valid")
+        .expect("prepared reserve must have one buffer");
+    let short = rejected_chunk(spec, 1);
+
+    let result = assert_no_alloc(|| buffers.recycle(short));
+
+    assert!(matches!(result, RecycleOutcome::Rejected(_)));
+    drop(result);
+    drop(held);
+}

--- a/crates/kithara-audio/src/renderer/presentation/tests/tempo.rs
+++ b/crates/kithara-audio/src/renderer/presentation/tests/tempo.rs
@@ -1,0 +1,425 @@
+use super::*;
+
+#[kithara::test]
+fn slow_tempo_never_exceeds_one_output_credit() {
+    let max_credit = Arc::new(AtomicUsize::new(0));
+    let tempo = SlowStage::new(Arc::clone(&max_credit), 0);
+    let (output, mut input) = connect_strict(1, None);
+    let (publisher, _) = presentation_cell(0);
+    let mut presentation = Presentation::new(
+        4,
+        PresentationChain {
+            effects: Vec::new(),
+            tempo: Some(Box::new(tempo)),
+        },
+        PcmPool::default(),
+        spec(44_100),
+        output,
+        publisher,
+        0,
+    );
+    admit(
+        &mut presentation,
+        Fetch::data(chunk(2.0, 0), 0),
+        "raw chunk fits",
+    );
+
+    assert_eq!(step(&mut presentation), PresentResult::Advanced);
+    assert!(matches!(
+        presentation.step(|_| {}),
+        Ok(PresentResult::Produced(_))
+    ));
+    assert_eq!(
+        data(
+            &mut presentation,
+            input.try_pop().expect("first slow block"),
+        )
+        .frames(),
+        512
+    );
+    assert!(matches!(
+        presentation.step(|_| {}),
+        Ok(PresentResult::Produced(_))
+    ));
+    assert_eq!(
+        data(
+            &mut presentation,
+            input.try_pop().expect("second slow block"),
+        )
+        .frames(),
+        512
+    );
+    assert_eq!(max_credit.load(Ordering::Acquire), PRESENTATION_FRAMES);
+}
+
+#[kithara::test]
+fn deep_raw_buffer_does_not_become_post_effect_latency() {
+    let tempo = SlowStage::new(Arc::new(AtomicUsize::new(0)), 0);
+    let (output, mut input) = connect_strict(1, None);
+    let (publisher, _) = presentation_cell(0);
+    let mut presentation = Presentation::new(
+        10,
+        PresentationChain {
+            effects: Vec::new(),
+            tempo: Some(Box::new(tempo)),
+        },
+        PcmPool::default(),
+        spec(44_100),
+        output,
+        publisher,
+        0,
+    );
+    for block in 0_u16..10 {
+        admit(
+            &mut presentation,
+            Fetch::data(chunk(f32::from(block), u64::from(block) * 512), 0),
+            "all ten raw blocks fit before presentation",
+        );
+    }
+    assert!(presentation.is_raw_full());
+
+    assert_eq!(step(&mut presentation), PresentResult::Advanced);
+    assert!(matches!(
+        presentation.step(|_| {}),
+        Ok(PresentResult::Produced(PresentedBlock { frames: 512, .. }))
+    ));
+    let first = data(
+        &mut presentation,
+        input
+            .try_pop()
+            .expect("first processed block is final output"),
+    );
+    assert_eq!(first.samples[0], 0.0);
+    assert!(presentation.is_raw_full());
+}
+
+#[kithara::test]
+fn tempo_source_quantum_remains_charged_until_consumed() {
+    let tempo = SlowStage::new(Arc::new(AtomicUsize::new(0)), 0);
+    let (output, _input) = connect_strict(1, None);
+    let (publisher, _) = presentation_cell(0);
+    let mut presentation = Presentation::new(
+        2,
+        PresentationChain {
+            effects: Vec::new(),
+            tempo: Some(Box::new(tempo)),
+        },
+        PcmPool::default(),
+        spec(44_100),
+        output,
+        publisher,
+        0,
+    );
+    admit(
+        &mut presentation,
+        Fetch::data(chunk(1.0, 0), 0),
+        "first raw chunk fits",
+    );
+    assert_eq!(step(&mut presentation), PresentResult::Advanced);
+    admit(
+        &mut presentation,
+        Fetch::data(chunk(2.0, 512), 0),
+        "one queued plus one stage-held chunk fits",
+    );
+
+    assert!(presentation.is_raw_full());
+    assert!(
+        presentation
+            .admit(Fetch::data(chunk(3.0, 1_024), 0))
+            .is_some(),
+        "stage-held source remains charged to the deep capacity",
+    );
+}
+
+#[kithara::test]
+fn tempo_render_receives_the_current_canonical_presentation_point() {
+    let seen = Arc::new(AtomicU64::new(u64::MAX));
+    let tempo = SlowStage::new(Arc::new(AtomicUsize::new(0)), 0)
+        .with_seen_presentation_output_end(Arc::clone(&seen));
+    let (output, mut input) = connect_strict(1, None);
+    let (publisher, _) = presentation_cell(0);
+    let mut presentation = Presentation::new(
+        1,
+        PresentationChain {
+            effects: Vec::new(),
+            tempo: Some(Box::new(tempo)),
+        },
+        PcmPool::default(),
+        spec(44_100),
+        output,
+        publisher,
+        0,
+    );
+    admit(
+        &mut presentation,
+        Fetch::data(chunk(1.0, 0), 0),
+        "source chunk fits",
+    );
+
+    assert_eq!(step(&mut presentation), PresentResult::Advanced);
+    assert!(matches!(
+        presentation.step(|_| {}),
+        Ok(PresentResult::Produced(_))
+    ));
+    assert_eq!(seen.load(Ordering::Acquire), 0);
+    assert!(input.try_pop().is_some());
+    assert!(matches!(
+        presentation.step(|_| {}),
+        Ok(PresentResult::Produced(_))
+    ));
+    assert_eq!(seen.load(Ordering::Acquire), 512);
+}
+
+#[kithara::test]
+fn eof_tail_drains_only_through_output_credits() {
+    let max_credit = Arc::new(AtomicUsize::new(0));
+    let tempo = SlowStage::new(Arc::clone(&max_credit), 700);
+    let (output, mut input) = connect_strict(1, None);
+    let (publisher, _) = presentation_cell(7);
+    let mut presentation = Presentation::new(
+        2,
+        PresentationChain {
+            effects: Vec::new(),
+            tempo: Some(Box::new(tempo)),
+        },
+        PcmPool::default(),
+        spec(44_100),
+        output,
+        publisher,
+        7,
+    );
+    admit(
+        &mut presentation,
+        Fetch::data(chunk(1.0, 0), 7),
+        "final source chunk fits",
+    );
+    presentation.finish_eof(7);
+
+    assert_eq!(step(&mut presentation), PresentResult::Advanced);
+    for _ in 0..2 {
+        assert!(matches!(
+            presentation.step(|_| {}),
+            Ok(PresentResult::Produced(PresentedBlock { frames: 512, .. }))
+        ));
+        let source = data(
+            &mut presentation,
+            input.try_pop().expect("source block before EOF debt"),
+        );
+        assert_eq!(source.frames(), 512);
+        assert_eq!(source.samples[0], 1.0);
+    }
+    assert_eq!(step(&mut presentation), PresentResult::Advanced);
+    assert!(matches!(
+        presentation.step(|_| {}),
+        Ok(PresentResult::Produced(PresentedBlock { frames: 512, .. }))
+    ));
+    assert_eq!(
+        data(
+            &mut presentation,
+            input.try_pop().expect("first EOF debt block"),
+        )
+        .frames(),
+        512
+    );
+    assert!(matches!(
+        presentation.step(|_| {}),
+        Ok(PresentResult::Produced(PresentedBlock { frames: 188, .. }))
+    ));
+    assert_eq!(
+        data(
+            &mut presentation,
+            input.try_pop().expect("second EOF debt block"),
+        )
+        .frames(),
+        188
+    );
+    assert_eq!(step(&mut presentation), PresentResult::Terminal);
+    assert!(matches!(
+        input.try_pop(),
+        Some(Fetch::NaturalEof { epoch: 7 })
+    ));
+    assert_eq!(max_credit.load(Ordering::Acquire), PRESENTATION_FRAMES);
+}
+
+#[cfg(feature = "stretch-signalsmith")]
+#[kithara::test]
+fn signalsmith_unity_keylock_accepts_short_decoder_chunks() {
+    const FRAMES: usize = 128;
+    let source_spec = PcmSpec::new(
+        2,
+        NonZeroU32::new(44_100).expect("test sample rate is non-zero"),
+    );
+    let pool = PcmPool::new(128, 200_000);
+    let controls = StretchControls::new(1.0);
+    controls.set_keylock(true);
+    controls.set_backend(StretchKind::Signalsmith);
+    let chain = create_presentation_chain(source_spec, Some(&controls), &pool, Vec::new());
+    let (output, mut input) = connect_strict(2, None);
+    let (publisher, _) = presentation_cell(9);
+    let mut presentation = Presentation::new(4, chain, pool, source_spec, output, publisher, 9);
+    let mut produced = 0;
+
+    for chunk_index in 0..16_u64 {
+        let mut meta = PcmMeta::default();
+        meta.spec = source_spec;
+        meta.frames = u32::try_from(FRAMES).expect("test frame count fits u32");
+        meta.frame_offset = chunk_index * u64::try_from(FRAMES).expect("test frames fit u64");
+        let samples = vec![0.25; FRAMES * usize::from(source_spec.channels)];
+        admit(
+            &mut presentation,
+            Fetch::data(PcmChunk::new(meta, PcmPool::default().attach(samples)), 9),
+            "short source chunk fits",
+        );
+        for _ in 0..4 {
+            match step(&mut presentation) {
+                PresentResult::Produced(_) => {
+                    produced += 1;
+                    let _ = data(
+                        &mut presentation,
+                        input.try_pop().expect("short tempo output"),
+                    );
+                }
+                PresentResult::Idle => break,
+                PresentResult::Advanced => {}
+                PresentResult::Backpressured | PresentResult::Terminal => {
+                    panic!("short source unexpectedly stopped presentation")
+                }
+            }
+        }
+    }
+    presentation.finish_eof(9);
+    for _ in 0..64 {
+        match step(&mut presentation) {
+            PresentResult::Produced(_) => {
+                produced += 1;
+                let _ = data(
+                    &mut presentation,
+                    input.try_pop().expect("short tempo tail output"),
+                );
+            }
+            PresentResult::Terminal => break,
+            PresentResult::Advanced | PresentResult::Idle => {}
+            PresentResult::Backpressured => panic!("short tempo tail exhausted its reserve"),
+        }
+    }
+    assert!(produced > 0, "short tempo input must produce audible PCM");
+}
+
+#[cfg(feature = "stretch-signalsmith")]
+#[kithara::test]
+fn tempo_stage_splits_large_decoder_chunks_at_the_rt_budget() {
+    const FRAMES: usize = 1_152;
+    let source_spec = PcmSpec::new(
+        2,
+        NonZeroU32::new(44_100).expect("test sample rate is non-zero"),
+    );
+    let pool = PcmPool::new(128, 200_000);
+    let controls = StretchControls::new(1.0);
+    controls.set_keylock(true);
+    controls.set_backend(StretchKind::Signalsmith);
+    let chain = create_presentation_chain(source_spec, Some(&controls), &pool, Vec::new());
+    let (output, mut input) = connect_strict(2, None);
+    let (publisher, _) = presentation_cell(9);
+    let mut presentation = Presentation::new(1, chain, pool, source_spec, output, publisher, 9);
+    let mut meta = PcmMeta::default();
+    meta.spec = source_spec;
+    meta.frames = u32::try_from(FRAMES).expect("test frame count fits u32");
+    let samples = FRAMES * usize::from(source_spec.channels);
+    admit(
+        &mut presentation,
+        Fetch::data(
+            PcmChunk::new(meta, PcmPool::default().attach(vec![0.25; samples])),
+            9,
+        ),
+        "large decoder chunk fits the raw queue",
+    );
+
+    assert_eq!(step(&mut presentation), PresentResult::Advanced);
+    let mut block_frames = Vec::new();
+    for _ in 0..3 {
+        let PresentResult::Produced(block) = step(&mut presentation) else {
+            panic!("each RT step must commit one bounded output block");
+        };
+        block_frames.push(block.frames);
+        let output = data(
+            &mut presentation,
+            input.try_pop().expect("bounded tempo output is committed"),
+        );
+        assert_eq!(output.frames(), block.frames);
+        assert!(output.samples.iter().all(|sample| *sample == 0.25));
+    }
+
+    assert_eq!(block_frames, [512, 512, 128]);
+    assert_eq!(step(&mut presentation), PresentResult::Idle);
+}
+
+#[cfg(feature = "stretch-signalsmith")]
+#[kithara::test]
+fn signalsmith_tail_payloads_advance_to_the_admitted_source_end() {
+    let source_spec = PcmSpec::new(
+        2,
+        NonZeroU32::new(44_100).expect("test sample rate is non-zero"),
+    );
+    let pool = PcmPool::new(128, 200_000);
+    let controls = StretchControls::new(0.5);
+    controls.set_keylock(true);
+    controls.set_backend(StretchKind::Signalsmith);
+    let chain = create_presentation_chain(source_spec, Some(&controls), &pool, Vec::new());
+    let (output, mut input) = connect_strict(1, None);
+    let (publisher, _) = presentation_cell(9);
+    let mut presentation = Presentation::new(1, chain, pool, source_spec, output, publisher, 9);
+    let start = 2_048_u64;
+    let mut meta = PcmMeta::default();
+    meta.spec = source_spec;
+    let presentation_frames = u32::try_from(PRESENTATION_FRAMES).expect("frame count fits u32");
+    meta.frames = presentation_frames;
+    meta.frame_offset = start;
+    meta.end_timestamp = duration_for_frames(
+        source_spec.sample_rate.get(),
+        start + u64::from(presentation_frames),
+    );
+    let samples = vec![0.25; PRESENTATION_FRAMES * 2];
+    admit(
+        &mut presentation,
+        Fetch::data(PcmChunk::new(meta, PcmPool::default().attach(samples)), 9),
+        "source chunk fits",
+    );
+    presentation.finish_eof(9);
+
+    let mut tail_points = Vec::new();
+    for _ in 0..64 {
+        let draining = presentation.eof_debt.is_some();
+        match step(&mut presentation) {
+            PresentResult::Produced(_) => {
+                let Fetch::Data { data, .. } = input.try_pop().expect("presented payload") else {
+                    panic!("expected presented PCM");
+                };
+                if draining {
+                    tail_points.push(data.point());
+                }
+                presentation.recycle_output(data.into());
+            }
+            PresentResult::Terminal => break,
+            PresentResult::Advanced | PresentResult::Idle | PresentResult::Backpressured => {}
+        }
+    }
+
+    assert!(
+        tail_points.len() > 1,
+        "fixture must emit a multi-block tail"
+    );
+    assert!(
+        tail_points
+            .windows(2)
+            .all(|pair| pair[0].source_frame() <= pair[1].source_frame()),
+        "every tail payload source coordinate is monotonic"
+    );
+    assert_eq!(
+        tail_points.last().map(|point| point.source_frame()),
+        Some(start + u64::from(presentation_frames))
+    );
+    assert!(matches!(
+        input.try_pop(),
+        Some(Fetch::NaturalEof { epoch: 9 })
+    ));
+}

--- a/crates/kithara-audio/src/renderer/source.rs
+++ b/crates/kithara-audio/src/renderer/source.rs
@@ -1,8 +1,8 @@
-use kithara_decode::PcmChunk;
+use kithara_decode::{DecodeError, PcmSpec};
 use kithara_platform::sync::Arc;
 use kithara_stream::SeekObserve;
 
-use crate::{pipeline::track, traits::AudioEffect};
+use crate::pipeline::track;
 
 mod kithara {
     pub(crate) use kithara_test_macros::mock;
@@ -13,7 +13,7 @@ mod kithara {
 /// The worker calls `step_track()` once per scheduling round. Each call
 /// performs at most one FSM transition and returns a [`TrackStep`] that
 /// tells the worker what happened.
-#[kithara::mock(api = MockAudioWorkerSource, type Chunk = PcmChunk;)]
+#[kithara::mock(api = MockAudioWorkerSource, type Chunk = kithara_decode::PcmChunk;)]
 pub trait AudioWorkerSource: Send + 'static {
     type Chunk: Send + 'static;
 
@@ -56,27 +56,24 @@ pub trait AudioWorkerSource: Send + 'static {
     /// - `Failed` — terminal failure.
     fn step_track(&mut self) -> track::TrackStep<Self::Chunk>;
 
+    /// Take one ordered same-epoch decoder replacement boundary.
+    ///
+    /// Sources without decoder replacement retain the default empty result.
+    fn take_presentation_barrier(&mut self) -> Option<(u64, PcmSpec)> {
+        None
+    }
+
+    /// Transition the source FSM after presentation can no longer continue.
+    ///
+    /// Sources with a typed failure state override this so activity and UI
+    /// observe the same terminal failure as the final PCM marker.
+    fn presentation_failed(&mut self, error: DecodeError) {
+        let _ = error;
+    }
+
     /// One-time worker-thread warmup, called from the scheduler shell when the
     /// node registers. Pre-touches the produce-core read path so lazy global
     /// thread-locals (the `arc_swap` committed-read debt node) allocate here,
     /// off the forbid-blocking decode core. Default no-op.
     fn warm_up(&mut self) {}
-}
-
-/// Apply the effect chain to the chunk.
-pub(crate) fn apply_effects(
-    effects: &mut [Box<dyn AudioEffect>],
-    mut chunk: PcmChunk,
-) -> Option<PcmChunk> {
-    for effect in &mut *effects {
-        chunk = effect.process(chunk)?;
-    }
-    Some(chunk)
-}
-
-/// Reset effects chain (e.g. after seek).
-pub(crate) fn reset_effects(effects: &mut [Box<dyn AudioEffect>]) {
-    for effect in &mut *effects {
-        effect.reset();
-    }
 }

--- a/crates/kithara-audio/src/renderer/tests.rs
+++ b/crates/kithara-audio/src/renderer/tests.rs
@@ -1,5 +1,7 @@
+use std::num::NonZeroU32;
+
 use kithara_bufpool::PcmPool;
-use kithara_decode::{PcmChunk, PcmMeta};
+use kithara_decode::{PcmChunk, PcmMeta, PcmSpec};
 use kithara_platform::sync::Arc;
 use kithara_stream::{SeekControl, SeekObserve, SeekState};
 
@@ -9,8 +11,22 @@ use crate::pipeline::{
     track::{TrackStep, WaitingReason},
 };
 
-fn empty_chunk() -> PcmChunk {
-    PcmChunk::new(PcmMeta::default(), PcmPool::default().attach(Vec::new()))
+const MOCK_FRAMES: usize = 512;
+
+fn mock_chunk(frame_offset: u64) -> PcmChunk {
+    let spec = PcmSpec::new(
+        2,
+        NonZeroU32::new(48_000).expect("fixture rate is non-zero"),
+    );
+    PcmChunk::new(
+        PcmMeta {
+            spec,
+            frames: u32::try_from(MOCK_FRAMES).expect("fixture frame count fits u32"),
+            frame_offset,
+            ..Default::default()
+        },
+        PcmPool::default().attach(vec![0.0; MOCK_FRAMES * usize::from(spec.channels)]),
+    )
 }
 
 pub(crate) struct MockSource {
@@ -75,7 +91,9 @@ impl AudioWorkerSource for MockSource {
         if self.cursor >= self.chunks_to_produce {
             return TrackStep::Eof;
         }
+        let frame_offset =
+            u64::try_from(self.cursor.saturating_mul(MOCK_FRAMES)).unwrap_or(u64::MAX);
         self.cursor += 1;
-        TrackStep::Produced(Fetch::data(empty_chunk(), 0))
+        TrackStep::Produced(Fetch::data(mock_chunk(frame_offset), self.seek_obs.epoch()))
     }
 }

--- a/crates/kithara-audio/src/runtime/mod.rs
+++ b/crates/kithara-audio/src/runtime/mod.rs
@@ -11,6 +11,6 @@ pub(crate) use handle::{SchedulerCmd, SchedulerHandle, Slot, SlotId};
 pub use node::ServiceClass;
 pub(crate) use node::{AtomicServiceClass, Node, RtPolicy, TickResult};
 pub(crate) use observer::{PassOutcome, PassReport, SchedulerEvent, SchedulerObserver};
-pub(crate) use ports::{Inlet, Outlet, WakeSignal, connect};
+pub(crate) use ports::{Inlet, Outlet, StrictOutlet, WakeSignal, connect, connect_strict};
 pub(crate) use scheduler::Scheduler;
 pub(crate) use wake::SchedulerWake;

--- a/crates/kithara-audio/src/runtime/ports.rs
+++ b/crates/kithara-audio/src/runtime/ports.rs
@@ -41,6 +41,36 @@ pub(crate) struct Outlet<T> {
     wake: Option<Arc<dyn WakeSignal>>,
 }
 
+/// Bounded output port without a hidden overflow slot.
+pub(crate) struct StrictOutlet<T> {
+    producer: HeapProd<T>,
+    wake: Option<Arc<dyn WakeSignal>>,
+}
+
+impl<T> StrictOutlet<T> {
+    pub(crate) fn flush_wake_signals(&self) {
+        if let Some(wake) = &self.wake {
+            wake.flush_deferred();
+        }
+    }
+
+    pub(crate) fn has_capacity(&self) -> bool {
+        !self.producer.is_full()
+    }
+
+    pub(crate) fn try_push(&mut self, item: T) -> Result<(), T> {
+        let was_empty = self.producer.is_empty();
+        self.producer.try_push(item)?;
+        if let Some(wake) = &self.wake {
+            wake.wake();
+            if was_empty {
+                wake.on_data_available();
+            }
+        }
+        Ok(())
+    }
+}
+
 impl<T> Outlet<T> {
     /// Try to drain the parked overflow item into the ring buffer.
     ///
@@ -53,13 +83,6 @@ impl<T> Outlet<T> {
             return true;
         };
         self.push_or_park(item)
-    }
-
-    /// Flush any deferred work owned by the wake signal.
-    pub(crate) fn flush_wake_signals(&self) {
-        if let Some(wake) = &self.wake {
-            wake.flush_deferred();
-        }
     }
 
     /// Whether both the ring buffer and the overflow slot are full.
@@ -131,6 +154,7 @@ impl<T> Outlet<T> {
     delegate::delegate! {
         to self.overflow {
             /// Whether an item is currently parked in the overflow slot.
+            #[cfg(test)]
             #[call(is_some)]
             pub(crate) const fn has_pending(&self) -> bool;
             /// Discard the parked overflow item, returning it to the caller.
@@ -138,6 +162,7 @@ impl<T> Outlet<T> {
             /// Useful when a producer needs to invalidate previously enqueued data
             /// (e.g. on a seek epoch change) without waiting for the consumer to
             /// drain the ring.
+            #[cfg(test)]
             #[call(take)]
             pub(crate) const fn take_pending(&mut self) -> Option<T>;
         }
@@ -177,6 +202,17 @@ pub(crate) fn connect<T>(
         },
         Inlet { consumer },
     )
+}
+
+/// Connect a producer directly to a consumer without an overflow slot.
+#[must_use]
+pub(crate) fn connect_strict<T>(
+    capacity: usize,
+    wake: Option<Arc<dyn WakeSignal>>,
+) -> (StrictOutlet<T>, Inlet<T>) {
+    let rb = HeapRb::<T>::new(capacity.max(1));
+    let (producer, consumer) = rb.split();
+    (StrictOutlet { producer, wake }, Inlet { consumer })
 }
 
 #[cfg(test)]
@@ -234,6 +270,17 @@ mod tests {
         assert_eq!(inl.try_pop(), Some(3));
         assert_eq!(inl.try_pop(), None);
         assert!(inl.is_empty());
+    }
+
+    #[kithara::test]
+    fn strict_outlet_never_parks_an_extra_item() {
+        let (mut out, mut inlet) = connect_strict::<i32>(1, None);
+
+        assert_eq!(out.try_push(1), Ok(()));
+        assert!(!out.has_capacity());
+        assert_eq!(out.try_push(2), Err(2));
+        assert_eq!(inlet.try_pop(), Some(1));
+        assert!(out.has_capacity());
     }
 
     #[kithara::test]

--- a/crates/kithara-audio/src/traits/effect.rs
+++ b/crates/kithara-audio/src/traits/effect.rs
@@ -1,20 +1,210 @@
-use kithara_decode::PcmChunk;
+use kithara_decode::{DecodeResult, PcmChunk, PcmMeta, PcmSpec};
+
+use super::PresentationPoint;
 
 mod kithara {
     pub(crate) use kithara_test_macros::mock;
 }
 
-/// Audio processing effect in the chain (transforms PCM chunks).
+/// Fixed-shape PCM visible to a frame-preserving effect.
+///
+/// Metadata and slice length are immutable, so an effect can observe source
+/// provenance and mutate samples but cannot buffer, drop, resize, or retime a
+/// presentation block.
+#[non_exhaustive]
+pub struct AudioBlockMut<'a> {
+    meta: &'a PcmMeta,
+    samples: &'a mut [f32],
+}
+
+impl<'a> AudioBlockMut<'a> {
+    /// Borrow immutable PCM metadata and the matching fixed-length samples.
+    #[must_use]
+    pub fn new(meta: &'a PcmMeta, samples: &'a mut [f32]) -> Self {
+        Self { meta, samples }
+    }
+
+    /// Immutable metadata for this presentation block.
+    #[must_use]
+    pub fn meta(&self) -> &PcmMeta {
+        self.meta
+    }
+
+    /// Mutable interleaved samples with a fixed length.
+    pub fn samples_mut(&mut self) -> &mut [f32] {
+        self.samples
+    }
+}
+
+/// Sample-domain effect that preserves block frames and metadata exactly.
 #[kithara::mock(api = AudioEffectMock)]
 pub trait AudioEffect: Send + 'static {
-    /// Flush remaining buffered data (called at end of stream).
-    fn flush(&mut self) -> Option<PcmChunk>;
-
-    /// Process a PCM chunk, returning transformed output.
+    /// Process one fixed-shape block in place.
     ///
-    /// Returns `None` if the effect is accumulating data (not enough for output yet).
-    fn process(&mut self, chunk: PcmChunk) -> Option<PcmChunk>;
+    /// # Errors
+    ///
+    /// Returns a decode error when the samples cannot be processed. Effects
+    /// cannot represent accumulation: the duration-changing stage has a
+    /// separate private protocol.
+    fn process(&mut self, block: AudioBlockMut<'_>) -> DecodeResult<()>;
 
-    /// Reset internal state (called after seek).
+    /// Clear state after a seek or decoder discontinuity.
     fn reset(&mut self);
+}
+
+/// One final-output reservation. It cannot be cloned or retained beyond the
+/// render call that received it.
+#[derive(fieldwork::Fieldwork)]
+#[fieldwork(opt_in, get)]
+pub(crate) struct OutputCredit<'a> {
+    #[field(get, vis = "pub(crate)", copy)]
+    channels: usize,
+    #[field(get, vis = "pub(crate)", copy)]
+    max_frames: usize,
+    samples: &'a mut [f32],
+}
+
+impl<'a> OutputCredit<'a> {
+    pub(crate) fn new(samples: &'a mut [f32], channels: usize, max_frames: usize) -> Self {
+        Self {
+            channels,
+            max_frames,
+            samples,
+        }
+    }
+
+    pub(crate) fn samples_mut(&mut self) -> &mut [f32] {
+        self.samples
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum TempoStep {
+    /// The latest controls or decoder shape have not been prepared off-RT yet.
+    Preparing,
+    /// Source advanced without output while the admitted chunk still has data.
+    Consumed,
+    /// The stage consumed its admitted chunk and needs another one.
+    NeedSource,
+    Rendered {
+        frames: usize,
+        meta: PcmMeta,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct TempoBoundaryId(u64);
+
+impl TempoBoundaryId {
+    pub(crate) const fn new(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum TempoPrepareRequest {
+    Current { spec: PcmSpec },
+    DecoderBoundary { spec: PcmSpec },
+}
+
+/// Proof that true source EOF was declared before finite DSP-tail draining.
+pub(crate) struct TempoEofDebt {
+    _private: (),
+}
+
+impl TempoEofDebt {
+    pub(crate) const fn new() -> Self {
+        Self { _private: () }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum TempoEofStep {
+    Drained,
+    Rendered { frames: usize, meta: PcmMeta },
+}
+
+/// Proof that an ordered tempo boundary was reached after all older raw PCM,
+/// before replacing the resident tempo engine.
+pub(crate) struct TempoDiscontinuityDebt {
+    _private: (),
+}
+
+impl TempoDiscontinuityDebt {
+    pub(crate) const fn new() -> Self {
+        Self { _private: () }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum TempoDiscontinuityStep {
+    Drained,
+    Rendered { frames: usize, meta: PcmMeta },
+}
+
+/// The sole duration-changing presentation stage.
+///
+/// Steady rendering owns at most one admitted source chunk, consumes at most
+/// 512 source frames per call, and writes at most the caller's output credit.
+/// It cannot retain rendered output. True EOF and an ordered tempo boundary
+/// are the only typed states that enable a finite caller-credited drain.
+pub(crate) trait TempoStage: Send + 'static {
+    /// Drop cores retired by the previous RT boundary in the unchecked shell.
+    fn release_retired_off_rt(&mut self) {}
+
+    /// Prepare the exact desired backend and control snapshot outside RT.
+    fn service_off_rt(&mut self, request: TempoPrepareRequest) -> DecodeResult<()>;
+
+    /// Boundary awaiting an ordered drain and allocation-free RT commit.
+    fn prepared_boundary(&self) -> Option<TempoBoundaryId>;
+
+    /// Move a previously prepared core into the active slot at an RT boundary.
+    fn commit_prepared(&mut self, id: TempoBoundaryId) -> DecodeResult<()>;
+
+    /// Number of admitted future-source chunks, always `0` or `1`.
+    fn buffered_source_quanta(&self) -> usize;
+
+    /// Current output PCM shape.
+    fn output_spec(&self) -> PcmSpec;
+
+    /// Admit one source chunk. Callers invoke this only when
+    /// [`buffered_source_quanta`](Self::buffered_source_quanta) is zero.
+    fn push_source(&mut self, chunk: PcmChunk) -> DecodeResult<()>;
+
+    /// Render at most one caller-budgeted output block.
+    fn render(
+        &mut self,
+        point: Option<PresentationPoint>,
+        credit: OutputCredit<'_>,
+        retire: &mut dyn FnMut(PcmChunk),
+    ) -> DecodeResult<TempoStep>;
+
+    /// Source frames admitted but not yet represented by rendered output.
+    fn held_source_frames(&self) -> u64;
+
+    /// Declare true source exhaustion and create one of the two legal finite
+    /// rendered debts.
+    fn finish_eof(&mut self) -> DecodeResult<TempoEofDebt>;
+
+    /// Drain at most one credited EOF-tail block.
+    fn render_eof(
+        &mut self,
+        debt: &mut TempoEofDebt,
+        credit: OutputCredit<'_>,
+        retire: &mut dyn FnMut(PcmChunk),
+    ) -> DecodeResult<TempoEofStep>;
+
+    /// Begin the bounded non-EOF drain at an ordered tempo boundary.
+    fn begin_discontinuity(&mut self) -> DecodeResult<TempoDiscontinuityDebt>;
+
+    /// Emit at most one credited block of old-engine source before reset.
+    fn render_discontinuity(
+        &mut self,
+        debt: &mut TempoDiscontinuityDebt,
+        credit: OutputCredit<'_>,
+        retire: &mut dyn FnMut(PcmChunk),
+    ) -> DecodeResult<TempoDiscontinuityStep>;
+
+    /// Retire all owned state without resetting or dropping a backend on RT.
+    fn deactivate(&mut self, retire: &mut dyn FnMut(PcmChunk)) -> DecodeResult<()>;
 }

--- a/crates/kithara-audio/src/traits/mod.rs
+++ b/crates/kithara-audio/src/traits/mod.rs
@@ -2,11 +2,18 @@ mod effect;
 mod outcome;
 mod reader;
 
-pub use effect::AudioEffect;
 #[cfg(any(test, feature = "mock"))]
 pub use effect::AudioEffectMock;
+pub use effect::{AudioBlockMut, AudioEffect};
+pub(crate) use effect::{
+    OutputCredit, TempoBoundaryId, TempoDiscontinuityDebt, TempoDiscontinuityStep, TempoEofDebt,
+    TempoEofStep, TempoPrepareRequest, TempoStage, TempoStep,
+};
 pub use kithara_decode::{DecodeError, DecodeResult};
-pub use outcome::{ChunkOutcome, PendingReason, ReadOutcome, SeekOutcome};
+pub use outcome::{
+    ChunkOutcome, PendingReason, PresentationAdvance, PresentationCursor, PresentationPoint,
+    ReadOutcome, SeekOutcome,
+};
 pub use reader::{PcmControl, PcmRead, PcmReader, PcmSession, SeekBegin};
 #[cfg(any(test, feature = "mock"))]
 pub use reader::{PcmControlMock, PcmReadMock, PcmSessionMock};

--- a/crates/kithara-audio/src/traits/outcome.rs
+++ b/crates/kithara-audio/src/traits/outcome.rs
@@ -1,7 +1,158 @@
-use std::num::NonZeroUsize;
+use std::num::{NonZeroU32, NonZeroUsize};
 
 use kithara_decode::PcmChunk;
 use kithara_platform::time::Duration;
+
+use crate::musical::SessionFrame;
+
+/// Immutable producer endpoint attached to one final PCM block.
+///
+/// The point describes committed presentation state. It does not prove that
+/// the consumer has played the block; [`PresentationAdvance`] carries that
+/// proof after the block boundary is crossed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct PresentationPoint {
+    epoch: u64,
+    source_frame: u64,
+    generation: u64,
+    output_end: u64,
+    sample_rate: NonZeroU32,
+}
+
+impl PresentationPoint {
+    /// Creates one final-output presentation endpoint.
+    #[must_use]
+    pub const fn new(
+        seek_epoch: u64,
+        source_frame: u64,
+        generation: u64,
+        output_end: u64,
+        sample_rate: NonZeroU32,
+    ) -> Self {
+        Self {
+            epoch: seek_epoch,
+            source_frame,
+            generation,
+            output_end,
+            sample_rate,
+        }
+    }
+
+    /// Seek epoch that owns this point.
+    #[must_use]
+    pub const fn seek_epoch(self) -> u64 {
+        self.epoch
+    }
+
+    /// Source frame presented through this block boundary.
+    #[must_use]
+    pub const fn source_frame(self) -> u64 {
+        self.source_frame
+    }
+
+    /// Presentation generation within the seek epoch.
+    #[must_use]
+    pub const fn generation(self) -> u64 {
+        self.generation
+    }
+
+    /// Cumulative output frame ordinal within the presentation generation.
+    #[must_use]
+    pub const fn output_end(self) -> u64 {
+        self.output_end
+    }
+
+    /// Sample rate of the source-frame axis.
+    #[must_use]
+    pub const fn sample_rate(self) -> NonZeroU32 {
+        self.sample_rate
+    }
+}
+
+/// One producer endpoint mapped to the absolute session clock.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct PresentationCursor {
+    point: PresentationPoint,
+    session_frame: SessionFrame,
+}
+
+impl PresentationCursor {
+    /// Maps an available producer endpoint to an absolute session frame.
+    ///
+    #[must_use]
+    pub const fn new(point: PresentationPoint, session_frame: SessionFrame) -> Self {
+        Self {
+            point,
+            session_frame,
+        }
+    }
+
+    /// Producer point mapped by this cursor.
+    #[must_use]
+    pub const fn point(self) -> PresentationPoint {
+        self.point
+    }
+
+    delegate::delegate! {
+        to self.point {
+            /// Seek epoch owning the producer point.
+            #[must_use]
+            pub const fn seek_epoch(self) -> u64;
+            /// Source frame presented through the producer point.
+            #[must_use]
+            pub const fn source_frame(self) -> u64;
+            /// Presentation generation within the seek epoch.
+            #[must_use]
+            pub const fn generation(self) -> u64;
+            /// Cumulative output-frame ordinal within the presentation generation.
+            #[must_use]
+            pub const fn output_end(self) -> u64;
+            /// Sample rate of the source-frame axis.
+            #[must_use]
+            #[call(sample_rate)]
+            pub const fn source_rate(self) -> NonZeroU32;
+        }
+    }
+
+    /// Absolute host-session frame corresponding to [`Self::point`].
+    #[must_use]
+    pub const fn session_frame(self) -> SessionFrame {
+        self.session_frame
+    }
+}
+
+/// Exact presentation boundary crossed by the most recent PCM read.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct PresentationAdvance {
+    point: PresentationPoint,
+    read_offset_frames: usize,
+}
+
+impl PresentationAdvance {
+    /// Creates proof that `point` was crossed at a frame offset in one read.
+    #[must_use]
+    pub const fn new(point: PresentationPoint, read_offset_frames: usize) -> Self {
+        Self {
+            point,
+            read_offset_frames,
+        }
+    }
+
+    /// Producer point whose final PCM block was consumed.
+    #[must_use]
+    pub const fn point(self) -> PresentationPoint {
+        self.point
+    }
+
+    /// Frame offset of that boundary within the PCM read that crossed it.
+    #[must_use]
+    pub const fn read_offset_frames(self) -> usize {
+        self.read_offset_frames
+    }
+}
 
 /// Reason a [`ReadOutcome::Pending`] / [`ChunkOutcome::Pending`] was
 /// returned — i.e. why the reader did not advance this call. Each

--- a/crates/kithara-audio/src/traits/reader.rs
+++ b/crates/kithara-audio/src/traits/reader.rs
@@ -4,7 +4,7 @@ use kithara_decode::{DecodeError, PcmSpec, TrackMetadata};
 use kithara_events::EventBus;
 use kithara_platform::{maybe_send::MaybeSend, sync::Arc, time::Duration};
 
-use super::{ChunkOutcome, ReadOutcome, SeekOutcome};
+use super::{ChunkOutcome, PresentationAdvance, PresentationPoint, ReadOutcome, SeekOutcome};
 use crate::{ServiceClass, renderer::PreloadGate};
 
 mod kithara {
@@ -27,6 +27,23 @@ pub trait PcmRead {
     /// or chunk-less readers may report `0`.
     fn decoded_frontier(&self) -> Duration {
         Duration::from_secs(0)
+    }
+
+    /// Latest coherent producer-side presentation endpoint.
+    ///
+    /// This may describe PCM still ahead of the consumer. Use
+    /// [`Self::take_presentation_advance`] for proof of consumption.
+    fn presentation_point(&self) -> Option<PresentationPoint> {
+        None
+    }
+
+    /// Takes the latest exact final-block boundary crossed by PCM reads.
+    ///
+    /// Partial block consumption does not produce an advance. If one read
+    /// crosses multiple boundaries, this returns the latest one and its exact
+    /// frame offset within that read.
+    fn take_presentation_advance(&mut self) -> Option<PresentationAdvance> {
+        None
     }
 
     /// Read the next decoded chunk with full metadata.

--- a/crates/kithara-decode/src/composed.rs
+++ b/crates/kithara-decode/src/composed.rs
@@ -500,7 +500,7 @@ mod default_priming_tests {
 /// seek landing a fraction of a sample below the exact target frame, a floored
 /// label reads one frame short of the contiguous decode head (a −1 seam at a
 /// mid-playback recreate), while the trimmed audio itself stays continuous.
-fn frame_offset_for(at: Duration, sample_rate: u32) -> u64 {
+pub(crate) fn frame_offset_for(at: Duration, sample_rate: u32) -> u64 {
     let secs = at.as_secs();
     let subsec_frames = (u64::from(at.subsec_nanos()) * u64::from(sample_rate))
         .saturating_add(500_000_000)

--- a/crates/kithara-decode/src/resampled.rs
+++ b/crates/kithara-decode/src/resampled.rs
@@ -1,6 +1,7 @@
 use std::num::{NonZeroU32, NonZeroUsize};
 
 use kithara_bufpool::{PcmBuf, PcmPool};
+use kithara_platform::time::Duration;
 use kithara_resampler::{
     Resampler, ResamplerBackend, ResamplerConfig, ResamplerMode, ResamplerProcess,
     ResamplerSettings, create_resampler,
@@ -11,8 +12,8 @@ use smallvec::SmallVec;
 use crate::{
     BlenderProfile, DecodeError, DecodeResult, Decoder, DecoderChunkOutcome,
     DecoderResamplerConfig, DecoderSeekOutcome, DecoderTrackInfo, Frames, GaplessInfo,
-    GaplessTailCompensation, PcmChunk, PcmMeta, PcmSpec, TrackMetadata, duration_for_frames,
-    frames_for_duration, sanitize_sample,
+    GaplessTailCompensation, PcmChunk, PcmMeta, PcmSpec, TrackMetadata, composed::frame_offset_for,
+    duration_for_frames, sanitize_sample,
 };
 
 pub(crate) fn wrap<B>(
@@ -53,6 +54,7 @@ where
     eof_flushed: bool,
     emitted_frames: u64,
     output_frame_offset: u64,
+    reanchor_output_on_next_chunk: bool,
     source_frames_seen: u64,
     output_skip_frames: usize,
 }
@@ -91,6 +93,7 @@ where
             pending_meta: None,
             pool: pool.clone(),
             quality: config.quality,
+            reanchor_output_on_next_chunk: false,
             resampler,
             scratch: channel_buffers(pool, source_spec.channels),
             source_frames_seen: 0,
@@ -102,13 +105,14 @@ where
 
     fn append_chunk(&mut self, chunk: &PcmChunk) -> DecodeResult<()> {
         let spec = chunk.spec();
-        if spec != self.source_spec {
+        let source_spec_changed = spec != self.source_spec;
+        if source_spec_changed {
             self.rebuild_for_source_spec(spec)?;
-            self.output_frame_offset = u64::try_from(frames_for_duration(
-                self.target_sample_rate.get(),
-                chunk.meta.timestamp,
-            ))
-            .unwrap_or(u64::MAX);
+        }
+        if source_spec_changed || self.reanchor_output_on_next_chunk {
+            self.output_frame_offset =
+                frame_offset_for(chunk.meta.timestamp, self.target_sample_rate.get());
+            self.reanchor_output_on_next_chunk = false;
         }
         if self.pending_meta.is_none() {
             self.pending_meta = Some(chunk.meta);
@@ -326,6 +330,7 @@ where
         Self::clear_planar(&mut self.input, channels);
         Self::clear_planar(&mut self.output, channels);
         self.pending_meta = None;
+        self.reanchor_output_on_next_chunk = false;
         self.last_input_meta = None;
         self.emitted_frames = 0;
         self.eof_flushed = false;
@@ -386,7 +391,7 @@ where
         }
     }
 
-    fn seek(&mut self, pos: kithara_platform::time::Duration) -> DecodeResult<DecoderSeekOutcome> {
+    fn seek(&mut self, pos: Duration) -> DecodeResult<DecoderSeekOutcome> {
         let outcome = self.decoder.seek(pos)?;
         self.reset_resampler_state();
         match outcome {
@@ -396,11 +401,9 @@ where
                 preroll,
                 ..
             } => {
-                self.output_frame_offset = u64::try_from(frames_for_duration(
-                    self.target_sample_rate.get(),
-                    landed_at,
-                ))
-                .unwrap_or(u64::MAX);
+                self.output_frame_offset =
+                    frame_offset_for(landed_at, self.target_sample_rate.get());
+                self.reanchor_output_on_next_chunk = true;
                 Ok(DecoderSeekOutcome::Landed {
                     landed_at,
                     landed_byte,
@@ -446,7 +449,7 @@ where
 
     delegate::delegate! {
         to self.decoder {
-            fn duration(&self) -> Option<kithara_platform::time::Duration>;
+            fn duration(&self) -> Option<Duration>;
             fn flush_reader_signals(&mut self);
             fn metadata(&self) -> TrackMetadata;
             fn update_byte_len(&self, len: u64);

--- a/crates/kithara-decode/tests/resampled.rs
+++ b/crates/kithara-decode/tests/resampled.rs
@@ -9,8 +9,10 @@ use std::{
 
 use kithara_bufpool::{BytePool, PcmPool};
 use kithara_decode::{
-    DecoderChunkOutcome, DecoderConfig, DecoderFactory, DecoderResamplerConfig, PcmChunk,
+    DecoderChunkOutcome, DecoderConfig, DecoderFactory, DecoderResamplerConfig, DecoderSeekOutcome,
+    PcmChunk, duration_for_frames, frames_for_duration,
 };
+use kithara_platform::time::Duration;
 use kithara_resampler::{
     Resampler, ResamplerBackend, ResamplerBuildError, ResamplerCapabilities, ResamplerMode,
     ResamplerProcess, ResamplerSettings,
@@ -313,6 +315,88 @@ fn standalone_decoder_adapter_flushes_backend_delay_at_eof() {
 }
 
 #[test]
+fn standalone_decoder_seek_reanchors_output_to_trimmed_target() {
+    const TARGET: Duration = Duration::from_millis(30);
+    const WAV_FRAMES: usize = 4_096;
+
+    let target_rate = NonZeroU32::new(TARGET_RATE).expect("test rate");
+    let mut decoder = decoder_over(
+        test_wav_with_frames(WAV_FRAMES),
+        target_rate,
+        AdapterProbeBackend,
+    );
+    let DecoderSeekOutcome::Landed { landed_at, .. } =
+        decoder.seek(TARGET).expect("seek resampled decoder")
+    else {
+        panic!("seek target must be inside the test WAV");
+    };
+    assert!(
+        landed_at < TARGET,
+        "test requires a coarse inner landing before the requested target"
+    );
+    let output: PcmChunk = decoder
+        .next_chunk()
+        .expect("first chunk after seek")
+        .try_into()
+        .expect("resampled output chunk");
+    let target_frame =
+        u64::try_from(frames_for_duration(TARGET_RATE, TARGET)).expect("target frame fits u64");
+
+    assert_eq!(output.meta.frame_offset, target_frame);
+    assert_eq!(output.meta.timestamp, TARGET);
+    assert_eq!(
+        output.meta.timestamp,
+        duration_for_frames(TARGET_RATE, output.meta.frame_offset)
+    );
+}
+
+#[test]
+fn standalone_decoder_seek_rounds_timeline_frames_half_up() {
+    const SOURCE_TARGET_FRAME: u64 = 1_441;
+    const ROUNDING_TARGET_RATE: u32 = 44_085;
+    const EXPECTED_LANDED_FRAME: u64 = 1_152;
+    const EXPECTED_OUTPUT_FRAME: u64 = 1_441;
+    const WAV_FRAMES: usize = 4_096;
+
+    let target = duration_for_frames(SOURCE_RATE, SOURCE_TARGET_FRAME);
+    let target_rate = NonZeroU32::new(ROUNDING_TARGET_RATE).expect("test rate");
+    let mut decoder = decoder_over(
+        test_wav_with_frames(WAV_FRAMES),
+        target_rate,
+        AdapterProbeBackend,
+    );
+    let DecoderSeekOutcome::Landed {
+        landed_at,
+        landed_frame,
+        ..
+    } = decoder.seek(target).expect("seek resampled decoder")
+    else {
+        panic!("seek target must be inside the test WAV");
+    };
+    let output: PcmChunk = decoder
+        .next_chunk()
+        .expect("first chunk after seek")
+        .try_into()
+        .expect("resampled output chunk");
+
+    assert_eq!(
+        frames_for_duration(ROUNDING_TARGET_RATE, landed_at),
+        1_151,
+        "test landing must distinguish floor from half-up"
+    );
+    assert_eq!(
+        frames_for_duration(ROUNDING_TARGET_RATE, target),
+        1_440,
+        "test target must distinguish floor from half-up"
+    );
+    assert_eq!(
+        (landed_frame, output.meta.frame_offset),
+        (EXPECTED_LANDED_FRAME, EXPECTED_OUTPUT_FRAME)
+    );
+    assert_eq!(output.meta.timestamp, Duration::from_nanos(32_686_854));
+}
+
+#[test]
 fn resampler_never_sees_a_sample_the_file_poisoned() {
     let captured: Captured = Arc::default();
     let target_rate = NonZeroU32::new(TARGET_RATE).expect("test rate");
@@ -418,7 +502,11 @@ const fn marker_samples() -> &'static [f32] {
 }
 
 fn test_wav() -> Vec<u8> {
-    let data_size = FRAMES
+    test_wav_with_frames(FRAMES)
+}
+
+fn test_wav_with_frames(frames: usize) -> Vec<u8> {
+    let data_size = frames
         .saturating_mul(usize::from(CHANNELS))
         .saturating_mul(usize::from(WAV_BYTES_PER_SAMPLE));
     let mut wav = wav_header(WAV_PCM_FORMAT, WAV_BITS_PER_SAMPLE, data_size);

--- a/crates/kithara-play/CONTEXT.md
+++ b/crates/kithara-play/CONTEXT.md
@@ -44,23 +44,25 @@ also need playlist/segment headers keep the same immutable `Arc<DomainKeyPolicy>
 ## Tempo & Key-Lock
 
 `kithara_audio::StretchControls` (one `Arc` per deck, in `PlayerConfig.timestretch`) is the single
-source of truth for playback speed, shared between the UI and the worker effect chain, which reads
-it each chunk. It always carries `speed` + `region_plan`; with a stretch backend compiled in
+source of truth for playback speed, shared between the UI and the worker's resident presentation
+tempo stage, which reads it for each admitted source quantum. It always carries `speed` +
+`region_plan`; with a stretch backend compiled in
 (`kithara-audio`'s `stretch-signalsmith` / `stretch-bungee`, native targets only) it also carries
 `keylock` and `backend`. Rate setters (`PlayerImpl::set_rate`, `play`) write this one handle - no
 second rate atomic, no manual mirror. `Queue` delegates `set_rate` to the player; key-lock and
 backend are set by the consumer directly on the shared handle. `prepare_config` always passes the
-shared controls into every track (`stretch = Some(..)`). With a backend compiled in the effect
-chain runs a source-domain `TimeStretchProcessor` at `ratio = 1/speed`, and:
+shared controls into every track (`stretch = Some(..)`). With a backend compiled in the late
+presentation stage runs one persistent `TimeStretchProcessor` at `ratio = 1/speed`, and:
 
 - **key-lock off** (the constructed default): `pitch = speed` - speed shifts pitch, vinyl-style.
 - **key-lock on**: `pitch = 1.0` - speed preserves pitch.
 
 At speed 1.0 with no region plan the slot bypasses. Without a backend - including every wasm build,
 where it is cfg'd out regardless of features - no speed DSP is inserted and PCM output stays pinned
-to 1.0. Because the controls are read each chunk, **speed, key-lock, and backend all apply live,
-mid-track - no reload.** Switching backend rebuilds the DSP backend; returning to unity passthrough
-resets buffered stretch state.
+to 1.0. Because controls are read at every admitted source quantum, **speed, key-lock, and backend
+all apply live, mid-track - no reload.** Switching backend rebuilds the DSP backend; returning to
+unity retires buffered stretch state before byte-identical passthrough resumes. The stage emits
+under a fixed 512-frame output credit and never retains more than one admitted source quantum.
 
 Fixed-ratio sample-rate conversion is a separate stage: Apple fused builds use the codec-embedded
 placement, other builds the standalone decode-adapter resampler.
@@ -190,11 +192,20 @@ The audio thread never logs. Discrete facts leave through `PlayerNotification`, 
 through `PlaybackShared::metrics()` (`bridge::RtMetrics`); `RtSink` carries both into the per-track
 read path.
 
+Final decoded PCM carries an immutable producer `PresentationPoint`. `PlayerResource` preserves the
+point's boundary while it copies through its preallocated scratch buffer and releases a
+`PresentationAdvance` only when the callback actually crosses that boundary. The leading
+`PlayerTrack` maps the consumed boundary to an absolute `SessionFrame`; partial/empty reads, seek,
+generation or rate mismatches invalidate the mapping instead of projecting stale state.
+
 **Memory ordering.** `playing` and `seek_epoch` decide whether the audio thread acts and carry
 `SeqCst`; touched once per command or block, never per sample. The `fetch_add` in
 `next_seek_epoch` **is** the publication - storing its result back would let two concurrent seeks
 reinstate the older epoch. Everything else is `Relaxed`: `RtMetrics` counters are monotonic deltas,
-and `PlaybackSnapshot`'s scalars are independent readouts that need not agree across a block.
+and `PlaybackSnapshot`'s scalar readouts need not agree across a block. Its optional presentation
+cursor is the exception: one non-cloneable RT publisher writes its atomic words under a revision,
+and a reader performs one bounded validation attempt. An in-flight or changed value reads as
+`None`; neither side spins or locks.
 
 ## Seek Ownership
 

--- a/crates/kithara-play/src/bridge/channels.rs
+++ b/crates/kithara-play/src/bridge/channels.rs
@@ -5,7 +5,7 @@ use kithara_platform::{sync::Arc, time::Duration};
 use ringbuf::{HeapCons, HeapProd, HeapRb, traits::Split};
 use smallvec::SmallVec;
 
-use super::PlaybackShared;
+use super::{PlaybackPresentationPublisher, PlaybackShared};
 use crate::{
     bridge::{PlayerCmd, PlayerNotification, SharedEq},
     rt::{PlayerNodeProcessor, track::PlayerTrack},
@@ -15,6 +15,7 @@ use crate::{
 #[non_exhaustive]
 pub struct NodeInputs {
     pub(crate) playback: Arc<PlaybackShared>,
+    pub(crate) presentation: PlaybackPresentationPublisher,
     pub(crate) cmd_rx: HeapCons<PlayerCmd>,
     pub(crate) notif_tx: HeapProd<PlayerNotification>,
     pub(crate) trash_tx: HeapProd<PlayerTrack>,
@@ -82,12 +83,14 @@ pub fn slot_channels(eq: SharedEq) -> (NodeInputs, SlotControl) {
     let (notif_tx, notif_rx) = HeapRb::<PlayerNotification>::new(NOTIFICATION_CAPACITY).split();
     let (trash_tx, trash_rx) = HeapRb::<PlayerTrack>::new(TRASH_CAPACITY).split();
     let playback = Arc::new(PlaybackShared::default());
+    let presentation = PlaybackPresentationPublisher::new(Arc::clone(&playback));
 
     let inputs = NodeInputs {
         cmd_rx,
         notif_tx,
         trash_tx,
         playback: Arc::clone(&playback),
+        presentation,
     };
     let control = SlotControl {
         playback,

--- a/crates/kithara-play/src/bridge/mod.rs
+++ b/crates/kithara-play/src/bridge/mod.rs
@@ -8,6 +8,7 @@ pub use channels::{MixTapWriter, NodeInputs, SlotControl, slot_channels};
 pub use eq::SharedEq;
 pub(crate) use eq::{EQ_MAX_GAIN_DB, EQ_MIN_GAIN_DB};
 pub use metrics::{RtMetrics, RtMetricsSnapshot};
+pub(crate) use playback::PlaybackPresentationPublisher;
 pub use playback::{PlaybackShared, PlaybackSnapshot};
 pub use protocol::{
     PlayerCmd, PlayerNotification, TrackPlaybackStopReason, TrackState, TrackTransition,

--- a/crates/kithara-play/src/bridge/playback.rs
+++ b/crates/kithara-play/src/bridge/playback.rs
@@ -1,13 +1,19 @@
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::{
+    num::NonZeroU32,
+    sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering, fence},
+};
 
+use kithara_audio::{PresentationCursor, PresentationPoint, SessionFrame};
+use kithara_platform::sync::Arc;
 use portable_atomic::{AtomicF64, AtomicU32};
 
 use super::RtMetrics;
 
 /// One read of each live playback scalar.
 ///
-/// The fields are independent relaxed loads and can straddle two audio blocks, so a consumer
-/// needing two of them to agree must derive both from one field.
+/// The scalar fields are independent relaxed loads and can straddle two audio
+/// blocks, so a consumer needing two of them to agree must derive both from one
+/// field. [`Self::presentation`] is a separate coherent snapshot.
 #[derive(Clone, Copy, Debug, Default, PartialEq, fieldwork::Fieldwork)]
 #[non_exhaustive]
 #[fieldwork(get)]
@@ -27,6 +33,9 @@ pub struct PlaybackSnapshot {
     pub(crate) position: f64,
     /// Current output sample rate.
     pub(crate) sample_rate: u32,
+    /// Latest leading-track producer point mapped to the session clock.
+    #[field(get, copy)]
+    pub(crate) presentation: Option<PresentationCursor>,
 }
 
 /// Atomic playback state written by the RT processor and read by control code.
@@ -49,7 +58,86 @@ pub struct PlaybackShared {
     pub process_count: AtomicU64,
     /// Current seek epoch used to invalidate stale seek requests.
     pub seek_epoch: AtomicU64,
+    presentation: AtomicPresentationCursor,
     metrics: RtMetrics,
+}
+
+#[derive(Default)]
+struct AtomicPresentationCursor {
+    epoch: AtomicU64,
+    source_frame: AtomicU64,
+    generation: AtomicU64,
+    output_end: AtomicU64,
+    sample_rate: AtomicU32,
+    session_frame: AtomicI64,
+    valid: AtomicBool,
+    revision: AtomicU64,
+}
+
+impl AtomicPresentationCursor {
+    fn load(&self) -> Option<PresentationCursor> {
+        let before = self.revision.load(Ordering::Acquire);
+        if before & 1 != 0 {
+            return None;
+        }
+
+        let valid = self.valid.load(Ordering::Relaxed);
+        let sample_rate = NonZeroU32::new(self.sample_rate.load(Ordering::Relaxed))?;
+        let point = PresentationPoint::new(
+            self.epoch.load(Ordering::Relaxed),
+            self.source_frame.load(Ordering::Relaxed),
+            self.generation.load(Ordering::Relaxed),
+            self.output_end.load(Ordering::Relaxed),
+            sample_rate,
+        );
+        let session_frame = SessionFrame::new(self.session_frame.load(Ordering::Relaxed));
+        fence(Ordering::Acquire);
+        let after = self.revision.load(Ordering::Acquire);
+        if before != after || !valid {
+            return None;
+        }
+        Some(PresentationCursor::new(point, session_frame))
+    }
+
+    fn store(&self, cursor: Option<PresentationCursor>) {
+        let start = self.revision.fetch_add(1, Ordering::AcqRel);
+        debug_assert_eq!(start & 1, 0, "playback presentation has one writer");
+        if let Some(cursor) = cursor {
+            let point = cursor.point();
+            self.epoch.store(point.seek_epoch(), Ordering::Relaxed);
+            self.source_frame
+                .store(point.source_frame(), Ordering::Relaxed);
+            self.generation.store(point.generation(), Ordering::Relaxed);
+            self.output_end.store(point.output_end(), Ordering::Relaxed);
+            self.sample_rate
+                .store(point.sample_rate().get(), Ordering::Relaxed);
+            self.session_frame
+                .store(i64::from(cursor.session_frame()), Ordering::Relaxed);
+            self.valid.store(true, Ordering::Relaxed);
+        } else {
+            self.valid.store(false, Ordering::Relaxed);
+        }
+        self.revision
+            .store(start.wrapping_add(2), Ordering::Release);
+    }
+}
+
+/// Sole publisher for one playback slot's presentation coordinate.
+///
+/// This handle is intentionally not cloneable, and publishing requires
+/// mutable access. The playback slot transfers it to exactly one processor.
+pub(crate) struct PlaybackPresentationPublisher {
+    playback: Arc<PlaybackShared>,
+}
+
+impl PlaybackPresentationPublisher {
+    pub(crate) fn new(playback: Arc<PlaybackShared>) -> Self {
+        Self { playback }
+    }
+
+    pub(crate) fn publish(&mut self, cursor: Option<PresentationCursor>) {
+        self.playback.presentation.store(cursor);
+    }
 }
 
 impl PlaybackShared {
@@ -78,6 +166,7 @@ impl PlaybackShared {
             duration: self.duration.load(Ordering::Relaxed),
             sample_rate: self.sample_rate.load(Ordering::Relaxed),
             playing: self.playing.load(Ordering::Relaxed),
+            presentation: self.presentation.load(),
         }
     }
 }
@@ -98,6 +187,7 @@ mod tests {
         assert_eq!(playback.position.load(Ordering::Relaxed), 0.0);
         assert_eq!(playback.duration.load(Ordering::Relaxed), 0.0);
         assert_eq!(playback.sample_rate.load(Ordering::Relaxed), 0);
+        assert_eq!(playback.snapshot().presentation(), None);
     }
 
     #[kithara::test]
@@ -138,5 +228,33 @@ mod tests {
             snap.frontier,
             snap.position
         );
+    }
+
+    #[kithara::test]
+    fn presentation_snapshot_round_trips_and_invalidates_as_one_value() {
+        let playback = Arc::new(PlaybackShared::default());
+        let mut publisher = PlaybackPresentationPublisher::new(Arc::clone(&playback));
+        let point = PresentationPoint::new(
+            7,
+            9_600,
+            3,
+            192,
+            NonZeroU32::new(48_000).expect("fixture rate is non-zero"),
+        );
+        let cursor = PresentationCursor::new(point, SessionFrame::new(10_256));
+
+        publisher.publish(Some(cursor));
+        assert_eq!(playback.snapshot().presentation(), Some(cursor));
+
+        publisher.publish(None);
+        assert_eq!(playback.snapshot().presentation(), None);
+    }
+
+    #[kithara::test]
+    fn a_busy_or_changed_presentation_snapshot_never_spins() {
+        let playback = PlaybackShared::default();
+        playback.presentation.revision.store(1, Ordering::Release);
+
+        assert_eq!(playback.snapshot().presentation(), None);
     }
 }

--- a/crates/kithara-play/src/player/config.rs
+++ b/crates/kithara-play/src/player/config.rs
@@ -15,8 +15,8 @@ use crate::session::SessionDispatcher;
 #[builder(state_mod(vis = "pub"))]
 #[non_exhaustive]
 pub struct PlayerConfig {
-    /// Per-deck time-stretch control handle, shared with the UI and the
-    /// worker effect chain (see `kithara_audio::StretchControls`).
+    /// Per-deck time-stretch controls shared with the UI and snapshotted off
+    /// RT for the resident presentation stage.
     #[builder(default = StretchControls::new(1.0))]
     pub(crate) timestretch: Arc<StretchControls>,
     /// Byte buffer pool shared by resources created for this player.

--- a/crates/kithara-play/src/player/flow/control.rs
+++ b/crates/kithara-play/src/player/flow/control.rs
@@ -122,8 +122,8 @@ impl PlayerImpl {
 
     /// Set playback rate.
     ///
-    /// Stores the speed in the shared time-stretch controls (the single source
-    /// of truth, read each chunk by the effect chain) and propagates it via
+    /// Publishes speed to the shared time-stretch controls, which the worker
+    /// snapshots off RT for the resident tempo stage, and propagates it via
     /// `PlayerCmd::SetPlaybackRate`. Values below 0.01 are clamped to 0.01.
     pub fn set_rate(&self, rate: f32) {
         self.core.params.set_rate(

--- a/crates/kithara-play/src/resource/config.rs
+++ b/crates/kithara-play/src/resource/config.rs
@@ -73,8 +73,9 @@ pub struct ResourceConfig<B: Default = PlaybackResamplerBackend> {
     /// non-tempo (no-`stretch`) chain.
     pub(crate) playback_rate: Option<Arc<AtomicF32>>,
     /// Live time-stretch controls (speed + key-lock + backend). `Some` selects
-    /// tempo mode; the same `Arc` must flow to every track so live changes
-    /// reach the running effect chain. `None` keeps the resampler-first chain.
+    /// the resident tempo stage; the same `Arc` must flow to every track so
+    /// the worker can prepare live changes off RT. `None` keeps identity
+    /// presentation.
     pub(crate) stretch: Option<Arc<StretchControls>>,
     /// Shared audio worker handle for cooperative multi-track decoding.
     pub(crate) worker: Option<AudioWorkerHandle>,

--- a/crates/kithara-play/src/resource/reader.rs
+++ b/crates/kithara-play/src/resource/reader.rs
@@ -2,8 +2,8 @@ use std::num::NonZeroU32;
 
 use delegate::delegate;
 use kithara_audio::{
-    Audio, AudioConfig, ChunkOutcome, PcmReader, ReadOutcome, ResamplerBackend, SeekOutcome,
-    ServiceClass,
+    Audio, AudioConfig, ChunkOutcome, PcmReader, PresentationAdvance, PresentationPoint,
+    ReadOutcome, ResamplerBackend, SeekOutcome, ServiceClass,
 };
 use kithara_decode::{DecodeError, DecodeResult, PcmSpec, TrackMetadata};
 use kithara_events::EventBus;
@@ -201,6 +201,9 @@ impl Resource {
             /// Decoded-ahead frontier of the underlying reader (always `>=` position).
             #[must_use]
             pub fn decoded_frontier(&self) -> Duration;
+            /// Latest coherent producer-side presentation endpoint.
+            #[must_use]
+            pub fn presentation_point(&self) -> Option<PresentationPoint>;
             /// Get total duration (if known).
             #[must_use]
             pub fn duration(&self) -> Option<Duration>;
@@ -219,6 +222,8 @@ impl Resource {
                 &mut self,
                 output: &'a mut [&'a mut [f32]],
             ) -> Result<ReadOutcome, DecodeError>;
+            /// Take the latest exact presentation boundary crossed by PCM reads.
+            pub fn take_presentation_advance(&mut self) -> Option<PresentationAdvance>;
             /// Seek to position. Begins and applies in one call, so it takes locks — off the audio
             /// thread only. Audio-thread callers begin through [`seek_handle`](Self::seek_handle)
             /// instead.

--- a/crates/kithara-play/src/rt/mod.rs
+++ b/crates/kithara-play/src/rt/mod.rs
@@ -12,6 +12,6 @@ pub(crate) use eq::MasterEqNode;
 pub(crate) use limiter::LimiterNode;
 pub use node::PlayerNode;
 pub use processor::{PlayerNodeProcessor, StreamShape};
-pub(crate) use render::{RenderPass, RenderTargets};
+pub(crate) use render::{RenderOutcome, RenderPass, RenderTargets};
 pub(crate) use slots::{TrackSlot, TrackSlots};
 pub(crate) use tap::TapNode;

--- a/crates/kithara-play/src/rt/processor.rs
+++ b/crates/kithara-play/src/rt/processor.rs
@@ -7,6 +7,7 @@ use firewheel::{
     event::ProcEvents,
     node::{AudioNodeProcessor, ProcBuffers, ProcExtra, ProcInfo, ProcStreamCtx, ProcessStatus},
 };
+use kithara_audio::SessionFrame;
 use kithara_bufpool::PcmPool;
 use kithara_platform::sync::Arc;
 use kithara_test_utils::kithara;
@@ -17,9 +18,10 @@ use smallvec::SmallVec;
 use super::track::PlayerTrack;
 use crate::{
     bridge::{
-        NodeInputs, PlaybackShared, PlayerCmd, PlayerNotification, TrackState, TrackTransition,
+        NodeInputs, PlaybackPresentationPublisher, PlaybackShared, PlayerCmd, PlayerNotification,
+        TrackState, TrackTransition,
     },
-    rt::{RenderPass, RenderTargets, TrackSlot, TrackSlots},
+    rt::{RenderOutcome, RenderPass, RenderTargets, TrackSlot, TrackSlots},
 };
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
@@ -75,6 +77,7 @@ pub struct PlayerNodeProcessor {
     pub(super) playback_rate: f32,
     pub(super) prefetch_duration: f32,
     trash_tx: HeapProd<PlayerTrack>,
+    presentation: PlaybackPresentationPublisher,
 }
 
 /// Stream dimensions needed to pre-size RT scratch buffers.
@@ -106,6 +109,7 @@ impl PlayerNodeProcessor {
             playback_rate: 1.0,
             tracks: TrackSlots::default(),
             tracks_transitions: VecDeque::with_capacity(Self::MAX_TRACKS),
+            presentation: inputs.presentation,
         }
     }
 
@@ -185,6 +189,18 @@ impl PlayerNodeProcessor {
         frames: usize,
         is_playing: bool,
     ) -> (bool, Option<(f64, f64)>) {
+        let outcome = self.render_block(buffers, frames, is_playing, None);
+        self.presentation.publish(None);
+        (outcome.playback_started, outcome.leading_position_duration)
+    }
+
+    fn render_block(
+        &mut self,
+        buffers: &mut ProcBuffers,
+        frames: usize,
+        is_playing: bool,
+        block_frame: Option<SessionFrame>,
+    ) -> RenderOutcome {
         self.render.render_audio(
             RenderTargets {
                 tracks: &mut self.tracks,
@@ -194,7 +210,14 @@ impl PlayerNodeProcessor {
             buffers,
             frames,
             is_playing,
+            block_frame,
         )
+    }
+
+    fn invalidate_tracks_presentation(&mut self) {
+        self.tracks
+            .iter_mut()
+            .for_each(|(_, track)| track.invalidate_presentation());
     }
 
     fn set_tracks_host_sample_rate(&mut self, sample_rate: NonZeroU32) {
@@ -299,6 +322,8 @@ impl PlayerNodeProcessor {
 
 impl AudioNodeProcessor for PlayerNodeProcessor {
     fn new_stream(&mut self, stream_info: &StreamInfo, _context: &mut ProcStreamCtx) {
+        self.invalidate_tracks_presentation();
+        self.presentation.publish(None);
         self.update_host_sample_rate(stream_info.sample_rate);
         self.render.resize(stream_info.max_block_frames.get().as_());
     }
@@ -319,15 +344,329 @@ impl AudioNodeProcessor for PlayerNodeProcessor {
 
         let is_playing = self.playback.playing.load(Ordering::SeqCst);
 
-        let (playback_started, leading_outcome_pos_dur) =
-            self.render_audio(&mut buffers, info.frames, is_playing);
+        let block_frame = Some(SessionFrame::new(info.clock_samples.0));
+        let outcome = self.render_block(&mut buffers, info.frames, is_playing, block_frame);
 
-        self.update_position_duration(leading_outcome_pos_dur);
+        self.update_position_duration(outcome.leading_position_duration);
+        self.presentation.publish(outcome.presentation);
 
-        if playback_started {
+        if outcome.playback_started {
             ProcessStatus::OutputsModified
         } else {
             ProcessStatus::ClearAllOutputs
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::VecDeque,
+        num::{NonZeroU32, NonZeroUsize},
+    };
+
+    use firewheel::{
+        clock::InstantSamples,
+        dsp::{buffer::ChannelBuffer, declick::DeclickValues},
+        event::{NodeEvent, ProcEvents, ProcEventsIndex, ScheduledEventEntry},
+        log::{RealtimeLoggerConfig, realtime_logger},
+        mask::{ConnectedMask, ConstantMask, SilenceMask},
+        node::{
+            AudioNodeProcessor, NUM_SCRATCH_BUFFERS, ProcBuffers, ProcExtra, ProcInfo, ProcStore,
+            StreamStatus,
+        },
+    };
+    use kithara_audio::{
+        PcmControl, PcmRead, PcmSession, PendingReason, PresentationAdvance, PresentationPoint,
+        ReadOutcome, SeekOutcome, SessionFrame,
+    };
+    use kithara_decode::{DecodeError, PcmSpec, TrackMetadata};
+    use kithara_events::EventBus;
+    use kithara_platform::{sync::Arc, time::Duration};
+
+    use super::*;
+    use crate::{
+        bridge::{SharedEq, slot_channels},
+        resource::Resource,
+        rt::track::PlayerResource,
+    };
+
+    struct Consts;
+
+    impl Consts {
+        const BLOCK_FRAMES: usize = 512;
+        const SAMPLE_RATE: u32 = 48_000;
+    }
+
+    #[derive(Clone, Copy)]
+    struct ReadStep {
+        frames: Option<NonZeroUsize>,
+        point: PresentationPoint,
+        advance: Option<PresentationAdvance>,
+        expected_request: usize,
+    }
+
+    impl ReadStep {
+        fn frames(
+            frames: usize,
+            point: PresentationPoint,
+            advance: Option<PresentationAdvance>,
+            expected_request: usize,
+        ) -> Self {
+            Self {
+                frames: NonZeroUsize::new(frames),
+                point,
+                advance,
+                expected_request,
+            }
+        }
+
+        const fn pending(point: PresentationPoint, expected_request: usize) -> Self {
+            Self {
+                frames: None,
+                point,
+                advance: None,
+                expected_request,
+            }
+        }
+    }
+
+    struct PresentationReader {
+        steps: VecDeque<ReadStep>,
+        point: Option<PresentationPoint>,
+        advance: Option<PresentationAdvance>,
+        bus: EventBus,
+        metadata: TrackMetadata,
+        spec: PcmSpec,
+    }
+
+    impl PresentationReader {
+        fn new(steps: impl IntoIterator<Item = ReadStep>) -> Self {
+            Self {
+                steps: steps.into_iter().collect(),
+                point: None,
+                advance: None,
+                bus: EventBus::default(),
+                metadata: TrackMetadata::default(),
+                spec: PcmSpec::new(2, sample_rate()),
+            }
+        }
+    }
+
+    impl PcmRead for PresentationReader {
+        fn presentation_point(&self) -> Option<PresentationPoint> {
+            self.point
+        }
+
+        fn take_presentation_advance(&mut self) -> Option<PresentationAdvance> {
+            self.advance.take()
+        }
+
+        fn position(&self) -> Duration {
+            Duration::ZERO
+        }
+
+        fn read(&mut self, _buf: &mut [f32]) -> Result<ReadOutcome, DecodeError> {
+            Ok(ReadOutcome::Pending {
+                reason: PendingReason::Buffering,
+                position: Duration::ZERO,
+            })
+        }
+
+        fn read_planar<'a>(
+            &mut self,
+            output: &'a mut [&'a mut [f32]],
+        ) -> Result<ReadOutcome, DecodeError> {
+            let Some(step) = self.steps.pop_front() else {
+                return Ok(ReadOutcome::Pending {
+                    reason: PendingReason::Buffering,
+                    position: Duration::ZERO,
+                });
+            };
+            assert_eq!(output[0].len(), step.expected_request);
+            self.point = Some(step.point);
+            self.advance = step.advance;
+            let Some(count) = step.frames else {
+                return Ok(ReadOutcome::Pending {
+                    reason: PendingReason::Buffering,
+                    position: Duration::ZERO,
+                });
+            };
+            let frames = count.get();
+            for channel in output.iter_mut() {
+                channel[..frames].fill(1.0);
+            }
+            Ok(ReadOutcome::Frames {
+                count,
+                position: Duration::ZERO,
+            })
+        }
+
+        fn spec(&self) -> PcmSpec {
+            self.spec
+        }
+    }
+
+    impl PcmSession for PresentationReader {
+        fn duration(&self) -> Option<Duration> {
+            Some(Duration::from_secs(60))
+        }
+
+        fn event_bus(&self) -> &EventBus {
+            &self.bus
+        }
+
+        fn metadata(&self) -> &TrackMetadata {
+            &self.metadata
+        }
+    }
+
+    impl PcmControl for PresentationReader {
+        fn seek(&mut self, position: Duration) -> Result<SeekOutcome, DecodeError> {
+            Ok(SeekOutcome::Landed {
+                target: position,
+                landed_at: position,
+            })
+        }
+    }
+
+    fn sample_rate() -> NonZeroU32 {
+        NonZeroU32::new(Consts::SAMPLE_RATE).expect("static sample rate is non-zero")
+    }
+
+    fn point(source_frame: u64, generation: u64, output_end: u64) -> PresentationPoint {
+        PresentationPoint::new(7, source_frame, generation, output_end, sample_rate())
+    }
+
+    fn processor_with_track(
+        reader: PresentationReader,
+    ) -> (PlayerNodeProcessor, Arc<PlaybackShared>) {
+        let pool = PcmPool::default();
+        let (inputs, control) = slot_channels(SharedEq::new(0));
+        let playback = Arc::clone(&control.playback);
+        let src: Arc<str> = Arc::from("presentation-fixture");
+        let resource = Resource::from_reader(reader, Some(Arc::clone(&src)));
+        let resource = Box::new(PlayerResource::new(resource, src, &pool));
+        let mut track = PlayerTrack::builder()
+            .sample_rate(sample_rate())
+            .build(resource);
+        track.play();
+
+        let mut processor = PlayerNodeProcessor::new(
+            inputs,
+            StreamShape {
+                max_block_frames: NonZeroU32::new(
+                    u32::try_from(Consts::BLOCK_FRAMES).expect("block size fits u32"),
+                )
+                .expect("block size is non-zero"),
+                sample_rate: sample_rate(),
+            },
+            &pool,
+        );
+        assert!(processor.tracks.insert(track).is_none());
+        playback.playing.store(true, Ordering::SeqCst);
+        (processor, playback)
+    }
+
+    fn process_block(processor: &mut PlayerNodeProcessor, clock_samples: i64) {
+        let info = ProcInfo {
+            sample_rate: sample_rate(),
+            frames: Consts::BLOCK_FRAMES,
+            in_silence_mask: SilenceMask::default(),
+            out_silence_mask: SilenceMask::default(),
+            in_constant_mask: ConstantMask::default(),
+            out_constant_mask: ConstantMask::default(),
+            in_connected_mask: ConnectedMask::default(),
+            out_connected_mask: ConnectedMask::default(),
+            prev_output_was_silent: true,
+            sample_rate_recip: f64::from(Consts::SAMPLE_RATE).recip(),
+            clock_samples: InstantSamples(clock_samples),
+            duration_since_stream_start: Duration::ZERO,
+            stream_status: StreamStatus::empty(),
+            dropped_frames: 0,
+        };
+        let inputs: [&[f32]; 0] = [];
+        let mut output_storage = [
+            vec![0.0; Consts::BLOCK_FRAMES],
+            vec![0.0; Consts::BLOCK_FRAMES],
+        ];
+        let mut outputs: Vec<&mut [f32]> =
+            output_storage.iter_mut().map(Vec::as_mut_slice).collect();
+        let buffers = ProcBuffers {
+            inputs: &inputs,
+            outputs: &mut outputs,
+        };
+        let (logger, _logger_rx) = realtime_logger(RealtimeLoggerConfig::default());
+        let mut extra = ProcExtra {
+            logger,
+            store: ProcStore::with_capacity(0),
+            scratch_buffers: ChannelBuffer::<f32, NUM_SCRATCH_BUFFERS>::new(Consts::BLOCK_FRAMES),
+            declick_values: DeclickValues::new(
+                NonZeroU32::new(16).expect("declick duration is non-zero"),
+            ),
+        };
+        let mut immediate: [Option<NodeEvent>; 0] = [];
+        let mut scheduled: [Option<ScheduledEventEntry>; 0] = [];
+        let mut indices: Vec<ProcEventsIndex> = Vec::new();
+        let mut events = ProcEvents::new(&mut immediate, &mut scheduled, &mut indices);
+
+        let _ = processor.process(&info, buffers, &mut events, &mut extra);
+    }
+
+    #[kithara::test]
+    fn presentation_boundary_uses_consumed_offset_not_requested_range_end() {
+        let expected = point(9_600, 3, 192);
+        let reader = PresentationReader::new([
+            ReadStep::frames(128, expected, None, 512),
+            ReadStep::frames(
+                384,
+                expected,
+                Some(PresentationAdvance::new(expected, 64)),
+                384,
+            ),
+        ]);
+        let (mut processor, playback) = processor_with_track(reader);
+
+        process_block(&mut processor, 10_000);
+
+        let cursor = playback
+            .snapshot()
+            .presentation()
+            .expect("consumed producer boundary must be published");
+        assert_eq!(cursor.point(), expected);
+        assert_eq!(cursor.session_frame(), SessionFrame::new(10_192));
+        assert_ne!(cursor.session_frame(), SessionFrame::new(10_512));
+    }
+
+    #[kithara::test]
+    fn no_advance_before_the_final_boundary_is_consumed() {
+        let ahead = point(9_600, 3, 512);
+        let reader = PresentationReader::new([ReadStep::frames(512, ahead, None, 512)]);
+        let (mut processor, playback) = processor_with_track(reader);
+
+        process_block(&mut processor, 10_000);
+
+        assert_eq!(playback.snapshot().presentation(), None);
+    }
+
+    #[kithara::test]
+    fn underrun_invalidates_the_previous_presentation_mapping() {
+        let anchored = point(9_600, 3, 192);
+        let reader = PresentationReader::new([
+            ReadStep::frames(
+                512,
+                anchored,
+                Some(PresentationAdvance::new(anchored, 192)),
+                512,
+            ),
+            ReadStep::pending(anchored, 512),
+        ]);
+        let (mut processor, playback) = processor_with_track(reader);
+
+        process_block(&mut processor, 10_000);
+        assert!(playback.snapshot().presentation().is_some());
+
+        process_block(&mut processor, 10_512);
+        assert_eq!(playback.snapshot().presentation(), None);
     }
 }

--- a/crates/kithara-play/src/rt/render.rs
+++ b/crates/kithara-play/src/rt/render.rs
@@ -9,6 +9,7 @@ use firewheel::{
     node::ProcBuffers,
     param::smoother::SmootherConfig,
 };
+use kithara_audio::{PresentationCursor, SessionFrame};
 use kithara_bufpool::{PcmBuf, PcmPool};
 use num_traits::cast::AsPrimitive;
 use ringbuf::HeapProd;
@@ -35,6 +36,13 @@ pub(crate) struct RenderTargets<'a> {
     pub(crate) tracks: &'a mut TrackSlots<{ PlayerNodeProcessor::MAX_TRACKS }>,
     pub(crate) notification_tx: &'a mut HeapProd<PlayerNotification>,
     pub(crate) metrics: &'a RtMetrics,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct RenderOutcome {
+    pub(crate) playback_started: bool,
+    pub(crate) leading_position_duration: Option<(f64, f64)>,
+    pub(crate) presentation: Option<PresentationCursor>,
 }
 
 pub(crate) struct RenderPass {
@@ -79,39 +87,17 @@ impl RenderPass {
         buffers: &mut ProcBuffers,
         frames: usize,
         is_playing: bool,
-    ) -> (bool, Option<(f64, f64)>) {
+        block_frame: Option<SessionFrame>,
+    ) -> RenderOutcome {
         let mut playback_started = false;
         let mut leading_outcome_pos_dur: Option<(f64, f64)> = None;
-
-        if buffers.outputs.len() < Self::MIN_STEREO {
-            return (false, None);
-        }
-
-        for ch_buffer in buffers.outputs.iter_mut() {
-            ch_buffer[..frames].fill(0.0);
-        }
-
-        // Growing a pooled buffer here would allocate on the audio thread. The fill above already
-        // covered the frames past the clamp with silence.
-        let frames = frames.min(self.capacity);
-
-        self.gate.set_mix(
-            if is_playing {
-                Mix::FULLY_DRY
-            } else {
-                Mix::FULLY_WET
-            },
-            Self::GATE_CURVE,
-        );
-        if self.priming {
-            self.priming = false;
-            self.gate.reset_to_target();
-        }
-        // A closed gate outputs silence whatever the tracks hold, so readers stop only once its
-        // ramp has run out.
-        if !is_playing && self.gate.has_settled() {
-            return (false, None);
-        }
+        let mut leading_presentation = None;
+        let tracks = targets.tracks;
+        let Some((frames, block_frame)) =
+            self.prepare_block(tracks, buffers, frames, is_playing, block_frame)
+        else {
+            return RenderOutcome::default();
+        };
 
         let (read, rest) = self.scratch_bufs.split_at_mut(Self::MIN_STEREO);
         let (mix, bus) = rest.split_at_mut(Self::MIN_STEREO);
@@ -124,7 +110,6 @@ impl RenderPass {
         for ch_buffer in &mut bus_bufs {
             ch_buffer.fill(0.0);
         }
-        let tracks = targets.tracks;
         let mut sink = RtSink::new(targets.notification_tx, targets.metrics);
         let loaded_tracks: SmallVec<[(TrackSlot, TrackState); PlayerNodeProcessor::MAX_TRACKS]> =
             tracks
@@ -156,10 +141,15 @@ impl RenderPass {
             }
 
             let mut read_outcome = {
-                let Some(outcome) = tracks
-                    .at_mut(*track_handle)
-                    .map(|track| track.read(&mut read_bufs, &mut mix_bufs, 0..frames, &mut sink))
-                else {
+                let Some(outcome) = tracks.at_mut(*track_handle).map(|track| {
+                    track.read(
+                        &mut read_bufs,
+                        &mut mix_bufs,
+                        0..frames,
+                        block_frame,
+                        &mut sink,
+                    )
+                }) else {
                     continue;
                 };
                 playback_started = true;
@@ -170,6 +160,7 @@ impl RenderPass {
                 if let Some(snapshot) = outcome_position_duration(&read_outcome) {
                     leading_outcome_pos_dur = Some(snapshot);
                 }
+                leading_presentation = outcome_presentation(&read_outcome);
 
                 let mut handover = initial_handover(&read_outcome);
 
@@ -188,7 +179,13 @@ impl RenderPass {
                     }
 
                     let Some(outcome) = tracks.at_mut(*next_handle).map(|track| {
-                        track.read(&mut read_bufs, &mut mix_bufs, offset..frames, &mut sink)
+                        track.read(
+                            &mut read_bufs,
+                            &mut mix_bufs,
+                            offset..frames,
+                            block_frame,
+                            &mut sink,
+                        )
                     }) else {
                         continue;
                     };
@@ -198,6 +195,7 @@ impl RenderPass {
                     if let Some(snapshot) = outcome_position_duration(&read_outcome) {
                         leading_outcome_pos_dur = Some(snapshot);
                     }
+                    leading_presentation = outcome_presentation(&read_outcome);
 
                     handover = next_handover(&read_outcome, offset);
                 }
@@ -217,7 +215,15 @@ impl RenderPass {
                             continue;
                         };
                         next_track.play();
-                        next_track.read(&mut read_bufs, &mut mix_bufs, offset..frames, &mut sink);
+                        let outcome = next_track.read(
+                            &mut read_bufs,
+                            &mut mix_bufs,
+                            offset..frames,
+                            block_frame,
+                            &mut sink,
+                        );
+                        leading_outcome_pos_dur = outcome_position_duration(&outcome);
+                        leading_presentation = outcome_presentation(&outcome);
                         break;
                     }
                 }
@@ -240,7 +246,57 @@ impl RenderPass {
             frames,
         );
 
-        (playback_started, leading_outcome_pos_dur)
+        RenderOutcome {
+            playback_started,
+            leading_position_duration: leading_outcome_pos_dur,
+            presentation: leading_presentation,
+        }
+    }
+
+    fn prepare_block(
+        &mut self,
+        tracks: &mut TrackSlots<{ PlayerNodeProcessor::MAX_TRACKS }>,
+        buffers: &mut ProcBuffers,
+        frames: usize,
+        is_playing: bool,
+        block_frame: Option<SessionFrame>,
+    ) -> Option<(usize, Option<SessionFrame>)> {
+        if buffers.outputs.len() < Self::MIN_STEREO {
+            tracks
+                .iter_mut()
+                .for_each(|(_, track)| track.invalidate_presentation());
+            return None;
+        }
+        for ch_buffer in buffers.outputs.iter_mut() {
+            ch_buffer[..frames].fill(0.0);
+        }
+        let clamped = frames > self.capacity;
+        if clamped {
+            tracks
+                .iter_mut()
+                .for_each(|(_, track)| track.invalidate_presentation());
+        }
+        let frames = frames.min(self.capacity);
+        let block_frame = block_frame.filter(|_| !clamped);
+        self.gate.set_mix(
+            if is_playing {
+                Mix::FULLY_DRY
+            } else {
+                Mix::FULLY_WET
+            },
+            Self::GATE_CURVE,
+        );
+        if self.priming {
+            self.priming = false;
+            self.gate.reset_to_target();
+        }
+        if !is_playing && self.gate.has_settled() {
+            tracks
+                .iter_mut()
+                .for_each(|(_, track)| track.invalidate_presentation());
+            return None;
+        }
+        Some((frames, block_frame))
     }
 
     pub(crate) fn update_sample_rate(&mut self, sample_rate: NonZeroU32) {
@@ -288,6 +344,14 @@ const fn outcome_position_duration(outcome: &TrackReadOutcome) -> Option<(f64, f
             position, duration, ..
         } => Some((position, duration)),
         TrackReadOutcome::Partial { duration, .. } => Some((duration, duration)),
+        TrackReadOutcome::Eof | TrackReadOutcome::Failed => None,
+    }
+}
+
+const fn outcome_presentation(outcome: &TrackReadOutcome) -> Option<PresentationCursor> {
+    match *outcome {
+        TrackReadOutcome::Full { presentation, .. }
+        | TrackReadOutcome::Partial { presentation, .. } => presentation,
         TrackReadOutcome::Eof | TrackReadOutcome::Failed => None,
     }
 }

--- a/crates/kithara-play/src/rt/track/core.rs
+++ b/crates/kithara-play/src/rt/track/core.rs
@@ -1,8 +1,10 @@
-use std::num::NonZeroU32;
+use std::{num::NonZeroU32, ops::Range};
 
 use bon::bon;
 use firewheel::dsp::fade::FadeCurve;
-use kithara_audio::ServiceClass;
+use kithara_audio::{
+    PresentationAdvance, PresentationCursor, PresentationPoint, ServiceClass, SessionFrame,
+};
 use kithara_platform::sync::Arc;
 use num_traits::cast::{AsPrimitive, ToPrimitive};
 
@@ -31,10 +33,8 @@ pub struct PlayerTrack {
     pub(super) ended_at_eof: bool,
     pub(super) state_dirty: bool,
     /// Media seconds consumed per output second, mirroring the speed the
-    /// time-stretch slot runs the source at. The mix output is on the output
-    /// clock; `duration`, the near-end triggers and every position consumer
-    /// are on the media clock, so served output frames only become a position
-    /// once scaled by this.
+    /// time-stretch slot runs the source at. This advances the media clock only
+    /// when a read carries no exact consumed presentation boundary.
     pub(super) playback_rate: f32,
     /// Lead time before EOF at which the prefetch trigger fires.
     ///
@@ -48,15 +48,17 @@ pub struct PlayerTrack {
     /// Mirrors `PlayerResource::duration()` (post-gapless-trim, visible
     /// duration) captured under the resource lock.
     pub(super) observed_duration: f64,
-    /// Cumulative *media* frames this track has served into the mix output:
-    /// output frames scaled by [`Self::playback_rate`].
+    /// Canonical media clock expressed on the host sample-rate axis.
     ///
-    /// Used as the source of truth for near-end trigger position so the
-    /// trigger reflects what has been rendered to the audio output, not the
-    /// decoder's pre-buffered position (which can be ~200 ms ahead of the
-    /// mixer thanks to `PlayerResource`'s scratch buffer).
+    /// Exact consumed presentation boundaries rebase this from their source
+    /// frame and source rate. Reads without such proof advance it from output
+    /// frames scaled by [`Self::playback_rate`]. Near-end triggers and position
+    /// consumers therefore follow audible source progress without reading the
+    /// decoder's pre-buffered position.
     pub(super) served_media_frames: f64,
     pub(super) sample_rate: u32,
+    /// Last final-output boundary proven consumed, anchored to its host frame.
+    pub(super) consumed_presentation: Option<PresentationCursor>,
 }
 
 #[bon]
@@ -90,6 +92,7 @@ impl PlayerTrack {
             sample_rate: sample_rate.get(),
             served_media_frames: 0.0,
             ended_at_eof: false,
+            consumed_presentation: None,
         };
         track.update_service_class(TrackState::Preloading);
         track
@@ -141,14 +144,61 @@ impl PlayerTrack {
 
     /// Current media position in seconds.
     ///
-    /// Tracks `served_media_frames / sample_rate` — i.e. what has actually
-    /// been mixed into the output, on the media clock — so the value matches
-    /// the trigger evaluator and `duration` instead of the decoder's
-    /// pre-buffered position.
+    /// Tracks `served_media_frames / sample_rate`: exact presentation proof
+    /// rebases it to the consumed source endpoint, while unproven reads use the
+    /// scalar playback-rate advance. The trigger evaluator reads this same
+    /// clock.
     #[must_use]
     pub fn position(&self) -> f64 {
         let sample_rate = self.sample_rate.max(1);
         self.served_media_frames / f64::from(sample_rate)
+    }
+
+    pub(super) fn update_presentation(
+        &mut self,
+        point: Option<PresentationPoint>,
+        advance: Option<PresentationAdvance>,
+        block_frame: Option<SessionFrame>,
+        range: &Range<usize>,
+        real_frames: usize,
+    ) -> Option<PresentationCursor> {
+        let Some(block_frame) = block_frame else {
+            self.invalidate_presentation();
+            return None;
+        };
+
+        if let Some(advance) = advance {
+            let read_offset = advance.read_offset_frames();
+            if read_offset > real_frames {
+                self.invalidate_presentation();
+                return None;
+            }
+            let boundary_offset = range.start.checked_add(read_offset);
+            self.consumed_presentation = boundary_offset
+                .and_then(|offset| u64::try_from(offset).ok())
+                .and_then(|offset| block_frame.offset(offset))
+                .map(|frame| PresentationCursor::new(advance.point(), frame));
+            self.consumed_presentation?;
+        }
+
+        let point = point?;
+        let consumed = self.consumed_presentation?;
+        if point.seek_epoch() != consumed.seek_epoch()
+            || point.generation() != consumed.generation()
+            || point.sample_rate() != consumed.source_rate()
+        {
+            self.invalidate_presentation();
+            return None;
+        }
+        let Some(delta_output) = point.output_end().checked_sub(consumed.output_end()) else {
+            self.invalidate_presentation();
+            return None;
+        };
+        let Some(session_frame) = consumed.session_frame().offset(delta_output) else {
+            self.invalidate_presentation();
+            return None;
+        };
+        Some(PresentationCursor::new(point, session_frame))
     }
 
     /// Re-base the track on a seek the control thread already begun.
@@ -158,6 +208,7 @@ impl PlayerTrack {
     /// happened on the control thread through [`PlayerResource::seek_handle`].
     pub fn seek(&mut self, seconds: f64) {
         self.resource.reset_for_seek();
+        self.invalidate_presentation();
         let frames = seek_frame_index(seconds, self.sample_rate, self.observed_duration);
         self.served_media_frames = AsPrimitive::as_(frames);
         self.triggers.reset();
@@ -174,6 +225,10 @@ impl PlayerTrack {
     /// Update the prefetch lead time used for the preload trigger.
     pub const fn set_prefetch_duration(&mut self, prefetch_duration: f32) {
         self.prefetch_duration = prefetch_duration.max(0.0);
+    }
+
+    pub(crate) fn invalidate_presentation(&mut self) {
+        self.consumed_presentation = None;
     }
 
     /// Set the track state and mark as dirty.

--- a/crates/kithara-play/src/rt/track/core.rs
+++ b/crates/kithara-play/src/rt/track/core.rs
@@ -11,6 +11,12 @@ use num_traits::cast::{AsPrimitive, ToPrimitive};
 use super::{PlayerResource, fade::TrackFade, triggers::TrackTriggers};
 use crate::bridge::TrackState;
 
+#[derive(Clone, Copy)]
+pub(super) struct MediaPresentationAnchor {
+    pub(super) frames: f64,
+    pub(super) point: PresentationPoint,
+}
+
 /// Per-track state in the processor arena.
 ///
 /// Manages the `MixDSP` fade, track state, cached position/duration,
@@ -50,12 +56,14 @@ pub struct PlayerTrack {
     pub(super) observed_duration: f64,
     /// Canonical media clock expressed on the host sample-rate axis.
     ///
-    /// Exact consumed presentation boundaries rebase this from their source
-    /// frame and source rate. Reads without such proof advance it from output
-    /// frames scaled by [`Self::playback_rate`]. Near-end triggers and position
-    /// consumers therefore follow audible source progress without reading the
-    /// decoder's pre-buffered position.
+    /// Exact consumed presentation boundaries advance this from source-frame
+    /// deltas after the first boundary anchors the decoder's codec-specific
+    /// origin to the audible clock. Reads without such proof advance it from
+    /// output frames scaled by [`Self::playback_rate`]. Near-end triggers and
+    /// position consumers therefore follow audible source progress without
+    /// importing decoder pre-roll into the public position.
     pub(super) served_media_frames: f64,
+    pub(super) media_presentation: Option<MediaPresentationAnchor>,
     pub(super) sample_rate: u32,
     /// Last final-output boundary proven consumed, anchored to its host frame.
     pub(super) consumed_presentation: Option<PresentationCursor>,
@@ -91,6 +99,7 @@ impl PlayerTrack {
             prefetch_duration: prefetch_duration.max(0.0),
             sample_rate: sample_rate.get(),
             served_media_frames: 0.0,
+            media_presentation: None,
             ended_at_eof: false,
             consumed_presentation: None,
         };
@@ -209,6 +218,7 @@ impl PlayerTrack {
     pub fn seek(&mut self, seconds: f64) {
         self.resource.reset_for_seek();
         self.invalidate_presentation();
+        self.media_presentation = None;
         let frames = seek_frame_index(seconds, self.sample_rate, self.observed_duration);
         self.served_media_frames = AsPrimitive::as_(frames);
         self.triggers.reset();

--- a/crates/kithara-play/src/rt/track/feeder.rs
+++ b/crates/kithara-play/src/rt/track/feeder.rs
@@ -1,6 +1,6 @@
 use std::{num::NonZeroU32, ops::Range};
 
-use kithara_audio::ServiceClass;
+use kithara_audio::{PresentationAdvance, PresentationPoint, ServiceClass};
 use kithara_bufpool::{PcmBuf, PcmPool};
 use kithara_decode::Frames;
 use kithara_platform::{maybe_send::WasmSend, sync::Arc};
@@ -26,6 +26,8 @@ pub struct PlayerResource {
     failed: bool,
     write_len: usize,
     write_pos: usize,
+    buffered_presentation_advance: Option<PresentationAdvance>,
+    read_presentation_advance: Option<PresentationAdvance>,
 }
 
 /// Result of a bounded audio-thread read from [`PlayerResource`].
@@ -90,6 +92,8 @@ impl PlayerResource {
             write_pos: 0,
             eof_seen: false,
             failed: false,
+            buffered_presentation_advance: None,
+            read_presentation_advance: None,
         }
     }
 
@@ -111,18 +115,23 @@ impl PlayerResource {
         let mut eof_reached = self.eof_seen;
 
         while target_frames > self.write_len && !eof_reached {
-            let avail = self.channel_buffers[0].len() - self.write_pos;
+            let deficit = target_frames - self.write_len;
+            let avail = (self.channel_buffers[0].len() - self.write_pos).min(deficit);
             if avail == 0 {
                 break;
             }
 
-            let channel_buffers = &mut self.channel_buffers;
-            let (left_buf, right_buf) = channel_buffers.split_at_mut(1);
-            let left = &mut left_buf[0][self.write_pos..self.write_pos + avail];
-            let right = &mut right_buf[0][self.write_pos..self.write_pos + avail];
-            let mut planar: [&mut [f32]; Self::STEREO_CHANNELS] = [left, right];
-
-            let n = match self.resource.get_mut().read_planar(&mut planar) {
+            let write_len_before = self.write_len;
+            let read_outcome = {
+                let channel_buffers = &mut self.channel_buffers;
+                let (left_buf, right_buf) = channel_buffers.split_at_mut(1);
+                let left = &mut left_buf[0][self.write_pos..self.write_pos + avail];
+                let right = &mut right_buf[0][self.write_pos..self.write_pos + avail];
+                let mut planar: [&mut [f32]; Self::STEREO_CHANNELS] = [left, right];
+                self.resource.get_mut().read_planar(&mut planar)
+            };
+            let advance = self.resource.get_mut().take_presentation_advance();
+            let n = match read_outcome {
                 Ok(kithara_audio::ReadOutcome::Frames { count, .. }) => count.get(),
                 Ok(kithara_audio::ReadOutcome::Pending { .. }) => 0,
                 Ok(kithara_audio::ReadOutcome::Eof { .. }) => {
@@ -137,13 +146,48 @@ impl PlayerResource {
                 }
             };
             if n == 0 {
+                if advance.is_some() {
+                    self.buffered_presentation_advance = None;
+                }
                 break;
             }
+            self.record_presentation_advance(write_len_before, n, advance);
             self.write_len += n;
             self.write_pos += n;
         }
 
         eof_reached
+    }
+
+    fn record_presentation_advance(
+        &mut self,
+        write_len_before: usize,
+        frames_read: usize,
+        advance: Option<PresentationAdvance>,
+    ) {
+        let Some(advance) = advance else {
+            return;
+        };
+        let read_offset = advance.read_offset_frames();
+        if read_offset > frames_read {
+            self.buffered_presentation_advance = None;
+            return;
+        }
+        self.buffered_presentation_advance = write_len_before
+            .checked_add(read_offset)
+            .map(|offset| PresentationAdvance::new(advance.point(), offset));
+    }
+
+    fn take_consumed_presentation_advance(&mut self, frames: usize) -> Option<PresentationAdvance> {
+        let advance = self.buffered_presentation_advance?;
+        let offset = advance.read_offset_frames();
+        if offset <= frames {
+            self.buffered_presentation_advance = None;
+            return Some(advance);
+        }
+        self.buffered_presentation_advance =
+            Some(PresentationAdvance::new(advance.point(), offset - frames));
+        None
     }
 
     /// Remaining buffered frames when the wrapped reader has reached EOF.
@@ -172,6 +216,7 @@ impl PlayerResource {
         range: Range<usize>,
         metrics: &RtMetrics,
     ) -> ReadOutcome {
+        self.read_presentation_advance = None;
         let frames_to_read = range.end - range.start;
         let mut eof_reached = self.fill_scratch(frames_to_read, metrics);
 
@@ -203,6 +248,8 @@ impl PlayerResource {
 
             self.write_len -= frames_to_write;
             self.write_pos = tail_size;
+            self.read_presentation_advance =
+                self.take_consumed_presentation_advance(frames_to_write);
 
             if frames_to_write == frames_to_read {
                 eof_reached |= self.fill_scratch(frames_to_read, metrics);
@@ -245,6 +292,8 @@ impl PlayerResource {
         self.write_pos = 0;
         self.eof_seen = false;
         self.failed = false;
+        self.buffered_presentation_advance = None;
+        self.read_presentation_advance = None;
     }
 
     /// Control-plane handle used to begin a seek off the audio thread.
@@ -253,12 +302,19 @@ impl PlayerResource {
         self.resource.get().seek_handle()
     }
 
+    pub(super) fn take_presentation_advance(&mut self) -> Option<PresentationAdvance> {
+        self.read_presentation_advance.take()
+    }
+
     delegate::delegate! {
         to self.resource.get() {
             /// Total duration in seconds. Returns 0.0 if unknown.
             #[must_use]
             #[expr($.map_or(0.0, |d| d.as_secs_f64()))]
             pub fn duration(&self) -> f64;
+            /// Latest coherent producer-side presentation endpoint.
+            #[must_use]
+            pub(crate) fn presentation_point(&self) -> Option<PresentationPoint>;
             /// Set the target sample rate of the audio host.
             pub(crate) fn set_host_sample_rate(&self, sample_rate: NonZeroU32);
             /// Set the playback rate for the active stretch controls.

--- a/crates/kithara-play/src/rt/track/read.rs
+++ b/crates/kithara-play/src/rt/track/read.rs
@@ -1,5 +1,6 @@
 use std::ops::Range;
 
+use kithara_audio::{PresentationAdvance, PresentationCursor, PresentationPoint, SessionFrame};
 use kithara_platform::sync::Arc;
 use num_traits::cast::AsPrimitive;
 use ringbuf::{HeapProd, traits::Producer};
@@ -19,6 +20,7 @@ struct TrackReadContext<'a> {
 struct PartialRead {
     duration: f64,
     frames: usize,
+    presentation: Option<PresentationCursor>,
 }
 
 /// Result of a single track render attempt.
@@ -34,6 +36,8 @@ pub enum TrackReadOutcome {
         duration: f64,
         /// Exact remaining buffered frames after EOF has been observed.
         frames_until_eof: Option<usize>,
+        /// Producer point mapped from an exactly consumed final boundary.
+        presentation: Option<PresentationCursor>,
     },
     /// Only the first `frames` samples were written; EOF was reached in-block.
     Partial {
@@ -41,6 +45,8 @@ pub enum TrackReadOutcome {
         frames: usize,
         /// Visible duration snapshot in seconds.
         duration: f64,
+        /// Producer point mapped from an exactly consumed final boundary.
+        presentation: Option<PresentationCursor>,
     },
     /// No frames were written because the track is already finished.
     Eof,
@@ -49,15 +55,19 @@ pub enum TrackReadOutcome {
 }
 
 impl PlayerTrack {
-    /// Advance the media clock by `frames` of mixed output.
+    /// Advance the media clock after one read of real output frames.
     ///
-    /// The mix output runs on the output clock; one output frame carries
-    /// `playback_rate` media frames, which is what the stretch slot consumed
-    /// from the source to produce it.
-    fn advance_media_clock(&mut self, frames: usize) {
-        let output_frames: f64 = AsPrimitive::as_(frames);
-        self.served_media_frames =
-            output_frames.mul_add(f64::from(self.playback_rate), self.served_media_frames);
+    /// A proven consumed presentation boundary replaces accumulated scalar
+    /// drift with its exact source coordinate. Playback rate advances the
+    /// whole read only when no proof was consumed.
+    fn advance_media_clock(&mut self, frames: usize, consumed: Option<PresentationPoint>) {
+        self.served_media_frames = media_frames_after_read(
+            self.served_media_frames,
+            frames,
+            self.playback_rate,
+            self.sample_rate,
+            consumed,
+        );
     }
 
     fn check_notifications(
@@ -94,13 +104,13 @@ impl PlayerTrack {
             duration,
             frames,
             frames_until_eof,
+            presentation,
             ..
         } = outcome
         else {
             return outcome;
         };
 
-        self.advance_media_clock(frames);
         self.observed_duration = duration;
         self.update_observed_eof(frames_until_eof);
         let position = self.position();
@@ -130,6 +140,7 @@ impl PlayerTrack {
             duration,
             frames,
             frames_until_eof,
+            presentation,
         }
     }
 
@@ -160,8 +171,11 @@ impl PlayerTrack {
     ) -> TrackReadOutcome {
         let TrackReadContext { sink, range } = ctx;
         let notification_tx = sink.notifications;
-        let PartialRead { frames, duration } = partial;
-        self.advance_media_clock(frames);
+        let PartialRead {
+            frames,
+            duration,
+            presentation,
+        } = partial;
         let position = self.position();
         self.observed_duration = if position > 0.0 { position } else { duration };
         let duration = self.observed_duration;
@@ -185,7 +199,11 @@ impl PlayerTrack {
         );
         self.handle_natural_end(notification_tx);
 
-        TrackReadOutcome::Partial { frames, duration }
+        TrackReadOutcome::Partial {
+            frames,
+            duration,
+            presentation,
+        }
     }
 
     fn notify_state_change(&mut self, notification_tx: &mut HeapProd<PlayerNotification>) {
@@ -224,13 +242,15 @@ impl PlayerTrack {
         scratch_bufs: &mut [&mut [f32]],
         mix_bufs: &mut [&mut [f32]],
         range: Range<usize>,
+        block_frame: Option<SessionFrame>,
         sink: &mut RtSink<'_>,
     ) -> TrackReadOutcome {
         if self.state == TrackState::Finished {
             return TrackReadOutcome::Eof;
         }
 
-        let read_outcome = self.read_resource(scratch_bufs, range.clone(), sink.metrics);
+        let read_outcome =
+            self.read_resource(scratch_bufs, range.clone(), block_frame, sink.metrics);
         match read_outcome {
             TrackReadOutcome::Full { .. } => self.handle_full_read(
                 scratch_bufs,
@@ -241,14 +261,22 @@ impl PlayerTrack {
                 },
                 read_outcome,
             ),
-            TrackReadOutcome::Partial { frames, duration } => self.handle_partial_read(
+            TrackReadOutcome::Partial {
+                frames,
+                duration,
+                presentation,
+            } => self.handle_partial_read(
                 scratch_bufs,
                 mix_bufs,
                 TrackReadContext {
                     sink: sink.reborrow(),
                     range,
                 },
-                PartialRead { duration, frames },
+                PartialRead {
+                    duration,
+                    frames,
+                    presentation,
+                },
             ),
             TrackReadOutcome::Eof => {
                 self.handle_natural_end(sink.notifications);
@@ -265,28 +293,81 @@ impl PlayerTrack {
         &mut self,
         scratch_bufs: &mut [&mut [f32]],
         range: Range<usize>,
+        block_frame: Option<SessionFrame>,
         metrics: &RtMetrics,
     ) -> TrackReadOutcome {
-        let resource = &mut self.resource;
         let (scratch_left, scratch_right) = scratch_bufs.split_at_mut(1);
         let mut scratch_window = [
             &mut scratch_left[0][range.clone()],
             &mut scratch_right[0][range.clone()],
         ];
 
-        match resource.read(&mut scratch_window, 0..range.len(), metrics) {
-            ReadOutcome::Full { frames } => TrackReadOutcome::Full {
-                frames,
-                duration: resource.duration(),
-                frames_until_eof: resource.frames_until_eof(),
-                position: 0.0,
-            },
-            ReadOutcome::Partial { frames } => TrackReadOutcome::Partial {
-                frames,
-                duration: resource.duration(),
-            },
-            ReadOutcome::Eof => TrackReadOutcome::Eof,
-            ReadOutcome::Failed => TrackReadOutcome::Failed,
+        let (read_outcome, point, duration, frames_until_eof, presentation_advance) = {
+            let resource = &mut self.resource;
+            let read_outcome = resource.read(&mut scratch_window, 0..range.len(), metrics);
+            let presentation_advance = resource.take_presentation_advance();
+            (
+                read_outcome,
+                resource.presentation_point(),
+                resource.duration(),
+                resource.frames_until_eof(),
+                presentation_advance,
+            )
+        };
+
+        match read_outcome {
+            ReadOutcome::Full { frames } => {
+                let presentation = if frames == range.len() && frames > 0 {
+                    self.update_presentation(
+                        point,
+                        presentation_advance,
+                        block_frame,
+                        &range,
+                        frames,
+                    )
+                } else {
+                    self.invalidate_presentation();
+                    None
+                };
+                let consumed = consumed_point(presentation_advance, frames);
+                self.advance_media_clock(frames, consumed);
+                TrackReadOutcome::Full {
+                    frames,
+                    duration,
+                    frames_until_eof,
+                    position: 0.0,
+                    presentation,
+                }
+            }
+            ReadOutcome::Partial { frames } => {
+                let presentation = if frames > 0 {
+                    self.update_presentation(
+                        point,
+                        presentation_advance,
+                        block_frame,
+                        &range,
+                        frames,
+                    )
+                } else {
+                    self.invalidate_presentation();
+                    None
+                };
+                let consumed = consumed_point(presentation_advance, frames);
+                self.advance_media_clock(frames, consumed);
+                TrackReadOutcome::Partial {
+                    frames,
+                    duration,
+                    presentation,
+                }
+            }
+            ReadOutcome::Eof => {
+                self.invalidate_presentation();
+                TrackReadOutcome::Eof
+            }
+            ReadOutcome::Failed => {
+                self.invalidate_presentation();
+                TrackReadOutcome::Failed
+            }
         }
     }
 
@@ -318,5 +399,59 @@ impl PlayerTrack {
             current => current,
         };
         self.set_state(new_state);
+    }
+}
+
+fn consumed_point(
+    advance: Option<PresentationAdvance>,
+    frames: usize,
+) -> Option<PresentationPoint> {
+    let advance = advance?;
+    (advance.read_offset_frames() <= frames).then_some(advance.point())
+}
+
+fn media_frames_after_read(
+    current: f64,
+    frames: usize,
+    playback_rate: f32,
+    host_rate: u32,
+    consumed: Option<PresentationPoint>,
+) -> f64 {
+    let Some(consumed) = consumed else {
+        let output_frames: f64 = AsPrimitive::as_(frames);
+        return output_frames.mul_add(f64::from(playback_rate), current);
+    };
+    let source_frames: f64 = AsPrimitive::as_(consumed.source_frame());
+    let source_rate = f64::from(consumed.sample_rate().get());
+    let host_rate = f64::from(host_rate.max(1));
+    source_frames / source_rate * host_rate
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU32;
+
+    use kithara_audio::{PresentationAdvance, PresentationPoint};
+    use kithara_test_utils::kithara;
+
+    use super::{consumed_point, media_frames_after_read};
+
+    #[kithara::test]
+    fn consumed_presentation_replaces_scalar_media_clock_advance() {
+        let source_rate = NonZeroU32::new(48_000).expect("test source rate is non-zero");
+        let point = PresentationPoint::new(0, 48_000, 0, 4_096, source_rate);
+        let advance = PresentationAdvance::new(point, 256);
+        let consumed = consumed_point(Some(advance), 512)
+            .expect("consumed boundary inside the read is valid proof");
+
+        let corrected = media_frames_after_read(44_000.0, 512, 1.5, 44_100, Some(consumed));
+        let scalar_only = media_frames_after_read(44_000.0, 512, 1.5, 44_100, None);
+
+        assert_eq!(corrected, 44_100.0);
+        assert_eq!(scalar_only, 44_768.0);
+        assert_ne!(
+            corrected, scalar_only,
+            "source proof must replace scalar drift"
+        );
     }
 }

--- a/crates/kithara-play/src/rt/track/read.rs
+++ b/crates/kithara-play/src/rt/track/read.rs
@@ -7,6 +7,7 @@ use ringbuf::{HeapProd, traits::Producer};
 
 use super::{
     PlayerTrack, ReadOutcome, RtSink,
+    core::MediaPresentationAnchor,
     triggers::{TrackTriggers, TriggerInput},
 };
 use crate::bridge::{PlayerNotification, RtMetrics, TrackPlaybackStopReason, TrackState};
@@ -57,17 +58,20 @@ pub enum TrackReadOutcome {
 impl PlayerTrack {
     /// Advance the media clock after one read of real output frames.
     ///
-    /// A proven consumed presentation boundary replaces accumulated scalar
-    /// drift with its exact source coordinate. Playback rate advances the
-    /// whole read only when no proof was consumed.
-    fn advance_media_clock(&mut self, frames: usize, consumed: Option<PresentationPoint>) {
-        self.served_media_frames = media_frames_after_read(
+    /// The first consumed presentation boundary anchors the decoder's absolute
+    /// source origin to the audible clock. Later compatible boundaries replace
+    /// accumulated scalar drift with exact source progress.
+    fn advance_media_clock(&mut self, frames: usize, advance: Option<PresentationAdvance>) {
+        let (served, anchor) = media_frames_after_read(
             self.served_media_frames,
             frames,
             self.playback_rate,
             self.sample_rate,
-            consumed,
+            advance,
+            self.media_presentation,
         );
+        self.served_media_frames = served;
+        self.media_presentation = anchor;
     }
 
     fn check_notifications(
@@ -329,8 +333,7 @@ impl PlayerTrack {
                     self.invalidate_presentation();
                     None
                 };
-                let consumed = consumed_point(presentation_advance, frames);
-                self.advance_media_clock(frames, consumed);
+                self.advance_media_clock(frames, presentation_advance);
                 TrackReadOutcome::Full {
                     frames,
                     duration,
@@ -352,8 +355,7 @@ impl PlayerTrack {
                     self.invalidate_presentation();
                     None
                 };
-                let consumed = consumed_point(presentation_advance, frames);
-                self.advance_media_clock(frames, consumed);
+                self.advance_media_clock(frames, presentation_advance);
                 TrackReadOutcome::Partial {
                     frames,
                     duration,
@@ -402,29 +404,57 @@ impl PlayerTrack {
     }
 }
 
-fn consumed_point(
-    advance: Option<PresentationAdvance>,
-    frames: usize,
-) -> Option<PresentationPoint> {
-    let advance = advance?;
-    (advance.read_offset_frames() <= frames).then_some(advance.point())
-}
-
 fn media_frames_after_read(
     current: f64,
     frames: usize,
     playback_rate: f32,
     host_rate: u32,
-    consumed: Option<PresentationPoint>,
-) -> f64 {
-    let Some(consumed) = consumed else {
+    advance: Option<PresentationAdvance>,
+    previous: Option<MediaPresentationAnchor>,
+) -> (f64, Option<MediaPresentationAnchor>) {
+    let scalar = |frames: usize, current: f64| {
         let output_frames: f64 = AsPrimitive::as_(frames);
-        return output_frames.mul_add(f64::from(playback_rate), current);
+        output_frames.mul_add(f64::from(playback_rate), current)
     };
-    let source_frames: f64 = AsPrimitive::as_(consumed.source_frame());
-    let source_rate = f64::from(consumed.sample_rate().get());
+    let Some(advance) = advance else {
+        return (scalar(frames, current), previous);
+    };
+    let Some(suffix_frames) = frames.checked_sub(advance.read_offset_frames()) else {
+        return (scalar(frames, current), None);
+    };
+    let consumed = advance.point();
     let host_rate = f64::from(host_rate.max(1));
-    source_frames / source_rate * host_rate
+    let prefix_boundary = scalar(advance.read_offset_frames(), current);
+    let boundary = previous
+        .filter(|previous| compatible_media_points(previous.point, consumed))
+        .and_then(|previous| {
+            consumed
+                .source_frame()
+                .checked_sub(previous.point.source_frame())
+                .map(|delta| {
+                    let source_frames: f64 = AsPrimitive::as_(delta);
+                    source_frames.mul_add(
+                        host_rate / f64::from(consumed.sample_rate().get()),
+                        previous.frames,
+                    )
+                })
+        })
+        .unwrap_or(prefix_boundary);
+    let suffix_frames: f64 = AsPrimitive::as_(suffix_frames);
+    (
+        suffix_frames.mul_add(f64::from(playback_rate), boundary),
+        Some(MediaPresentationAnchor {
+            frames: boundary,
+            point: consumed,
+        }),
+    )
+}
+
+fn compatible_media_points(previous: PresentationPoint, current: PresentationPoint) -> bool {
+    previous.seek_epoch() == current.seek_epoch()
+        && previous.generation() == current.generation()
+        && previous.sample_rate() == current.sample_rate()
+        && previous.output_end() <= current.output_end()
 }
 
 #[cfg(test)]
@@ -434,24 +464,53 @@ mod tests {
     use kithara_audio::{PresentationAdvance, PresentationPoint};
     use kithara_test_utils::kithara;
 
-    use super::{consumed_point, media_frames_after_read};
+    use super::media_frames_after_read;
 
     #[kithara::test]
-    fn consumed_presentation_replaces_scalar_media_clock_advance() {
+    fn consumed_presentation_rebases_then_advances_the_read_suffix() {
         let source_rate = NonZeroU32::new(48_000).expect("test source rate is non-zero");
         let point = PresentationPoint::new(0, 48_000, 0, 4_096, source_rate);
         let advance = PresentationAdvance::new(point, 256);
-        let consumed = consumed_point(Some(advance), 512)
-            .expect("consumed boundary inside the read is valid proof");
 
-        let corrected = media_frames_after_read(44_000.0, 512, 1.5, 44_100, Some(consumed));
-        let scalar_only = media_frames_after_read(44_000.0, 512, 1.5, 44_100, None);
+        let (corrected, anchor) =
+            media_frames_after_read(44_000.0, 512, 1.5, 44_100, Some(advance), None);
+        let (scalar_only, _) = media_frames_after_read(44_000.0, 512, 1.5, 44_100, None, None);
 
-        assert_eq!(corrected, 44_100.0);
+        assert_eq!(corrected, 44_768.0);
         assert_eq!(scalar_only, 44_768.0);
-        assert_ne!(
+        assert_eq!(
             corrected, scalar_only,
-            "source proof must replace scalar drift"
+            "the first source proof must anchor without importing its codec-specific origin"
         );
+
+        let later = PresentationAdvance::new(
+            PresentationPoint::new(0, 48_240, 0, 4_608, source_rate),
+            128,
+        );
+        let (corrected, later_anchor) =
+            media_frames_after_read(corrected, 512, 1.5, 44_100, Some(later), anchor);
+        assert_eq!(corrected, 45_180.5);
+
+        let changed_rate = NonZeroU32::new(44_100).expect("test source rate is non-zero");
+        let rate_change = PresentationAdvance::new(
+            PresentationPoint::new(0, 48_480, 0, 5_120, changed_rate),
+            64,
+        );
+        let (rate_reanchored, rate_anchor) =
+            media_frames_after_read(corrected, 512, 1.5, 44_100, Some(rate_change), later_anchor);
+        assert_eq!(
+            rate_anchor
+                .expect("rate change establishes an anchor")
+                .frames,
+            45_276.5,
+            "a sample-rate change reanchors at the scalar prefix boundary"
+        );
+        assert_eq!(rate_reanchored, 45_948.5);
+
+        let replacement =
+            PresentationAdvance::new(PresentationPoint::new(0, 96_000, 1, 512, source_rate), 64);
+        let (reanchored, _) =
+            media_frames_after_read(corrected, 512, 1.5, 44_100, Some(replacement), later_anchor);
+        assert_eq!(reanchored, 45_948.5);
     }
 }

--- a/crates/kithara-stretch/CONTEXT.md
+++ b/crates/kithara-stretch/CONTEXT.md
@@ -47,21 +47,23 @@ Backends process interleaved `f32` PCM. `set_ratio` and `set_pitch` are independ
 decoupling is what makes keylock real. `set_ratio(stretch)` is the time factor
 `output_frames / input_frames` (above `1.0` lengthens the output); `set_pitch(scale)` is the pitch
 factor (`1.0` keeps pitch locked). Both reject non-finite or non-positive values with
-`StretchBackendError::Param`. `Process` errors exist so the outer `AudioEffect::process` (fixed at
-`-> Option<PcmChunk>`) maps a backend failure to "drop this chunk + warn", never a panic.
+`StretchBackendError::Param`. `Process` errors propagate through the resident tempo stage as typed
+decode failures; source PCM is never silently dropped and the backend never panics across the
+adapter boundary.
 
-The produce path must stay allocation-free in steady state: callers ask
-`max_output_samples(input_frames)` before `process` or `flush`, reserve that much scratch capacity,
-then reuse the same output buffer across chunks. Backends that need planar scratch use the `PcmPool`
-supplied in `StretchOptions`; no backend owns a global pool.
+The produce path must stay allocation-free in steady state. Before playback the resident tempo
+stage reserves both `max_output_samples(input_frames)` and `max_tail_samples()` and then reuses the
+same scratch across source quanta and drains. A backend must never append beyond either declared
+bound. Backends that need planar scratch use the `PcmPool` supplied in `StretchOptions`; no backend
+owns a global pool.
 
 `flush(out)` drains the buffered tail at end of stream or at a real region ratio boundary. It is a
 one-shot tail drain: repeated flushes without new input or `reset` append nothing, so an EOF drain
-can loop until it yields an empty append. A backend that cannot expose a true tail drain must
-document that in its adapter. `reset()` clears buffered state after seek, source-spec change, or
-backend swap; a spec change is handled by the caller rebuilding the backend with the new scalar
-sample rate and channel count, so the trait intentionally does not depend on
-`kithara-decode::PcmSpec`.
+can advance under bounded fixed-size output credits until it yields an empty append. A backend that
+cannot expose a true tail drain must document that in its adapter. `reset()` clears buffered state
+after seek, source-spec change, backend swap, or return to unity passthrough; a spec change is
+handled by the caller rebuilding the backend with the new scalar sample rate and channel count, so
+the trait intentionally does not depend on `kithara-decode::PcmSpec`.
 
 ## Backend limitations
 
@@ -69,8 +71,8 @@ sample rate and channel count, so the trait intentionally does not depend on
   stretched silence instead of the buffered tail, inflating duration): `flush` is a no-op and roughly
   one latency of audio is dropped at end of stream. A real drain needs the low-level granular
   `Stretcher` API.
-- Bungee constructs disabled (warning once) when the pool budget cannot cover its planar scratch or
-  `Stream::new` fails; `process` then emits nothing rather than erroring per chunk.
+- Bungee construction fails with a typed error when the pool budget cannot cover its planar scratch
+  or `Stream::new` fails; an unusable backend is never installed as a silent disabled instance.
 - `BungeeElastic` does not implement `ElasticPriming`, for the same root cause as the missing tail
   drain. Its `Stream` emits with a fixed lag: the input-frame coordinate of the next output frame is
   always `emitted_output_frames - latency`, so absorbing history costs exactly as much emitted

--- a/crates/kithara-stretch/Cargo.toml
+++ b/crates/kithara-stretch/Cargo.toml
@@ -22,7 +22,6 @@ fieldwork = { workspace = true }
 num-traits = { workspace = true }
 smallvec = { workspace = true }
 thiserror = { workspace = true }
-tracing = { workspace = true }
 
 # `bungee-sys` builds its C++ through `cmake`, which fails under MSVC (see
 # `windows_build_env` in xtask's Windows lane for the toolchain fight this

--- a/crates/kithara-stretch/src/backend.rs
+++ b/crates/kithara-stretch/src/backend.rs
@@ -1,15 +1,31 @@
-/// Error from a [`StretchBackend`]. Carried so the outer
-/// `AudioEffect::process` (fixed at `-> Option<PcmChunk>`) maps a backend
-/// failure to "drop this chunk + warn", never a panic.
+/// Error from a [`StretchBackend`], carried through the resident tempo stage
+/// without panicking or silently dropping source PCM.
 #[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum StretchBackendError {
+    /// Backend state or its fixed-capacity scratch could not be constructed.
+    #[error("stretch backend construction failed: {0}")]
+    Construction(String),
     /// A `process` / `flush` call failed inside the library.
     #[error("stretch backend processing failed: {0}")]
-    Process(String),
+    Process(&'static str),
     /// An invalid ratio / pitch value was rejected by the library.
     #[error("invalid stretch parameter: {0}")]
-    Param(String),
+    Param(&'static str),
+}
+
+/// How a backend resolves source latency when a typed drain begins.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DrainDisposition {
+    /// Buffered source is represented by the samples appended by
+    /// [`StretchBackend::flush`]. A missing tail while source is held violates
+    /// the backend contract.
+    RenderedTail,
+    /// The backend cannot expose its buffered tail and intentionally retires
+    /// that source at the boundary. [`StretchBackend::flush`] must append no
+    /// samples.
+    DiscardHeld,
 }
 
 /// DSP-only time-stretch backend living behind an audio graph processor.
@@ -20,19 +36,31 @@ pub enum StretchBackendError {
 /// ([`set_pitch`](Self::set_pitch)) are independent — that decoupling is
 /// what makes keylock real. See this crate's `CONTEXT.md`.
 pub trait StretchBackend: Send + 'static {
-    /// Drain the buffered tail at end of stream. One-shot: once the tail is
-    /// drained, further calls (until the next `process` or `reset`) must
-    /// append nothing — EOF drain pulls `flush` in a loop until it yields
-    /// an empty append.
+    /// Declare how a typed EOF or decoder barrier resolves held source.
+    fn drain_disposition(&self) -> DrainDisposition {
+        DrainDisposition::RenderedTail
+    }
+
+    /// Drain the buffered tail once at a typed EOF or decoder discontinuity.
+    /// Further calls append nothing until the next `process` or `reset`.
     ///
     /// # Errors
     /// Returns [`StretchBackendError::Process`] if the library fails to drain.
     fn flush(&mut self, out: &mut Vec<f32>) -> Result<(), StretchBackendError>;
 
-    /// Upper bound on interleaved output samples a single `process` / `flush`
-    /// can emit for `input_frames`, so the processor pre-reserves its output
-    /// scratch once and stays alloc-free on the produce-core.
+    /// Upper bound on interleaved output samples a single `process` can emit
+    /// for `input_frames`, so the processor can fit source to output credit.
     fn max_output_samples(&self, input_frames: usize) -> usize;
+
+    /// Upper bound on interleaved samples emitted by one true-EOF flush.
+    ///
+    /// The duration-changing stage reserves this storage before playback. A
+    /// backend must not append more than this bound when [`flush`](Self::flush)
+    /// is called.
+    fn max_tail_samples(&self) -> usize;
+
+    /// Source-frame input latency currently held by the backend.
+    fn source_latency_frames(&self) -> usize;
 
     /// Push interleaved `input`; append whatever interleaved output is ready.
     ///

--- a/crates/kithara-stretch/src/backends/bungee/streaming.rs
+++ b/crates/kithara-stretch/src/backends/bungee/streaming.rs
@@ -4,9 +4,8 @@ use bungee_rs::Stream;
 use fast_interleave::{deinterleave_variable, interleave_variable};
 use kithara_bufpool::{BudgetExhausted, PcmPool};
 use num_traits::cast::AsPrimitive;
-use tracing::warn;
 
-use crate::{StretchBackend, StretchBackendError, StretchOptions};
+use crate::{DrainDisposition, StretchBackend, StretchBackendError, StretchOptions};
 
 struct PooledPlanar {
     pool: PcmPool,
@@ -29,19 +28,18 @@ impl PooledPlanar {
         })
     }
 
-    fn empty(pool: &PcmPool) -> Self {
-        Self {
-            pool: pool.clone(),
-            channels: Vec::default(),
+    fn resize_prepared(&mut self, frames: usize) -> Result<(), StretchBackendError> {
+        if self
+            .channels
+            .iter()
+            .any(|samples| samples.capacity() < frames)
+        {
+            return Err(StretchBackendError::Process(
+                "bungee planar request exceeds prepared capacity",
+            ));
         }
-    }
-
-    fn ensure_len(&mut self, frames: usize) -> Result<(), BudgetExhausted> {
         for samples in &mut self.channels {
-            let mut pooled = self.pool.attach(std::mem::take(samples));
-            let result = pooled.ensure_len(frames);
-            *samples = pooled.into_inner();
-            result?;
+            samples.resize(frames, 0.0);
         }
         Ok(())
     }
@@ -52,8 +50,8 @@ impl PooledPlanar {
         start: usize,
         frames: usize,
         channels: NonZeroUsize,
-    ) -> Result<(), BudgetExhausted> {
-        self.ensure_len(frames)?;
+    ) -> Result<(), StretchBackendError> {
+        self.resize_prepared(frames)?;
         let ch = channels.get();
         let start = start * ch;
         deinterleave_variable(
@@ -94,62 +92,51 @@ pub(crate) struct BungeeBackend {
     ratio: f64,
     channels: usize,
     max_input_frames: usize,
+    max_output_frames: usize,
+    source_latency_frames: usize,
 }
 
 impl BungeeBackend {
-    pub(crate) fn new(options: &StretchOptions) -> Self {
+    pub(crate) fn new(options: &StretchOptions) -> Result<Self, StretchBackendError> {
         let channels = options.channels.max(1);
         let max_input_frames = options.max_input_frames.max(1);
+        let max_output_frames = options.max_output_frames;
+        if max_output_frames < max_input_frames {
+            return Err(StretchBackendError::Construction(format!(
+                "bungee output bound {max_output_frames} is smaller than input bound {max_input_frames}"
+            )));
+        }
         let sample_rate: usize = options.sample_rate.as_();
-        let scratch =
-            PooledPlanar::new(&options.pool, channels, max_input_frames).and_then(|in_planar| {
-                PooledPlanar::new(&options.pool, channels, max_input_frames)
-                    .map(|out_planar| (in_planar, out_planar))
-            });
-        let (in_planar, out_planar, scratch_ready) = match scratch {
-            Ok((in_planar, out_planar)) => (in_planar, out_planar, true),
-            Err(e) => {
-                warn!(
-                    error = %e,
-                    sample_rate,
-                    channels,
-                    max_input_frames,
-                    "bungee scratch checkout failed; backend disabled"
-                );
-                (
-                    PooledPlanar::empty(&options.pool),
-                    PooledPlanar::empty(&options.pool),
-                    false,
-                )
-            }
-        };
-        let inner = if scratch_ready {
-            match Stream::new(sample_rate, channels, max_input_frames) {
-                Ok(stream) => Some(stream),
-                Err(e) => {
-                    warn!(
-                        error = e,
-                        sample_rate, channels, "bungee Stream::new failed; backend disabled"
-                    );
-                    None
-                }
-            }
-        } else {
-            None
-        };
-        Self {
-            inner,
+        let in_planar = PooledPlanar::new(&options.pool, channels, max_input_frames)
+            .map_err(|error| StretchBackendError::Construction(error.to_string()))?;
+        let out_planar = PooledPlanar::new(&options.pool, channels, max_output_frames)
+            .map_err(|error| StretchBackendError::Construction(error.to_string()))?;
+        let inner = Stream::new(sample_rate, channels, max_input_frames)
+            .map_err(|error| StretchBackendError::Construction(error.to_string()))?;
+        Ok(Self {
+            inner: Some(inner),
             channels,
             max_input_frames,
+            max_output_frames,
             in_planar,
             out_planar,
             ratio: 1.0,
             pitch: 1.0,
-        }
+            source_latency_frames: 0,
+        })
+    }
+
+    fn output_capacity_frames(&self, ratio: f64) -> Option<usize> {
+        let full: f64 = self.max_input_frames.as_();
+        num_traits::cast((full * ratio).ceil())
     }
 }
 
 impl StretchBackend for BungeeBackend {
+    fn drain_disposition(&self) -> DrainDisposition {
+        DrainDisposition::DiscardHeld
+    }
+
     fn flush(&mut self, _out: &mut Vec<f32>) -> Result<(), StretchBackendError> {
         // No-op: bungee's high-level `Stream` exposes no tail drain, and
         // feeding muted input would emit stretched *silence*, not the real
@@ -160,19 +147,27 @@ impl StretchBackend for BungeeBackend {
     }
 
     fn max_output_samples(&self, input_frames: usize) -> usize {
-        let frames_f64: f64 = input_frames.as_();
-        let out_frames: usize =
-            num_traits::cast((frames_f64 * self.ratio).ceil()).unwrap_or(usize::MAX);
-        out_frames.saturating_mul(self.channels)
+        if input_frames == 0 {
+            return 0;
+        }
+        let block_frames = self
+            .output_capacity_frames(self.ratio)
+            .unwrap_or(usize::MAX);
+        let blocks = input_frames.div_ceil(self.max_input_frames);
+        block_frames
+            .saturating_mul(blocks)
+            .saturating_mul(self.channels)
+    }
+
+    fn max_tail_samples(&self) -> usize {
+        0
+    }
+
+    fn source_latency_frames(&self) -> usize {
+        self.source_latency_frames
     }
 
     fn process(&mut self, input: &[f32], out: &mut Vec<f32>) -> Result<(), StretchBackendError> {
-        let Some(stream) = self.inner.as_mut() else {
-            // Stream::new failed at construction (already warned once); emit
-            // nothing rather than erroring per chunk. Unreachable for a valid
-            // spec — see the bungee note in the crate CONTEXT.md.
-            return Ok(());
-        };
         let ch = self.channels;
         let Some(num_ch) = NonZeroUsize::new(ch) else {
             return Ok(());
@@ -184,21 +179,39 @@ impl StretchBackend for BungeeBackend {
         // Size the output buffer for a FULL input block so the stream can
         // always drain its pending grain even on a short final sub-block;
         // a too-small output backs up the input ring and trips a C++ assert.
-        let full_f: f64 = self.max_input_frames.as_();
-        let cap: usize = num_traits::cast::<f64, usize>((full_f * self.ratio).ceil())
-            .ok_or_else(|| StretchBackendError::Process("bungee output frame cap overflow".into()))?
+        let cap = self
+            .output_capacity_frames(self.ratio)
+            .ok_or(StretchBackendError::Process(
+                "bungee output frame cap overflow",
+            ))?
             .max(1);
+        if cap > self.max_output_frames {
+            return Err(StretchBackendError::Process(
+                "bungee output frame cap exceeds prepared bound",
+            ));
+        }
+        let reserved_samples = self.max_output_samples(total);
+        let required_capacity = out
+            .len()
+            .checked_add(reserved_samples)
+            .ok_or(StretchBackendError::Process("bungee output size overflow"))?;
+        if required_capacity > out.capacity() {
+            return Err(StretchBackendError::Process(
+                "bungee output request exceeds caller capacity",
+            ));
+        }
+        let Some(stream) = self.inner.as_mut() else {
+            return Err(StretchBackendError::Process(
+                "bungee stream is unavailable after reset",
+            ));
+        };
         let mut done = 0;
         while done < total {
             let n = (total - done).min(self.max_input_frames);
-            self.in_planar
-                .fill_interleaved(input, done, n, num_ch)
-                .map_err(|e| StretchBackendError::Process(e.to_string()))?;
+            self.in_planar.fill_interleaved(input, done, n, num_ch)?;
             let n_f: f64 = n.as_();
             let out_frames = (n_f * self.ratio).max(1.0);
-            self.out_planar
-                .ensure_len(cap)
-                .map_err(|e| StretchBackendError::Process(e.to_string()))?;
+            self.out_planar.resize_prepared(cap)?;
             let rendered = stream.process(
                 Some(self.in_planar.as_ref()),
                 self.out_planar.as_mut(),
@@ -206,6 +219,15 @@ impl StretchBackend for BungeeBackend {
                 out_frames,
                 self.pitch,
             );
+            let source_latency = stream.latency();
+            if !source_latency.is_finite() || source_latency < 0.0 {
+                return Err(StretchBackendError::Process(
+                    "bungee reported invalid input latency",
+                ));
+            }
+            self.source_latency_frames = num_traits::cast(source_latency.ceil()).ok_or(
+                StretchBackendError::Process("bungee input latency is out of range"),
+            )?;
             let rendered = rendered.min(cap);
             let output = self.out_planar.as_ref();
             let base = out.len();
@@ -222,11 +244,14 @@ impl StretchBackend for BungeeBackend {
             let sample_rate = self.inner.as_ref().map_or(1, Stream::sample_rate);
             self.inner = Stream::new(sample_rate, spec_channels, self.max_input_frames).ok();
         }
+        self.source_latency_frames = 0;
     }
 
     fn set_pitch(&mut self, scale: f64) -> Result<(), StretchBackendError> {
         if !scale.is_finite() || scale <= 0.0 {
-            return Err(StretchBackendError::Param(format!("pitch scale {scale}")));
+            return Err(StretchBackendError::Param(
+                "bungee pitch scale must be finite and positive",
+            ));
         }
         self.pitch = scale;
         Ok(())
@@ -234,11 +259,106 @@ impl StretchBackend for BungeeBackend {
 
     fn set_ratio(&mut self, stretch: f64) -> Result<(), StretchBackendError> {
         if !stretch.is_finite() || stretch <= 0.0 {
-            return Err(StretchBackendError::Param(format!(
-                "stretch ratio {stretch}"
-            )));
+            return Err(StretchBackendError::Param(
+                "bungee stretch ratio must be finite and positive",
+            ));
+        }
+        let Some(output_frames) = self.output_capacity_frames(stretch) else {
+            return Err(StretchBackendError::Param(
+                "bungee stretch ratio exceeds the output frame range",
+            ));
+        };
+        if output_frames > self.max_output_frames {
+            return Err(StretchBackendError::Param(
+                "bungee stretch ratio exceeds the prepared output bound",
+            ));
         }
         self.ratio = stretch;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use kithara_bufpool::PcmPool;
+
+    use super::*;
+
+    #[test]
+    fn source_latency_matches_bungee_and_clears_on_reset() {
+        let options = StretchOptions::builder()
+            .sample_rate(48_000)
+            .channels(2)
+            .max_input_frames(4_096)
+            .pool(PcmPool::default())
+            .build();
+        let mut backend = BungeeBackend::new(&options).expect("Bungee construction must succeed");
+        backend.set_ratio(1.5).expect("valid stretch ratio");
+        let input = vec![0.25; 8_192];
+        let mut out = Vec::with_capacity(backend.max_output_samples(input.len() / 2));
+        backend
+            .process(&input, &mut out)
+            .expect("Bungee process must succeed");
+        let measured = backend
+            .inner
+            .as_ref()
+            .expect("Bungee stream must be available")
+            .latency();
+        let expected: usize = num_traits::cast(measured.ceil()).expect("latency must fit usize");
+        assert_eq!(backend.source_latency_frames(), expected);
+
+        backend.reset();
+
+        assert_eq!(backend.source_latency_frames(), 0);
+    }
+
+    #[test]
+    fn drain_disposition_explicitly_discards_held_source() {
+        let options = StretchOptions::builder()
+            .sample_rate(48_000)
+            .channels(2)
+            .max_input_frames(4_096)
+            .pool(PcmPool::default())
+            .build();
+        let backend = BungeeBackend::new(&options).expect("Bungee construction must succeed");
+
+        assert_eq!(backend.drain_disposition(), DrainDisposition::DiscardHeld);
+        assert_eq!(backend.max_tail_samples(), 0);
+    }
+
+    #[test]
+    fn output_planar_capacity_covers_the_configured_ratio_window() {
+        const MAX_INPUT_FRAMES: usize = 25;
+        const MAX_OUTPUT_FRAMES: usize = 512;
+        let options = StretchOptions::builder()
+            .sample_rate(48_000)
+            .channels(2)
+            .max_input_frames(MAX_INPUT_FRAMES)
+            .max_output_frames(MAX_OUTPUT_FRAMES)
+            .pool(PcmPool::default())
+            .build();
+        let mut backend = BungeeBackend::new(&options).expect("Bungee construction must succeed");
+        let prepared_capacity = backend.out_planar.channels[0].capacity();
+        let input = vec![0.25; MAX_INPUT_FRAMES * 2];
+
+        for ratio in [2.0, 20.0] {
+            backend
+                .set_ratio(ratio)
+                .expect("ratio fits prepared output");
+            let mut output = Vec::with_capacity(backend.max_output_samples(MAX_INPUT_FRAMES));
+            backend
+                .process(&input, &mut output)
+                .expect("prepared Bungee process must succeed");
+            assert_eq!(backend.out_planar.channels[0].capacity(), prepared_capacity);
+            assert_eq!(backend.out_planar.channels[1].capacity(), prepared_capacity);
+        }
+
+        assert!(prepared_capacity >= MAX_OUTPUT_FRAMES);
+        assert!(matches!(
+            backend.set_ratio(21.0),
+            Err(StretchBackendError::Param(
+                "bungee stretch ratio exceeds the prepared output bound"
+            ))
+        ));
     }
 }

--- a/crates/kithara-stretch/src/backends/signalsmith.rs
+++ b/crates/kithara-stretch/src/backends/signalsmith.rs
@@ -54,6 +54,9 @@ impl SignalsmithBackend {
 pub struct SignalsmithElastic {
     inner: Stretch,
     capabilities: ElasticCapabilities,
+    channels: usize,
+    flushed: bool,
+    ratio: f64,
 }
 
 impl SignalsmithElastic {
@@ -62,6 +65,12 @@ impl SignalsmithElastic {
     const MAX_SOURCE_FRAMES_PER_OUTPUT: f64 = 4.0 / 3.0;
     const MIN_SOURCE_FRAMES_PER_OUTPUT: f64 = 2.0 / 3.0;
 
+    /// Declared source-frame advance supported by the exact-span engine.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ElasticError`] when the declared bounds do not form a
+    /// representable envelope.
     fn rate_envelope() -> Result<ElasticRateEnvelope, ElasticError> {
         ElasticRateEnvelope::try_from(
             Self::MIN_SOURCE_FRAMES_PER_OUTPUT..=Self::MAX_SOURCE_FRAMES_PER_OUTPUT,
@@ -88,6 +97,9 @@ impl ElasticEngine for SignalsmithElastic {
         Ok(Self {
             inner,
             capabilities: ElasticCapabilities::new(config, latency, rate_envelope),
+            channels: config.channels(),
+            flushed: false,
+            ratio: 1.0,
         })
     }
 
@@ -103,12 +115,90 @@ impl ElasticEngine for SignalsmithElastic {
     ) -> Result<(), ElasticError> {
         self.capabilities
             .validate(request, source.len(), output.len())?;
+        self.flushed = false;
         self.inner.process(source, output);
         Ok(())
     }
 
     fn reset(&mut self) -> Result<(), ElasticError> {
         self.inner.reset();
+        self.flushed = false;
+        Ok(())
+    }
+}
+
+impl StretchBackend for SignalsmithElastic {
+    fn flush(&mut self, out: &mut Vec<f32>) -> Result<(), StretchBackendError> {
+        if self.flushed {
+            return Ok(());
+        }
+        self.flushed = true;
+        let tail = self
+            .capabilities
+            .latency()
+            .output_frames()
+            .saturating_mul(self.channels);
+        let start = out.len();
+        out.resize(start + tail, 0.0);
+        self.inner.flush(&mut out[start..]);
+        Ok(())
+    }
+
+    fn max_output_samples(&self, input_frames: usize) -> usize {
+        let frames_f64: f64 = input_frames.as_();
+        let frames: usize =
+            num_traits::cast((frames_f64 * self.ratio).round()).unwrap_or(usize::MAX);
+        frames.saturating_mul(self.channels)
+    }
+
+    fn max_tail_samples(&self) -> usize {
+        self.capabilities
+            .latency()
+            .output_frames()
+            .saturating_mul(self.channels)
+    }
+
+    fn source_latency_frames(&self) -> usize {
+        if self.flushed {
+            0
+        } else {
+            self.capabilities.latency().source_frames()
+        }
+    }
+
+    fn process(&mut self, input: &[f32], out: &mut Vec<f32>) -> Result<(), StretchBackendError> {
+        let in_frames = input.len() / self.channels;
+        if in_frames == 0 {
+            return Ok(());
+        }
+        self.flushed = false;
+        let start = out.len();
+        let want = self.max_output_samples(in_frames);
+        out.resize(start + want, 0.0);
+        self.inner.process(input, &mut out[start..]);
+        Ok(())
+    }
+
+    fn reset(&mut self) {
+        self.inner.reset();
+        self.flushed = false;
+    }
+
+    fn set_pitch(&mut self, scale: f64) -> Result<(), StretchBackendError> {
+        if !scale.is_finite() || scale <= 0.0 {
+            return Err(StretchBackendError::Param("invalid pitch scale"));
+        }
+        let mult: f32 =
+            num_traits::cast(scale).ok_or(StretchBackendError::Param("pitch scale exceeds f32"))?;
+        self.inner.set_transpose_factor(mult, None);
+        Ok(())
+    }
+
+    fn set_ratio(&mut self, stretch: f64) -> Result<(), StretchBackendError> {
+        if !stretch.is_finite() || stretch <= 0.0 {
+            return Err(StretchBackendError::Param("invalid stretch ratio"));
+        }
+        self.ratio = stretch;
         Ok(())
     }
 }
@@ -162,6 +252,18 @@ impl StretchBackend for SignalsmithBackend {
         self.out_frames(input_frames).saturating_mul(self.channels)
     }
 
+    fn max_tail_samples(&self) -> usize {
+        self.latency.output_frames().saturating_mul(self.channels)
+    }
+
+    fn source_latency_frames(&self) -> usize {
+        if self.flushed {
+            0
+        } else {
+            self.latency.source_frames()
+        }
+    }
+
     fn process(&mut self, input: &[f32], out: &mut Vec<f32>) -> Result<(), StretchBackendError> {
         let in_frames = input.len() / self.channels;
         if in_frames == 0 {
@@ -182,18 +284,17 @@ impl StretchBackend for SignalsmithBackend {
 
     fn set_pitch(&mut self, scale: f64) -> Result<(), StretchBackendError> {
         if !scale.is_finite() || scale <= 0.0 {
-            return Err(StretchBackendError::Param(format!("pitch scale {scale}")));
+            return Err(StretchBackendError::Param("invalid pitch scale"));
         }
-        let mult: f32 = num_traits::cast(scale).unwrap_or(1.0);
+        let mult: f32 =
+            num_traits::cast(scale).ok_or(StretchBackendError::Param("pitch scale exceeds f32"))?;
         self.inner.set_transpose_factor(mult, None);
         Ok(())
     }
 
     fn set_ratio(&mut self, stretch: f64) -> Result<(), StretchBackendError> {
         if !stretch.is_finite() || stretch <= 0.0 {
-            return Err(StretchBackendError::Param(format!(
-                "stretch ratio {stretch}"
-            )));
+            return Err(StretchBackendError::Param("invalid stretch ratio"));
         }
         self.ratio = stretch;
         Ok(())

--- a/crates/kithara-stretch/src/config.rs
+++ b/crates/kithara-stretch/src/config.rs
@@ -9,4 +9,7 @@ pub struct StretchOptions {
     pub channels: usize,
     #[builder(default = 8192)]
     pub max_input_frames: usize,
+    /// Maximum output frames one backend processing block may address.
+    #[builder(default = 8192)]
+    pub max_output_frames: usize,
 }

--- a/crates/kithara-stretch/src/factory.rs
+++ b/crates/kithara-stretch/src/factory.rs
@@ -2,18 +2,25 @@
 use crate::backends::BungeeBackend;
 #[cfg(feature = "stretch-signalsmith")]
 use crate::backends::SignalsmithBackend;
-use crate::{StretchBackend, StretchKind, StretchOptions};
+use crate::{StretchBackend, StretchBackendError, StretchKind, StretchOptions};
 
 /// Construct the backend for `kind` at the configured source shape. Called once
 /// per chain build and on a source-spec change inside the audio processor.
-#[must_use]
-pub fn build_backend(kind: StretchKind, options: &StretchOptions) -> Box<dyn StretchBackend> {
-    match kind {
+///
+/// # Errors
+///
+/// Returns [`StretchBackendError::Construction`] when the selected backend
+/// cannot initialize its fixed-capacity processing state.
+pub fn build_backend(
+    kind: StretchKind,
+    options: &StretchOptions,
+) -> Result<Box<dyn StretchBackend>, StretchBackendError> {
+    Ok(match kind {
         #[cfg(feature = "stretch-signalsmith")]
         StretchKind::Signalsmith => Box::new(SignalsmithBackend::new(options)),
         #[cfg(feature = "stretch-bungee")]
-        StretchKind::Bungee => Box::new(BungeeBackend::new(options)),
-    }
+        StretchKind::Bungee => Box::new(BungeeBackend::new(options)?),
+    })
 }
 
 #[cfg(test)]

--- a/crates/kithara-stretch/src/factory_tests.rs
+++ b/crates/kithara-stretch/src/factory_tests.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "stretch-bungee")]
+use kithara_bufpool::ByteBudget;
 use kithara_bufpool::PcmPool;
 
 use super::build_backend;
@@ -27,7 +29,7 @@ fn interleaved_stereo() -> Vec<f32> {
 
 fn smoke(kind: StretchKind) {
     let options = options();
-    let mut backend = build_backend(kind, &options);
+    let mut backend = build_backend(kind, &options).expect("backend construction must succeed");
     if let Err(error) = backend.set_ratio(1.0) {
         panic!("{kind}: set_ratio(1.0) failed: {error}");
     }
@@ -63,4 +65,20 @@ fn builds_and_processes_signalsmith_backend() {
 #[test]
 fn builds_and_processes_bungee_backend() {
     smoke(StretchKind::Bungee);
+}
+
+#[cfg(feature = "stretch-bungee")]
+#[test]
+fn bungee_construction_fails_closed_when_scratch_budget_is_exhausted() {
+    let options = StretchOptions::builder()
+        .sample_rate(44_100)
+        .channels(CHANNELS)
+        .max_input_frames(INPUT_FRAMES)
+        .pool(PcmPool::with_byte_budget(0, 0, ByteBudget(0)))
+        .build();
+
+    let Err(error) = build_backend(StretchKind::Bungee, &options) else {
+        panic!("Bungee cannot install a backend without its fixed scratch");
+    };
+    assert!(matches!(error, crate::StretchBackendError::Construction(_)));
 }

--- a/crates/kithara-stretch/src/lib.rs
+++ b/crates/kithara-stretch/src/lib.rs
@@ -6,7 +6,7 @@ compile_error!(
 );
 
 mod backend;
-pub use backend::{StretchBackend, StretchBackendError};
+pub use backend::{DrainDisposition, StretchBackend, StretchBackendError};
 
 mod config;
 pub use config::StretchOptions;

--- a/tests/perf/memory_rss.rs
+++ b/tests/perf/memory_rss.rs
@@ -5,7 +5,7 @@
 
 use hotpath::HotpathGuardBuilder;
 use kithara::{
-    audio::{Audio, AudioConfig},
+    audio::{Audio, AudioConfig, ConsumerWakeMode},
     hls::{Hls, HlsConfig},
     platform::{time::Duration, tokio::task::spawn_blocking},
     stream::Stream,
@@ -53,6 +53,7 @@ async fn test_hls_playback_rss_within_budget(temp_dir: TestTempDir) {
         let config = AudioConfig::<Hls>::for_stream(hls_config)
             .byte_pool(kithara::bufpool::BytePool::default())
             .pcm_pool(kithara::bufpool::PcmPool::default())
+            .consumer_wake_mode(ConsumerWakeMode::ImmediateOffRt)
             .build();
         let mut audio = Audio::<Stream<Hls>>::new(config)
             .await
@@ -142,6 +143,7 @@ async fn test_hls_playback_no_rss_leak(temp_dir: TestTempDir) {
     let config = AudioConfig::<Hls>::for_stream(hls_config)
         .byte_pool(kithara::bufpool::BytePool::default())
         .pcm_pool(kithara::bufpool::PcmPool::default())
+        .consumer_wake_mode(ConsumerWakeMode::ImmediateOffRt)
         .build();
     let mut audio = Audio::<Stream<Hls>>::new(config)
         .await

--- a/tests/tests/kithara_audio/dsp_properties.rs
+++ b/tests/tests/kithara_audio/dsp_properties.rs
@@ -5,7 +5,7 @@ use std::{
 
 use kithara::{
     audio::{
-        AudioEffect, EqEffect, PeakLimiter,
+        AudioBlockMut, AudioEffect, EqEffect, PeakLimiter,
         effects::eq::{MAX_GAIN_DB, MIN_GAIN_DB, generate_log_spaced_bands},
     },
     bufpool::PcmPool,
@@ -78,14 +78,15 @@ fn eq_with_gain(gain_db: f32, band_count: usize, channels: u16) -> EqEffect {
 
 fn settle(eq: &mut EqEffect, pool: &PcmPool, spec: PcmSpec) {
     let samples = vec![0.0f32; SETTLE_FRAMES * usize::from(spec.channels)];
-    let _ = eq.process(pcm_chunk(pool, spec, samples));
+    let mut chunk = pcm_chunk(pool, spec, samples);
+    let _ = eq.process(AudioBlockMut::new(&chunk.meta, &mut chunk.samples));
 }
 
 fn process_eq(eq: &mut EqEffect, pool: &PcmPool, spec: PcmSpec, samples: Vec<f32>) -> Vec<f32> {
-    eq.process(pcm_chunk(pool, spec, samples))
-        .expect("EqEffect must emit the chunk it was handed")
-        .samples
-        .to_vec()
+    let mut chunk = pcm_chunk(pool, spec, samples);
+    eq.process(AudioBlockMut::new(&chunk.meta, &mut chunk.samples))
+        .expect("EqEffect processing must succeed");
+    chunk.samples.to_vec()
 }
 
 fn limiter_with_ceiling(ceiling: f32) -> PeakLimiter {

--- a/tests/tests/kithara_audio/no_sync_passthrough.rs
+++ b/tests/tests/kithara_audio/no_sync_passthrough.rs
@@ -2,10 +2,9 @@
 
 use kithara::{
     audio::{
-        Audio, AudioConfig, AudioEffect, AudioWorkerHandle, PcmSession, StretchControls,
-        StretchKind,
+        Audio, AudioBlockMut, AudioConfig, AudioEffect, AudioWorkerHandle, DecodeResult,
+        PcmSession, StretchControls, StretchKind,
     },
-    decode::PcmChunk,
     platform::{
         CancelToken,
         sync::{
@@ -82,11 +81,7 @@ impl BurstLoadEffect {
 }
 
 impl AudioEffect for BurstLoadEffect {
-    fn flush(&mut self) -> Option<PcmChunk> {
-        None
-    }
-
-    fn process(&mut self, chunk: PcmChunk) -> Option<PcmChunk> {
+    fn process(&mut self, _block: AudioBlockMut<'_>) -> DecodeResult<()> {
         self.blocks = self.blocks.saturating_add(1);
         if self.blocks.is_multiple_of(LOAD_INTERVAL_BLOCKS) {
             self.probe.observe_burst();
@@ -95,7 +90,7 @@ impl AudioEffect for BurstLoadEffect {
                 std::hint::spin_loop();
             }
         }
-        Some(chunk)
+        Ok(())
     }
 
     fn reset(&mut self) {

--- a/tests/tests/kithara_hls/abr_mode_switch.rs
+++ b/tests/tests/kithara_hls/abr_mode_switch.rs
@@ -1250,7 +1250,7 @@ async fn runtime_cross_codec_manual_switch_no_hang() {
     let bus = EventBus::new(8192);
     // EventCollector's segment URL parser is HlsTestServer-specific; for
     // real-asset URLs we capture VariantApplied targets directly.
-    let collector = EventCollector::new(&bus);
+    let collector = Arc::new(EventCollector::new(&bus));
 
     let hls_config = HlsConfig::for_url(url)
         .store(kithara_integration_tests::disk_asset_store(temp_dir.path()))
@@ -1280,36 +1280,57 @@ async fn runtime_cross_codec_manual_switch_no_hang() {
     let handle = audio
         .abr_handle()
         .expect("HLS stream must expose AbrHandle");
+    let applied_before = collector.applied_transitions().len();
     handle
         .set_mode(AbrMode::manual(3))
         .expect("Manual(3) (FLAC variant) target must be valid");
 
-    // Read for several seconds after the flip — if the decoder hangs on
-    // `Pending(VariantChange)` without recovery, the hang_watchdog or
-    // the test timeout will fail. Otherwise we should see post-switch
-    // samples coming from the FLAC variant.
-    let post_total = spawn_blocking(move || read_to_eof(&mut audio))
+    let switch_seen = Arc::clone(&collector);
+    let (mut audio, transition) = spawn_blocking(move || {
+        let stats = read_phase_until(&mut audio, 0, "cross-codec manual transition", || {
+            switch_seen.applied_transitions()[applied_before..]
+                .contains(&(3, AbrReason::ManualOverride))
+        });
+        (audio, stats)
+    })
+    .await
+    .expect("transition read");
+    let (mut audio, post_promotion) = spawn_blocking(move || {
+        let stats = read_phase_until_samples(&mut audio, 8_192, "cross-codec promoted FLAC audio");
+        (audio, stats)
+    })
+    .await
+    .expect("post-promotion read");
+    let tail_total = spawn_blocking(move || read_to_eof(&mut audio))
         .await
-        .expect("read");
+        .expect("tail drain");
 
-    let targets = collector.applied_targets();
-    let saw_flac = targets.contains(&3);
+    let transitions = collector.applied_transitions();
+    let manual_flac = transitions[applied_before..].contains(&(3, AbrReason::ManualOverride));
 
     info!(
-        ?targets,
-        pre_total, post_total, "L2: cross-codec Manual switch result"
+        ?transitions,
+        pre_total,
+        ?transition,
+        ?post_promotion,
+        tail_total,
+        "L2: cross-codec Manual switch result"
     );
 
     assert!(
-        !targets.is_empty(),
-        "cross-codec Manual(3) must fire at least one VariantApplied"
+        !transition.saw_eof,
+        "Manual(3) must promote before outgoing EOF: {transition:?}"
     );
     assert!(
-        saw_flac,
-        "Manual(3) must publish a VariantApplied with to=3, saw: {targets:?}"
+        manual_flac,
+        "Manual(3) must publish a manual VariantApplied to FLAC, saw: {transitions:?}"
     );
     assert!(
-        post_total > 0,
+        !post_promotion.saw_eof && post_promotion.samples >= 8_192,
+        "promoted FLAC variant must produce a fresh audio budget: {post_promotion:?}"
+    );
+    assert!(
+        tail_total > 0,
         "playback must continue after the cross-codec flip — \
          pre-K bug: hang_watchdog panic at 10s"
     );

--- a/tests/tests/kithara_hls/abr_switch_playback.rs
+++ b/tests/tests/kithara_hls/abr_switch_playback.rs
@@ -1,6 +1,6 @@
 use kithara::{
     assets::AssetStore,
-    audio::{Audio, AudioConfig, ChunkOutcome, ReadOutcome},
+    audio::{Audio, AudioConfig, ChunkOutcome, ConsumerWakeMode, ReadOutcome},
     decode::DecoderBackend,
     events::{AbrEvent, AbrReason, Event, EventBus, EventReceiver},
     file::{File, FileConfig},
@@ -796,6 +796,7 @@ async fn abr_frozen_during_seek_resumes_after(temp_dir: TestTempDir) {
         AudioConfig::<Hls>::for_stream(hls_config)
             .byte_pool(kithara::bufpool::BytePool::default())
             .pcm_pool(kithara::bufpool::PcmPool::default())
+            .consumer_wake_mode(ConsumerWakeMode::ImmediateOffRt)
             .build(),
     )
     .await

--- a/tests/tests/kithara_hls/idle_behavior.rs
+++ b/tests/tests/kithara_hls/idle_behavior.rs
@@ -8,7 +8,10 @@ use kithara::{
     audio::{Audio, AudioConfig},
     events::{Event, EventBus},
     hls::{AbrMode, Hls, HlsConfig},
-    platform::{sync::Arc, time::Duration},
+    platform::{
+        sync::Arc,
+        time::{Duration, Instant as PlatformInstant},
+    },
     stream::Stream,
 };
 use kithara_integration_tests::{TestServerHelper, TestTempDir, temp_dir};
@@ -174,16 +177,24 @@ async fn idle_prefetch_is_capped(temp_dir: TestTempDir) {
     // quiescent. Under flash the window collapses to ~0 wall while the
     // virtual clock advances to the deadline whenever nothing is runnable.
     const SETTLE_WINDOW: Duration = Duration::from_secs(3);
+    let mut last_download = PlatformInstant::now();
     loop {
-        match time::timeout(SETTLE_WINDOW, rx.recv())
+        let remaining = SETTLE_WINDOW.saturating_sub(last_download.elapsed());
+        if remaining.is_zero() {
+            break;
+        }
+        match time::timeout(remaining, rx.recv())
             .await
             .map(|r| r.map(|env| env.event))
         {
             // A downloader event arrived inside the window: still active,
             // keep waiting. Lagged is also "events are flowing".
             Ok(Ok(Event::Downloader(_)))
-            | Ok(Err(kithara::platform::tokio::sync::broadcast::error::RecvError::Lagged(_))) => {}
-            // Non-downloader event: ignore, keep waiting for quiescence.
+            | Ok(Err(kithara::platform::tokio::sync::broadcast::error::RecvError::Lagged(_))) => {
+                last_download = PlatformInstant::now();
+            }
+            // Non-downloader event: ignore without extending the downloader
+            // quiescence window.
             Ok(Ok(_)) => {}
             // Bus closed or the settle window elapsed with no event:
             // prefetch has gone quiescent.

--- a/tests/tests/kithara_play/hls_seek_past_end_terminates.rs
+++ b/tests/tests/kithara_play/hls_seek_past_end_terminates.rs
@@ -13,6 +13,7 @@ use kithara_integration_tests::{
     PackagedTestServer,
     offline::{NotificationKind, OfflinePlayer},
     temp_dir,
+    waits::render_until_position,
 };
 
 use crate::common::test_defaults::Consts as Shared;
@@ -21,7 +22,9 @@ struct Consts;
 impl Consts {
     const SAMPLE_RATE: u32 = Shared::SAMPLE_RATE;
     const BLOCK_FRAMES: usize = Shared::OFFLINE_BLOCK_FRAMES;
+    const PRE_SEEK_POSITION_SECS: f64 = 0.2;
     const PRE_SEEK_RENDER_SECS: f64 = 1.5;
+    const PRE_SEEK_WALL_MS: u64 = 1_500;
     const POST_SEEK_RENDER_SECS: f64 = 6.0;
     /// Far past the 12 s fixture duration. The decoder must reject this
     /// (Symphonia returns "seek past EOF"), forcing the
@@ -82,14 +85,17 @@ async fn hls_seek_past_end_terminates_in_bounded_time() {
     let mut player = OfflinePlayer::new(Consts::SAMPLE_RATE);
     player.load_and_fadein(resource, "t0");
 
-    render_burst(
+    render_until_position(
         &mut player,
         blocks_for_seconds(Consts::PRE_SEEK_RENDER_SECS),
+        Consts::PRE_SEEK_POSITION_SECS,
+        Consts::BLOCK_FRAMES,
+        Consts::PRE_SEEK_WALL_MS,
     )
     .await;
     let pos_before = player.position();
     assert!(
-        pos_before > 0.2,
+        pos_before > Consts::PRE_SEEK_POSITION_SECS,
         "decoder never produced PCM before the seek (pos={pos_before:.3}s)"
     );
     let _ = player.take_notification_kinds();

--- a/tests/tests/kithara_play/player_track_internal.rs
+++ b/tests/tests/kithara_play/player_track_internal.rs
@@ -174,6 +174,7 @@ async fn eof_playback_stopped_notification_carries_item_id() {
             &mut scratch_bufs,
             &mut mix_bufs,
             0..512,
+            None,
             &mut RtSink::new(&mut notification_tx, &RtMetrics::default()),
         );
 
@@ -214,6 +215,7 @@ async fn read_outcome_full_on_normal_read() {
         &mut scratch_bufs,
         &mut mix_bufs,
         0..512,
+        None,
         &mut RtSink::new(&mut notification_tx, &RtMetrics::default()),
     );
 
@@ -272,6 +274,7 @@ async fn read_outcome_partial_then_eof() {
             &mut scratch_bufs,
             &mut mix_bufs,
             0..512,
+            None,
             &mut RtSink::new(&mut notification_tx, &RtMetrics::default()),
         );
 
@@ -329,6 +332,7 @@ async fn handover_emits_once_when_position_crosses_fade_threshold() {
             &mut scratch_bufs,
             &mut mix_bufs,
             0..512,
+            None,
             &mut RtSink::new(&mut notification_tx, &RtMetrics::default()),
         );
         for notification in collect_notifications(&mut rx) {
@@ -362,6 +366,7 @@ async fn handover_emits_once_when_position_crosses_fade_threshold() {
         &mut scratch_bufs,
         &mut mix_bufs,
         0..512,
+        None,
         &mut RtSink::new(&mut notification_tx, &RtMetrics::default()),
     );
     let notifications = collect_notifications(&mut rx);
@@ -398,6 +403,7 @@ async fn handover_uses_buffered_eof_when_duration_is_overestimated() {
         &mut scratch_bufs,
         &mut mix_bufs,
         0..512,
+        None,
         &mut RtSink::new(&mut notification_tx, &RtMetrics::default()),
     );
 
@@ -450,6 +456,7 @@ async fn handover_backstops_eof_when_threshold_was_not_reached_earlier() {
         &mut scratch_bufs,
         &mut mix_bufs,
         0..512,
+        None,
         &mut RtSink::new(&mut notification_tx, &RtMetrics::default()),
     );
     assert!(matches!(outcome, TrackReadOutcome::Partial { .. }));
@@ -503,6 +510,7 @@ async fn handover_is_not_duplicated_at_eof_after_early_trigger() {
             &mut scratch_bufs,
             &mut mix_bufs,
             0..512,
+            None,
             &mut RtSink::new(&mut notification_tx, &RtMetrics::default()),
         );
 
@@ -555,6 +563,7 @@ async fn prefetch_fires_before_handover_when_prefetch_exceeds_fade() {
         &mut scratch_bufs,
         &mut mix_bufs,
         0..512,
+        None,
         &mut RtSink::new(&mut notification_tx, &RtMetrics::default()),
     );
 
@@ -597,6 +606,7 @@ async fn handover_fires_after_prefetch_when_position_reaches_fade_threshold() {
         &mut scratch_bufs,
         &mut mix_bufs,
         0..512,
+        None,
         &mut RtSink::new(&mut notification_tx, &RtMetrics::default()),
     );
     let after_prefetch = collect_notifications(&mut rx);
@@ -619,6 +629,7 @@ async fn handover_fires_after_prefetch_when_position_reaches_fade_threshold() {
             &mut scratch_bufs,
             &mut mix_bufs,
             0..512,
+            None,
             &mut RtSink::new(&mut notification_tx, &RtMetrics::default()),
         );
         for notification in collect_notifications(&mut rx) {
@@ -656,6 +667,7 @@ async fn prefetch_fires_immediately_when_track_shorter_than_prefetch_duration() 
         &mut scratch_bufs,
         &mut mix_bufs,
         0..512,
+        None,
         &mut RtSink::new(&mut notification_tx, &RtMetrics::default()),
     );
 
@@ -688,6 +700,7 @@ async fn prefetch_and_handover_both_fire_when_thresholds_coincide() {
         &mut scratch_bufs,
         &mut mix_bufs,
         0..512,
+        None,
         &mut RtSink::new(&mut notification_tx, &RtMetrics::default()),
     );
     let mid = collect_notifications(&mut rx);
@@ -704,6 +717,7 @@ async fn prefetch_and_handover_both_fire_when_thresholds_coincide() {
             &mut scratch_bufs,
             &mut mix_bufs,
             0..512,
+            None,
             &mut RtSink::new(&mut notification_tx, &RtMetrics::default()),
         );
         for notification in collect_notifications(&mut rx) {
@@ -743,6 +757,7 @@ async fn read_outcome_eof_when_track_finished() {
         &mut scratch_bufs,
         &mut mix_bufs,
         0..512,
+        None,
         &mut RtSink::new(&mut notification_tx, &RtMetrics::default()),
     );
 

--- a/tests/tests/kithara_play/resource_regressions.rs
+++ b/tests/tests/kithara_play/resource_regressions.rs
@@ -5,7 +5,7 @@ use std::{io::Read, num::NonZeroUsize};
 
 use kithara::{
     assets::{AssetStore, StorageBackend},
-    audio::{Audio, AudioConfig, AudioWorkerHandle, ReadOutcome},
+    audio::{Audio, AudioConfig, AudioWorkerHandle, ConsumerWakeMode, ReadOutcome},
     decode::DecoderBackend,
     file::{File as FileSource, FileConfig, FileSrc},
     hls::{Hls, HlsConfig},
@@ -326,6 +326,7 @@ async fn open_packaged_hls_audio(
         AudioConfig::<Hls>::for_stream(HlsConfig::for_url(url.clone()).store(store).build())
             .byte_pool(kithara::bufpool::BytePool::default())
             .pcm_pool(kithara::bufpool::PcmPool::default())
+            .consumer_wake_mode(ConsumerWakeMode::ImmediateOffRt)
             .decoder(
                 kithara::audio::AudioDecoderConfig::builder()
                     .backend(backend)

--- a/tests/tests/kithara_queue/flac_swallow_fixture.rs
+++ b/tests/tests/kithara_queue/flac_swallow_fixture.rs
@@ -38,7 +38,6 @@ const TOP_VARIANT: usize = VARIANT_COUNT - 1;
 
 const OUT_RATE: u32 = 44_100;
 const BLOCK_FRAMES: usize = 512;
-const BLOCKS_PER_WINDOW: usize = 8;
 const PLAY_SECS: f64 = 18.0;
 const MIN_DELAYED_PLAYHEAD_SECS: f64 = 14.0;
 /// The committed playhead advances ~one decoded chunk (~0.1 s) per
@@ -87,16 +86,14 @@ fn build_fixture() -> HlsFixtureBuilder {
         })
 }
 
-async fn play_realtime(player: &mut OfflinePlayer, windows: u64, window_secs: f64) {
+async fn play_realtime(player: &mut OfflinePlayer, blocks: u64, block_secs: f64) {
     let _real_io = real_io();
-    for _ in 0..windows {
+    for _ in 0..blocks {
         let started = Instant::now();
-        for _ in 0..BLOCKS_PER_WINDOW {
-            let _ = player.render(BLOCK_FRAMES);
-        }
+        let _ = player.render(BLOCK_FRAMES);
         let elapsed = started.elapsed().as_secs_f64();
-        if window_secs > elapsed {
-            time::sleep(Duration::from_secs_f64(window_secs - elapsed)).await;
+        if block_secs > elapsed {
+            time::sleep(Duration::from_secs_f64(block_secs - elapsed)).await;
         }
     }
 }
@@ -158,9 +155,8 @@ async fn flac_swallow_fixture(#[case] backend: DecoderBackend) {
     let mut player = OfflinePlayer::new(OUT_RATE);
     player.load_and_fadein(resource, "t0");
 
-    let window_secs = (BLOCKS_PER_WINDOW * BLOCK_FRAMES) as f64 / f64::from(OUT_RATE);
-    let windows =
-        num_traits::cast::<f64, u64>((PLAY_SECS / window_secs).ceil()).unwrap_or(u64::MAX);
+    let block_secs = BLOCK_FRAMES as f64 / f64::from(OUT_RATE);
+    let blocks = num_traits::cast::<f64, u64>((PLAY_SECS / block_secs).ceil()).unwrap_or(u64::MAX);
     // This reproduces a REAL-TIME-DEADLINE bug: the swallow only occurs when a
     // delayed FLAC segment (700 ms real) is not ready by the player's real-time
     // render deadline. Hold a `RealIoScope` across the playout so the virtual
@@ -169,7 +165,7 @@ async fn flac_swallow_fixture(#[case] backend: DecoderBackend) {
     // instead of the virtual clock racing past the producer (which starves the
     // worker so the track never plays). Off the `flash` feature this is a ZST
     // no-op and the clock is already real.
-    play_realtime(&mut player, windows, window_secs).await;
+    play_realtime(&mut player, blocks, block_secs).await;
 
     assert_committed_reached(&recorder, MIN_DELAYED_PLAYHEAD_SECS);
     assert_no_committed_swallow(&recorder, MAX_COMMITTED_STEP_SECS);

--- a/tests/tests/phase_continuity/hls.rs
+++ b/tests/tests/phase_continuity/hls.rs
@@ -3,7 +3,7 @@ use std::num::NonZeroUsize;
 use kithara::{
     abr::AbrMode,
     assets::{AssetStore, StorageBackend},
-    audio::{Audio, AudioConfig},
+    audio::{Audio, AudioConfig, ConsumerWakeMode},
     decode::DecoderBackend,
     hls::{Hls, HlsConfig},
     platform::{CancelToken, time::Duration},
@@ -174,8 +174,7 @@ async fn run_case_paced(
         .cancel(cancel)
         .initial_abr_mode(initial_mode)
         .build();
-    // Keep HLS scan nonblocking: readiness is observed through Frames/Pending,
-    // not through the blocking read watchdog's wall-clock budget.
+    // Keep the off-RT HLS scan nonblocking while waking its producer after each pop.
     let audio_config = AudioConfig::<Hls>::for_stream(hls_config)
         .byte_pool(kithara::bufpool::BytePool::default())
         .pcm_pool(kithara::bufpool::PcmPool::default())
@@ -184,6 +183,7 @@ async fn run_case_paced(
                 .backend(backend)
                 .build(),
         )
+        .consumer_wake_mode(ConsumerWakeMode::ImmediateOffRt)
         .build();
     let mut audio = Audio::<Stream<Hls>>::new(audio_config)
         .await


### PR DESCRIPTION
## Summary

This PR adds the resident late-presentation renderer required by deck synchronization. Final post-effect PCM now carries one exact source/presentation coordinate, the player publishes that coordinate only after the corresponding frames are consumed, and tempo DSP cores are prepared and retired outside the RT callback.

Both predecessors are **merged**: #177 (`51bdc8937`) and #186 (`fe5e12bbd`). This branch is no longer stacked — it is exactly **nine commits** on top of current `main`.

## Base

- Re-cut onto `main` at `fe5e12bbd67751dfc9177d879890f84cffcf9424` after #186 landed.
- #186 was **squash**-merged, so its old branch head `1c72ed1a0` is not an ancestor of `main`. The rebase therefore cut at that exact old head, which is why the foundation commit is absorbed by the squash rather than replayed a second time.
- Head `ccde033c8f4c3e958349d6ab903782fdce8fbd26`; `git rev-list --count main..HEAD` is `9`.
- `git range-diff` against the pre-re-cut range reports all nine commits `=`, so the patches are byte-identical and the reviewed contract is unchanged. The re-cut needed no conflict resolution, including against #185's test-suite reorganisation.

## Behavior / scope
- contract or behavior: commit fixed-size final PCM blocks together with coherent seek epoch, generation, source frame, output ordinal, and source rate
- contract or behavior: map consumed presentation boundaries to exact session frames and invalidate the mapping on underrun, seek, handover, or incompatible generation/rate
- contract or behavior: keep one resident tempo stage whose active/prepared/retired cores cross decoder, control, region, EOF, and seek boundaries without allocation, blocking, reset, logging, or destructor work on RT
- contract or behavior: preserve exact source endpoints through Signalsmith tails; handle the documented Bungee no-tail disposition explicitly; apply playback speeds above 2x without a hidden DSP clamp
- affected area: `kithara-audio` presentation/tempo pipeline, `kithara-play` RT consumption, and `kithara-stretch` backend bounds
- excluded: Queue-owned sync plans, deck bind/unbind commands, app SYNC controls, cold analysis retention, and audible two-deck synchronization

## Validation
- `just lint fast` — pass, including workspace Clippy with `-D warnings`, formatting, AST, typos, architecture, and idioms
- final audio owner filter — 76/76 passed: presentation, tempo processor, region, and decoder-node contracts
- final player presentation filter — 4/4 passed
- active no-SYNC deadline test — passed; worst observed p99 was 4.08 us for 1024 frames / 4 tracks, about 0.02% of the callback period
- final independent architecture review — clean after fixing partial-source decoder/control ordering and region-before-decoder ordering
- final code-hygiene review — clean
- **Fork CI on this exact head is the deciding run.** Earlier runs were on pre-re-cut heads and are not merge proof. When reading a failure, compare test *names* against the fork's own red `main` baseline (`abr_switch_playback::packaged_abr_switch_keeps_player_continuity`, `phase_continuity::file::phase_continuity_file_mp3_symphonia_eph_10seek`, `stress_seek_abr_audio_flac_fmp4`, `rtsan-file`/`rtsan-hls`) — a match there is baseline, not a regression from this branch.

## Surface impact
- Public API: changed: presentation point/cursor and tempo-stage contracts are exported from `kithara-audio`; no Queue or app SYNC API is added
- Platform/runtime: changed: native playback now routes final PCM through the resident presentation stage
- Perf-sensitive paths: changed: RT work is bounded to fixed 512-frame credits and fixed local buffers; backend construction, replacement, retirement, and rejected-buffer release occur off RT

## Risks / follow-ups
- Heavy real-media and platform-specific RT lanes are intentionally delegated to CI.
- This PR does not claim audible deck synchronization. It supplies the exact, RT-safe execution base; the durable sync plan and the real app control land in later PRs.
