### PR TITLE
refactor: let each crate's config own its policy parameters (batch 2/6)

### DIFF
--- a/crates/kithara-abr/CONTEXT.md
+++ b/crates/kithara-abr/CONTEXT.md
@@ -83,7 +83,7 @@ Dual-track EWMA — fast (2 s half-life) and slow (10 s half-life); estimate = `
 
 ## Event throttling
 
-Per peer: `ThroughputSample` at most every 200 ms (fixed constant); `BandwidthEstimate` when `bandwidth_emit_min_interval` has elapsed **or** the relative change reaches `bandwidth_emit_min_delta_ratio`; `BufferAhead` on any `Some`/`None` transition, otherwise when both the interval and the absolute-delta thresholds are met.
+Per peer: `ThroughputSample` at most every `throughput_sample_min_interval` (default 200 ms); `BandwidthEstimate` when `bandwidth_emit_min_interval` has elapsed **or** the relative change reaches `bandwidth_emit_min_delta_ratio`; `BufferAhead` on any `Some`/`None` transition, otherwise when both the interval and the absolute-delta thresholds are met.
 
 ## Module layout
 

--- a/crates/kithara-abr/src/controller/core.rs
+++ b/crates/kithara-abr/src/controller/core.rs
@@ -33,6 +33,7 @@ impl Defaults {
     const MIN_BUFFER_FOR_UP_SWITCH: Duration = Duration::from_secs(10);
     const MIN_SWITCH_INTERVAL: Duration = Duration::from_secs(30);
     const THROUGHPUT_SAFETY_FACTOR: f64 = 1.5;
+    const THROUGHPUT_SAMPLE_MIN_INTERVAL: Duration = Duration::from_millis(200);
     const UP_HYSTERESIS_RATIO: f64 = 1.3;
     const URGENT_DOWNSWITCH_BUFFER: Duration = Duration::from_secs(5);
 }
@@ -74,6 +75,11 @@ pub struct AbrSettings {
     /// Minimum interval between `AbrEvent::BufferAhead` emits.
     #[builder(default = Defaults::BUFFER_EMIT_MIN_INTERVAL)]
     pub buffer_emit_min_interval: Duration,
+    /// Minimum interval between `AbrEvent::ThroughputSample` emits. Every
+    /// sample still reaches the estimator; this bounds only how often the
+    /// raw per-fetch rate is published to the bus.
+    #[builder(default = Defaults::THROUGHPUT_SAMPLE_MIN_INTERVAL)]
+    pub throughput_sample_min_interval: Duration,
     /// Minimum buffer-ahead required before an up-switch is allowed.
     #[builder(default = Defaults::MIN_BUFFER_FOR_UP_SWITCH)]
     pub min_buffer_for_up_switch: Duration,
@@ -126,9 +132,6 @@ pub struct AbrController {
 }
 
 impl AbrController {
-    /// Minimum delay between `AbrEvent::ThroughputSample` emits (fixed).
-    pub(super) const MIN_THROUGHPUT_SAMPLE_INTERVAL: Duration = Duration::from_millis(200);
-
     /// Create a new controller with the default [`ThroughputEstimator`].
     #[must_use]
     pub fn new(settings: AbrSettings) -> Arc<Self> {

--- a/crates/kithara-abr/src/controller/tick.rs
+++ b/crates/kithara-abr/src/controller/tick.rs
@@ -44,9 +44,9 @@ impl AbrController {
         let bus = entry.bus();
         if let Some(ref bus) = bus {
             let mut throttle = entry.throttle.lock();
-            let emit = throttle
-                .last_throughput_sample_at
-                .is_none_or(|t| now.duration_since(t) >= Self::MIN_THROUGHPUT_SAMPLE_INTERVAL);
+            let emit = throttle.last_throughput_sample_at.is_none_or(|t| {
+                now.duration_since(t) >= self.settings.throughput_sample_min_interval
+            });
             if emit {
                 throttle.last_throughput_sample_at = Some(now);
                 drop(throttle);

--- a/crates/kithara-abr/src/state/tests.rs
+++ b/crates/kithara-abr/src/state/tests.rs
@@ -5,8 +5,8 @@ use std::{
 };
 
 use kithara_events::{
-    AbrMode, AbrProgressSnapshot, AbrReason, BandwidthSource, VariantDuration, VariantIndex,
-    VariantInfo,
+    AbrEvent, AbrMode, AbrProgressSnapshot, AbrReason, BandwidthSource, DEFAULT_EVENT_BUS_CAPACITY,
+    Envelope, Event, EventBus, VariantDuration, VariantIndex, VariantInfo,
 };
 use kithara_platform::{
     CancelToken,
@@ -893,6 +893,56 @@ async fn bandwidth_samples_are_preserved_across_immediate_ticks() {
     assert_eq!(samples.load(Ordering::Acquire), SAMPLES);
     assert_eq!(ticks.load(Ordering::Acquire), SAMPLES);
     assert!(!poll_controller(&controller, false).await);
+}
+
+/// Publish two back-to-back samples through a controller whose emit throttle
+/// is `interval`, and count what reached the bus.
+fn throughput_samples_published_with(interval: Duration) -> usize {
+    let controller = AbrController::with_estimator(
+        AbrSettings::builder()
+            .throughput_sample_min_interval(interval)
+            .build(),
+        Arc::new(ThroughputEstimator::new()) as Arc<_>,
+    );
+    let peer: Arc<dyn Abr> = Arc::new(TickPeer {
+        cancel: CancelToken::never(),
+        state: Arc::new(AbrState::new(AbrMode::Auto(Some(VariantIndex::new(0))))),
+        wake: Arc::new(Notify::default()),
+    });
+    let bus = EventBus::new(DEFAULT_EVENT_BUS_CAPACITY);
+    let mut rx = bus.subscribe();
+    let handle = controller.register(&peer).with_bus(bus);
+
+    for _ in 0..2 {
+        controller.record_bandwidth(
+            handle.peer_id(),
+            32 * 1024,
+            Duration::from_millis(50),
+            BandwidthSource::Network,
+        );
+    }
+
+    std::iter::from_fn(|| rx.try_recv().ok())
+        .filter(|Envelope { event, .. }| {
+            matches!(event, Event::Abr(AbrEvent::ThroughputSample { .. }))
+        })
+        .count()
+}
+
+/// The knob is a throttle, so a zero interval throttles nothing.
+#[kithara::test]
+fn a_zero_sample_interval_publishes_every_throughput_sample() {
+    assert_eq!(throughput_samples_published_with(Duration::ZERO), 2);
+}
+
+/// A second sample arriving inside the interval is dropped, which is what
+/// makes the interval a parameter worth setting.
+#[kithara::test]
+fn a_throughput_sample_inside_the_interval_is_not_published() {
+    assert_eq!(
+        throughput_samples_published_with(Duration::from_secs(3600)),
+        1
+    );
 }
 
 fn audio_variants_4tier() -> Vec<VariantInfo> {

--- a/crates/kithara-bufpool/src/global.rs
+++ b/crates/kithara-bufpool/src/global.rs
@@ -12,6 +12,10 @@ use crate::{
 
 pub(crate) const BYTE_MAX_BUFFERS: usize = usize::MAX;
 pub(crate) const BYTE_TRIM_CAPACITY: usize = 0;
+/// Workspace default byte budget: the cap a `Region` shares between its two
+/// pools, and the cap on the process-wide `BytePool` singleton. One number,
+/// because the two describe the same "how much memory may pooling hold".
+pub(crate) const DEFAULT_MAX_BYTES: usize = 256 * 1024 * 1024;
 pub(crate) const PCM_MAX_BUFFERS: usize = 128;
 pub(crate) const PCM_TRIM_CAPACITY: usize = 200_000;
 
@@ -163,7 +167,7 @@ impl fmt::Debug for PcmBuf {
 impl Default for BytePool {
     fn default() -> Self {
         static GLOBAL: OnceLock<BytePool> = OnceLock::new();
-        const BUDGET: ByteBudget = ByteBudget(256 * 1024 * 1024);
+        const BUDGET: ByteBudget = ByteBudget(DEFAULT_MAX_BYTES);
         GLOBAL
             .get_or_init(|| Self::with_byte_budget(BYTE_MAX_BUFFERS, BYTE_TRIM_CAPACITY, BUDGET))
             .clone()

--- a/crates/kithara-bufpool/src/region.rs
+++ b/crates/kithara-bufpool/src/region.rs
@@ -4,10 +4,10 @@ use kithara_platform::sync::Arc;
 use crate::{
     BytePool, PcmPool,
     budget::RegionBudget,
-    global::{BYTE_MAX_BUFFERS, BYTE_TRIM_CAPACITY, PCM_MAX_BUFFERS, PCM_TRIM_CAPACITY},
+    global::{
+        BYTE_MAX_BUFFERS, BYTE_TRIM_CAPACITY, DEFAULT_MAX_BYTES, PCM_MAX_BUFFERS, PCM_TRIM_CAPACITY,
+    },
 };
-
-const DEFAULT_MAX_BYTES: usize = 256 * 1024 * 1024;
 
 /// Configuration for a shared buffer-pool region.
 ///

--- a/crates/kithara-net/CONTEXT.md
+++ b/crates/kithara-net/CONTEXT.md
@@ -139,9 +139,13 @@ speed", and a 10s cap raced real fixtures.
 
 `NetOptions` is a `bon` builder with defaults: `compression` all four codings, `inactivity_timeout` 30s, `impersonate`
 `Safari`, `retry_policy` (3 retries / 100ms base / 5s max, exponential ×2), `is_insecure` false, `body_queue_capacity` 32,
-`body_queue_resume_at` 16, `pool_max_idle_per_host` 8, default `byte_pool`. `FromWithParams<Self, BytePool>` injects a
-shared pool without rebuilding the rest. Native clients additionally pin a hard-coded 5s `pool_idle_timeout` and enable
+`body_queue_resume_at` 16, `pool_max_idle_per_host` 8, `pool_idle_timeout` 5s, default `byte_pool`.
+`FromWithParams<Self, BytePool>` injects a shared pool without rebuilding the rest. `pool_idle_timeout` reaches the two
+native client builders only; the Apple backend has no Foundation equivalent for it. Native clients additionally enable
 the cookie store.
+
+`HttpClient::with_observer` rebuilds `NetOptions` by struct update, so a new option is carried over by construction —
+a field-by-field rebuild would silently reset any knob it forgot.
 
 Retryability is decided from the typed `NetError` discriminant, never by substring matching: `Timeout`, `Network`, and
 `Status` with 5xx / 429 / 408 are `Transient`; everything else — including `Decode`, `Cancelled`, and `RetryExhausted` —

--- a/crates/kithara-net/src/backend/apple/client.rs
+++ b/crates/kithara-net/src/backend/apple/client.rs
@@ -217,10 +217,7 @@ impl AppleNet {
 
     #[must_use]
     pub fn with_observer(&self, observer: Option<Observer>) -> Self {
-        let options = NetOptions {
-            observer,
-            ..self.options.clone()
-        };
+        let options = self.options.with_observer(observer);
         let raw = RawAppleNet {
             session: self.session.clone(),
             cancel: self.cancel.clone(),

--- a/crates/kithara-net/src/backend/apple/client.rs
+++ b/crates/kithara-net/src/backend/apple/client.rs
@@ -217,18 +217,10 @@ impl AppleNet {
 
     #[must_use]
     pub fn with_observer(&self, observer: Option<Observer>) -> Self {
-        let options = NetOptions::builder()
-            .compression(self.options.compression)
-            .inactivity_timeout(self.options.inactivity_timeout)
-            .impersonate(self.options.impersonate)
-            .byte_pool(self.options.byte_pool.clone())
-            .retry_policy(self.options.retry_policy.clone())
-            .is_insecure(self.options.is_insecure)
-            .body_queue_capacity(self.options.body_queue_capacity)
-            .body_queue_resume_at(self.options.body_queue_resume_at)
-            .pool_max_idle_per_host(self.options.pool_max_idle_per_host)
-            .maybe_observer(observer)
-            .build();
+        let options = NetOptions {
+            observer,
+            ..self.options.clone()
+        };
         let raw = RawAppleNet {
             session: self.session.clone(),
             cancel: self.cancel.clone(),

--- a/crates/kithara-net/src/backend/native/reqwest.rs
+++ b/crates/kithara-net/src/backend/native/reqwest.rs
@@ -1,5 +1,4 @@
 pub(crate) use ::reqwest::{Client, ClientBuilder, RequestBuilder, Response, StatusCode};
-use kithara_platform::time::Duration;
 
 use super::metrics::CountConnectionsLayer;
 use crate::{metrics::ConnectionMetrics, types::NetOptions};
@@ -18,7 +17,7 @@ pub(crate) fn build_client(
         .connector_layer(CountConnectionsLayer::new(metrics.clone()))
         .cookie_store(true)
         .pool_max_idle_per_host(options.pool_max_idle_per_host)
-        .pool_idle_timeout(Some(Duration::from_secs(5)))
+        .pool_idle_timeout(Some(options.pool_idle_timeout))
         .danger_accept_invalid_certs(options.is_insecure);
     super::apply_compression(base, options.compression).build()
 }

--- a/crates/kithara-net/src/backend/native/wreq.rs
+++ b/crates/kithara-net/src/backend/native/wreq.rs
@@ -1,5 +1,4 @@
 pub(crate) use ::wreq::{Client, ClientBuilder, RequestBuilder, Response, StatusCode};
-use kithara_platform::time::Duration;
 
 use super::metrics::CountConnectionsLayer;
 use crate::{
@@ -36,7 +35,7 @@ pub(crate) fn build_client(
         .emulation(::wreq_util::Profile::from(options.impersonate))
         .cookie_store(true)
         .pool_max_idle_per_host(options.pool_max_idle_per_host)
-        .pool_idle_timeout(Some(Duration::from_secs(5)))
+        .pool_idle_timeout(Some(options.pool_idle_timeout))
         .tls_cert_verification(!options.is_insecure);
     super::apply_compression(base, options.compression).build()
 }

--- a/crates/kithara-net/src/client.rs
+++ b/crates/kithara-net/src/client.rs
@@ -393,10 +393,7 @@ impl HttpClient {
 
     #[must_use]
     pub fn with_observer(&self, observer: Option<Observer>) -> Self {
-        let options = NetOptions {
-            observer,
-            ..self.options.clone()
-        };
+        let options = self.options.with_observer(observer);
         let raw = RawHttp {
             inner: self.inner.clone(),
             options: options.clone(),

--- a/crates/kithara-net/src/client.rs
+++ b/crates/kithara-net/src/client.rs
@@ -393,18 +393,10 @@ impl HttpClient {
 
     #[must_use]
     pub fn with_observer(&self, observer: Option<Observer>) -> Self {
-        let options = NetOptions::builder()
-            .compression(self.options.compression)
-            .inactivity_timeout(self.options.inactivity_timeout)
-            .impersonate(self.options.impersonate)
-            .byte_pool(self.options.byte_pool.clone())
-            .retry_policy(self.options.retry_policy.clone())
-            .is_insecure(self.options.is_insecure)
-            .body_queue_capacity(self.options.body_queue_capacity)
-            .body_queue_resume_at(self.options.body_queue_resume_at)
-            .pool_max_idle_per_host(self.options.pool_max_idle_per_host)
-            .maybe_observer(observer)
-            .build();
+        let options = NetOptions {
+            observer,
+            ..self.options.clone()
+        };
         let raw = RawHttp {
             inner: self.inner.clone(),
             options: options.clone(),
@@ -1179,6 +1171,22 @@ mod tests {
             counter.load(Ordering::SeqCst),
             2,
             "exactly 2 attempts: 1 failed (503) + 1 ok"
+        );
+    }
+
+    /// `with_observer` rebuilds the options around the new observer. A field
+    /// it fails to carry over is a knob that silently reverts to its default
+    /// the moment the downloader attaches an observer to the client.
+    #[kithara::test]
+    fn attaching_an_observer_carries_the_options_over() {
+        let options = NetOptions::builder()
+            .pool_idle_timeout(Duration::from_secs(77))
+            .build();
+        let client = HttpClient::new(options, CancelToken::never());
+
+        assert_eq!(
+            client.with_observer(None).options().pool_idle_timeout,
+            Duration::from_secs(77)
         );
     }
 }

--- a/crates/kithara-net/src/types.rs
+++ b/crates/kithara-net/src/types.rs
@@ -203,6 +203,46 @@ pub struct NetOptions {
     pub pool_idle_timeout: Duration,
 }
 
+impl NetOptions {
+    /// The same options carrying a different observer.
+    ///
+    /// The source is destructured exhaustively on purpose. Rebuilding through
+    /// the builder is the workspace form for a config, and a bare
+    /// `Self::builder()` chain would silently reset any option nobody
+    /// remembered to list here; the pattern has no rest, so an option added
+    /// to the struct breaks this build instead.
+    #[must_use]
+    pub fn with_observer(&self, observer: Option<Observer>) -> Self {
+        let Self {
+            byte_pool,
+            compression,
+            inactivity_timeout,
+            impersonate,
+            observer: _,
+            retry_policy,
+            is_insecure,
+            body_queue_capacity,
+            body_queue_resume_at,
+            pool_max_idle_per_host,
+            pool_idle_timeout,
+        } = self.clone();
+
+        Self::builder()
+            .byte_pool(byte_pool)
+            .compression(compression)
+            .inactivity_timeout(inactivity_timeout)
+            .impersonate(impersonate)
+            .maybe_observer(observer)
+            .retry_policy(retry_policy)
+            .is_insecure(is_insecure)
+            .body_queue_capacity(body_queue_capacity)
+            .body_queue_resume_at(body_queue_resume_at)
+            .pool_max_idle_per_host(pool_max_idle_per_host)
+            .pool_idle_timeout(pool_idle_timeout)
+            .build()
+    }
+}
+
 impl Default for NetOptions {
     fn default() -> Self {
         Self::builder().build()

--- a/crates/kithara-net/src/types.rs
+++ b/crates/kithara-net/src/types.rs
@@ -192,6 +192,15 @@ pub struct NetOptions {
     /// Set to 0 to disable pooling.
     #[builder(default = 8)]
     pub pool_max_idle_per_host: usize,
+    /// How long a pooled connection may sit idle before it is dropped.
+    /// Governs the same pool as [`Self::pool_max_idle_per_host`]: the count
+    /// caps how many idle connections survive, this caps how long. The
+    /// default matches the keep-alive window CDNs commonly advertise, so a
+    /// segment burst reuses connections while a paused player does not hold
+    /// sockets open. Ignored by the Apple backend, whose `URLSession`
+    /// configuration exposes no idle-pool timeout.
+    #[builder(default = Duration::from_secs(5))]
+    pub pool_idle_timeout: Duration,
 }
 
 impl Default for NetOptions {

--- a/crates/kithara-queue/CONTEXT.md
+++ b/crates/kithara-queue/CONTEXT.md
@@ -29,7 +29,9 @@ Contracts and invariants for `kithara-queue`; the README is the overview.
   `TrackSource::Uri` resources share it; a caller-supplied `ResourceConfig` keeps its
   own.
 - `max_concurrent_loads` (default 3) sizes the prefetch lane only.
-- `prefetch_duration` (default 3.5) is declared but not applied by `Queue::new`.
+- `prefetch_duration` (default 3.5) is applied to the player the queue drives — built
+  or caller-supplied — the same way `auto_advance_enabled` is.
+- `max_history_size` (default 100) caps `NavigationState`'s history.
 - `should_autoplay` (default `true`) is consumed only by the
   `cfg(any(test, feature = "probe"))` harness. The production append / insert path
   never starts playback: the caller drives the first `select` / `play`, so order is
@@ -184,7 +186,8 @@ seeking — not from `PlayerImpl::current_index`.
   so it stays in that address space (FFI reserves the id at item construction and
   surfaces it as `audioId`).
 - `NavigationState` is pure logic; the caller owns locking. History is deduped against
-  its tail and capped at 100 entries. `next()`: unselected → `0`; `RepeatMode::One` →
+  its tail and capped at the `history_limit` it is constructed with
+  (`QueueConfig::max_history_size`). `next()`: unselected → `0`; `RepeatMode::One` →
   current; `All` wraps to `0`; `Off` returns `None` and clears the current index at the
   end. `prev()` returns `None` at index 0 or before the first selection. `finish()`
   pushes the current index into history and clears it, keeping `last_selected_index()`.

--- a/crates/kithara-queue/src/config.rs
+++ b/crates/kithara-queue/src/config.rs
@@ -55,6 +55,12 @@ pub struct QueueConfig {
     /// is preloaded into the audio processor. Default: 3.5.
     #[builder(default = DEFAULT_PREFETCH_DURATION)]
     pub prefetch_duration: f32,
+
+    /// Entries the navigation history keeps. Only explicit selections and
+    /// auto-advances land there, so the default is a listening session's
+    /// worth of back-steps; the queue's own track list is unbounded.
+    #[builder(default = 100)]
+    pub max_history_size: usize,
 }
 
 impl fmt::Debug for QueueConfig {
@@ -63,6 +69,7 @@ impl fmt::Debug for QueueConfig {
             .field("max_concurrent_loads", &self.max_concurrent_loads)
             .field("should_autoplay", &self.should_autoplay)
             .field("prefetch_duration", &self.prefetch_duration)
+            .field("max_history_size", &self.max_history_size)
             .finish_non_exhaustive()
     }
 }

--- a/crates/kithara-queue/src/navigation.rs
+++ b/crates/kithara-queue/src/navigation.rs
@@ -18,7 +18,7 @@ pub enum RepeatMode {
 /// Mirrors `kithara-app::playlist::PlaylistState`. Caller owns locking;
 /// methods take `&mut self` so the surrounding [`Queue`](crate::Queue) can
 /// decide the lock granularity.
-#[derive(Debug, Default, fieldwork::Fieldwork)]
+#[derive(Debug, fieldwork::Fieldwork)]
 #[fieldwork(opt_in, get)]
 pub struct NavigationState {
     #[field(get)]
@@ -26,23 +26,31 @@ pub struct NavigationState {
     #[field(get, copy, set = set_repeat)]
     repeat_mode: RepeatMode,
     history: VecDeque<usize>,
+    /// Entries [`Self::history`] keeps; the oldest is dropped past it.
+    history_limit: usize,
     #[field(get = is_shuffle_enabled, set = set_shuffle)]
     shuffle_enabled: bool,
 }
 
 impl NavigationState {
     /// New empty state: no current track, history empty, shuffle off,
-    /// [`RepeatMode::Off`].
+    /// [`RepeatMode::Off`]. `history_limit` comes from
+    /// `QueueConfig::max_history_size`.
     #[must_use]
-    // ast-grep-ignore: style.prefer-default-derive
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(history_limit: usize) -> Self {
+        Self {
+            current_index: None,
+            repeat_mode: RepeatMode::Off,
+            history: VecDeque::new(),
+            history_limit,
+            shuffle_enabled: false,
+        }
     }
 
     /// Mark the queue exhausted without selecting a successor.
     pub(crate) fn finish(&mut self) {
         if let Some(current) = self.current_index {
-            add_to_history(&mut self.history, current);
+            self.push_history(current);
         }
         self.current_index = None;
     }
@@ -67,7 +75,7 @@ impl NavigationState {
             (_, Some(current), RepeatMode::One) => return Some(current),
             (_, Some(current), _) => current,
         };
-        add_to_history(&mut self.history, current);
+        self.push_history(current);
         let next = match self.repeat_mode {
             _ if current + 1 < len => current + 1,
             RepeatMode::All => 0,
@@ -92,6 +100,18 @@ impl NavigationState {
         Some(prev)
     }
 
+    /// Push `track_idx` onto history, deduped against the tail. Past
+    /// [`Self::history_limit`] the oldest entry is dropped.
+    fn push_history(&mut self, track_idx: usize) {
+        if self.history.back() == Some(&track_idx) {
+            return;
+        }
+        if self.history.len() >= self.history_limit {
+            self.history.pop_front();
+        }
+        self.history.push_back(track_idx);
+    }
+
     /// Record an explicit selection. If the previously-current track is
     /// different, it is pushed onto history (deduped against the tail).
     pub fn select(&mut self, idx: usize) {
@@ -99,23 +119,10 @@ impl NavigationState {
             && current != idx
             && self.history.back() != Some(&current)
         {
-            add_to_history(&mut self.history, current);
+            self.push_history(current);
         }
         self.current_index = Some(idx);
     }
-}
-
-fn add_to_history(history: &mut VecDeque<usize>, track_idx: usize) {
-    /// Maximum history entries retained for [`NavigationState::prev`].
-    const MAX_HISTORY_SIZE: usize = 100;
-
-    if history.back() == Some(&track_idx) {
-        return;
-    }
-    if history.len() >= MAX_HISTORY_SIZE {
-        history.pop_front();
-    }
-    history.push_back(track_idx);
 }
 
 #[cfg(test)]
@@ -124,17 +131,34 @@ mod tests {
 
     use super::*;
 
+    /// History deep enough that no test below trips the cap; the cap has
+    /// its own test.
+    fn nav() -> NavigationState {
+        NavigationState::new(16)
+    }
+
     #[kithara::test]
     fn defaults() {
-        let nav = NavigationState::new();
+        let nav = nav();
         assert_eq!(nav.current_index(), None);
         assert!(!nav.is_shuffle_enabled());
         assert_eq!(nav.repeat_mode(), RepeatMode::Off);
     }
 
+    /// What the cap buys: past it history forgets its oldest entry instead
+    /// of growing for the life of the queue.
+    #[kithara::test]
+    fn a_full_history_drops_its_oldest_entry() {
+        let mut nav = NavigationState::new(2);
+        for idx in 0..4 {
+            nav.select(idx);
+        }
+        assert_eq!(nav.history, VecDeque::from(vec![1, 2]));
+    }
+
     #[kithara::test]
     fn select_updates_current_and_pushes_history() {
-        let mut nav = NavigationState::new();
+        let mut nav = nav();
         nav.select(2);
         assert_eq!(nav.current_index(), Some(2));
         assert_eq!(nav.history.len(), 0);
@@ -145,7 +169,7 @@ mod tests {
 
     #[kithara::test]
     fn select_dedupes_adjacent_history() {
-        let mut nav = NavigationState::new();
+        let mut nav = nav();
         nav.select(1);
         nav.select(1);
         nav.select(1);
@@ -154,19 +178,19 @@ mod tests {
 
     #[kithara::test]
     fn next_from_empty_queue_is_none() {
-        let mut nav = NavigationState::new();
+        let mut nav = nav();
         assert_eq!(nav.next(0), None);
     }
 
     #[kithara::test]
     fn next_from_unselected_starts_at_zero() {
-        let mut nav = NavigationState::new();
+        let mut nav = nav();
         assert_eq!(nav.next(3), Some(0));
     }
 
     #[kithara::test]
     fn next_wraps_with_repeat_all() {
-        let mut nav = NavigationState::new();
+        let mut nav = nav();
         nav.set_repeat(RepeatMode::All);
         assert_eq!(nav.next(3), Some(0));
         assert_eq!(nav.next(3), Some(1));
@@ -176,14 +200,14 @@ mod tests {
 
     #[kithara::test]
     fn next_stops_at_end_with_repeat_off() {
-        let mut nav = NavigationState::new();
+        let mut nav = nav();
         nav.select(2);
         assert_eq!(nav.next(3), None);
     }
 
     #[kithara::test]
     fn finish_clears_current() {
-        let mut nav = NavigationState::new();
+        let mut nav = nav();
         nav.select(2);
         nav.finish();
         assert_eq!(nav.current_index(), None);
@@ -191,7 +215,7 @@ mod tests {
 
     #[kithara::test]
     fn finish_preserves_last_selected_index() {
-        let mut nav = NavigationState::new();
+        let mut nav = nav();
         nav.select(2);
         nav.finish();
         assert_eq!(nav.last_selected_index(), Some(2));
@@ -199,7 +223,7 @@ mod tests {
 
     #[kithara::test]
     fn next_returns_current_with_repeat_one() {
-        let mut nav = NavigationState::new();
+        let mut nav = nav();
         nav.select(1);
         nav.set_repeat(RepeatMode::One);
         assert_eq!(nav.next(3), Some(1));
@@ -208,20 +232,20 @@ mod tests {
 
     #[kithara::test]
     fn prev_at_zero_is_none() {
-        let mut nav = NavigationState::new();
+        let mut nav = nav();
         nav.select(0);
         assert_eq!(nav.prev(), None);
     }
 
     #[kithara::test]
     fn prev_at_unselected_is_none() {
-        let mut nav = NavigationState::new();
+        let mut nav = nav();
         assert_eq!(nav.prev(), None);
     }
 
     #[kithara::test]
     fn prev_decrements() {
-        let mut nav = NavigationState::new();
+        let mut nav = nav();
         nav.select(2);
         assert_eq!(nav.prev(), Some(1));
         assert_eq!(nav.prev(), Some(0));
@@ -229,19 +253,8 @@ mod tests {
     }
 
     #[kithara::test]
-    fn history_caps_at_max() {
-        const MAX: usize = 100;
-        let mut nav = NavigationState::new();
-        nav.select(0);
-        for i in 1..=(MAX + 10) {
-            nav.select(i);
-        }
-        assert_eq!(nav.history.len(), MAX);
-    }
-
-    #[kithara::test]
     fn shuffle_toggle() {
-        let mut nav = NavigationState::new();
+        let mut nav = nav();
         assert!(!nav.is_shuffle_enabled());
         nav.set_shuffle(true);
         assert!(nav.is_shuffle_enabled());
@@ -251,7 +264,7 @@ mod tests {
 
     #[kithara::test]
     fn repeat_mode_roundtrip() {
-        let mut nav = NavigationState::new();
+        let mut nav = nav();
         nav.set_repeat(RepeatMode::All);
         assert_eq!(nav.repeat_mode(), RepeatMode::All);
         nav.set_repeat(RepeatMode::One);

--- a/crates/kithara-queue/src/queue/state.rs
+++ b/crates/kithara-queue/src/queue/state.rs
@@ -126,7 +126,8 @@ impl Queue {
             store,
             cancel: config_cancel,
             max_concurrent_loads,
-            prefetch_duration: _,
+            max_history_size,
+            prefetch_duration,
             #[cfg(any(test, feature = "probe"))]
             should_autoplay,
             #[cfg(not(any(test, feature = "probe")))]
@@ -152,6 +153,7 @@ impl Queue {
                 .build()
         });
         player.set_auto_advance_enabled(false);
+        player.set_prefetch_duration(prefetch_duration);
         let bus = player.bus().clone();
         let tracks = Arc::new(Tracks::new(bus.clone()));
         let loader = Arc::new(Loader::new(
@@ -169,7 +171,7 @@ impl Queue {
             #[cfg(any(test, feature = "probe"))]
             should_autoplay,
             shutdown: cancel,
-            navigation: Arc::new(Mutex::new(NavigationState::new())),
+            navigation: Arc::new(Mutex::new(NavigationState::new(max_history_size))),
             pending_select: Arc::new(Mutex::new(SelectPhase::Idle)),
             select_apply: Arc::new(Mutex::new(())),
             #[cfg(any(test, feature = "probe"))]
@@ -283,6 +285,16 @@ pub(super) mod tests {
     #[kithara::test]
     fn queue_new_constructs_without_panic() {
         let _queue = make_queue();
+    }
+
+    /// `PlayerImpl::set_prefetch_duration` names the queue as the canonical
+    /// owner of this knob, so what the queue's config says has to be what
+    /// the player it drives runs with.
+    #[kithara::test]
+    fn the_configured_prefetch_lead_reaches_the_player() {
+        let queue = Queue::new(QueueConfig::builder().prefetch_duration(8.0).build());
+
+        assert!((queue.player.prefetch_duration() - 8.0).abs() < f32::EPSILON);
     }
 
     #[kithara::test]


### PR DESCRIPTION
## Summary

Batch 2 of the config-ownership wave: four more crates stop hiding policy
parameters in constants and let the config each of them already has own them.
One commit per crate, same shape as #218.

`kithara-hls` was the planned second batch. It is deferred: #199 is open on
`stream/coord.rs` and `variant/io/dispatch.rs`, which is where the two hls
parameters live. This batch takes the next collision-free set instead.

| crate | parameter | owner it moved to |
|---|---|---|
| abr | `MIN_THROUGHPUT_SAMPLE_INTERVAL` (200 ms) | `AbrSettings::throughput_sample_min_interval` |
| net | `pool_idle_timeout` (5 s, duplicated across two backends) | `NetOptions::pool_idle_timeout` |
| queue | `MAX_HISTORY_SIZE` (100) | `QueueConfig::max_history_size` |
| bufpool | the 256 `MiB` default budget, written twice | one `global::DEFAULT_MAX_BYTES` |

Two defects found on the way are fixed in their own crate's commit:

- `QueueConfig::prefetch_duration` was destructured as `prefetch_duration: _`
  and thrown away, so its documented 3.5 s default was inert and no caller
  could set the lead time — while `PlayerImpl::set_prefetch_duration` names
  `kithara_queue::Queue` as the knob's canonical owner. It is now applied to
  the player the queue drives.
- `HttpClient::with_observer` and its Apple twin rebuilt `NetOptions`
  field-by-field, so any option not listed there silently reverted to its
  default the first time an observer was attached. `NetOptions::with_observer`
  now owns that derivation for both: it rebuilds through the crate's `bon`
  builder, from a destructuring pattern with no rest, so a new option is an
  `E0027` here instead of a knob that quietly resets.

## Behavior / scope

No default changes value, so nothing moves unless a caller sets it.

- `AbrSettings::throughput_sample_min_interval` throttles only the
  `AbrEvent::ThroughputSample` publish; every sample still reaches the
  estimator first.
- `NetOptions::pool_idle_timeout` reaches the reqwest and wreq client
  builders. The Apple backend has no Foundation equivalent and ignores it,
  which the field documents.
- `NavigationState::new` now takes the history limit; `Default` comes off the
  struct, because a zero limit would silently drop every entry.
- `Queue::new` applies `prefetch_duration` to a caller-supplied player exactly
  as it already applies `set_auto_advance_enabled(false)`.

## Validation

- `just test` — 4010 tests run: 4010 passed, 26 skipped.
- `just lint fast` — 0 regression(s), 0 new across 36 checks, and the
  same across the two idiom checks.
- `cargo check -p kithara-net --no-default-features --features client-apple`
  and `--features client-wreq` for the two non-default backends.

## Surface impact

- `AbrSettings`, `NetOptions`, `QueueConfig` each gain one public field. All
  three are `#[non_exhaustive]` bon builders, so the new setters are additive.
- `NavigationState::new(history_limit: usize)` is a breaking signature change
  and `NavigationState: Default` is gone. The only production construction
  site is `Queue::new`.
- No new dependency, no lint suppression, no baseline entry.

## Risks / follow-ups

- `kithara-hls` still owns two hardcoded parameters — the 25 ms reader re-aim
  interval in `HlsCoord` and the 256-deep `DeferredBus` ring in
  `Hls::create`. They land once #199 is merged.
- `kithara-play`'s `set_prefetch_duration` doc points at a
  `Queue::set_prefetch_duration` that does not exist. Left alone: #187 holds
  that file.
- `production/main` does not build with `--all-targets`:
  `tests/benches/perf_audit.rs:135` still calls the two-argument
  `WaveformAnalyzer::new` that #198 changed. Benches are outside the gate, so
  CI is unaffected. Not this PR's to fix.
