### PR TITLE
fix(ci): keep the coverage bar at 80

### DIFF
--- a/.config/just/test.just
+++ b/.config/just/test.just
@@ -140,15 +140,13 @@ coverage:
     #!/usr/bin/env bash
     set -uo pipefail
     OUTPUT_DIR="${COVERAGE_OUTPUT_DIR:-./coverage}"
-    # The floor is a ratchet: raise it, never lower it. Measured on the
-    # coverage lane on 2026-08-23 (run 32605953272, 5318 tests, all passing):
-    # 76.48% of lines, 75.01% of regions, 78.77% of functions. It is set at 76
-    # rather than 76.48 so that platform-gated skips and the functions llvm-cov
-    # reports as mismatched cannot turn ordinary jitter red; half a point here is
-    # some six hundred lines, so a real regression still moves it. The number
-    # lives only here — the CI lane inherits it, because a second copy is how a
-    # local run and CI came to gate at different bars.
-    COVERAGE_MIN="${COVERAGE_MIN:-76}"
+    # The bar stands at 80 while the workspace holds 76.5% of lines. The gap is
+    # the UI surface — kithara-ui widgets and kithara-app/src/gui, several files
+    # of it at zero — and it closes by covering that surface, not by moving the
+    # number. The number lives only here: the CI lane inherits it, because a
+    # second copy is one edit away from gating a local run and CI at different
+    # bars.
+    COVERAGE_MIN="${COVERAGE_MIN:-80}"
     IGNORE_REGEX='(tests/|examples/|benches/|xtask/)'
     COBERTURA="$OUTPUT_DIR/cobertura.xml"
     LCOV="$OUTPUT_DIR/lcov.info"

--- a/xtask/tests/lane_config.rs
+++ b/xtask/tests/lane_config.rs
@@ -37,12 +37,14 @@ fn a_selenium_lane_names_its_browser_in_its_own_environment() {
     assert!(checked > 0, "no selenium lane is configured to check");
 }
 
-// The coverage floor gates a report that nothing else gates, so it has to be
+// The coverage bar gates a report that nothing else gates, so it has to be
 // enforced where it is declared, and declared once. Two copies is what let the
 // lane pass 80 while the recipe defaulted to 80: agreeing by accident, and one
-// edit away from gating a local run and CI at different bars.
+// edit away from gating a local run and CI at different bars. The bar is above
+// what the workspace holds today on purpose — the UI surface gets its own tests
+// — so this also fixes the number a green lane may not be bought with.
 #[test]
-fn the_coverage_floor_is_declared_once_and_enforced_where_it_is_declared() {
+fn the_coverage_bar_is_declared_once_and_enforced_where_it_is_declared() {
     let root = Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .expect("xtask has a workspace root");
@@ -50,18 +52,18 @@ fn the_coverage_floor_is_declared_once_and_enforced_where_it_is_declared() {
         .expect("the test recipes are readable");
 
     assert!(
-        recipe.contains(r#"COVERAGE_MIN="${COVERAGE_MIN:-76}""#),
-        "the coverage floor is declared in .config/just/test.just"
+        recipe.contains(r#"COVERAGE_MIN="${COVERAGE_MIN:-80}""#),
+        "the coverage bar is declared in .config/just/test.just"
     );
     assert!(
         recipe.contains(r#"--fail-under-lines "$COVERAGE_MIN""#),
-        "the declared floor is the one the report is failed under"
+        "the declared bar is the one the report is failed under"
     );
 
     let lane = fs::read_to_string(root.join("xtask/src/ci/lane/linux.rs"))
         .expect("the Linux lanes are readable");
     assert!(
         !lane.contains("COVERAGE_MIN"),
-        "the coverage lane inherits the floor instead of keeping a second copy"
+        "the coverage lane inherits the bar instead of keeping a second copy"
     );
 }


### PR DESCRIPTION
## Goal

Restore the coverage bar to 80 in main. #216 landed with it at 76, which is a
decision that had been reversed before the merge and did not belong on main.

## What happened

#216 first lowered the bar to 76 as a ratchet at the measured floor. That was
reversed: the bar stays at 80, and the gap closes by covering the UI surface,
which is separate work. The commit restoring 80 was pushed to the branch after
#216 had already been squash-merged, so it stayed on the branch and never
reached main. Main has been gating at 76 since.

This is that commit, applied to main.

## The change

`COVERAGE_MIN` goes back to 80 in `.config/just/test.just`, and the comment says
why the bar sits above what the workspace holds: the gap is `kithara-ui` widgets
and `kithara-app/src/gui` — several files of it at zero — and it closes by
covering that surface, not by moving the number.

`Code Coverage` is therefore red until those tests land. It gates nothing else,
so that costs a red line in the run list and no merge.

The number stays declared once. `.config/just/test.just` owns it, because that
is where `--fail-under-lines` reads it; the Linux lane inherits it rather than
passing its own literal. Both said 80 before, so they agreed by accident and
were one edit away from gating a local run and CI at different bars — and a
parallel copy is how a red lane could be bought quietly in whichever file
someone happened to open.

## Validation

`the_coverage_bar_is_declared_once_and_enforced_where_it_is_declared` holds all
three properties, each falsified on its own and measured, not inferred:

| falsification | fires at |
| --- | --- |
| the bar lowered to buy a green lane | `xtask/tests/lane_config.rs:54` |
| the bar declared but not enforced | `:58` |
| the lane keeping a second copy | `:65` |

- `just test run --lane=tooling`: **1489 passed**, 3 skipped, no timeout.
- `just lint fast`: `0 deny, 0 warn, 0 regression(s), 0 new`. Run by hand
  because a cherry-pick does not fire the pre-commit hook.
- The test fix that made this lane reach its threshold at all is already in
  main, verified there: the dispatched coverage run reported
  `5319 tests run: 5319 passed, 23 skipped`.
