### PR TITLE
fix(ci): drop the quarantine branches a moved base leaves behind

### DIFF
--- a/docs/guides/ci-host.md
+++ b/docs/guides/ci-host.md
@@ -209,6 +209,21 @@ Activate the staged launch daemon only after validation:
 sudo -E /Volumes/KitharaCI/services/bin/kithara-ci ci host activate-bridge
 ```
 
+The daemon keeps running the executable that was installed, not the one on
+`main`, so a fix to the bridge itself changes nothing until it is reinstalled.
+From a checkout of a reviewed GitLab commit, with `KITHARA_CI_HOST_CONFIG`
+exported as above:
+
+```text
+cargo build --locked --release -p xtask
+sudo -E target/release/xtask ci host install-services
+sudo -E /Volumes/KitharaCI/services/bin/kithara-ci ci host activate-bridge
+```
+
+`install-services` replaces the installed binary and the staged service
+definitions without revalidating Xcode; `activate-bridge` boots the daemon out
+and kickstarts it, so the next tick runs the new binary.
+
 The old GitLab pull mirror is disabled because it force-updated `main` and
 could discard work already merged here. The bridge now moves `main` only by
 fast-forward. When GitLab is ahead, it fast-forwards GitHub to the same commit;

--- a/docs/guides/ci-host.md
+++ b/docs/guides/ci-host.md
@@ -224,6 +224,13 @@ is written to the exact head commit under the status context
 context on `main` and prevent direct pushes or bypasses; otherwise the verifier
 is advisory and an unverified commit can still reach `main`.
 
+A quarantine ref is addressed by the exact head and base pair it was judged
+for. Once `main` moves, the next attempt reserves against the new base and
+publishes a new ref, so nothing names the old branch again and nothing reads
+its pipeline. Those branches are removed on the following tick; the pipelines,
+jobs and artifacts they produced stay in GitLab's interface, which keys them by
+commit rather than by branch.
+
 A pull request that changes a CI control path is rejected before a pipeline is
 created. Port that change through a GitLab merge request instead, so the code
 that judges GitHub pull requests changes under GitLab review. Once a protected

--- a/xtask/src/ci/bridge/git.rs
+++ b/xtask/src/ci/bridge/git.rs
@@ -313,16 +313,51 @@ impl GitRepo {
             .to_owned())
     }
 
-    pub(super) fn push_gitlab(&self, gitlab: &Gitlab, sha: &str, destination: &str) -> Result<()> {
-        let url = format!(
+    fn gitlab_url(&self) -> String {
+        format!(
             "{}/{}.git",
             self.config.gitlab_origin(),
             self.config.gitlab_project_path
-        );
+        )
+    }
+
+    pub(super) fn push_gitlab(&self, gitlab: &Gitlab, sha: &str, destination: &str) -> Result<()> {
         self.run(
-            &["push", &url, &format!("{sha}:refs/heads/{destination}")],
+            &[
+                "push",
+                &self.gitlab_url(),
+                &format!("{sha}:refs/heads/{destination}"),
+            ],
             Some(gitlab.git_header()),
         )?;
+        Ok(())
+    }
+
+    /// The verification branches `GitLab` still carries. Asked of the remote
+    /// rather than of the local mirror, which never fetches them back.
+    pub(super) fn gitlab_quarantine_refs(&self, gitlab: &Gitlab) -> Result<Vec<String>> {
+        let listing = self.run(
+            &[
+                "ls-remote",
+                "--heads",
+                &self.gitlab_url(),
+                "refs/heads/quarantine/*",
+            ],
+            Some(gitlab.git_header()),
+        )?;
+        let listing = String::from_utf8(listing).context("git ls-remote returned invalid UTF-8")?;
+        Ok(quarantine_heads(&listing))
+    }
+
+    pub(super) fn delete_gitlab(&self, gitlab: &Gitlab, refs: &[&str]) -> Result<()> {
+        let url = self.gitlab_url();
+        let deletions: Vec<String> = refs
+            .iter()
+            .map(|reference| format!(":refs/heads/{reference}"))
+            .collect();
+        let mut args = vec!["push", url.as_str()];
+        args.extend(deletions.iter().map(String::as_str));
+        self.run(&args, Some(gitlab.git_header()))?;
         Ok(())
     }
 
@@ -367,6 +402,16 @@ fn checked(output: Output, label: &str) -> Result<Vec<u8>> {
         );
     }
     Ok(output.stdout)
+}
+
+/// Branch names out of an `ls-remote` listing, which answers `<sha>\t<ref>`.
+fn quarantine_heads(listing: &str) -> Vec<String> {
+    listing
+        .lines()
+        .filter_map(|line| line.split_once('\t'))
+        .filter_map(|(_, reference)| reference.trim().strip_prefix("refs/heads/"))
+        .map(str::to_owned)
+        .collect()
 }
 
 fn path_text(path: &Path) -> Result<&str> {
@@ -729,5 +774,25 @@ mod tests {
             repo.weakening_control_paths(&base, &head).unwrap(),
             [".gitlab-ci.yml", "xtask/src/main.rs"]
         );
+    }
+
+    #[test]
+    fn a_remote_listing_is_read_back_as_branch_names() {
+        let listing = "04fcb5a0a1978c3d1f0e2b3a4c5d6e7f80910111\trefs/heads/quarantine/gh/8a4e697a770d-418167884f6c/attempt-1
+418167884f6c2e1d3a4b5c6d7e8f90a1b2c3d4e5\trefs/heads/quarantine/gh/ccde033c8f4c-04fcb5a0a197/attempt-2
+";
+
+        assert_eq!(
+            quarantine_heads(listing),
+            [
+                "quarantine/gh/8a4e697a770d-418167884f6c/attempt-1",
+                "quarantine/gh/ccde033c8f4c-04fcb5a0a197/attempt-2"
+            ]
+        );
+    }
+
+    #[test]
+    fn a_listing_line_that_names_no_branch_is_skipped() {
+        assert_eq!(quarantine_heads("\n"), [] as [String; 0]);
     }
 }

--- a/xtask/src/ci/bridge/reconcile.rs
+++ b/xtask/src/ci/bridge/reconcile.rs
@@ -159,6 +159,17 @@ impl Bridge {
                 );
             }
         }
+        if let Err(error) = sweep_quarantine_refs(
+            base_sha,
+            || self.repo.gitlab_quarantine_refs(&self.gitlab),
+            |refs| self.repo.delete_gitlab(&self.gitlab, refs),
+        ) {
+            warn!(
+                %base_sha,
+                %error,
+                "verification branches left behind by a moved base were not removed"
+            );
+        }
         Ok(())
     }
 
@@ -294,6 +305,48 @@ fn quarantine_ref(head_sha: &str, base_sha: &str, attempt: u64) -> String {
 /// land between two pull-request heads verified against the same base.
 fn abbreviate(sha: &str) -> &str {
     &sha[..sha.len().min(12)]
+}
+
+/// The verification branches nothing will ever name again.
+///
+/// A quarantine ref is addressed by the pair it was judged for, so the moment
+/// main moves the bridge writes a new name and the old branch is left behind.
+/// Matching on the base alone covers every naming scheme the bridge has used,
+/// because each one spells the base out abbreviated or in full.
+fn superseded_quarantine_refs<'a>(refs: &'a [String], base_sha: &str) -> Vec<&'a str> {
+    let base = abbreviate(base_sha);
+    refs.iter()
+        .map(String::as_str)
+        .filter(|reference| reference.starts_with("quarantine/") && !reference.contains(base))
+        .collect()
+}
+
+/// Drop the verification branches a moved base left behind.
+///
+/// The bridge pushes one of these per attempt and never reads it back: the
+/// verdict lives in the ledger, and `verify_pull` reserves against whatever
+/// main is now, so a branch judged for an earlier base is orphaned the moment
+/// main moves. Nothing addresses it again and nothing reads its pipeline, so
+/// what is left is exhaust - 197 of them had piled up on `GitLab` by the time
+/// anyone counted. Cancelling an orphan's pipeline on the way out is a gain on
+/// a runner that takes one job at a time.
+fn sweep_quarantine_refs(
+    base_sha: &str,
+    list: impl FnOnce() -> Result<Vec<String>>,
+    delete: impl FnOnce(&[&str]) -> Result<()>,
+) -> Result<()> {
+    let listed = list()?;
+    let superseded = superseded_quarantine_refs(&listed, base_sha);
+    if superseded.is_empty() {
+        return Ok(());
+    }
+    delete(&superseded)?;
+    info!(
+        dropped = superseded.len(),
+        %base_sha,
+        "verification branches left behind by a moved base removed"
+    );
+    Ok(())
 }
 
 fn resolve_pipeline(pipeline_ids: &[u64]) -> Result<Option<u64>> {

--- a/xtask/src/ci/bridge/reconcile_tests.rs
+++ b/xtask/src/ci/bridge/reconcile_tests.rs
@@ -514,3 +514,88 @@ fn an_unmergeable_head_is_failed_and_rejected_with_the_reason() {
         ]
     );
 }
+
+const CURRENT_BASE: &str = "04fcb5a0a1978c3d1f0e2b3a4c5d6e7f80910111";
+const OLDER_BASE: &str = "418167884f6c2e1d3a4b5c6d7e8f90a1b2c3d4e5";
+const PULL_HEAD: &str = "8a4e697a770d5e6f8091a2b3c4d5e6f708192a3b";
+
+#[test]
+fn a_quarantine_ref_judged_against_an_older_base_is_superseded() {
+    let refs = [quarantine_ref(PULL_HEAD, OLDER_BASE, 1)];
+
+    assert_eq!(
+        superseded_quarantine_refs(&refs, CURRENT_BASE),
+        [refs[0].as_str()]
+    );
+}
+
+#[test]
+fn a_quarantine_ref_judged_against_the_current_base_is_kept() {
+    let refs = [quarantine_ref(PULL_HEAD, CURRENT_BASE, 2)];
+
+    assert_eq!(
+        superseded_quarantine_refs(&refs, CURRENT_BASE),
+        [] as [&str; 0]
+    );
+}
+
+#[test]
+fn a_branch_that_is_not_a_verification_run_is_never_swept() {
+    let refs = ["main".to_owned(), "laba/419-connectivity".to_owned()];
+
+    assert_eq!(
+        superseded_quarantine_refs(&refs, CURRENT_BASE),
+        [] as [&str; 0]
+    );
+}
+
+#[test]
+fn the_older_quarantine_naming_scheme_is_swept_by_the_same_rule() {
+    let refs = [format!(
+        "quarantine/github/{PULL_HEAD}/{OLDER_BASE}/attempt-1"
+    )];
+
+    assert_eq!(
+        superseded_quarantine_refs(&refs, CURRENT_BASE),
+        [refs[0].as_str()]
+    );
+}
+
+#[test]
+fn a_sweep_drops_every_branch_a_moved_base_left_behind() {
+    let stale = quarantine_ref(PULL_HEAD, OLDER_BASE, 1);
+    let live = quarantine_ref(PULL_HEAD, CURRENT_BASE, 2);
+    let listed = vec![stale.clone(), live, "main".to_owned()];
+    let deleted = RefCell::new(Vec::new());
+
+    sweep_quarantine_refs(
+        CURRENT_BASE,
+        || Ok(listed),
+        |refs| {
+            deleted
+                .borrow_mut()
+                .extend(refs.iter().map(|reference| (*reference).to_owned()));
+            Ok(())
+        },
+    )
+    .unwrap();
+
+    assert_eq!(*deleted.borrow(), [stale]);
+}
+
+#[test]
+fn a_sweep_with_nothing_left_behind_never_reaches_the_remote() {
+    let called = Cell::new(false);
+
+    sweep_quarantine_refs(
+        CURRENT_BASE,
+        || Ok(vec![quarantine_ref(PULL_HEAD, CURRENT_BASE, 1)]),
+        |_| {
+            called.set(true);
+            Ok(())
+        },
+    )
+    .unwrap();
+
+    assert!(!called.get());
+}


### PR DESCRIPTION
## Summary

The bridge publishes one `quarantine/gh/<head>-<base>/attempt-N` branch per
verification attempt and never reads it back: the verdict lives in the ledger on
the host, and every tick reserves against whatever `main` is now. The moment
`main` moves, the next attempt reserves a new pair, publishes a new branch, and
the old one is orphaned by construction - nothing addresses it again and nothing
reads its pipeline. Nothing ever deleted them either, so they only accumulated:
GitLab was carrying 243 branches, 197 of which were dead quarantine refs (those
197 have been swept by hand; this is what stops them coming back).

The reconcile tick now asks the remote for its quarantine heads and deletes the
ones that do not name the current base. The rule matches on the base alone,
which covers both naming schemes the bridge has used - the current abbreviated
pair and the older `quarantine/github/<head40>/<base40>/attempt-N`.

The second commit is documentation for something the guide never said: the
launch daemon runs the executable that was installed, not the one on `main`. A
bridge fix merged to `main` changes nothing on the host until the binary is
reinstalled and the service restarted, and `ci host install-services` - the
command for exactly that - was undocumented. This is not hypothetical: the
base-merge fix that landed in #192 is still inert on the host for this reason,
and one of the three red GitLab pipelines investigated this week
(`8a4e697a`, stale image pin) is that stale binary judging against an old base.

## Behavior / scope

- contract or behavior: the reconcile tick removes GitLab quarantine branches
  that do not name the current base. Verdicts, ledger entries, pipelines, jobs
  and artifacts are untouched - GitLab keys those by commit, not by branch. A
  failed sweep warns and does not fail the tick.
- affected area: `xtask` CI bridge (`ci/bridge/reconcile.rs`, `ci/bridge/git.rs`),
  `docs/guides/ci-host.md`.

## Validation

- `cargo test -p xtask --bin xtask ci::bridge` - 66 passed, 0 failed
- `cargo test -p xtask --bin xtask` - 362 passed, 0 failed
- `cargo fmt -p xtask -- --check`
- `cargo clippy -p xtask --all-targets` - no new warnings
- pre-commit hook (`lint-fast`) passed on both commits
- the rule replayed against the real listing: of the 201 quarantine refs GitLab
  carried today, the 197 this rule marks superseded are exactly the 197 removed
  by hand, and the 4 it keeps are exactly the four that name the current base
  `04fcb5a0a197`
- not run: the sweep itself against a live GitLab remote. The rule and the
  orchestration are covered by unit tests; the two new `GitRepo` methods are
  `git ls-remote --heads` and a batch `git push :refs/heads/...`, and the same
  operation was executed by hand today against the real project when the 197
  dead refs were removed.

## Surface impact

- Public API: none
- Platform/runtime: changed: tooling surface (`xtask ci bridge` reconcile tick)
- Perf-sensitive paths: none. One `ls-remote` per tick, and a push only when
  there is something to drop.

## Risks / follow-ups

- A quarantine branch whose pipeline is still running will be deleted when
  `main` moves under it. That entry is already orphaned - the ledger reserved a
  new pair and nothing will read the old verdict - so cancelling it frees a
  runner that takes one job at a time.
- Not in this PR, raised for a decision:
  - **`CONTROL_PATHS` restores split atomic units.** `.config/xtask.toml` is
    restored from the base while its parser in `crates/kithara-devtools/` is
    not; `xtask/Cargo.toml` is restored while `Cargo.lock` is not. That produced
    two of this week's three red pipelines (`unknown field ci_report` and
    `--locked`). The fix changes the trust boundary, so it is the owner's call,
    not a cleanup.
  - **Quarantine runs a weaker lint gate than `main`.** `PipelineKind::Quarantine`
    maps to `just lint fast`, `PipelineKind::Main` to `just lint full`, so a PR
    can be verified green and still break `main`'s Lint job - which is how the
    Cyrillic debt in `kithara-ui/tests/text.rs` reached `main`. The lighter
    quarantine gate looks deliberate, so it is left alone here.
