### PR TITLE
fix(ci): let the shared fork queue actually queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,18 @@ env:
 # A fork's branches share one pool of Linux runners, so their pushes queue
 # rather than overlap. The stress run no longer queues here: it has a
 # runner of its own and a group of its own.
-# Production keeps the per-ref cancellation used for superseded pushes.
+#
+# `queue: max` is what makes that queue honest. The default `single` holds one
+# pending run and lets every new arrival evict it, so one push to any branch
+# cancelled whichever branch had been waiting its turn — a queue in name only.
+# `queue` takes no expression and may not be declared beside
+# `cancel-in-progress: true`, so the per-ref cancellation of superseded pushes
+# goes with it, the trade lanes.yml already made. A superseded push now runs to
+# completion instead of being cancelled.
 concurrency:
   group: ${{ github.event.repository.fork && format('fork-linux-{0}', github.repository) || format('ci-{0}', github.ref) }}
-  cancel-in-progress: ${{ !github.event.repository.fork }}
+  cancel-in-progress: false
+  queue: max
 
 jobs:
   # Authorization runs on a GitHub-hosted machine, before any job can reach a

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,12 +9,12 @@ on:
   workflow_dispatch:
 
 # An instrumented run costs the same pool the stress campaign measures, so on a
-# fork it waits for the campaign rather than taking cores from it. See ci.yml.
-# It keeps the default one-pending queue: `queue` takes no expression, and `max`
-# may not be declared beside the cancellation production still wants.
+# fork it waits for the campaign rather than taking cores from it, and waits in
+# a queue nothing evicts. See ci.yml for why that costs the cancellation.
 concurrency:
   group: ${{ github.event.repository.fork && format('fork-linux-{0}', github.repository) || format('coverage-{0}', github.ref) }}
-  cancel-in-progress: ${{ !github.event.repository.fork }}
+  cancel-in-progress: false
+  queue: max
 
 jobs:
   coverage:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -23,12 +23,12 @@ env:
   RUST_BACKTRACE: 1
 
 # This analysis runs on the pool the stress campaign measures, so on a fork it
-# waits for the campaign rather than taking cores from it. See ci.yml. It keeps
-# the default one-pending queue: `queue` takes no expression, and `max` may not
-# be declared beside the cancellation production still wants.
+# waits for the campaign rather than taking cores from it, and waits in a queue
+# nothing evicts. See ci.yml for why that costs the cancellation.
 concurrency:
   group: ${{ github.event.repository.fork && format('fork-linux-{0}', github.repository) || format('quality-{0}-{1}', github.ref, inputs.depth) }}
-  cancel-in-progress: ${{ !github.event.repository.fork }}
+  cancel-in-progress: false
+  queue: max
 
 jobs:
   assess:


### PR DESCRIPTION
## Summary

Every workflow that runs on the fork's Linux pool shares one concurrency group,
`fork-linux-<repo>`. That is deliberate: the 17 attached runners are one host,
so two full gates at once measure contention rather than the code. The group is
supposed to serialize the runs, and `ci.yml` says so in its own comment - "their
pushes queue rather than overlap".

It did not queue. Three of the group's members - CI, Coverage, Quality -
declared the group without declaring `queue`, which defaults to `single`: at
most one run may be *pending*, and each new arrival replaces the one already
waiting. So a push to any branch cancelled whichever branch was next in line.
The victim shows up as `cancelled` with zero jobs and no red check to explain
it, which reads as an infrastructure flake rather than as what it is.

Observed twice in a row on the fork today, each cancellation timed to the next
arrival:

| run | branch | created | cancelled | by |
| --- | --- | --- | --- | --- |
| 32395927426 | `claude/hls-stale-tmp-claim` | 17:08:21Z | 17:11:19Z | main's push |
| 32396203131 | `main` | 17:11:18Z | 17:13:09Z | the push after it |

`queue: max` holds up to a hundred pending runs in arrival order, which is what
these three already promised. `lanes.yml`, `miri.yml`, `mutants.yml` and the
scheduled soak in `schedule.yml` already carry it; these three are the gap, and
being the only member with a `push:` trigger makes `ci.yml` the one that
actually did the evicting.

## Behavior / scope

- contract or behavior: all seven members of `fork-linux-<repo>` now carry
  `cancel-in-progress: false` and `queue: max`, so nothing in the group can
  evict anything else. Runs still serialize - only the waiting is honest.
- the cost, and it is a real one: `queue` accepts literal values only, and the
  combination of `queue: max` and `cancel-in-progress: true` is a workflow
  validation error, so production's per-ref cancellation of superseded pushes
  goes with it for these three. A superseded push now runs to completion.
  The blast radius is narrow: Coverage only reacts to pushes on `main`, Quality
  has no push trigger at all, and CI on production sees pushes rather than pull
  requests - those arrive from the fork. Group expressions are untouched, so
  production still gets its per-ref groups.
- affected area: `.github/workflows/{ci,coverage,quality}.yml`, concurrency
  block and its comment. No job, step, trigger or permission changed.

## Validation

- `git commit` pre-commit hook (`lint-fast`) passed
- all three files parse, and the resolved `concurrency` mapping was read back
  per file
- every member of the group audited, not just the three edited:
  `ci`, `coverage`, `lanes`, `miri`, `mutants`, `quality` at workflow level and
  `schedule.yml`'s `rtsan` job at job level - all seven now
  `cancel-in-progress: false` + `queue: max`
- observed live on the fork after the push that opened this PR: run
  `32403338778` (this branch, carrying the new file) entered the queue at
  18:28:00Z while `32399861535` was already pending, and `32399861535` stayed
  pending. Under `queue: single` that push would have cancelled it - the
  arriving run's own policy is what decides, which is why the fix takes effect
  from the first branch that carries it.
- not run: the production side of the trade. `cancel-in-progress: false` on a
  `ci-<ref>` group cannot be exercised from a fork, where the group expression
  resolves to the other branch. The key itself is already proven on this pool
  by the four workflows that carried it before this change.

## Surface impact

- Public API: none
- Platform/runtime: changed: CI scheduling only
- Perf-sensitive paths: none in the product. On the fork this reduces wasted
  runner time, since a run that was going to be evicted no longer starts over.

## Risks / follow-ups

- A queue that never evicts can grow. On the fork that is the point - the host
  is the bottleneck, not the queue - but a burst of pushes to one production ref
  will now run every one of them instead of only the last. If that becomes
  expensive, the answer is a `push` path that filters refs, not a return to an
  eviction that cannot tell a superseded run from an unrelated branch.
