### PR TITLE
feat(ci): queue heavy lanes together, pushes per branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,19 +12,23 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
-# A fork's branches share one pool of Linux runners, so their pushes queue
-# rather than overlap. The stress run no longer queues here: it has a
-# runner of its own and a group of its own.
+# One queue per branch. Pushes to different branches hold nothing from each
+# other: they share the machine at the runner, where a job waits for the cores
+# it asks for, which is the resource actually being rationed. Serialising whole
+# runs instead was measured on the Linux host — two pushes waited fourteen
+# minutes behind one nightly assessment with fifteen of eighteen runner slots
+# and two thirds of the CPU idle. The lanes that do want the whole fleet queue
+# together under `heavy-linux-`, and the stress campaign has a runner of its own
+# and a group of its own.
 #
-# `queue: max` is what makes that queue honest. The default `single` holds one
-# pending run and lets every new arrival evict it, so one push to any branch
-# cancelled whichever branch had been waiting its turn — a queue in name only.
-# `queue` takes no expression and may not be declared beside
-# `cancel-in-progress: true`, so the per-ref cancellation of superseded pushes
-# goes with it, the trade lanes.yml already made. A superseded push now runs to
-# completion instead of being cancelled.
+# `queue: max` is what makes this queue honest. The default `single` holds one
+# pending run and lets every new arrival evict it, so a second push to a branch
+# cancelled the run already waiting there — a queue in name only. `queue` takes
+# no expression and may not be declared beside `cancel-in-progress: true`, so
+# the cancellation of superseded pushes goes with it, the trade lanes.yml
+# already made. A superseded push runs to completion instead of being cancelled.
 concurrency:
-  group: ${{ github.event.repository.fork && format('fork-linux-{0}', github.repository) || format('ci-{0}', github.ref) }}
+  group: ci-${{ github.ref }}
   cancel-in-progress: false
   queue: max
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,11 +8,12 @@ on:
     branches: [main]
   workflow_dispatch:
 
-# An instrumented run costs the same pool the stress campaign measures, so on a
-# fork it waits for the campaign rather than taking cores from it, and waits in
-# a queue nothing evicts. See ci.yml for why that costs the cancellation.
+# Heavy work: an instrumented run costs several times a plain one, so it queues
+# with the other heavy lanes and takes its turn among them rather than beside
+# them. A push is not behind that queue; see ci.yml, which also says why a
+# queue nothing evicts costs the cancellation.
 concurrency:
-  group: ${{ github.event.repository.fork && format('fork-linux-{0}', github.repository) || format('coverage-{0}', github.ref) }}
+  group: heavy-linux-${{ github.repository }}
   cancel-in-progress: false
   queue: max
 

--- a/.github/workflows/lanes.yml
+++ b/.github/workflows/lanes.yml
@@ -17,10 +17,11 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
-# These lanes run on the pool the stress campaign measures, so on a fork they
-# wait for the campaign rather than taking cores from it. See ci.yml.
+# Heavy work: this asks for the whole fleet, so it queues with the other heavy
+# lanes and takes its turn among them rather than beside them. A push is not
+# behind that queue; see ci.yml.
 concurrency:
-  group: ${{ github.event.repository.fork && format('fork-linux-{0}', github.repository) || format('lanes-{0}', github.ref) }}
+  group: heavy-linux-${{ github.repository }}
   cancel-in-progress: false
   queue: max
 

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -12,10 +12,11 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
-# The interpreter runs on the pool the stress campaign measures, so on a fork
-# it waits for the campaign rather than taking cores from it. See ci.yml.
+# Heavy work: this asks for the whole fleet, so it queues with the other heavy
+# lanes and takes its turn among them rather than beside them. A push is not
+# behind that queue; see ci.yml.
 concurrency:
-  group: ${{ github.event.repository.fork && format('fork-linux-{0}', github.repository) || format('miri-{0}', github.ref) }}
+  group: heavy-linux-${{ github.repository }}
   cancel-in-progress: false
   queue: max
 

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -11,10 +11,11 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
-# The mutation suites run on the pool the stress campaign measures, so on a
-# fork they wait for the campaign rather than taking cores from it. See ci.yml.
+# Heavy work: this asks for the whole fleet, so it queues with the other heavy
+# lanes and takes its turn among them rather than beside them. A push is not
+# behind that queue; see ci.yml.
 concurrency:
