### PR TITLE
fix(ci): point the bridge tests at the example they read

### DIFF
--- a/xtask/src/ci/bridge/command.rs
+++ b/xtask/src/ci/bridge/command.rs
@@ -188,7 +188,7 @@ mod tests {
         let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .parent()
             .unwrap()
-            .join("ci/bridge/config.example.toml");
+            .join(".config/bridge/config.example.toml");
         std::fs::read_to_string(path).unwrap()
     }
 


### PR DESCRIPTION
## Description

`#212` moved `ci/bridge/config.example.toml` into `.config/bridge/` and left one
reader behind — the test helper that reads the example to prove the bridge
configuration parses:

```
xtask/src/ci/bridge/command.rs:192
  called `Result::unwrap()` on an `Err` value:
  Os { code: 2, kind: NotFound, message: "No such file or directory" }
```

Three tests fail on `main` as it stands: `bridge_config_trusts_the_platform_store_only`,
`trusted_authors_come_from_the_host_configuration_and_default_to_none`, and
`the_installer_is_handed_both_tokens_from_the_bridge_configuration`. One line of
path repairs all three.

**How it got in.** My search for the old paths excluded `xtask/src/ci/` — the
directory both readers live in. The Windows pair turned up only because a second
search looked for the file names instead. A search that returns nothing is a
statement about the filter before it is a statement about the tree, and after a
rename the check that would have caught this is the owning suite, not the module
that was edited.

`Support suites` selects the `tooling` suite for any push touching `xtask/`, so
the pipeline was equipped to catch it; the run for #212 was still queued behind
the fork's serialised runs when the merge happened.

## Type of Change

- [x] Bug fix

## Checklist

- [x] `just fmt check` passes
- [x] `just lint` passes — commit hook `lint-fast` green
- [x] Tests added/updated — the three existing tests go from red to green;
      `ci::bridge::command` 5/5, whole `tooling` lane run locally
- [x] No `unwrap()`/`expect()` in production code
- [x] Documentation updated — not applicable, the guide already names the new path
