### PR TITLE
fix(ci): shorten the quarantine branch name

### DIFF
--- a/xtask/src/ci/bridge/reconcile.rs
+++ b/xtask/src/ci/bridge/reconcile.rs
@@ -274,8 +274,29 @@ fn reconcile_main_first(
     Ok(())
 }
 
+/// Branch a verification runs on.
+///
+/// Abbreviated, because this name is read by people in `GitLab`'s own interface,
+/// and two full shas in it came to 101 characters — enough to break the layout
+/// of every list the branch appears in. The pair is not what identifies the run
+/// anyway: the pipeline carries `KITHARA_QUARANTINE_HEAD_SHA` and
+/// `KITHARA_QUARANTINE_BASE_SHA` in full, and `verification_pipelines` refuses
+/// any pipeline whose variables disagree. The name only has to address one
+/// branch, and the rule that starts these runs matches the `quarantine/`
+/// prefix alone.
 fn quarantine_ref(head_sha: &str, base_sha: &str, attempt: u64) -> String {
-    format!("quarantine/github/{head_sha}/{base_sha}/attempt-{attempt}")
+    format!(
+        "quarantine/gh/{}-{}/attempt-{attempt}",
+        abbreviate(head_sha),
+        abbreviate(base_sha)
+    )
+}
+
+/// Twelve hex digits, the width git itself grows to on a repository this size.
+/// Shorter reads better and collides sooner; a collision here would have to
+/// land between two pull-request heads verified against the same base.
+fn abbreviate(sha: &str) -> &str {
+    &sha[..sha.len().min(12)]
 }
 
 fn resolve_pipeline(pipeline_ids: &[u64]) -> Result<Option<u64>> {

--- a/xtask/src/ci/bridge/reconcile_tests.rs
+++ b/xtask/src/ci/bridge/reconcile_tests.rs
@@ -264,11 +264,47 @@ fn ambiguous_recovery_fails_closed_without_creating() {
 fn an_attempt_ref_changes_only_when_retry_advances_the_generation() {
     assert_eq!(
         quarantine_ref("head", "base", 1),
-        "quarantine/github/head/base/attempt-1"
+        "quarantine/gh/head-base/attempt-1"
     );
     assert_eq!(
         quarantine_ref("head", "base", 2),
-        "quarantine/github/head/base/attempt-2"
+        "quarantine/gh/head-base/attempt-2"
+    );
+}
+
+/// The name is read in GitLab's interface, where two full shas came to 101
+/// characters and broke the layout of every list the branch appeared in.
+#[test]
+fn an_attempt_ref_abbreviates_both_shas() {
+    let reference = quarantine_ref(
+        "1dba4b9b0689ca0e12a88093f7321fb4c432636e",
+        "fe3c9e2d92564790b24d9d9d27f6f08d2f39af29",
+        1,
+    );
+
+    assert_eq!(
+        reference,
+        "quarantine/gh/1dba4b9b0689-fe3c9e2d9256/attempt-1"
+    );
+}
+
+/// Shortening must not merge two runs into one branch. Both sides of the pair
+/// have to keep separating them — a pull request rebased onto a newer base is
+/// a different verification, not the same one again.
+#[test]
+fn each_side_of_the_pair_separates_one_run_from_another() {
+    let head = "1dba4b9b0689ca0e12a88093f7321fb4c432636e";
+    let base = "fe3c9e2d92564790b24d9d9d27f6f08d2f39af29";
+    let other_head = "1dba4b9b0000ca0e12a88093f7321fb4c432636e";
+    let other_base = "fe3c9e2d00004790b24d9d9d27f6f08d2f39af29";
+
+    assert_ne!(
+        quarantine_ref(head, base, 1),
+        quarantine_ref(other_head, base, 1)
+    );
+    assert_ne!(
+        quarantine_ref(head, base, 1),
+        quarantine_ref(head, other_base, 1)
     );
 }
 


### PR DESCRIPTION
## Summary

The verification branch name carried two full shas and came to 101 characters:

```
quarantine/github/1dba4b9b0689ca0e12a88093f7321fb4c432636e/fe3c9e2d92564790b24d9d9d27f6f08d2f39af29/attempt-1
```

GitLab prints that name in every list the branch appears in, and the layout breaks on it. It is now 49 characters:

```
quarantine/gh/1dba4b9b0689-fe3c9e2d9256/attempt-1
```

Nothing rested on the full pair being in the name. The pipeline carries `KITHARA_QUARANTINE_HEAD_SHA` and `KITHARA_QUARANTINE_BASE_SHA` in full, and `verification_pipelines` refuses any pipeline whose variables disagree with the attempt it is recovering — that check is what identifies a run, not the branch it sits on. The rule that starts these pipelines matches the `quarantine/` prefix alone, so it is unaffected.

## Behavior / scope

- New verifications push to the shortened ref. Attempts still get their own branch, so a retry is still a separate run.
- In-flight verifications are unaffected: the bridge follows the `pipeline_id` recorded in its ledger, not the ref.
- Branches already pushed under the old name stay where they are; nothing reads them.

## Validation

- `cargo test -p xtask --bin xtask -- ci::bridge` — 55 passed.
- `just lint fast` through the pre-commit hook — passed.
- Not run: the full `just test` suite; this touches `xtask` only.

## Tests

- `an_attempt_ref_abbreviates_both_shas` pins the new shape against the exact name that broke the layout.
- `each_side_of_the_pair_separates_one_run_from_another` keeps the shortening from merging two verifications onto one branch — a head change and a base change each have to produce a different ref.
- `an_attempt_ref_changes_only_when_retry_advances_the_generation` is unchanged in intent and updated to the new shape.

## Risks or follow-ups

- Twelve hex digits per side. A collision would need two pull-request heads sharing a 12-digit prefix and verified against the same base; if it ever happened, the pipeline-variable check fails the tick loudly rather than passing the wrong run.
- The old long-named branches are still in GitLab and could be swept separately.