-  group: ${{ github.event.repository.fork && format('fork-linux-{0}', github.repository) || format('mutants-{0}', github.ref) }}
+  group: heavy-linux-${{ github.repository }}
   cancel-in-progress: false
   queue: max
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -22,11 +22,11 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
-# This analysis runs on the pool the stress campaign measures, so on a fork it
-# waits for the campaign rather than taking cores from it, and waits in a queue
-# nothing evicts. See ci.yml for why that costs the cancellation.
+# Heavy work: this asks for the whole fleet, so it queues with the other heavy
+# lanes and takes its turn among them rather than beside them. A push is not
+# behind that queue; see ci.yml.
 concurrency:
-  group: ${{ github.event.repository.fork && format('fork-linux-{0}', github.repository) || format('quality-{0}-{1}', github.ref, inputs.depth) }}
+  group: heavy-linux-${{ github.repository }}
   cancel-in-progress: false
   queue: max
 

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -58,11 +58,11 @@ jobs:
 
   rtsan:
     if: vars.KITHARA_RUNNER_LABELS != '' && github.event.schedule == '0 5 * * *'
-    # The soak carries no queue of its own, because CI calls it too. Started
-    # here it shares a machine with the stress campaign, so on a fork this call
-    # waits for the campaign; elsewhere it names its own run and never waits.
+    # Started here the soak is heavy work — a full night of it — so this call
+    # takes its turn with the other heavy lanes. Its own group stays per-ref,
+    # because CI calls it too and that call belongs to the push.
     concurrency:
-      group: ${{ github.event.repository.fork && format('fork-linux-{0}', github.repository) || format('scheduled-rtsan-{0}', github.run_id) }}
+      group: heavy-linux-${{ github.repository }}
       cancel-in-progress: false
       queue: max
     uses: ./.github/workflows/rtsan.yml

--- a/xtask/tests/github_workflows.rs
+++ b/xtask/tests/github_workflows.rs
@@ -16,6 +16,14 @@ const DOWNLOAD_ARTIFACT: &str =
 const INSTALL_ACTION: &str = "taiki-e/install-action@b20dedce73af6905cdc30d6611090c9b67557c8d";
 const UPLOAD_ARTIFACT: &str = "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a";
 const STRESS_RAW_DIR: &str = "${{ runner.temp }}/kithara-stress/raw";
+const HEAVY_LINUX_GROUP: &str = "heavy-linux-${{ github.repository }}";
+const HEAVY_LINUX_WORKFLOWS: [&str; 5] = [
+    "coverage.yml",
+    "lanes.yml",
+    "miri.yml",
+    "mutants.yml",
+    "quality.yml",
+];
 const STRESS_EXECUTE_COMMAND: &str = r#"args=(
   --subject-root "$GITHUB_WORKSPACE/subject"
   --output "$RUNNER_TEMP/kithara-stress/raw"
