### PR TITLE
fix(ci): stop asking for machines this repository does not have

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,15 @@ jobs:
   # check, never a skipped workflow that can be mistaken for success.
   authorize:
     name: CI authorization
+    # Runner labels are attached to the repository that owns runners. Upstream
+    # has none and is not getting any — its gate is the GitLab verification
+    # status the bridge writes — so a push there has nothing to authorize and
+    # nothing to run. Every other workflow beside this one already skips on the
+    # same variable; this one turned the question into a failing job, so every
+    # upstream push was red with all twenty checks skipped. A permanent red
+    # reads as a regression and hides the next real one. A malformed value is
+    # still a hard failure: it passes this guard and fails the step below.
+    if: vars.KITHARA_RUNNER_LABELS != ''
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -415,7 +424,10 @@ jobs:
   # reject every result other than an executed success.
   required:
     name: CI required
-    if: ${{ always() }}
+    # `always()` alone would keep this job red on a repository the guard above
+    # skipped: it demands success from every job it needs, and a skip is not a
+    # success. It carries the same guard so the whole run is skipped there.
+    if: ${{ always() && vars.KITHARA_RUNNER_LABELS != '' }}
     needs:
       - authorize
       - gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,19 +30,28 @@ concurrency:
 
 jobs:
   # Authorization runs on a GitHub-hosted machine, before any job can reach a
-  # self-hosted runner. Missing or malformed runner configuration is a failed
-  # check, never a skipped workflow that can be mistaken for success.
+  # self-hosted runner. Malformed runner configuration is a failed check, never
+  # a skipped workflow that can be mistaken for success. Absent configuration
+  # is a different statement — this repository runs no CI — and the guard below
+  # answers it before a job is requested.
   authorize:
     name: CI authorization
-    # Runner labels are attached to the repository that owns runners. Upstream
-    # has none and is not getting any — its gate is the GitLab verification
-    # status the bridge writes — so a push there has nothing to authorize and
-    # nothing to run. Every other workflow beside this one already skips on the
-    # same variable; this one turned the question into a failing job, so every
-    # upstream push was red with all twenty checks skipped. A permanent red
-    # reads as a regression and hides the next real one. A malformed value is
-    # still a hard failure: it passes this guard and fails the step below.
-    if: vars.KITHARA_RUNNER_LABELS != ''
+    # Every job below takes its `runs-on` from the runner-labels variable, so a
+    # repository without one runs nothing: upstream has no runners and is not
+    # getting any — its gate is the GitLab verification status the bridge
+    # writes. Every other workflow already skips on that variable; this one
+    # turned the question into a job, and on upstream that job cannot even
+    # start ("your account is locked due to a billing issue"), so every push
+    # there was red with all twenty checks skipped. A permanent red reads as a
+    # regression and hides the next real one.
+    #
+    # A fork is admitted on its own, without the variable being readable from
+    # here, because a fork someone else owns is where this repository is
+    # developed and its settings are not ours to inspect. The trade is that a
+    # fork with no runners starts a run whose jobs fail to resolve `runs-on`
+    # rather than being skipped. A malformed value is still a hard failure: it
+    # passes this guard and fails the step below.
+    if: github.event.repository.fork || vars.KITHARA_RUNNER_LABELS != ''
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -427,7 +436,7 @@ jobs:
     # `always()` alone would keep this job red on a repository the guard above
     # skipped: it demands success from every job it needs, and a skip is not a
     # success. It carries the same guard so the whole run is skipped there.
-    if: ${{ always() && vars.KITHARA_RUNNER_LABELS != '' }}
+    if: ${{ always() && (github.event.repository.fork || vars.KITHARA_RUNNER_LABELS != '') }}
     needs:
       - authorize
       - gate

--- a/.github/workflows/nightly-report.yml
+++ b/.github/workflows/nightly-report.yml
@@ -19,6 +19,13 @@ concurrency:
 jobs:
   report:
     name: Summarize the nightly result
