### PR TITLE
refactor: let each crate's config own its policy parameters (batch 3/6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4388,6 +4388,7 @@ dependencies = [
 name = "kithara-beat"
 version = "0.0.1-alpha4"
 dependencies = [
+ "bon",
  "kithara-test-utils",
  "kithara-workspace-hack",
  "num-traits",

--- a/crates/kithara-app/src/broadcast/live.rs
+++ b/crates/kithara-app/src/broadcast/live.rs
@@ -5,6 +5,7 @@ use kithara::{
 use kithara_platform::{
     CancelToken,
     sync::{Arc, atomic::AtomicU64},
+    time::Duration,
 };
 use ringbuf::{HeapRb, traits::Split};
 
@@ -27,11 +28,15 @@ impl Packager for Backend {
         live.handle.status().is_live
     }
 
-    fn start(session: &SessionHandle, shutdown: &CancelToken) -> BroadcastResult<Option<Stream>> {
+    fn start(
+        session: &SessionHandle,
+        shutdown: &CancelToken,
+        tap_lead: Duration,
+    ) -> BroadcastResult<Option<Stream>> {
         let Some(config) = measured_config(session)? else {
             return Ok(None);
         };
-        start(session, shutdown, &config).map(Some)
+        start(session, shutdown, &config, tap_lead).map(Some)
     }
 
     fn stop(live: Stream) {
@@ -46,13 +51,13 @@ impl Packager for Backend {
 struct Ring;
 
 impl Ring {
-    const SECONDS: usize = 2;
+    const MILLIS_PER_SECOND: usize = 1_000;
 
     /// Interleaved samples the mix tap may run ahead of the packager by.
-    fn capacity(sample_rate: usize, channels: usize) -> Option<usize> {
-        sample_rate
-            .checked_mul(channels)
-            .and_then(|capacity| capacity.checked_mul(Self::SECONDS))
+    fn capacity(sample_rate: usize, channels: usize, lead: Duration) -> Option<usize> {
+        let millis = usize::try_from(lead.as_millis()).ok()?;
+        let frames = sample_rate.checked_mul(millis)? / Self::MILLIS_PER_SECOND;
+        frames.checked_mul(channels)
     }
 }
 
@@ -68,8 +73,9 @@ fn start(
     session: &SessionHandle,
     shutdown: &CancelToken,
     config: &BroadcastConfig,
+    tap_lead: Duration,
 ) -> BroadcastResult<Stream> {
-    let capacity = ring_capacity(config)?;
+    let capacity = ring_capacity(config, tap_lead)?;
     let (producer, consumer) = HeapRb::<f32>::new(capacity).split();
     let drops = Arc::new(AtomicU64::new(0));
 
@@ -99,7 +105,7 @@ fn measured_config(session: &SessionHandle) -> BroadcastResult<Option<BroadcastC
         .map(|sample_rate| BroadcastConfig::builder().sample_rate(sample_rate).build()))
 }
 
-fn ring_capacity(config: &BroadcastConfig) -> BroadcastResult<usize> {
+fn ring_capacity(config: &BroadcastConfig, tap_lead: Duration) -> BroadcastResult<usize> {
     let sample_rate = usize::try_from(config.sample_rate)?;
     if sample_rate == 0 {
         return Err("session returned zero sample rate".into());
@@ -110,7 +116,14 @@ fn ring_capacity(config: &BroadcastConfig) -> BroadcastResult<usize> {
         return Err("broadcast configured with no channels".into());
     }
 
-    Ring::capacity(sample_rate, channels).ok_or_else(|| "broadcast ring capacity overflow".into())
+    match Ring::capacity(sample_rate, channels, tap_lead) {
+        None => Err("broadcast ring capacity overflow".into()),
+        Some(0) => Err(format!(
+            "broadcast tap lead {tap_lead:?} holds no samples at {sample_rate} Hz"
+        )
+        .into()),
+        Some(capacity) => Ok(capacity),
+    }
 }
 
 #[cfg(test)]
@@ -125,10 +138,12 @@ mod tests {
             atomic::{AtomicU32, Ordering},
         },
         thread,
-        time::Duration,
     };
 
     use super::*;
+
+    /// The lead every test that does not measure the ring starts on air with.
+    const TAP_LEAD: Duration = Duration::from_secs(2);
 
     struct SampleRateSession {
         sample_rate: AtomicU32,
@@ -178,7 +193,7 @@ mod tests {
         let dispatcher = Arc::new(SampleRateSession::new(sample_rate));
         let session = SessionHandle::new(dispatcher.clone());
         let shutdown = CancelToken::root();
-        let stream = Backend::start(&session, &shutdown)
+        let stream = Backend::start(&session, &shutdown, TAP_LEAD)
             .expect("the packager starts")
             .expect("a measured rate yields a stream");
         (stream, dispatcher, shutdown)
@@ -191,7 +206,7 @@ mod tests {
 
         assert!(measured_config(&session).unwrap().is_none());
         assert!(
-            Backend::start(&session, &CancelToken::root())
+            Backend::start(&session, &CancelToken::root(), TAP_LEAD)
                 .unwrap()
                 .is_none(),
             "an unmeasured rate is a retry, not a failure"
@@ -240,7 +255,9 @@ mod tests {
 
     #[kithara::test]
     fn missing_session_sample_rate_is_rejected_before_ring_creation() {
-        assert!(ring_capacity(&BroadcastConfig::builder().sample_rate(0).build()).is_err());
+        assert!(
+            ring_capacity(&BroadcastConfig::builder().sample_rate(0).build(), TAP_LEAD).is_err()
+        );
     }
 
     /// The ring carries interleaved samples, so its size has to follow the
@@ -248,11 +265,33 @@ mod tests {
     /// stereo pair starves a wider mix of half its lead.
     #[kithara::test]
     fn the_ring_is_sized_for_the_configured_channel_count() {
-        let stereo =
-            ring_capacity(&BroadcastConfig::builder().channels(2).build()).expect("a stereo ring");
-        let quad =
-            ring_capacity(&BroadcastConfig::builder().channels(4).build()).expect("a quad ring");
+        let stereo = ring_capacity(&BroadcastConfig::builder().channels(2).build(), TAP_LEAD)
+            .expect("a stereo ring");
+        let quad = ring_capacity(&BroadcastConfig::builder().channels(4).build(), TAP_LEAD)
+            .expect("a quad ring");
 
         assert_eq!(quad, stereo * 2);
+    }
+
+    /// The lead is what the ring buys: how long the packager may stall before
+    /// the mix tap starts dropping samples. Asking for twice the lead has to
+    /// yield twice the ring, or the knob does not mean what it says.
+    #[kithara::test]
+    fn a_longer_tap_lead_buys_a_proportionally_deeper_ring() {
+        let config = BroadcastConfig::builder().build();
+
+        let short = ring_capacity(&config, TAP_LEAD).expect("a ring for the default lead");
+        let long = ring_capacity(&config, TAP_LEAD * 2).expect("a ring for twice the lead");
+
+        assert_eq!(long, short * 2);
+    }
+
+    /// A lead below one sample rounds down to an empty ring, which would take
+    /// the mix tap's every write. That is a configuration error, not a ring.
+    #[kithara::test]
+    fn a_tap_lead_too_short_to_hold_a_sample_is_rejected() {
+        let config = BroadcastConfig::builder().build();
+
+        assert!(ring_capacity(&config, Duration::ZERO).is_err());
     }
 }

--- a/crates/kithara-app/src/broadcast/live.rs
+++ b/crates/kithara-app/src/broadcast/live.rs
@@ -46,13 +46,12 @@ impl Packager for Backend {
 struct Ring;
 
 impl Ring {
-    const CHANNELS: usize = 2;
     const SECONDS: usize = 2;
 
     /// Interleaved samples the mix tap may run ahead of the packager by.
-    fn capacity(sample_rate: usize) -> Option<usize> {
+    fn capacity(sample_rate: usize, channels: usize) -> Option<usize> {
         sample_rate
-            .checked_mul(Self::CHANNELS)
+            .checked_mul(channels)
             .and_then(|capacity| capacity.checked_mul(Self::SECONDS))
     }
 }
@@ -70,8 +69,7 @@ fn start(
     shutdown: &CancelToken,
     config: &BroadcastConfig,
 ) -> BroadcastResult<Stream> {
-    let sample_rate = config.sample_rate;
-    let capacity = ring_capacity(sample_rate)?;
+    let capacity = ring_capacity(config)?;
     let (producer, consumer) = HeapRb::<f32>::new(capacity).split();
     let drops = Arc::new(AtomicU64::new(0));
 
@@ -101,13 +99,18 @@ fn measured_config(session: &SessionHandle) -> BroadcastResult<Option<BroadcastC
         .map(|sample_rate| BroadcastConfig::builder().sample_rate(sample_rate).build()))
 }
 
-fn ring_capacity(sample_rate: u32) -> BroadcastResult<usize> {
-    let sample_rate = usize::try_from(sample_rate)?;
+fn ring_capacity(config: &BroadcastConfig) -> BroadcastResult<usize> {
+    let sample_rate = usize::try_from(config.sample_rate)?;
     if sample_rate == 0 {
         return Err("session returned zero sample rate".into());
     }
 
-    Ring::capacity(sample_rate).ok_or_else(|| "broadcast ring capacity overflow".into())
+    let channels = usize::from(config.channels);
+    if channels == 0 {
+        return Err("broadcast configured with no channels".into());
+    }
+
+    Ring::capacity(sample_rate, channels).ok_or_else(|| "broadcast ring capacity overflow".into())
 }
 
 #[cfg(test)]
@@ -237,6 +240,19 @@ mod tests {
 
     #[kithara::test]
     fn missing_session_sample_rate_is_rejected_before_ring_creation() {
-        assert!(ring_capacity(0).is_err());
+        assert!(ring_capacity(&BroadcastConfig::builder().sample_rate(0).build()).is_err());
+    }
+
+    /// The ring carries interleaved samples, so its size has to follow the
+    /// channel count the broadcast is configured for. Sizing it for a fixed
+    /// stereo pair starves a wider mix of half its lead.
+    #[kithara::test]
+    fn the_ring_is_sized_for_the_configured_channel_count() {
+        let stereo =
+            ring_capacity(&BroadcastConfig::builder().channels(2).build()).expect("a stereo ring");
+        let quad =
+            ring_capacity(&BroadcastConfig::builder().channels(4).build()).expect("a quad ring");
+
+        assert_eq!(quad, stereo * 2);
     }
 }

--- a/crates/kithara-app/src/broadcast/off.rs
+++ b/crates/kithara-app/src/broadcast/off.rs
@@ -1,5 +1,5 @@
 use kithara::play::SessionHandle;
-use kithara_platform::CancelToken;
+use kithara_platform::{CancelToken, time::Duration};
 
 use super::state::{BroadcastResult, Packager};
 
@@ -18,7 +18,11 @@ impl Packager for Backend {
         match *live {}
     }
 
-    fn start(_session: &SessionHandle, _shutdown: &CancelToken) -> BroadcastResult<Option<Stream>> {
+    fn start(
+        _session: &SessionHandle,
+        _shutdown: &CancelToken,
+        _tap_lead: Duration,
+    ) -> BroadcastResult<Option<Stream>> {
         Err("this build carries no broadcaster; rebuild with `--features broadcast`".into())
     }
 

--- a/crates/kithara-app/src/broadcast/state.rs
+++ b/crates/kithara-app/src/broadcast/state.rs
@@ -24,6 +24,7 @@ pub(crate) trait Packager: 'static {
     fn start(
         session: &SessionHandle,
         shutdown: &CancelToken,
+        tap_lead: Duration,
     ) -> BroadcastResult<Option<Self::Live>>;
 
     /// Drains the stream and shuts it down. Blocking.
@@ -36,6 +37,7 @@ pub(crate) struct Broadcaster<P: Packager> {
     shutdown: CancelToken,
     phase: Phase<P>,
     session: SessionHandle,
+    tap_lead: Duration,
 }
 
 enum Phase<P: Packager> {
@@ -49,11 +51,16 @@ enum Phase<P: Packager> {
 pub(crate) struct BroadcastStop<P: Packager>(P::Live);
 
 impl<P: Packager> Broadcaster<P> {
-    pub(crate) const fn new(session: SessionHandle, shutdown: CancelToken) -> Self {
+    pub(crate) const fn new(
+        session: SessionHandle,
+        shutdown: CancelToken,
+        tap_lead: Duration,
+    ) -> Self {
         Self {
             session,
             shutdown,
             phase: Phase::Off,
+            tap_lead,
         }
     }
 
@@ -80,7 +87,7 @@ impl<P: Packager> Broadcaster<P> {
         if !matches!(self.phase, Phase::Requested) {
             return;
         }
-        match P::start(&self.session, &self.shutdown) {
+        match P::start(&self.session, &self.shutdown, self.tap_lead) {
             Ok(Some(live)) => {
                 tracing::info!(url = P::url(&live), "broadcast is live");
                 self.phase = Phase::Running { live };
@@ -158,8 +165,14 @@ mod tests {
         }
     }
 
+    /// The phase machine only carries the lead to its packager, so the
+    /// value is arbitrary here; the sizing it drives is pinned in `live.rs`.
     fn broadcaster<P: Packager>() -> Broadcaster<P> {
-        Broadcaster::new(SessionHandle::new(Arc::new(NoSession)), CancelToken::root())
+        Broadcaster::new(
+            SessionHandle::new(Arc::new(NoSession)),
+            CancelToken::root(),
+            Duration::from_secs(2),
+        )
     }
 
     struct Stream(String);
@@ -189,6 +202,7 @@ mod tests {
         fn start(
             _session: &SessionHandle,
             _shutdown: &CancelToken,
+            _tap_lead: Duration,
         ) -> BroadcastResult<Option<Stream>> {
             LIVE.store(true, Ordering::Relaxed);
             Ok(Some(Self::stream()))
@@ -215,6 +229,7 @@ mod tests {
         fn start(
             _session: &SessionHandle,
             _shutdown: &CancelToken,
+            _tap_lead: Duration,
         ) -> BroadcastResult<Option<Stream>> {
             Ok(None)
         }
@@ -240,6 +255,7 @@ mod tests {
         fn start(
             _session: &SessionHandle,
             _shutdown: &CancelToken,
+            _tap_lead: Duration,
         ) -> BroadcastResult<Option<Stream>> {
             Err("no packager in this build".into())
         }

--- a/crates/kithara-app/src/config.rs
+++ b/crates/kithara-app/src/config.rs
@@ -11,7 +11,7 @@ use kithara::{
     stream::dl::Downloader,
 };
 use kithara_drm::KeyProcessorRegistry;
-use kithara_platform::{CancelToken, sync::Arc};
+use kithara_platform::{CancelToken, sync::Arc, time::Duration};
 use url::Url;
 
 use crate::{baked, theme::Palette};
@@ -97,6 +97,12 @@ pub struct AppConfig {
     /// Crossfade duration in seconds.
     #[builder(default = baked::BAKED_CROSSFADE_SECONDS)]
     pub crossfade_seconds: f32,
+    /// Media duration the broadcast mix tap may run ahead of the packager by.
+    /// The app allocates that ring, so it owns its depth: a longer lead rides
+    /// out a longer packager stall and pays for it in the memory those
+    /// interleaved samples occupy.
+    #[builder(default = Duration::from_secs(2))]
+    pub broadcast_tap_lead: Duration,
 }
 
 fn default_tracks() -> Vec<String> {
@@ -120,6 +126,7 @@ impl fmt::Debug for AppConfig {
                 &self.should_accept_invalid_certs,
             )
             .field("crossfade_seconds", &self.crossfade_seconds)
+            .field("broadcast_tap_lead", &self.broadcast_tap_lead)
             .field("beat_analysis", &self.beat_analysis)
             .field("size_probe_method", &self.size_probe_method)
             .finish_non_exhaustive()

--- a/crates/kithara-app/src/gui/frontend.rs
+++ b/crates/kithara-app/src/gui/frontend.rs
@@ -71,7 +71,11 @@ impl GuiFrontend {
         session: kithara::play::SessionHandle,
         shutdown: kithara_platform::CancelToken,
     ) {
-        self.broadcast = Some(crate::broadcast::Broadcaster::new(session, shutdown));
+        self.broadcast = Some(crate::broadcast::Broadcaster::new(
+            session,
+            shutdown,
+            self.config.broadcast_tap_lead,
+        ));
     }
 
     /// Runs the GUI event loop until the application exits.

--- a/crates/kithara-audio/src/analysis/beat/backend.rs
+++ b/crates/kithara-audio/src/analysis/beat/backend.rs
@@ -46,11 +46,13 @@ struct NnDetector {
 
 impl NnDetector {
     fn new() -> Result<Self, BeatDetectError> {
-        let inner = BeatThis::try_from((MEL_MODEL_BYTES, BEAT_MODEL_BYTES)).map_err(|e| {
-            BeatDetectError::Init {
+        let inner = BeatThis::builder()
+            .mel_model(MEL_MODEL_BYTES)
+            .beat_model(BEAT_MODEL_BYTES)
+            .build()
+            .map_err(|e| BeatDetectError::Init {
                 reason: e.to_string(),
-            }
-        })?;
+            })?;
         Ok(Self { inner })
     }
 }

--- a/crates/kithara-beat/CONTEXT.md
+++ b/crates/kithara-beat/CONTEXT.md
@@ -9,8 +9,9 @@ Detailed contracts and invariants for the kithara-beat crate; the README is the 
 - Output: `RawBeats { beats, downbeats }` — positions in **seconds**, sorted, deduplicated,
   every downbeat snapped to the nearest beat. Grid cleanup and source-frame conversion belong to
   the consumer (`kithara-audio`).
-- Models load from `(mel, beat)` ONNX bytes via `BeatThis::try_from` — the caller decides embed
-  vs file vs download; `embed-small-model` exposes the bundled bytes.
+- Models load from `(mel, beat)` ONNX bytes via `BeatThis::builder()` — the caller decides embed
+  vs file vs download; `embed-small-model` exposes the bundled bytes. The same builder takes the
+  `BeatConfig` the peak picker runs with.
 
 ## Pipeline
 
@@ -22,13 +23,20 @@ Detailed contracts and invariants for the kithara-beat crate; the README is the 
   the spectrogram end. Chunks run in reverse order so earlier chunks overwrite later ones in
   overlaps — that is the `keep_first` rule. Outputs are read as `beat` / `downbeat` with
   `beat_logits` / `downbeat_logits` as export-name fallbacks.
-1. `postprocess.rs` — minimal peak picking, no DBN: a frame is a peak when its logit > 0
-  (probability > 0.5 after sigmoid) and it is the max of a 7-frame window (±3 = ±60 ms); peaks at
-  most 1 frame apart merge to their running mean; each downbeat then snaps to the nearest beat.
+1. `postprocess.rs` — minimal peak picking, no DBN, driven by `BeatConfig`: a frame is a peak
+  when its logit clears `peak_threshold` and it is the max of the `2 * peak_half_width + 1` frames
+  around it; peaks at most `dedup_width` frames apart merge to their running mean; each downbeat
+  then snaps to the nearest beat.
 
-The pipeline constants (chunk 1500, border 6, stride 1488, hop 441, 50 fps, threshold 0, ±3
-window) are **frozen**: they define numerical parity with the Python reference and must be folded
-into any analysis cache key by consumers. Changing one invalidates the golden fixtures.
+Two groups of numbers, with different owners:
+
+- **Chunk geometry** (chunk 1500, border 6, stride 1488, hop 441, 50 fps) stays constant. It is
+  the segmentation the model was trained on, not a knob — a different chunking runs the model
+  outside its training regime.
+- **Picking policy** (`BeatConfig`: threshold 0, half-width 3 = ±60 ms, dedup width 1) is the
+  caller's. Its **defaults** are the frozen parity values: they define numerical parity with the
+  Python reference, the golden fixtures are held to them, and a consumer that moves them must
+  fold the new values into its analysis cache key. The crate does not do that for it.
 
 ## Validation
 

--- a/crates/kithara-beat/Cargo.toml
+++ b/crates/kithara-beat/Cargo.toml
@@ -19,6 +19,8 @@ embed-small-model = []
 
 [dependencies]
 kithara-workspace-hack = { version = "0.0.1-alpha4", path = "../kithara-workspace-hack" }
+
+bon = { workspace = true }
 num-traits = { workspace = true }
 rten = { workspace = true }
 rten-tensor = { workspace = true }

--- a/crates/kithara-beat/README.md
+++ b/crates/kithara-beat/README.md
@@ -28,9 +28,12 @@ grid cleanup.
 
 ## Key types
 
-- `BeatThis::try_from((mel_bytes, beat_bytes))` — load models from bytes
-  (caller chooses embed vs file vs download).
+- `BeatThis::builder()` — load models from bytes (caller chooses embed vs file
+  vs download) and pick the decoding policy.
 - `BeatThis::analyze(&mono_22050)` — run the mel → inference → peak-pick pipeline.
+- `BeatConfig` — peak threshold, max-pool half-width, dedup width. The defaults
+  are the values the golden fixtures are held to; see CONTEXT.md before moving
+  them.
 - `RawBeats { beats, downbeats }` — output positions in seconds, sorted and
   deduplicated.
 
@@ -39,7 +42,10 @@ grid cleanup.
 ```rust
 use kithara_beat::{BeatThis, RawBeats};
 
-let mut bt = BeatThis::try_from((mel_bytes, beat_bytes))?;
+let mut bt = BeatThis::builder()
+    .mel_model(mel_bytes)
+    .beat_model(beat_bytes)
+    .build()?;
 let raw: RawBeats = bt.analyze(&mono_22050)?;
 ```
 

--- a/crates/kithara-beat/src/api.rs
+++ b/crates/kithara-beat/src/api.rs
@@ -1,6 +1,9 @@
+use bon::bon;
 use thiserror::Error;
 
-use crate::{inference::BeatPredictor, mel::MelExtractor, postprocess::PeakPicker};
+use crate::{
+    config::BeatConfig, inference::BeatPredictor, mel::MelExtractor, postprocess::PeakPicker,
+};
 
 #[derive(Debug, Error)]
 #[non_exhaustive]
@@ -26,23 +29,25 @@ pub struct BeatThis {
     picker: PeakPicker,
 }
 
-/// Models from `(mel, beat)` ONNX bytes.
-///
-/// # Errors
-/// [`BeatError::ModelLoad`] when either model fails to parse.
-impl TryFrom<(&[u8], &[u8])> for BeatThis {
-    type Error = BeatError;
-
-    fn try_from((mel, beat): (&[u8], &[u8])) -> Result<Self, BeatError> {
+#[bon]
+impl BeatThis {
+    /// Models from mel and beat ONNX bytes, decoded with `config`.
+    ///
+    /// # Errors
+    /// [`BeatError::ModelLoad`] when either model fails to parse.
+    #[builder]
+    pub fn new(
+        mel_model: &[u8],
+        beat_model: &[u8],
+        #[builder(default)] config: BeatConfig,
+    ) -> Result<Self, BeatError> {
         Ok(Self {
-            mel: MelExtractor::try_from(mel)?,
-            predictor: BeatPredictor::try_from(beat)?,
-            picker: PeakPicker::default(),
+            mel: MelExtractor::try_from(mel_model)?,
+            predictor: BeatPredictor::try_from(beat_model)?,
+            picker: PeakPicker::new(config),
         })
     }
-}
 
-impl BeatThis {
     /// Input: whole-track mono f32 at `22_050` Hz. Output: seconds.
     ///
     /// # Errors

--- a/crates/kithara-beat/src/config.rs
+++ b/crates/kithara-beat/src/config.rs
@@ -1,0 +1,31 @@
+use bon::Builder;
+
+/// Policy for turning the beat model's raw logits into events.
+///
+/// The chunk geometry the model is run with is not here: it follows the
+/// segmentation `beat_this` was trained on and is not a knob.
+#[derive(Clone, Copy, Debug, Builder)]
+#[non_exhaustive]
+pub struct BeatConfig {
+    /// Logit a frame must exceed to be a peak candidate. `0.0` is probability
+    /// `0.5` after the sigmoid; lowering it admits quieter beats and the false
+    /// positives that come with them.
+    #[builder(default = 0.0)]
+    pub peak_threshold: f32,
+    /// Half-width, in model frames, of the max-pool window a frame must win to
+    /// be a peak. The window spans `2 * peak_half_width + 1` frames, so this
+    /// sets the shortest gap two beats may be reported at: at 50 fps the
+    /// default of 3 keeps beats at least ~120 ms apart, which is 500 BPM.
+    #[builder(default = 3)]
+    pub peak_half_width: usize,
+    /// Frames within which consecutive peaks collapse to their mean position.
+    /// Absorbs the plateaus the model produces on a strong beat.
+    #[builder(default = 1)]
+    pub dedup_width: usize,
+}
+
+impl Default for BeatConfig {
+    fn default() -> Self {
+        Self::builder().build()
+    }
+}

--- a/crates/kithara-beat/src/lib.rs
+++ b/crates/kithara-beat/src/lib.rs
@@ -1,4 +1,5 @@
 mod api;
+mod config;
 mod inference;
 mod mel;
 #[cfg(feature = "embed-small-model")]
@@ -7,5 +8,6 @@ mod postprocess;
 mod runtime;
 
 pub use api::{BeatError, BeatThis, RawBeats};
+pub use config::BeatConfig;
 #[cfg(feature = "embed-small-model")]
 pub use models::{BEAT_MODEL_BYTES, MEL_MODEL_BYTES};

--- a/crates/kithara-beat/src/postprocess.rs
+++ b/crates/kithara-beat/src/postprocess.rs
@@ -1,6 +1,6 @@
 use num_traits::cast::AsPrimitive;
 
-use crate::api::BeatError;
+use crate::{api::BeatError, config::BeatConfig};
 
 /// Frames per second of the beat model output.
 const FPS: f32 = 50.0;
@@ -8,16 +8,14 @@ const FPS: f32 = 50.0;
 /// Decodes raw beat/downbeat logits into timestamped events: max-pool peak
 /// picking, thresholding, deduplication, downbeat-to-beat snapping.
 pub(crate) struct PeakPicker {
-    fps: f32,
-}
-
-impl Default for PeakPicker {
-    fn default() -> Self {
-        Self { fps: FPS }
-    }
+    config: BeatConfig,
 }
 
 impl PeakPicker {
+    pub(crate) fn new(config: BeatConfig) -> Self {
+        Self { config }
+    }
+
     /// Decode beat and downbeat logits into `(beats, downbeats)` in seconds.
     ///
     /// Both slices must have the same length (one value per mel frame).
@@ -36,16 +34,16 @@ impl PeakPicker {
             });
         }
 
-        let beat_frames = find_peaks(beat_logits);
-        let downbeat_frames = find_peaks(downbeat_logits);
+        let beat_frames = find_peaks(beat_logits, &self.config);
+        let downbeat_frames = find_peaks(downbeat_logits, &self.config);
 
         let beats: Vec<f32> = beat_frames
             .iter()
-            .map(|&f| (f / f64::from(self.fps)).as_())
+            .map(|&f| (f / f64::from(FPS)).as_())
             .collect();
         let mut downbeats: Vec<f32> = downbeat_frames
             .iter()
-            .map(|&f| (f / f64::from(self.fps)).as_())
+            .map(|&f| (f / f64::from(FPS)).as_())
             .collect();
 
         snap_downbeats_to_beats(&beats, &mut downbeats);
@@ -54,22 +52,22 @@ impl PeakPicker {
     }
 }
 
-/// Identify local maxima exceeding the logit threshold (> 0.0).
+/// Identify local maxima exceeding [`BeatConfig::peak_threshold`].
 ///
-/// Max-pool window of 7 frames (±3), stride 1: a frame is a peak if it equals
-/// the local maximum and is positive.
-fn find_peaks(logits: &[f32]) -> Vec<f64> {
+/// Max-pool window of `2 * peak_half_width + 1` frames, stride 1: a frame is a
+/// peak if it equals the local maximum and clears the threshold.
+fn find_peaks(logits: &[f32], config: &BeatConfig) -> Vec<f64> {
     let len = logits.len();
     let mut peaks = Vec::new();
 
     for i in 0..len {
-        // logit > 0 corresponds to probability > 0.5 after sigmoid.
-        if logits[i] <= 0.0 {
+        // The default threshold of 0 is probability 0.5 after the sigmoid.
+        if logits[i] <= config.peak_threshold {
             continue;
         }
 
-        let start = i.saturating_sub(3);
-        let end = (i + 4).min(len);
+        let start = i.saturating_sub(config.peak_half_width);
+        let end = (i + config.peak_half_width + 1).min(len);
 
         let mut is_max = true;
         for j in start..end {
@@ -84,7 +82,7 @@ fn find_peaks(logits: &[f32]) -> Vec<f64> {
         }
     }
 
-    deduplicate_peaks(&peaks, 1)
+    deduplicate_peaks(&peaks, config.dedup_width)
 }
 
 /// Merge adjacent peak frame indices using a running mean.
@@ -150,17 +148,53 @@ mod tests {
 
     use super::*;
 
+    /// The threshold decides which model outputs become beats at all. Raising
+    /// it past a peak's logit drops that beat; the picker must not carry a
+    /// fixed sensitivity the caller cannot move.
+    #[kithara::test(native, flash(false))]
+    fn a_raised_threshold_drops_a_weak_peak() {
+        let logits = [0.0, 0.0, 0.5, 1.0, 0.5, 0.0, 0.0];
+        let strict = BeatConfig::builder().peak_threshold(1.5).build();
+
+        assert_eq!(find_peaks(&logits, &BeatConfig::default()), vec![3.0]);
+        assert!(find_peaks(&logits, &strict).is_empty());
+    }
+
+    /// The max-pool half-width is the shortest gap two beats may be reported
+    /// at. Widening it must suppress a smaller neighbour the default keeps.
+    #[kithara::test(native, flash(false))]
+    fn a_wider_window_suppresses_a_neighbour_the_default_keeps() {
+        // 4 frames apart: each wins its own +-3 window, neither wins a +-4 one.
+        let mut logits = vec![0.0; 10];
+        logits[2] = 2.0;
+        logits[6] = 1.0;
+        let wide = BeatConfig::builder().peak_half_width(4).build();
+
+        assert_eq!(find_peaks(&logits, &BeatConfig::default()), vec![2.0, 6.0]);
+        assert_eq!(find_peaks(&logits, &wide), vec![2.0]);
+    }
+
+    /// Dedup width is how far apart two surviving peaks still count as one
+    /// beat. A wider one must merge peaks the default reports separately.
+    #[kithara::test(native, flash(false))]
+    fn a_wider_dedup_merges_peaks_the_default_reports_apart() {
+        let peaks = [10, 14];
+
+        assert_eq!(deduplicate_peaks(&peaks, 1), vec![10.0, 14.0]);
+        assert_eq!(deduplicate_peaks(&peaks, 4), vec![12.0]);
+    }
+
     #[kithara::test(native, flash(false))]
     fn find_peaks_single_peak() {
         let logits = [0.0, 0.0, 0.5, 1.0, 0.5, 0.0, 0.0];
-        let peaks = find_peaks(&logits);
+        let peaks = find_peaks(&logits, &BeatConfig::default());
         assert_eq!(peaks, vec![3.0]);
     }
 
     #[kithara::test(native, flash(false))]
     fn find_peaks_below_threshold() {
         let logits = [-1.0, -0.5, -2.0, -0.1];
-        let peaks = find_peaks(&logits);
+        let peaks = find_peaks(&logits, &BeatConfig::default());
         assert!(peaks.is_empty());
     }
 
@@ -170,7 +204,7 @@ mod tests {
         let mut logits = vec![0.0; 20];
         logits[3] = 2.0;
         logits[15] = 1.5;
-        let peaks = find_peaks(&logits);
+        let peaks = find_peaks(&logits, &BeatConfig::default());
         assert_eq!(peaks, vec![3.0, 15.0]);
     }
 
@@ -180,7 +214,7 @@ mod tests {
         let mut logits = vec![0.0; 10];
         logits[4] = 2.0;
         logits[7] = 1.0;
-        let peaks = find_peaks(&logits);
+        let peaks = find_peaks(&logits, &BeatConfig::default());
         assert_eq!(peaks, vec![4.0]);
     }
 
@@ -190,7 +224,7 @@ mod tests {
         let mut logits = vec![0.0; 10];
         logits[2] = 2.0;
         logits[6] = 1.0;
-        let peaks = find_peaks(&logits);
+        let peaks = find_peaks(&logits, &BeatConfig::default());
         assert_eq!(peaks, vec![2.0, 6.0]);
     }
 
@@ -199,7 +233,7 @@ mod tests {
         // Adjacent frames with equal positive values: both tie the max-pool,
         // dedup merges them to the plateau centre.
         let logits = [0.0, 1.0, 1.0, 0.0];
-        let peaks = find_peaks(&logits);
+        let peaks = find_peaks(&logits, &BeatConfig::default());
         assert_eq!(peaks.len(), 1);
         assert_eq!(peaks[0], 1.5);
     }
@@ -279,7 +313,7 @@ mod tests {
         // Downbeat at frame 51 snaps to the beat at frame 50.
         downbeat_logits[51] = 2.0;
 
-        let pp = PeakPicker::default();
+        let pp = PeakPicker::new(BeatConfig::default());
         let (beats, downbeats) = pp.decode(&beat_logits, &downbeat_logits).unwrap();
 
         assert_eq!(beats, vec![1.0, 2.0, 3.0]);
@@ -288,7 +322,7 @@ mod tests {
 
     #[kithara::test(native, flash(false))]
     fn decode_empty_logits() {
-        let pp = PeakPicker::default();
+        let pp = PeakPicker::new(BeatConfig::default());
         let (beats, downbeats) = pp.decode(&[], &[]).unwrap();
         assert!(beats.is_empty());
         assert!(downbeats.is_empty());
@@ -296,7 +330,7 @@ mod tests {
 
     #[kithara::test(native, flash(false))]
     fn decode_mismatched_lengths() {
-        let pp = PeakPicker::default();
+        let pp = PeakPicker::new(BeatConfig::default());
         let err = pp.decode(&[1.0, 2.0], &[1.0]);
         assert!(err.is_err());
     }

--- a/crates/kithara-beat/tests/parity.rs
+++ b/crates/kithara-beat/tests/parity.rs
@@ -51,8 +51,11 @@ fn report(kind: &str, s: &Score) {
 #[kithara::test(native, flash(false))]
 fn python_parity_small_model() {
     let pcm = load_pcm_fixture();
-    let mut bt = BeatThis::try_from((MEL_MODEL_BYTES, BEAT_MODEL_BYTES))
-        .unwrap_or_else(|e| panic!("BeatThis::try_from failed: {e}"));
+    let mut bt = BeatThis::builder()
+        .mel_model(MEL_MODEL_BYTES)
+        .beat_model(BEAT_MODEL_BYTES)
+        .build()
+        .unwrap_or_else(|e| panic!("BeatThis::builder failed: {e}"));
     let raw = bt
         .analyze(&pcm)
         .unwrap_or_else(|e| panic!("analyze failed: {e}"));

--- a/crates/kithara-broadcast/CONTEXT.md
+++ b/crates/kithara-broadcast/CONTEXT.md
@@ -60,7 +60,7 @@ The serving thread is a plain OS thread. `kithara-platform`'s spawns enrol a thr
 
 The worker is the sole mutator of the segmenter and the window. It publishes each closed segment by swapping a whole `PlaylistSnapshot` into an `ArcSwap`, so no request ever waits on the worker. The handle's join slot is the crate's only mutex and the serving path never touches it; the counters the handle reports are the worker's alone, and the origin does not read them.
 
-Nothing in the pipeline reads a wall clock: rotation is media-driven and the playlist changes only when a segment closes. The worker's poll backoff paces an empty feed and is not part of the contract.
+Nothing in the pipeline reads a wall clock: rotation is media-driven and the playlist changes only when a segment closes. The worker's poll backoff paces an empty feed and is not part of the contract; `BroadcastConfig::poll_interval` sets it, and no output depends on the value.
 
 That backoff decides which tests can run on the simulated clock. On the sim path it waits for a clock advance, and the engine advances only once every participant is parked on a wait it wrapped. A test body holds its participant slot through synchronous work — a render loop, a poll loop over `status()`, a `stop()` that blocks on the worker's thread join — because the lexical rewriter reaches a body's `time::sleep` and `park_timeout` and leaves the rest as they are. Whether that matters turns on one thing: the backoff falls through to a plain yield while no timed waiter exists, so a test of the origin alone runs on the simulated clock, and one that also runs a session engine or an HLS client — either of which registers a timed waiter — has to run on the real clock and says so at the test.
 

--- a/crates/kithara-broadcast/src/config.rs
+++ b/crates/kithara-broadcast/src/config.rs
@@ -9,44 +9,35 @@ use crate::{BroadcastError, BroadcastResult};
 #[derive(Debug, Clone, Builder)]
 #[non_exhaustive]
 pub struct BroadcastConfig {
-    #[builder(default = BroadcastConfig::SAMPLE_RATE)]
+    /// Sample rate of the mix.
+    #[builder(default = 48_000)]
     pub sample_rate: u32,
-    #[builder(default = BroadcastConfig::CHANNELS)]
+    /// Channel count of the mix.
+    #[builder(default = 2)]
     pub channels: u16,
-    #[builder(default = BroadcastConfig::BIT_RATE)]
+    /// AAC-LC bit rate the encoder targets.
+    #[builder(default = 128_000)]
     pub bit_rate: u64,
-    #[builder(default = BroadcastConfig::TARGET)]
+    /// Media duration a segment is cut at.
+    #[builder(default = Duration::from_secs(4))]
     pub segment_target: Duration,
-    #[builder(default = BroadcastConfig::WINDOW)]
+    /// Segments a client sees in the playlist.
+    #[builder(default = 6)]
     pub window: usize,
-    #[builder(default = BroadcastConfig::GRACE)]
+    /// Segments kept fetchable past the playlist window.
+    #[builder(default = 3)]
     pub grace: usize,
-    #[builder(default = BroadcastConfig::BIND)]
+    /// Loopback on an ephemeral port.
+    #[builder(default = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))]
     pub bind: SocketAddr,
+    /// How long the packager thread waits before polling the mix tap again
+    /// after it found no samples. The floor on how promptly a segment is cut
+    /// once audio resumes, paid for in wake-ups on an idle broadcast.
+    #[builder(default = Duration::from_millis(2))]
+    pub poll_interval: Duration,
 }
 
 impl BroadcastConfig {
-    /// AAC-LC bit rate the encoder targets.
-    pub const BIT_RATE: u64 = 128_000;
-
-    /// Loopback on an ephemeral port.
-    pub const BIND: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
-
-    /// Channel count of the mix.
-    pub const CHANNELS: u16 = 2;
-
-    /// Segments kept fetchable past the playlist window.
-    pub const GRACE: usize = 3;
-
-    /// Sample rate of the mix.
-    pub const SAMPLE_RATE: u32 = 48_000;
-
-    /// Media duration a segment is cut at.
-    pub const TARGET: Duration = Duration::from_secs(4);
-
-    /// Segments a client sees in the playlist.
-    pub const WINDOW: usize = 6;
-
     const MILLIS_PER_SECOND: u64 = 1_000;
 
     const MIN_TARGETS: u64 = 3;

--- a/crates/kithara-broadcast/src/service.rs
+++ b/crates/kithara-broadcast/src/service.rs
@@ -127,6 +127,7 @@ struct Worker<F> {
     token: CancelToken,
     stop: Arc<AtomicBool>,
     samples: Vec<f32>,
+    poll_interval: Duration,
 }
 
 #[derive(Debug, Default)]
@@ -136,8 +137,6 @@ struct Counters {
 }
 
 impl<F: LivePcmFeed> Worker<F> {
-    const POLL: Duration = Duration::from_millis(2);
-
     fn new(
         config: &BroadcastConfig,
         feed: F,
@@ -168,6 +167,7 @@ impl<F: LivePcmFeed> Worker<F> {
             token,
             stop,
             samples: Vec::new(),
+            poll_interval: config.poll_interval,
         })
     }
 
@@ -184,7 +184,7 @@ impl<F: LivePcmFeed> Worker<F> {
                 break;
             }
             if self.samples.is_empty() {
-                thread::paced_backoff(Self::POLL);
+                thread::paced_backoff(self.poll_interval);
             }
         }
 
@@ -241,7 +241,7 @@ impl<F: LivePcmFeed> Worker<F> {
                 Ok(true) => return true,
                 Ok(false) => {
                     if self.samples.is_empty() {
-                        thread::paced_backoff(Self::POLL);
+                        thread::paced_backoff(self.poll_interval);
                     }
                 }
                 Err(error) => {
@@ -410,7 +410,7 @@ mod tests {
     }
 
     fn pcm(frames: usize) -> Vec<f32> {
-        (0..frames * usize::from(BroadcastConfig::CHANNELS))
+        (0..frames * usize::from(config().channels))
             .map(|index| {
                 if index.is_multiple_of(2) {
                     Consts::AMPLITUDE

--- a/crates/kithara-broadcast/src/window.rs
+++ b/crates/kithara-broadcast/src/window.rs
@@ -131,6 +131,10 @@ mod tests {
         const TIMESCALE: u32 = 48_000;
     }
 
+    fn listed_window() -> usize {
+        BroadcastConfig::builder().build().window
+    }
+
     fn window() -> LiveWindow {
         LiveWindow::new(&BroadcastConfig::builder().build()).expect("window")
     }
@@ -155,7 +159,7 @@ mod tests {
     }
 
     fn listed() -> u64 {
-        u64::try_from(BroadcastConfig::WINDOW).expect("the window fits a sequence number")
+        u64::try_from(listed_window()).expect("the window fits a sequence number")
     }
 
     #[kithara::test(native, flash(false))]
@@ -343,7 +347,7 @@ mod tests {
             .expect("the live playlist parses");
         assert_eq!(parsed.media_sequence, 5);
         assert_eq!(parsed.discontinuity_sequence, 0);
-        assert_eq!(parsed.segments.iter().count(), BroadcastConfig::WINDOW);
+        assert_eq!(parsed.segments.iter().count(), listed_window());
         assert!(!parsed.has_end_list);
 
         window.finish();


### PR DESCRIPTION
## Summary

Batch 3 of 6 in the programme that moves hardcoded policy parameters into the
config each crate already owns (batch 1: #218, batch 2: #222). Three crates
this time — `kithara-beat`, `kithara-broadcast`, `kithara-app` — plus the one
divergence the inventory turned up between a hardcoded channel count and a
configurable one.

The rule is unchanged: a value whose right setting depends on the deployment or
the workload becomes a config field; a value that is structural, protocol-, or
model-defined stays a constant and the commit says why.

## Behavior / scope

**`kithara-beat` — a config where there was none.** The peak picker carried its
whole policy as three private constants: the logit threshold raw model output
is cut at, the half-width of the non-maximum-suppression window, and the width
peaks are deduplicated over. New `BeatConfig` (bon builder, defaults on the
fields) is handed to `PeakPicker::new`. `BeatThis::try_from((mel, beat))` is
replaced by `BeatThis::builder()` taking `mel_model`, `beat_model` and an
optional `config` — the tuple could not grow a third member and stay readable.

The chunk geometry is deliberately not in the config: frame rate, chunk length,
hop and border size follow the segmentation `beat_this` was trained on, so
moving them does not tune the detector, it feeds the model input it never saw.
`CONTEXT.md` now separates the frozen half from the policy half and records
that the defaults are the Python-parity values the golden fixtures are held to.

**`kithara-broadcast` — defaults where the fields are.** Seven `pub const`s on
`BroadcastConfig` were each a second public name for a number the field already
owned, and nothing outside the crate read one. They fold into
`#[builder(default = …)]`, each constant's doc moving onto its field. The one
parameter the config did not cover — the 2 ms the packager thread backs off for
when the mix tap had no samples — becomes `poll_interval`: it sets the floor on
how promptly a segment is cut once audio resumes and is paid for in wake-ups on
an idle broadcast.

**`kithara-app` — a fixed stereo ring under a configurable channel count.**
`Ring::CHANNELS = 2` sat next to a `BroadcastConfig::channels` that is
configurable. The ring carries interleaved samples, so a four-channel broadcast
got half the lead it was sized for — silently, as extra backpressure rather
than as an error. Sizing now reads the config, and `ring_capacity` rejects a
zero sample rate and a zero channel count instead of building a zero-sized ring.

Its sibling `Ring::SECONDS = 2` becomes `AppConfig::broadcast_tap_lead`. Two
seconds of ring is a budget — how long the packager may stall before the mix
tap starts dropping samples, bought with the memory those interleaved samples
occupy. The app allocates that ring and hands the packager only the consumer,
and `kithara-broadcast` never reads its capacity, only `occupied_len()`, so the
depth is the app's to own rather than the broadcast config's. `Packager::start`
carries the lead to whichever packager the build has, and `ring_capacity`
rejects one too short to hold a sample instead of handing `HeapRb` a
zero-length ring.

## Validation

- `just test` — 4009 passed, 0 failed, 26 skipped (160 s).
- `just test run --lane=broadcast` — 25 passed, 118 skipped. The `broadcast`
  feature is not in `default`, so `broadcast::engine` — every ring test in this
  PR — runs only on this lane.
- `just lint fast` — 0 regression, 0 new across 36 + 2 checks.
- `cargo check -p kithara-beat --all-targets` with `embed-small-model`, which
  the default lane leaves off, so the golden parity test compiles against the
  new builder.

## Surface impact

- `BeatThis::try_from((&[u8], &[u8]))` is **removed**; construction is
  `BeatThis::builder().mel_model(..).beat_model(..).build()`, with
  `.config(..)` optional. One in-repo consumer (`kithara-audio`) updated.
- New public `kithara_beat::BeatConfig`.
- `BroadcastConfig::{SAMPLE_RATE, CHANNELS, BIT_RATE, SEGMENT_TARGET, WINDOW,
  GRACE, BIND}` are **removed**; the values live on the fields and reach a
  caller through `BroadcastConfig::builder().build()`.
- New `BroadcastConfig::poll_interval`.
- New `AppConfig::broadcast_tap_lead` (`Duration`, default 2 s).

## Risks / follow-ups

- Beat defaults are pinned by the golden parity fixtures; a consumer that moves
  them owns the cache key of its own analysis. Stated in `CONTEXT.md`.
- `poll_interval` has no test of its own: it paces an empty feed and, as
  `CONTEXT.md` already said, no output depends on the value. Asserting on it
  would be asserting on timing, not on a contract.
- Folding a constant into `#[builder(default = …)]` trades one `const` the
  `style.no-magic-numbers` rule exempts for one literal it flags. The rule is
  warning-severity and nothing passes ast-grep `--strict`, so no gate moves,
  but the advisory count grows by roughly one per moved parameter. Exempting
  `#[builder(...)]` in the rule — a builder default is named by its field — is
  a separate change.
- `kithara-beat` still allocates its chunk buffer per chunk (~768 KB, ~10 per
  track) instead of taking a `BytePool` the way #198 established. That is a
  perf change needing its own measurement and is deliberately not in this PR.

