### PR TITLE
fix(ci): make the declared cleanup schedule the one that runs

### DIFF
--- a/docs/guides/ci-host.md
+++ b/docs/guides/ci-host.md
@@ -220,9 +220,21 @@ sudo -E target/release/xtask ci host install-services
 sudo -E /Volumes/KitharaCI/services/bin/kithara-ci ci host activate-bridge
 ```
 
+Then, in the logged-in `kithara-ci` GUI session:
+
+```text
+/Volumes/KitharaCI/services/bin/kithara-ci ci host activate
+```
+
 `install-services` replaces the installed binary and the staged service
 definitions without revalidating Xcode; `activate-bridge` boots the daemon out
-and kickstarts it, so the next tick runs the new binary.
+and kickstarts it, so the next tick runs the new binary. `activate` does the
+same for the maintenance agents, and it is not optional: launchd keeps the
+definition it loaded, so the agents otherwise keep running the old one. This
+host spent days cleaning once an hour from a `StartCalendarInterval` left by an
+earlier install, while the plist beside it asked for every five minutes — a
+twelve-fold difference in cadence that comparing the files could not show.
+`launchctl print gui/<uid>/com.zvuk.kithara-ci.cleanup` reports what is loaded.
 
 The old GitLab pull mirror is disabled because it force-updated `main` and
 could discard work already merged here. The bridge now moves `main` only by

--- a/xtask/src/ci/host/services.rs
+++ b/xtask/src/ci/host/services.rs
@@ -273,7 +273,14 @@ impl<'a> ServiceInstaller<'a> {
             "<key>StartInterval</key><integer>300</integer>",
         );
         self.write_agent("cleanup", &cleanup)?;
-        self.write_agent("health", &health)
+        self.write_agent("health", &health)?;
+        // Writing the plist is half the job: launchd keeps the definition it
+        // loaded until something replaces it, and this runs as root, outside
+        // the GUI domain the agents live in. The cleanup agent on this host
+        // ran once an hour for days from an older definition while the file
+        // beside it asked for every five minutes.
+        info!("maintenance agents staged; load them with `ci host activate` as the CI user");
+        Ok(())
     }
 
     /// The daemon runs the copy under `toolchains/shared-bin`, the one the CI

--- a/xtask/src/ci/linux/services.rs
+++ b/xtask/src/ci/linux/services.rs
@@ -179,18 +179,30 @@ fn cleanup_unit(keep: &[&str]) -> String {
     )
 }
 
+/// Every two hours, because the fleet fills faster than a day. Measured across
+/// one day of this timer on the Linux host: the build caches waiting at a pass
+/// ranged from 20 GB to 515 GB, each amount accumulated inside a single
+/// two-hour window, against 3.0 TB free. A daily timer would meet twelve such
+/// windows at once, which a busy day does not fit on the volume — so the host
+/// this shipped to had been carrying a hand-written drop-in overriding the
+/// cadence, a second source of truth this file could not see. A pass over a
+/// volume already inside its budget frees nothing and costs seconds, so the
+/// frequency is only paid for when it is needed.
+fn cleanup_timer() -> &'static str {
+    "[Unit]\n\
+     Description=Kithara CI cleanup\n\n\
+     [Timer]\n\
+     OnCalendar=*-*-* 00/2:00:00\n\
+     Persistent=true\n\n\
+     [Install]\n\
+     WantedBy=timers.target\n"
+}
+
 fn install_cleanup_timer(keep: &[&str]) -> Result<()> {
     let service = cleanup_unit(keep);
-    let timer = "[Unit]\n\
-                 Description=Kithara CI cleanup\n\n\
-                 [Timer]\n\
-                 OnCalendar=daily\n\
-                 Persistent=true\n\n\
-                 [Install]\n\
-                 WantedBy=timers.target\n";
     for (name, body) in [
         (LAYOUT.cleanup_unit, service.as_str()),
-        (LAYOUT.cleanup_timer, timer),
+        (LAYOUT.cleanup_timer, cleanup_timer()),
     ] {
         let path = PathBuf::from(LAYOUT.systemd_root).join(name);
         std::fs::write(&path, body).with_context(|| format!("writing {}", path.display()))?;
@@ -395,6 +407,24 @@ mod tests {
             .collect::<Vec<_>>();
         let argv = std::iter::once("xtask").chain(command.iter().copied());
         assert!(Cli::try_parse_from(argv).is_ok(), "{command:?}");
+    }
+
+    /// The cadence is the whole of the disk policy: the cleaner runs when the
+    /// timer says so and at no other time. A daily pass was measured arriving
+    /// at up to 515 GB of build caches, and that was one two-hour window's
+    /// worth.
+    #[test]
+    fn the_cleanup_timer_outpaces_what_the_fleet_accumulates() {
+        assert!(
+            cleanup_timer().contains("OnCalendar=*-*-* 00/2:00:00"),
+            "{}",
+            cleanup_timer()
+        );
+        assert!(
+            !cleanup_timer().contains("OnCalendar=daily"),
+            "{}",
+            cleanup_timer()
+        );
     }
 
     /// Both lanes' images, and the toolchain each was built on. A runner image


### PR DESCRIPTION
## Description

Both CI hosts clean on a schedule this repository declares, and on both the
schedule that actually ran came from somewhere else. Neither gap is visible by
reading the files this repository writes — that is the point of the change.

**The Linux timer asked for once a day, and once a day cannot hold.** Measured
over one day of passes on the fork's Linux server: the build caches waiting at a
pass ranged from 20 GB to 515 GB, and each of those amounts had accumulated
inside a single two-hour window.

```
2026-08-21T20:00  before=125 GB  freed=104 GB
2026-08-21T22:00  before=515 GB  freed=502 GB
2026-08-22T00:00  before=207 GB  freed=183 GB
2026-08-22T14:00  before=469 GB  freed=316 GB  held=153 GB
```

The volume has 3.0 TB free. A daily timer would meet twelve such windows at
once, which a busy day does not fit. The reason that host has not filled up is
a hand-written `kithara-ci-cleanup.timer.d/every-two-hours.conf` drop-in — a
second source of truth for the cadence, outside the repository, invisible to
this file, and absent from any fresh install. The unit now declares the cadence
that was measured to hold, so the drop-in has nothing left to override.

**The mac agents keep the definition launchd loaded.** `install-services` writes
`com.zvuk.kithara-ci.cleanup.plist` and stops there, because it runs as root and
the agents live in the CI user's GUI domain — `ci host activate` is what
replaces the loaded definition. The documented update sequence ends with
`activate-bridge`, which covers the daemon and not the agents, so this host spent
days cleaning once an hour from a `StartCalendarInterval` left by an earlier
install while the plist beside it asked for every five minutes. Comparing the
files could not show it; `launchctl print` could. The guide now names the step,
and installation says out loud that writing the plist was half the job.

## Type of Change

- [x] Bug fix

## Checklist

- [x] `just fmt check` passes
- [x] `just lint` passes — commit hook `lint-fast` green
- [x] Tests added/updated — the cadence is pinned in
      `ci::linux::services::tests`, falsified by restoring `OnCalendar=daily`
- [x] No `unwrap()`/`expect()` in production code
- [x] Documentation updated — `docs/guides/ci-host.md`

> A cadence is a declaration, and a declaration nothing reads is unpinned. The
> new test is the first thing in this repository that fails if the Linux cleaner
> is slowed back down.
