### PR TITLE
fix(ci): judge with the host's own controls, and reclaim what a job is short

### DIFF
--- a/ci/bridge/config.example.toml
+++ b/ci/bridge/config.example.toml
@@ -8,10 +8,14 @@ gitlab_url = "https://gitlab.example.com"
 gitlab_username = "kithara-sync"
 state_dir = "/path/to/bridge-state"
 
-# GitHub logins whose pull requests may change the CI control paths directly:
-# they are judged with their own CI configuration instead of the default
-# branch's. Everyone else keeps the rule, so a contributor without GitLab access
-# is never asked to port a change through a merge request they cannot open.
+# GitHub logins whose pull requests may change the CI control paths directly.
+# Everyone else keeps the rule, so a contributor without GitLab access is never
+# asked to port a change through a merge request they cannot open.
+#
+# Listing an author does not change which CI configuration their pull requests
+# run: the default branch's control paths are still restored unless the pull
+# request changes them itself. That restoration is also what keeps a branch
+# older than the host runnable.
 #
 # Deliberately here and not in the repository: a list a pull request can edit is
 # a list that adds its own author.

--- a/xtask/src/ci/bridge/model.rs
+++ b/xtask/src/ci/bridge/model.rs
@@ -6,6 +6,13 @@ use serde::{Deserialize, Serialize};
 /// Paths that define the trusted `GitLab` judge. Pull-request product content is
 /// tested with these paths restored from the synchronized default branch.
 ///
+/// Restoring them does two jobs at once. It keeps a pull request from grading
+/// itself, and it keeps a branch runnable after the host moves on: these paths
+/// are what agrees with the machine, and a branch old enough to disagree fails
+/// on the host profile or on a job name before it reaches a test. Only a pull
+/// request that changes them is judged with its own, because a change to the
+/// judge has nowhere else to be tested.
+///
 /// Being listed here is not by itself a reason to reject a pull request. What a
 /// change does to the judge decides that, and `control::classify` is where it is
 /// decided: an entry added beside the existing ones promises nothing new about

