### PR TITLE
fix(tests): drain delivered seek events before judging the deadline

### DIFF
--- a/tests/tests/kithara_audio/stream_source_tests.rs
+++ b/tests/tests/kithara_audio/stream_source_tests.rs
@@ -303,6 +303,14 @@ async fn rapid_seeks_via_timeline_all_complete() {
             Err(_) => break,
         }
     }
+    // Paced blocking reads can exhaust the virtual-clock budget before the
+    // loop drains its own subscriber queue; events already delivered before
+    // the deadline still count toward the contract.
+    while let Ok(envelope) = events.try_recv() {
+        if let Event::Audio(AudioEvent::SeekComplete { seek_epoch, .. }) = envelope.event {
+            last_complete = Some(seek_epoch);
+        }
+    }
     assert_eq!(
         last_complete,
         Some(highest_expected),


### PR DESCRIPTION
## Summary
`rapid_seeks_via_timeline_all_complete` flaked on the flash lane (3/245 under a parallel cargo-build load) with `last SeekComplete = None`, even though the consumer had committed all six seek epochs and `pending` was already clear. The drain loop alternates a paced blocking read with one `recv` against a shared virtual-clock deadline; under load the paced reads alone burn the whole 8 s budget, so the loop exits with the subscriber queue still holding the tail of the backlog — delivered events, `SeekComplete(6)` among them. The system contract was met; the test stopped reading its own mailbox. The fix drains the subscriber non-blockingly (`try_recv`) after the deadline, so events delivered before the cutoff count while nothing new is waited for.

## Behavior / scope
- contract or behavior: test-only — the seek-event drain now consumes already-delivered events after the deadline; the deadline and the test timeout stay untouched, and a genuinely unpublished `SeekComplete` still leaves the queue empty and fails the same assert.
- affected area: `tests/tests/kithara_audio/stream_source_tests.rs`.

## Validation
- Flake hunt with the same harness that caught the flake (raw flash-lane binary under a parallel cargo-build load): before 3 failures / ~245 iterations (~1.2%), after **0 failures / 3000 iterations** (P(0/3000 | p=1.2%) ≈ 2×10⁻¹⁶).
- Instrumented red runs show the queue at exit still holding `BufferHealth, SeekApplied(6), DecodeStarted(6), OutputAvailable, OutputCommitted(6)`, with `SeekComplete(6)` as the next element of the same backlog in green runs.

## Surface impact
- Public API: none
- Platform/runtime: none
- Perf-sensitive paths: none

## Risks / follow-ups
- none. Unblocks #187, which currently goes red on this main-level flake.