@@ -338,14 +346,13 @@ fn github_ci_is_fail_closed_and_aggregates_every_job() {
     let concurrency = workflow_concurrency(&workflow);
     assert_eq!(
         mapping_field(concurrency, "group").as_str(),
-        Some(
-            "${{ github.event.repository.fork && format('fork-linux-{0}', github.repository) || format('ci-{0}', github.ref) }}"
-        )
+        Some("ci-${{ github.ref }}")
     );
-    // The fork's branches share one Linux pool, so they queue instead of
-    // evicting each other. `queue` takes no expression and may not sit beside a
-    // cancellation that can read true, so the one literal serves both sides and
-    // production gives up cancelling a superseded push. See ci.yml.
+    // One queue per branch: pushes to different branches hold nothing from each
+    // other, and the machine is shared at the runner, where a job waits for the
+    // three cores it asks for. `queue` takes no expression and may not sit
+    // beside a cancellation that can read true, so pushes to one branch queue
+    // rather than evict, and a superseded push is not cancelled. See ci.yml.
     assert_eq!(
         mapping_field(concurrency, "cancel-in-progress").as_bool(),
         Some(false)
@@ -501,7 +508,7 @@ fn a_queue_is_never_declared_beside_a_cancellation_that_can_fire() {
 }
 
 // What a group expression can evaluate to, down to the part no branch varies:
-// `fork-linux-{0}` and `fork-linux-${{ github.repository }}` name one queue.
+// `heavy-linux-{0}` and `heavy-linux-${{ github.repository }}` name one queue.
 fn group_prefix(group: &str) -> String {
     group
         .split(['{', '$'])
@@ -547,6 +554,39 @@ fn a_called_workflow_never_waits_on_the_group_its_caller_holds() {
         deadlocks.is_empty(),
         "a called workflow cannot start while its caller holds the same concurrency group: {deadlocks:?}"
     );
+}
+
+#[test]
+fn the_heavy_lanes_queue_together_and_ordinary_ci_queues_per_branch() {
+    // One machine serves every lane, and the queue that protects it must not
+    // also stall the pushes. Measured on the Linux host before this split, when
+    // every Linux workflow named one group per repository: a nightly assessment
+    // held the only slot with three jobs while two pushes waited fourteen
+    // minutes with fifteen of eighteen runner slots and two thirds of the CPU
+    // idle. Coverage, the extra suites, Miri, mutation, and assessment ask for
+    // the whole fleet, so they take turns; a push does not wait behind them.
+    for name in HEAVY_LINUX_WORKFLOWS {
+        let workflow = github_workflow(name);
+        let concurrency = workflow_concurrency(&workflow);
+        assert_eq!(
+            mapping_field(concurrency, "group").as_str(),
+            Some(HEAVY_LINUX_GROUP),
+            "{name}"
+        );
+        assert_eq!(
+            mapping_field(concurrency, "queue").as_str(),
+            Some("max"),
+            "{name}"
+        );
+    }
+
+    let ordinary = github_workflow("ci.yml");
+    let group = mapping_field(workflow_concurrency(&ordinary), "group")
+        .as_str()
+        .expect("the CI group is a string")
+        .to_owned();
+    assert!(group.contains("github.ref"), "{group}");
+    assert_ne!(group_prefix(&group), group_prefix(HEAVY_LINUX_GROUP));
 }
 
 #[test]


### PR DESCRIPTION
## Goal

Stop serialising the whole Linux fleet behind one concurrency group, so ordinary
pushes run in parallel while the lanes that want the whole machine take turns.

## The defect, measured

Six workflows — `ci`, `coverage`, `lanes`, `miri`, `mutants`, `quality` — each
evaluated its group to `fork-linux-<repo>` with `queue: max`. That is one slot
per repository, so exactly one run of any of them proceeded no matter how idle
the fleet was. Measured on the Linux host at 20:54 UTC, before this change:

| | |
| --- | --- |
| `pending` CI runs | 3 (20:25, 20:27, 20:49), each with **zero jobs** |
| oldest waiting | 29 minutes |
| holding the slot | `Scheduled runs`, 3 `quality` jobs since 20:32 |
| host | load 9.60, **vmstat idle 70 %** |
| containers above 5 % CPU | 4 of 25 (three pinned at their own 3-cpu ceiling) |
| fork runner slots busy | **3 of 18** |

A run `pending` with **zero jobs** is the signature: no job has been requested
yet, so nothing is waiting on a runner. Had runners been the constraint the jobs
would exist and be `queued`. `queue: max` does not relieve this — it only sets
the waiting policy (FIFO instead of the default `single`, which lets each
arrival evict the pending run). The slot count stays one.

## The change

The group now names what it rations.

- `ci.yml` → `ci-${{ github.ref }}`. One queue per branch: pushes to different
  branches hold nothing from each other and meet at the runner, where a job
  waits for the three cores it asks for. That is where cores are handed out.
- `coverage`, `lanes`, `miri`, `mutants`, `quality`, and the scheduled `rtsan`
  soak job → `heavy-linux-${{ github.repository }}`. These ask for the whole
  fleet, so at most one of them occupies it, and none of them stands in front of
  a push. Worst case is one heavy run's own fan-out, which leaves slots free.
- `stress.yml` is untouched: it already had its own group and its own
  `kithara-stress` runner label.

The fork branch is gone from six group expressions. That is not a loss of
behaviour — the policy is now identical everywhere, which is what both active
forks need, and the comments claiming these lanes waited for the stress campaign
described an arrangement the code stopped implementing when stress moved to a
group of its own. Those comments are rewritten to what the code does.

Upstream trade, stated: a nightly's heavy children now take turns instead of
running together, so the nightly is longer end to end. It no longer blocks a
push, which is the exchange being made.

## Validation

- `just test run --lane=tooling` — **1488 passed, 3 skipped, 0 failed** (107.7 s).
- New pin `the_heavy_lanes_queue_together_and_ordinary_ci_queues_per_branch`
  falsified twice before being trusted: `miri` escaping the heavy queue fires at
  `xtask/tests/github_workflows.rs:571`, `ci` rejoining it fires at `:584`.
- The existing cross-workflow pins still hold: no `queue: max` sits beside a
  cancellation that can read true, and no called workflow waits on a group its
  caller holds (`schedule.yml`'s `rtsan` job holds `heavy-linux-`, `rtsan.yml`
  keeps its own per-ref group, so the call does not deadlock).
- `git grep fork-linux` returns nothing outside a comment example, which is
  updated.

## Risks

Ordinary CI can now saturate the fleet for the first time, so several branches
pushing at once will queue at the runner instead of at the run. That is the
intended place to wait: 18 slots of 3 cores on 32 cores was never reached under
the old group, and the measurement above shows 15 slots idle while pushes waited.