--- a/xtask/src/ci/bridge/reconcile.rs
+++ b/xtask/src/ci/bridge/reconcile.rs
@@ -167,10 +167,10 @@ impl Bridge {
         self.repo
             .fetch_pull_head(&self.github, pull.number, &pull.head_sha)?;
         // A trusted author answers for the CI configuration the same way they
-        // answer for the code, so their pull request is judged with its own
-        // configuration rather than the default branch's. For everyone else the
-        // rule stands, and a contributor who cannot open a GitLab merge request
-        // is not the one it is aimed at — see the follow-up in `model`.
+        // answer for the code, so their pull request is never rejected for
+        // touching it. For everyone else the rule stands, and a contributor who
+        // cannot open a GitLab merge request is not the one it is aimed at —
+        // see the follow-up in `model`.
         let trusted = self
             .config
             .trusted_authors
@@ -182,6 +182,22 @@ impl Bridge {
             self.repo
                 .weakening_control_paths(base_sha, &pull.head_sha)?
         };
+        // Trust decides whether a pull request may change the CI configuration.
+        // It does not decide which configuration the run uses: the host is one
+        // machine on one version, and a branch that predates it carries an
+        // `xtask` that cannot parse the host profile and a pipeline that still
+        // names jobs the default branch dropped. Both fail before reaching a
+        // single test. So the base's control paths are restored for every pull
+        // request that does not touch them itself — trusted or not — and only a
+        // pull request that changes them is judged with its own, because there
+        // is no other way to test that change.
+        let owns_controls = judged_with_own_controls(
+            trusted,
+            !self
+                .repo
+                .changed_control_paths(base_sha, &pull.head_sha)?
+                .is_empty(),
+        );
         let entry = ledger.reserve(&pull.head_sha, base_sha)?;
         if reject_control_changes(
             pull.number,
@@ -199,7 +215,7 @@ impl Bridge {
 
         let Some(pipeline_id) = entry.pipeline_id else {
             let reference = quarantine_ref(&pull.head_sha, base_sha, entry.attempt);
-            let judged = if trusted {
+            let judged = if owns_controls {
                 pull.head_sha.clone()
             } else {
                 self.repo.judged_commit(base_sha, &pull.head_sha)?
@@ -287,6 +303,17 @@ fn start_verification(
     attach(attempt, pipeline_id)?;
     report(head_sha, "pending", "GitLab verification running")?;
     announce(attempt, pipeline_id)
+}
+
+/// Whether the verification runs the pull request's own control paths instead
+/// of the base branch's.
+///
+/// Only when the author may change them *and* actually did. Trust alone is not
+/// enough: restoring the base's control paths is also what keeps a branch that
+/// predates the host runnable, and a trusted author's stale branch needs that
+/// as much as anyone's.
+const fn judged_with_own_controls(trusted: bool, changes_controls: bool) -> bool {
+    trusted && changes_controls
 }
 
 fn reject_control_changes(

--- a/xtask/src/ci/bridge/reconcile_tests.rs
+++ b/xtask/src/ci/bridge/reconcile_tests.rs
@@ -437,3 +437,23 @@ fn a_direct_github_update_opens_an_incident_without_a_push() {
         )
     );
 }
+
+/// Trust says who may change the CI configuration. It does not say which
+/// configuration the verification runs, and conflating the two took the
+/// normalization away from every trusted branch at once: a June branch went to
+/// the host with its own `xtask`, which could not parse the host profile, and
+/// its own pipeline, which still named a job the default branch had dropped.
+/// Both died before a single test.
+#[test]
+fn only_a_pull_request_that_changes_the_controls_is_judged_with_its_own() {
+    assert!(
+        judged_with_own_controls(true, true),
+        "a trusted author's control-path change has nowhere else to be tested"
+    );
+    assert!(
+        !judged_with_own_controls(true, false),
+        "a trusted author's stale branch needs the base's controls like any other"
+    );
+    assert!(!judged_with_own_controls(false, true));
+    assert!(!judged_with_own_controls(false, false));
+}

--- a/xtask/src/ci/build_cache.rs
+++ b/xtask/src/ci/build_cache.rs
@@ -67,6 +67,29 @@ pub(crate) fn select_evictions(mut entries: Vec<CacheEntry>, budget_bytes: u64) 
 /// job holds cannot be evicted, but the room it occupies is still spent, so it
 /// is charged against the ceiling rather than excused from it.
 pub(crate) fn enforce_budget(target_dirs: &[PathBuf], budget_bytes: u64) -> Result<()> {
+    let (candidates, held_bytes, _locks) = collect(target_dirs, budget_bytes)?;
+    evict_to_budget(candidates, held_bytes, budget_bytes)
+}
+
+/// Evict until at least `bytes_needed` is gone, whatever the ceiling says.
+///
+/// A job that cannot fit asks a different question than the hourly pass does.
+/// The ceiling answers "may the host keep this much"; caches under it are left
+/// alone, which is right for a scheduled sweep and useless for a job standing
+/// in front of a full volume — 15.7 GB of caches under a 25 GB ceiling freed
+/// nothing while the job needed one more gigabyte and was refused. Here the
+/// shortfall is the budget: the oldest entries go until it is covered, or until
+/// nothing evictable is left and the caller reports the volume as it is.
+pub(crate) fn reclaim_at_least(target_dirs: &[PathBuf], bytes_needed: u64) -> Result<()> {
+    let (candidates, held_bytes, _locks) = collect(target_dirs, bytes_needed)?;
+    let keep = total_bytes(&candidates).saturating_sub(bytes_needed);
+    evict_to_budget(candidates, held_bytes, keep.saturating_add(held_bytes))
+}
+
+fn collect(
+    target_dirs: &[PathBuf],
+    budget_bytes: u64,
+) -> Result<(Vec<CacheEntry>, u64, Vec<File>)> {
     let mut target_dirs = target_dirs.to_vec();
     target_dirs.sort();
     let mut candidates = Vec::new();
@@ -89,7 +112,7 @@ pub(crate) fn enforce_budget(target_dirs: &[PathBuf], budget_bytes: u64) -> Resu
         }
         candidates.extend(contents.entries);
     }
-    evict_to_budget(candidates, held_bytes, budget_bytes)
+    Ok((candidates, held_bytes, locks))
 }
 
 fn total_bytes(entries: &[CacheEntry]) -> u64 {
@@ -381,6 +404,39 @@ mod tests {
         enforce_budget(&[first.clone(), second.clone()], budget).unwrap();
 
         assert!(occupied(&first) + occupied(&second) <= budget);
+    }
+
+    /// The refused job's state, which the ceiling cannot see: caches sit under
+    /// it, so an `enforce_budget` pass frees nothing, while the volume is short
+    /// of what one job needs because the rest of it is spent on checkouts,
+    /// toolchains and guests. That is how a job was refused over one missing
+    /// gigabyte with 15.7 GB of evictable cache beside it.
+    #[test]
+    fn a_shortfall_is_reclaimed_even_though_the_caches_are_under_the_ceiling() {
+        let root = tempfile::tempdir().unwrap();
+        let first = checkout_target(root.path(), "one", 100_000);
+        let second = checkout_target(root.path(), "two", 100_000);
+        let targets = [first.clone(), second.clone()];
+        let before = occupied(&first) + occupied(&second);
+        enforce_budget(&targets, before * 2).unwrap();
+        assert_eq!(
+            occupied(&first) + occupied(&second),
+            before,
+            "under the ceiling the hourly pass has nothing to do"
+        );
+        let shortfall = before / 4;
+
+        reclaim_at_least(&targets, shortfall).unwrap();
+
+        let left = occupied(&first) + occupied(&second);
+        assert!(
+            before - left >= shortfall,
+            "the shortfall of {shortfall} must be freed, {left} bytes left of {before}"
+        );
+        assert!(
+            left > 0,
+            "only the shortfall is owed; the rest of the cache is worth keeping"
+        );
     }
 
     fn checkout_target(root: &Path, name: &str, bytes: usize) -> PathBuf {

--- a/xtask/src/ci/environment.rs
+++ b/xtask/src/ci/environment.rs
@@ -517,12 +517,7 @@ fn ensure_room_for_a_job(config: &CiConfig, shared_root: &Path) -> Result<()> {
     if !is_ci() || free >= required {
         return Ok(());
     }
-    reclaim_build_caches(
-        config.host.build_root(),
-        config.host.build_cache_budget_bytes()?,
-        free,
-        required,
-    )?;
+    reclaim_build_caches(config.host.build_root(), free, required)?;
     let free = free_bytes(shared_root)?;
     if free < required {
         bail!(
@@ -545,26 +540,28 @@ fn ensure_room_for_a_job(config: &CiConfig, shared_root: &Path) -> Result<()> {
 /// the refusal mean what it says: the space is held by live work, not by
 /// leftovers.
 ///
+/// What is reclaimed is the shortfall, not the host's ceiling. The ceiling is
+/// the hourly pass's question and it answers "nothing to do" whenever the caches
+/// happen to sit under it — which is exactly the state a refused job finds
+/// itself in, since a full volume is rarely full of build caches alone.
+///
 /// Failing to reclaim is not itself a refusal — the gate re-reads free space
 /// and answers on that.
-fn reclaim_build_caches(
-    build_root: &Path,
-    budget_bytes: u64,
-    free: u64,
-    required: u64,
-) -> Result<()> {
+fn reclaim_build_caches(build_root: &Path, free: u64, required: u64) -> Result<()> {
     let workspaces = build_root.join("workspaces/gitlab");
     let targets = build_cache::persistent_target_dirs(&workspaces)?;
     if targets.is_empty() {
         return Ok(());
     }
+    let shortfall = required.saturating_sub(free);
     warn!(
         free_bytes = free,
         required_bytes = required,
+        shortfall_bytes = shortfall,
         targets = targets.len(),
         "reclaiming build caches before refusing the job"
     );
-    build_cache::enforce_budget(&targets, budget_bytes)
+    build_cache::reclaim_at_least(&targets, shortfall)
 }
 
 pub(crate) fn is_gitlab() -> bool {
@@ -895,7 +892,7 @@ mod tests {
         fs::write(checkout.join("Cargo.toml"), "[package]\n").unwrap();
         fs::write(target.join("artifact"), vec![0_u8; 400_000]).unwrap();
 
-        reclaim_build_caches(root.path(), 0, 0, u64::MAX).unwrap();
+        reclaim_build_caches(root.path(), 0, u64::MAX).unwrap();
 
         assert!(
             !target.join("artifact").exists(),
@@ -920,7 +917,7 @@ mod tests {
 
         let held = CheckoutLease::acquire(&checkout).expect("the running job takes its lease");
 
-        reclaim_build_caches(root.path(), 0, 0, u64::MAX).unwrap();
+        reclaim_build_caches(root.path(), 0, u64::MAX).unwrap();
 
         assert!(
             target.join("artifact").exists(),
@@ -928,7 +925,7 @@ mod tests {
         );
         drop(held);
 
-        reclaim_build_caches(root.path(), 0, 0, u64::MAX).unwrap();
+        reclaim_build_caches(root.path(), 0, u64::MAX).unwrap();
 
         assert!(
             !target.join("artifact").exists(),

--- a/xtask/src/ci/host/runners.rs
+++ b/xtask/src/ci/host/runners.rs
@@ -11,7 +11,7 @@ use tracing::info;
 
 use super::services::launchd;
 use crate::ci::{
-    HOST_JOB_CONCURRENCY,
+    HOST_CORES, HOST_JOB_CONCURRENCY,
     config::{CiConfig, MAC_CONFIG_PATH},
     environment::PROVISIONED_LINUX_IMAGE_ENV,
     process::Process,
@@ -29,10 +29,18 @@ enum LaunchdServiceState {
 }
 
 impl<'a> RunnerManager<'a> {
-    /// Two simultaneous jobs may each occupy four Cargo workers. The remaining
-    /// two cores stay available to the runner, sccache, linkers, and platform tools.
-    const CARGO_BUILD_JOBS_ENV: &'static str = "CARGO_BUILD_JOBS=4";
+    /// Cargo workers one admitted job may occupy.
+    ///
+    /// Derived rather than written down, because the two numbers drifted apart
+    /// the one time they were: admission went from two jobs to three while this
+    /// stayed at four, and twelve compilers on ten cores left nothing for the
+    /// runner, sccache, and the linkers. The spare core is that remainder.
+    const CARGO_BUILD_JOBS: usize = (HOST_CORES - 1) / HOST_JOB_CONCURRENCY;
     const LEGACY_MACOS_RUNNER_LABEL: &'static str = "com.zvuk.kithara-ci.macos-runner";
+
+    fn cargo_build_jobs_env() -> String {
+        format!("CARGO_BUILD_JOBS={}", Self::CARGO_BUILD_JOBS)
+    }
 
     pub(super) const fn new(config: &'a CiConfig, process: &'a Process) -> Self {
         Self { config, process }
@@ -255,7 +263,7 @@ impl<'a> RunnerManager<'a> {
     /// locally — a suite that runs in three minutes took an hour to reach.
     fn runner_config(&self, home: &Path, tokens: &Tokens) -> String {
         let concurrency = HOST_JOB_CONCURRENCY;
-        let cargo_build_jobs = Self::CARGO_BUILD_JOBS_ENV;
+        let cargo_build_jobs = Self::cargo_build_jobs_env();
         let root = self.config.host.host_root.display();
         let builds = self.config.host.build_root().display();
         let url = self.config.host.gitlab_origin();
@@ -569,7 +577,53 @@ mod tests {
     use std::{collections::BTreeMap, ffi::OsString, os::unix::fs::PermissionsExt};
 
     use super::*;
-    use crate::ci::{HOST_JOB_CONCURRENCY, config::fixture};
+    use crate::ci::config::fixture;
+
+    /// What the runner is actually handed has to fit the machine. Admission and
+    /// the per-job Cargo budget are rendered into the same file from two
+    /// different constants, and the machine is what pays when they disagree:
+    /// raising admission from two jobs to three while the budget stayed at four
+    /// put twelve compilers on ten cores, leaving the runner, sccache, and the
+    /// linkers nothing to run on.
+    #[test]
+    fn the_rendered_runner_config_fits_its_jobs_on_the_host() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .to_path_buf();
+        let config = fixture();
+        let process = Process::new(&root, BTreeMap::new());
+        let manager = RunnerManager::new(&config, &process);
+        let home = config
+            .host
+            .host_root
+            .join("home")
+            .join(&config.host.ci_user);
+        let tokens = Tokens {
+            macos: "glrt-macos".into(),
+            linux: "glrt-linux".into(),
+            android: "glrt-android".into(),
+            release: "glrt-release".into(),
+        };
+
+        let rendered: toml::Value = toml::from_str(&manager.runner_config(&home, &tokens)).unwrap();
+        let admitted = usize::try_from(rendered["concurrent"].as_integer().unwrap()).unwrap();
+        let workers: usize = rendered["runners"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .flat_map(|runner| runner["environment"].as_array().into_iter().flatten())
+            .filter_map(toml::Value::as_str)
+            .find_map(|entry| entry.strip_prefix("CARGO_BUILD_JOBS="))
+            .expect("every runner carries a per-job Cargo budget")
+            .parse()
+            .expect("the Cargo budget is a worker count");
+
+        assert!(
+            admitted * workers < HOST_CORES,
+            "{admitted} jobs of {workers} workers claim every one of the host's {HOST_CORES} cores"
+        );
+    }
 
     #[test]
     fn installing_an_executable_over_itself_keeps_it() {
@@ -881,7 +935,9 @@ mod tests {
                     .as_array()
                     .unwrap()
                     .iter()
-                    .any(|value| value.as_str() == Some(RunnerManager::CARGO_BUILD_JOBS_ENV)),
+                    .any(|value| {
+                        value.as_str() == Some(RunnerManager::cargo_build_jobs_env().as_str())
+                    }),
                 "{} has no per-job Cargo CPU budget",
                 runner["name"]
             );

--- a/xtask/src/ci/mod.rs
+++ b/xtask/src/ci/mod.rs
@@ -16,5 +16,5 @@ mod xcresult;
 
 pub(crate) use command::{CiArgs, is_standalone, run, run_standalone};
 pub(crate) use topology::{
-    HOST_JOB_CONCURRENCY, SCCACHE_SLOT_CACHE_NAMESPACE, SCCACHE_SLOT_CONTROL_NAMESPACE,
+    HOST_CORES, HOST_JOB_CONCURRENCY, SCCACHE_SLOT_CACHE_NAMESPACE, SCCACHE_SLOT_CONTROL_NAMESPACE,
 };

--- a/xtask/src/ci/topology.rs
+++ b/xtask/src/ci/topology.rs
@@ -6,6 +6,14 @@
 /// follows on its own — the host's budget is divided between the slots.
 pub(crate) const HOST_JOB_CONCURRENCY: usize = 3;
 
+/// Cores the CI host has.
+///
+/// Job admission and per-job Cargo workers are both carved out of this, and
+/// nothing else states the relation: raising the first without lowering the
+/// second is how the machine ends up with more compilers than cores and no
+/// room left for the runner, sccache, and the linkers.
+pub(crate) const HOST_CORES: usize = 10;
+
 /// Host-global lock namespace that coordinates the compiler-cache slots.
 pub(crate) const SCCACHE_SLOT_CONTROL_NAMESPACE: &str = ".kithara-ci-sccache-slots";
 


### PR DESCRIPTION
## Summary

Three repairs to what `trusted_authors` and the third job slot left behind on the CI host. All three were found by reading failing jobs, and each one is stated as the failure it produced.

Restoring the base branch's control paths was doing two jobs at once, and the trusted-author list took away both. It keeps a pull request from grading itself — the reason it was written — and it also keeps a branch older than the host runnable, because those paths are what agrees with the machine. A June branch judged with its own reached the host with an `xtask` that cannot parse the current host profile (`unknown field build_root`, job 9203636) and a pipeline still naming a `docker-ci` job the default branch has dropped, which then failed on a registry login the mirror no longer serves (job 9203646). Neither reached a test. Trust now decides only whether a control-path change is rejected; which configuration the run uses is decided separately, and only a pull request that changes the control paths is judged with its own — because a change to the judge has nowhere else to be tested.

The per-job Cargo budget is now derived from the host's core count rather than written down beside it. Admission went from two jobs to three while the budget stayed at four, which put twelve compilers on ten cores and left nothing for the runner, sccache, and the linkers.

The job-admission gate reclaims the shortfall instead of enforcing the host ceiling. The ceiling is the hourly pass's question, and it answers "nothing to do" whenever the caches happen to sit under it — which is exactly the state a refused job finds, since a full volume is rarely full of build caches alone. Job 9203621 was refused over one missing gigabyte with 15.7 GB of evictable cache beside it and `bytes_freed=0` in its log.

## Behavior / scope

- `bridge`: a pull request that does not touch the control paths is verified on the base's `.gitlab-ci.yml`, `.config/*`, `justfile` and `xtask/`, whoever its author is. A trusted author's pull request that does touch them is verified on its own, as before this change.
- Runner rendering: `CARGO_BUILD_JOBS` is `(HOST_CORES - 1) / HOST_JOB_CONCURRENCY` — three workers per job at the current three slots, one core left over.
- Job gate: `reclaim_at_least` evicts oldest-first until the shortfall is covered; a checkout an active job leases is still never touched. `enforce_budget` is unchanged and still what the hourly pass runs.

## Validation

- `cargo test -p xtask --bin xtask -- ci::build_cache ci::environment ci::host::runners ci::bridge` — 90 passed.
- `just lint fast` through the pre-commit hook — passed.
- Not run: the full `just test` suite; this touches `xtask` only, which the product suite does not compile.

## Tests

- `only_a_pull_request_that_changes_the_controls_is_judged_with_its_own` pins the rule the regression broke.
- `the_rendered_runner_config_fits_its_jobs_on_the_host` reads admission and the worker budget back out of the rendered runner config, so a change to either constant alone fails.
- `a_shortfall_is_reclaimed_even_though_the_caches_are_under_the_ceiling` reproduces the refused job: an `enforce_budget` pass frees nothing, and the shortfall is still recovered.

## Risks or follow-ups

- The host still needs `configure-runners` for the new worker budget and the third slot to reach the runner; `install-services` does not write that file.
- 15 GB per job times three slots is more than the volume holds at once. This makes the gate reclaim honestly rather than raising the ceiling; capacity is a separate question.