### PR TITLE
fix(xtask): move the CI concurrency pin to the contract that shipped

### DIFF
--- a/xtask/tests/github_workflows.rs
+++ b/xtask/tests/github_workflows.rs
@@ -343,14 +343,15 @@ fn github_ci_is_fail_closed_and_aggregates_every_job() {
             "${{ github.event.repository.fork && format('fork-linux-{0}', github.repository) || format('ci-{0}', github.ref) }}"
         )
     );
+    // The fork's branches share one Linux pool, so they queue instead of
+    // evicting each other. `queue` takes no expression and may not sit beside a
+    // cancellation that can read true, so the one literal serves both sides and
+    // production gives up cancelling a superseded push. See ci.yml.
     assert_eq!(
-        mapping_field(concurrency, "cancel-in-progress").as_str(),
-        Some("${{ !github.event.repository.fork }}")
+        mapping_field(concurrency, "cancel-in-progress").as_bool(),
+        Some(false)
     );
-    assert!(
-        !concurrency.contains_key("queue"),
-        "CI must preserve production cancel-in-progress semantics"
-    );
+    assert_eq!(mapping_field(concurrency, "queue").as_str(), Some("max"));
     let jobs = workflow_jobs(&workflow);
 
     let advisory_browser = workflow_job(jobs, "wasm-browser");


### PR DESCRIPTION
## Summary

#204 changed `ci.yml`'s concurrency and left its pin behind. `xtask`'s
`github_ci_is_fail_closed_and_aggregates_every_job` asserted the old contract
literally - `cancel-in-progress: ${{ !github.event.repository.fork }}` and no
`queue` key, with the message "CI must preserve production cancel-in-progress
semantics" - so the Lint job went red the moment the new file reached a runner.

That pin was the third place the superseded decision was recorded, after the
comments in `coverage.yml` and `quality.yml`, and the only one that could fail a
build. It went unnoticed because the gate that runs it is the fork's: upstream
has no self-hosted runners, so `main`'s own CI has stopped at `CI authorization`
since at least 18 Aug and every job after it is skipped.

The pin now states what shipped. The general rule beside it,
`a_queue_is_never_declared_beside_a_cancellation_that_can_fire`, is what forced
the trade in the first place and needed no change: it passes because the new
value is a literal `false`, not an expression that reads true upstream.

## Behavior / scope

- contract or behavior: test-only. The assertion for `ci.yml` moves from
  "`queue` is absent and cancellation follows the fork" to
  "`cancel-in-progress: false` and `queue: max`", with the reason on the
  assertion rather than in a commit message.
- `coverage.yml` and `quality.yml` carry no pin of their own; the general rule
  covers them.
- affected area: `xtask/tests/github_workflows.rs`. No workflow, product crate
  or tooling behavior changed.

## Validation

- `just test run --lane=tooling -E 'binary(github_workflows)'` - 14 tests run,
  14 passed, including the edited pin and the general rule
- pre-commit hook (`lint-fast`) passed
- the failure this fixes, from the fork gate on the branch of #203, run
  32404505985 attempt 3: `Lint` failed at
  `xtask/tests/github_workflows.rs:346`, `left: None`,
  `right: Some("${{ !github.event.repository.fork }}")`; the other 19 jobs
  passed and `CI required` failed only as their aggregator
- checked, not assumed: `main`'s CI failure is unrelated and predates this
  work. Runs on `6ca5e0ee0`, `d96e4d4c3`, `10a289e4b`, `04fcb5a0a` and
  `418167884` all fail at `CI authorization` with every later job skipped.

## Surface impact

- Public API: none
- Platform/runtime: none
- Perf-sensitive paths: none

## Risks / follow-ups

- The pin is now the record of a decision with a cost: production no longer
  cancels a superseded push on CI, Coverage and Quality. If that cost is judged
  too high later, this assertion is where the revert has to start, and the
  general rule explains why the two settings cannot be varied independently.