+    # A skipped source run has no verdict to make visible, and this collector
+    # exists only to show one. Where the scheduled workflow is skipped for want
+    # of runners, every completion still triggered this job, and on that same
+    # repository a GitHub-hosted job cannot start at all ("your account is
+    # locked due to a billing issue") — a red check about a run that never
+    # happened. Any other conclusion, failure included, is still reported.
+    if: github.event.workflow_run.conclusion != 'skipped'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/xtask/tests/github_workflows.rs
+++ b/xtask/tests/github_workflows.rs
@@ -366,10 +366,13 @@ fn github_ci_is_fail_closed_and_aggregates_every_job() {
     let authorize = workflow_job(jobs, "authorize");
     assert_hosted_authorization(authorize);
     // The one condition this job may carry. Anything else here, and a push that
-    // should have been judged is skipped instead — reported as a green run.
+    // should have been judged is skipped instead — reported as a green run. Both
+    // halves are load-bearing: the variable admits a repository that declares
+    // runners, the fork flag admits one whose settings this repository cannot
+    // read.
     assert_eq!(
         mapping_field(authorize, "if").as_str(),
-        Some("vars.KITHARA_RUNNER_LABELS != ''")
+        Some("github.event.repository.fork || vars.KITHARA_RUNNER_LABELS != ''")
     );
     let gate = workflow_job(jobs, "gate");
     assert_eq!(job_needs(gate), BTreeSet::from(["authorize".to_owned()]));
@@ -401,9 +404,14 @@ fn github_ci_is_fail_closed_and_aggregates_every_job() {
         mapping_field(required, "runs-on").as_str(),
         Some("ubuntu-latest")
     );
+    // The aggregate demands success from every job it needs, and a skip is not a
+    // success, so it has to carry the same guard verbatim or it alone stays red
+    // on a repository the run skipped.
     assert_eq!(
         mapping_field(required, "if").as_str(),
-        Some("${{ always() && vars.KITHARA_RUNNER_LABELS != '' }}")
+        Some(
+            "${{ always() && (github.event.repository.fork || vars.KITHARA_RUNNER_LABELS != '') }}"
+        )
     );
     let mut expected = workflow_job_names(jobs);
     expected.remove("required");
@@ -1459,7 +1467,13 @@ fn nightly_collector_is_read_only_and_does_not_mirror_the_source_verdict() {
         mapping_field(job, "runs-on").as_str(),
         Some("ubuntu-latest")
     );
-    assert!(!job.contains_key("if"));
+    // The collector shows the source verdict, so it runs for every conclusion
+    // that is one. A skipped source has none, and reporting on it turned into a
+    // red check about a run that never happened.
+    assert_eq!(
+        mapping_field(job, "if").as_str(),
+        Some("github.event.workflow_run.conclusion != 'skipped'")
+    );
 
     let collect = named_step(job, "Collect the source run jobs");
     let script = mapping_field(collect, "run")

--- a/xtask/tests/github_workflows.rs
+++ b/xtask/tests/github_workflows.rs
@@ -306,7 +306,6 @@ fn assert_hosted_authorization(job: &Mapping) {
         mapping_field(job, "runs-on").as_str(),
         Some("ubuntu-latest")
     );
-    assert!(!job.contains_key("if"));
 
     let step = first_step(job);
     let env = mapping_field(step, "env")
@@ -364,7 +363,14 @@ fn github_ci_is_fail_closed_and_aggregates_every_job() {
         Some(true)
     );
 
-    assert_hosted_authorization(workflow_job(jobs, "authorize"));
+    let authorize = workflow_job(jobs, "authorize");
+    assert_hosted_authorization(authorize);
+    // The one condition this job may carry. Anything else here, and a push that
+    // should have been judged is skipped instead — reported as a green run.
+    assert_eq!(
+        mapping_field(authorize, "if").as_str(),
+        Some("vars.KITHARA_RUNNER_LABELS != ''")
+    );
     let gate = workflow_job(jobs, "gate");
     assert_eq!(job_needs(gate), BTreeSet::from(["authorize".to_owned()]));
     assert_eq!(
@@ -397,7 +403,7 @@ fn github_ci_is_fail_closed_and_aggregates_every_job() {
     );
     assert_eq!(
         mapping_field(required, "if").as_str(),
-        Some("${{ always() }}")
+        Some("${{ always() && vars.KITHARA_RUNNER_LABELS != '' }}")
     );
     let mut expected = workflow_job_names(jobs);
     expected.remove("required");
@@ -541,7 +547,12 @@ fn standalone_rtsan_is_fail_closed_before_expanding_every_lane() {
     assert_no_key(&workflow, "continue-on-error");
     let jobs = workflow_jobs(&workflow);
 
-    assert_hosted_authorization(workflow_job(jobs, "authorize"));
+    let authorize = workflow_job(jobs, "authorize");
+    assert_hosted_authorization(authorize);
+    // Nothing starts this workflow on a repository without runners: it is only
+    // ever called. So it needs no guard, and a condition here could only ever
+    // skip a judgement someone asked for.
+    assert!(!authorize.contains_key("if"));
     let rtsan = workflow_job(jobs, "rtsan");
     assert_eq!(job_needs(rtsan), BTreeSet::from(["authorize".to_owned()]));
     assert!(!rtsan.contains_key("if"));


### PR DESCRIPTION
## Description

Every push to this repository was red, and the two workflows that stayed red are
the two that ask GitHub for a hosted machine. The cause is not in this file, and
my first reading of it was wrong: `authorize` never reached its actor check. The
job carries zero steps, lasts two seconds, and the check-run annotation says
what happened.

> The job was not started because your account is locked due to a billing issue.

Over the last hundred runs here: `CI` 13/13 failure, `Nightly report` 37/37
failure, `Code Coverage` 13/13 skipped, `Scheduled runs` 36/36 skipped. The two
that fail are the two that request a hosted runner; the two that pass are the
two already guarded by `vars.KITHARA_RUNNER_LABELS != ''`, so they request
nothing. A repository with no runners should request nothing at all, hosted or
self-hosted — and a permanent red reads as a regression and hides the next real
one.

**The repository already answers this question elsewhere, and differently.**
`coverage.yml`, `lanes.yml`, `miri.yml`, `mutants.yml`, `quality.yml`, and
`schedule.yml` all condition on that variable, and `coverage.yml` states the
reason inline: it is set only where runners are attached. `ci.yml` turned the
same question into a job. It now asks it the way its neighbours do.

**Why the variable, and why a fork is admitted beside it.** The variable is the
one thing this workflow cannot run without: fifteen jobs take
`runs-on: ${{ fromJSON(vars.KITHARA_RUNNER_LABELS) }}`. Absent, there is no
machine to dispatch to, so skipping states a fact rather than a policy. But that
variable lives in repository settings, and the fork where this work happens may
belong to someone else — two of the four forks of this repository are active and
neither one's settings are ours to read. So the guard admits a fork on its own:

```yaml
if: github.event.repository.fork || vars.KITHARA_RUNNER_LABELS != ''
```

The trade is stated where the guard is: a fork with no runners now starts a run
whose jobs fail to resolve `runs-on`, instead of skipping. Setting the variable
here is still all it takes to turn CI on upstream, with no edit to this file.

**What the guard does not weaken.** A malformed value passes `!= ''`, so
`authorize` still runs and still fails hard on it — the case that matters on a
machine that does have runners.

`required` carries the same condition verbatim. `always()` alone would leave it
red on a skipped repository: it demands success from every job it needs, and a
skip is not a success.

**The nightly collector was the other red.** It triggers on every completion of
`Scheduled runs`, including the skipped ones, and its own hosted job cannot
start. A collector whose whole purpose is to make the source verdict visible now
runs only when there is one: `github.event.workflow_run.conclusion != 'skipped'`.
Every other conclusion, failure included, is still reported — the source keeps
its own verdict, as its test name has always required.

**The pins are turned, not removed.** `assert_hosted_authorization` forbade the
job any condition at all — the codified form of "a failed check, never a skipped
workflow that can be mistaken for success". That policy is no longer the same in
both workflows that share the helper, so the helper keeps only the parts that
are: `ci.yml` pins the exact condition its authorization may carry and nothing
else, so a future edit cannot widen it into skipping a push that should have been
judged, and `rtsan.yml` keeps the stricter rule where it still holds — nothing
starts that workflow on a machine without runners, it is only ever called. The
nightly pin moves from "no condition" to that one condition. Each assertion was
falsified by violating it before being restored.

## Type of Change

- [x] Bug fix

## Checklist

- [x] `just fmt check` passes
- [x] `just lint` passes — commit hook `lint-fast` green
- [x] Tests added/updated — `xtask --test github_workflows` 14/14
- [x] No `unwrap()`/`expect()` in production code
- [x] Documentation updated — the reasoning is inline where the guard is

> The premise is no longer unverified: forty-nine runs on this repository already
> conclude `skipped`, which GitHub does not paint red. The two workflows changed
> here will join them.
