### PR TITLE
refactor: let each crate's config own its policy parameters (batch 4/6)

### DIFF
--- a/.config/ast-grep/style.no-magic-numbers.yml
+++ b/.config/ast-grep/style.no-magic-numbers.yml
@@ -75,6 +75,11 @@ rule:
               stopBy: end
         - not:
             inside:
+              kind: macro_invocation
+              regex: '^ranged!'
+              stopBy: end
+        - not:
+            inside:
               all:
                 - kind: mod_item
                 - follows:

--- a/.config/ast-grep/style.no-magic-numbers.yml
+++ b/.config/ast-grep/style.no-magic-numbers.yml
@@ -28,6 +28,11 @@ rule:
               stopBy: end
         - not:
             inside:
+              kind: attribute_item
+              regex: '^#\[(?:builder|serde)\('
+              stopBy: end
+        - not:
+            inside:
               kind: field_expression
               field: field
         - not:
@@ -62,6 +67,11 @@ rule:
         - not:
             inside:
               kind: static_item
+              stopBy: end
+        - not:
+            inside:
+              kind: attribute_item
+              regex: '^#\[(?:builder|serde)\('
               stopBy: end
         - not:
             inside:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4348,6 +4348,7 @@ dependencies = [
  "derive_more",
  "fast-interleave",
  "fieldwork",
+ "firewheel-core",
  "hotpath",
  "js-sys",
  "kithara-abr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -282,6 +282,7 @@ fdk-aac-sys = "0.5.0"
 ffmpeg-next = "8.1.0"
 fieldwork = "0.5"
 firewheel = { version = "0.10.0", default-features = false, features = ["scheduled_events", "std", "tracing"] }
+firewheel-core = { version = "0.10.1", default-features = false, features = ["std"] }
 firewheel-web-audio = { version = "0.4.0", default-features = false }
 fs4 = "1.1.0"
 futures = "0.3.32"

--- a/crates/kithara-app/src/analysis.rs
+++ b/crates/kithara-app/src/analysis.rs
@@ -28,10 +28,6 @@ use crate::{
 type AppBeatAnalysisConfig = BeatAnalysisConfig<PlaybackResamplerBackend>;
 type AppResourceConfig = ResourceConfig<PlaybackResamplerBackend>;
 
-/// Upper bound on waveform buckets (native = one per FFT window); only caps very
-/// long tracks to bound the cached blob.
-const WAVEFORM_MAX_BUCKETS: usize = 96_000;
-
 /// Analysis-aware state listener: mirrors queue events into [`UiState`] and
 /// drives the background [`AnalysisController`]. Starts analysing the already
 /// loaded library immediately — independent of which UI is open.
@@ -42,8 +38,12 @@ pub(crate) async fn listen(
     cancel: CancelToken,
     mut rx: EventReceiver,
 ) {
-    let mut driver =
-        AnalysisController::new(&cancel, &config.beat_analysis, config.pcm_pool.clone());
+    let mut driver = AnalysisController::new(
+        &cancel,
+        &config.beat_analysis,
+        config.pcm_pool.clone(),
+        config.waveform_max_buckets,
+    );
 
     // Analyse whatever is already loaded; later tracks arrive as events.
     driver.on_tracks_changed(&queue, &state, &config);
@@ -111,15 +111,16 @@ impl AnalysisController {
         cancel: &CancelToken,
         beat_config: &AppBeatAnalysisConfig,
         pcm_pool: PcmPool,
+        waveform_max_buckets: usize,
     ) -> Self {
         Self {
             runner: TrackAnalysisRunner::new(
                 cancel,
-                WAVEFORM_MAX_BUCKETS,
+                waveform_max_buckets,
                 beat_config.clone(),
                 pcm_pool,
             ),
-            cache: TrackAnalysisCache::new(analysis_fingerprint(beat_config)),
+            cache: TrackAnalysisCache::new(analysis_fingerprint(beat_config, waveform_max_buckets)),
             current: None,
             displayed: None,
             pending: VecDeque::new(),
@@ -323,9 +324,9 @@ impl AnalysisController {
 
 /// Fingerprint of the active analysis configuration, stored inside each durable blob.
 /// A mismatch is a cache miss, so config changes re-analyse.
-fn analysis_fingerprint(beat_config: &AppBeatAnalysisConfig) -> String {
+fn analysis_fingerprint(beat_config: &AppBeatAnalysisConfig, max_buckets: usize) -> String {
     let beat = beat_config.cache_tag().unwrap_or_else(|| "off".to_string());
-    format!("wave=native:max{WAVEFORM_MAX_BUCKETS};beat={beat}")
+    format!("wave=native:max{max_buckets};beat={beat}")
 }
 
 /// What [`AnalysisController::pump`] should do for a track.
@@ -427,12 +428,18 @@ mod tests {
     use kithara_queue::{Queue, QueueConfig};
     use kithara_test_utils::kithara;
 
-    use super::{AnalysisController, Plan, Run, pending_order, plan_analysis};
+    use super::{
+        AnalysisController, Plan, Run, analysis_fingerprint, pending_order, plan_analysis,
+    };
     use crate::{
         state::UiState,
         wave_cache::{AnalysisTarget, TrackAnalysisCache},
         waveform::TrackAnalysis,
     };
+
+    /// Bucket cap the controller tests run with; small so the value is
+    /// obviously the test's own and not a default leaking back in.
+    const MAX_BUCKETS: usize = 1_024;
 
     fn one_bucket_wave() -> Waveform {
         // version 1 + one bucket of three 0.5 band heights (0.5 = 0x3F000000).
@@ -485,6 +492,7 @@ mod tests {
             &cancel,
             &BeatAnalysisConfig::<PlaybackResamplerBackend>::default(),
             PcmPool::default(),
+            MAX_BUCKETS,
         );
         let (tx, rx) = watch::channel(value);
         controller.current = Some(Run {
@@ -672,6 +680,7 @@ mod tests {
             &cancel,
             &BeatAnalysisConfig::<PlaybackResamplerBackend>::default(),
             PcmPool::default(),
+            MAX_BUCKETS,
         );
         controller.displayed = Some(target("previous"));
 
@@ -679,5 +688,19 @@ mod tests {
 
         assert!(state.lock().analysis.is_none());
         assert!(controller.displayed.is_none());
+    }
+
+    /// The bucket cap shapes the waveform that lands in the durable blob, so
+    /// it belongs in the fingerprint that decides whether a blob may be
+    /// reused. Two apps configured with different caps must not read each
+    /// other's cached analysis.
+    #[kithara::test]
+    fn a_different_bucket_cap_is_a_different_fingerprint() {
+        let beat = BeatAnalysisConfig::<PlaybackResamplerBackend>::default();
+
+        assert_ne!(
+            analysis_fingerprint(&beat, MAX_BUCKETS),
+            analysis_fingerprint(&beat, MAX_BUCKETS * 2)
+        );
     }
 }

--- a/crates/kithara-app/src/config.rs
+++ b/crates/kithara-app/src/config.rs
@@ -97,6 +97,13 @@ pub struct AppConfig {
     /// Crossfade duration in seconds.
     #[builder(default = baked::BAKED_CROSSFADE_SECONDS)]
     pub crossfade_seconds: f32,
+    /// Upper bound on waveform buckets (native = one per FFT window). Only
+    /// caps very long tracks, to bound the cached blob.
+    #[builder(default = 96_000)]
+    pub waveform_max_buckets: usize,
+    /// Band count of the EQ layout every deck's player graph is built with.
+    #[builder(default = 3)]
+    pub eq_bands: usize,
 }
 
 fn default_tracks() -> Vec<String> {
@@ -120,6 +127,8 @@ impl fmt::Debug for AppConfig {
                 &self.should_accept_invalid_certs,
             )
             .field("crossfade_seconds", &self.crossfade_seconds)
+            .field("waveform_max_buckets", &self.waveform_max_buckets)
+            .field("eq_bands", &self.eq_bands)
             .field("beat_analysis", &self.beat_analysis)
             .field("size_probe_method", &self.size_probe_method)
             .finish_non_exhaustive()

--- a/crates/kithara-app/src/deck.rs
+++ b/crates/kithara-app/src/deck.rs
@@ -9,9 +9,6 @@ use kithara_queue::{Queue, QueueConfig};
 
 use crate::{config::AppConfig, mix::MixState};
 
-/// Band count used by the non-interactive player graph.
-const DEFAULT_EQ_BANDS: usize = 3;
-
 /// EQ topology shared by every deck and its player graph.
 #[cfg(feature = "gui")]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -88,7 +85,7 @@ impl Deck {
             PlayerConfig::builder()
                 .cancel(config.shutdown.child())
                 .crossfade_duration(config.crossfade_seconds)
-                .eq_layout(generate_log_spaced_bands(DEFAULT_EQ_BANDS))
+                .eq_layout(generate_log_spaced_bands(config.eq_bands))
                 .byte_pool(config.byte_pool.clone())
                 .pcm_pool(config.pcm_pool.clone())
                 .session(session.dispatcher())

--- a/crates/kithara-app/src/deck.rs
+++ b/crates/kithara-app/src/deck.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "gui")]
-use kithara::audio::EqBandConfig;
+use kithara::audio::{EqBandConfig, effects::eq::GainDb};
 use kithara::{
     audio::generate_log_spaced_bands,
     play::{PlayError, PlayerConfig, PlayerImpl, SessionHandle, StretchControls, apply_mix},
@@ -37,26 +37,33 @@ impl EqMode {
     }
 
     #[must_use]
-    pub(crate) fn remap(self, next: Self, gains: &[f32]) -> Option<Vec<f32>> {
+    pub(crate) fn remap(self, next: Self, gains: &[GainDb]) -> Option<Vec<GainDb>> {
         match (self, next, gains) {
             (Self::ThreeBand, Self::FourBand, [low, mid, high]) => {
                 Some(vec![*low, *mid, *mid, *high])
             }
             (Self::FourBand, Self::ThreeBand, [low, low_mid, high_mid, high]) => {
-                Some(vec![*low, (*low_mid + *high_mid) * 0.5, *high])
+                Some(vec![*low, midpoint(*low_mid, *high_mid), *high])
             }
             _ => None,
         }
     }
 
     #[must_use]
-    pub(crate) fn layout(self, gains: &[f32]) -> Vec<EqBandConfig> {
+    pub(crate) fn layout(self, gains: &[GainDb]) -> Vec<EqBandConfig> {
         let mut layout = generate_log_spaced_bands(self.bands().len());
         for (band, gain) in layout.iter_mut().zip(gains) {
             band.set_gain_db(*gain);
         }
         layout
     }
+}
+
+/// The gain halfway between two bands, for the four-to-three fold where two
+/// mids collapse into one.
+#[cfg(feature = "gui")]
+fn midpoint(low: GainDb, high: GainDb) -> GainDb {
+    GainDb::from(f32::from(low).midpoint(f32::from(high)))
 }
 
 /// App-local deck identity; never crosses into a shared playback crate.
@@ -290,14 +297,17 @@ mod tests {
     #[cfg(feature = "gui")]
     fn eq_mode_maps_the_middle_band_without_moving_the_outer_bands() {
         let four = EqMode::ThreeBand
-            .remap(EqMode::FourBand, &[-6.0, 2.0, 5.0])
+            .remap(EqMode::FourBand, &[-6.0f32, 2.0, 5.0].map(GainDb::from))
             .unwrap();
-        assert_eq!(four, [-6.0, 2.0, 2.0, 5.0]);
+        assert_eq!(four, [-6.0f32, 2.0, 2.0, 5.0].map(GainDb::from));
 
         let three = EqMode::FourBand
-            .remap(EqMode::ThreeBand, &[-6.0, -2.0, 4.0, 5.0])
+            .remap(
+                EqMode::ThreeBand,
+                &[-6.0f32, -2.0, 4.0, 5.0].map(GainDb::from),
+            )
             .unwrap();
-        assert_eq!(three, [-6.0, 1.0, 5.0]);
+        assert_eq!(three, [-6.0f32, 1.0, 5.0].map(GainDb::from));
     }
 
     #[kithara::test(native, flash(false))]

--- a/crates/kithara-app/src/gui/deck.rs
+++ b/crates/kithara-app/src/gui/deck.rs
@@ -1,4 +1,4 @@
-use kithara::{abr::AbrMode, events::AdvanceReason};
+use kithara::{abr::AbrMode, audio::effects::eq::GainDb, events::AdvanceReason};
 use kithara_platform::sync::Arc;
 use kithara_queue::{TrackId, Transition};
 use tracing::{debug, error};
@@ -63,7 +63,7 @@ pub(crate) enum DeckMsg {
     Next,
     Prev,
     SeekTo(f64),
-    EqBandChanged(usize, f32),
+    EqBandChanged(usize, GainDb),
     DeleteTrack,
     SetTempo(f32),
     SetQuality(Option<usize>),
@@ -128,7 +128,7 @@ fn seek(deck: &DeckUi, target: f64) {
     }
 }
 
-fn eq_band_changed(deck: &DeckUi, band: usize, db: f32) {
+fn eq_band_changed(deck: &DeckUi, band: usize, db: GainDb) {
     // `eq_bands` is the user's desired EQ and the source of truth: record it
     // regardless of whether a playback slot exists yet. The listener re-applies
     // it to the engine once a track becomes active.
@@ -142,7 +142,7 @@ fn eq_band_changed(deck: &DeckUi, band: usize, db: f32) {
     if !known {
         return;
     }
-    if let Err(e) = deck.controller.queue().set_eq_gain(band, db) {
+    if let Err(e) = deck.controller.queue().set_eq_gain(band, f32::from(db)) {
         // Expected before playback starts (no active slot yet); the gain is
         // retained in `eq_bands` and pushed down when playback begins.
         debug!("set EQ gain band={band} db={db:.1} deferred: {e:?}");

--- a/crates/kithara-app/src/gui/reads/deck.rs
+++ b/crates/kithara-app/src/gui/reads/deck.rs
@@ -1,3 +1,4 @@
+use kithara::audio::effects::eq::GainDb;
 use kithara_ui::render::{Node, ReadValue, Scope, WaveformView};
 use num_traits::cast::AsPrimitive;
 
@@ -8,7 +9,6 @@ use crate::{
         deck::{DeckView, TEMPO_RANGE, TimestretchState},
         ui::{
             cache::{DeckCache, analysis_bpm},
-            endpoints::knob_from_db,
             scope::deck_index,
         },
         view::playhead,
@@ -282,6 +282,6 @@ fn title(ui: &UiState) -> Option<&str> {
     (!ui.track_name.trim().is_empty()).then_some(ui.track_name.as_str())
 }
 
-fn eq_value(db: Option<&f32>) -> Option<ReadValue<'static>> {
-    Some(ReadValue::Scalar(f64::from(knob_from_db(*db?))))
+fn eq_value(db: Option<&GainDb>) -> Option<ReadValue<'static>> {
+    Some(ReadValue::Scalar(f64::from(db?.knob())))
 }

--- a/crates/kithara-app/src/gui/reads/root.rs
+++ b/crates/kithara-app/src/gui/reads/root.rs
@@ -81,6 +81,7 @@ impl<'a, 'b: 'a> Node<'a> for &'a ReadRoot<'b> {
 
 #[cfg(test)]
 mod tests {
+    use ::kithara::audio::effects::eq::GainDb;
     use iced::Size;
     use kithara_test_utils::kithara;
     use kithara_ui::render::{ReadValue, Reads, Walk};
@@ -190,7 +191,7 @@ mod tests {
     fn deck(tempo: &str) -> (UiState, DeckCache) {
         let mut ui = UiState::empty();
         ui.track_name = "Loaded".to_string();
-        ui.eq_bands = vec![0.0; 3];
+        ui.eq_bands = vec![GainDb::default(); 3];
         ui.duration = 120.0;
         ui.abr_variants = hls_ladder();
         let mut cache = DeckCache::default();
@@ -205,7 +206,7 @@ mod tests {
         let mut fixture = Fixture::new(["+2.0%", "-1.0%"]);
         fixture.eq_mode = mode;
         for (ui, _) in &mut fixture.decks {
-            ui.eq_bands = vec![0.0; mode.bands().len()];
+            ui.eq_bands = vec![GainDb::default(); mode.bands().len()];
         }
         fixture
     }

--- a/crates/kithara-app/src/gui/ui/endpoints.rs
+++ b/crates/kithara-app/src/gui/ui/endpoints.rs
@@ -1,25 +1,28 @@
+use kithara::audio::effects::eq::{MAX_GAIN_DB, MIN_GAIN_DB};
 use kithara_ui::{
     ids::EndpointId,
     registry::{EndpointCategory, EndpointDesc, EndpointRegistry, ValueKind},
 };
 
-/// EQ knob travel in dB: knob `0.0` is `EQ_MIN_DB`, knob `0.5` is unity, knob
-/// `1.0` is `EQ_MAX_DB`.
-pub(in crate::gui) const EQ_MIN_DB: f32 = -24.0;
-pub(in crate::gui) const EQ_MAX_DB: f32 = 6.0;
-
+/// EQ knob travel in dB: knob `0.0` is [`MIN_GAIN_DB`], knob `0.5` is unity,
+/// knob `1.0` is [`MAX_GAIN_DB`]. The range belongs to the EQ band itself, so
+/// the knob asks `kithara-audio` for it rather than keeping its own copy.
 pub(in crate::gui) fn db_from_knob(knob: f32) -> f32 {
     let offset = knob.clamp(0.0, 1.0) - 0.5;
     2.0 * offset * half_span(offset)
 }
 
 pub(in crate::gui) fn knob_from_db(db: f32) -> f32 {
-    let db = db.clamp(EQ_MIN_DB, EQ_MAX_DB);
+    let db = db.clamp(MIN_GAIN_DB, MAX_GAIN_DB);
     0.5 + db / (2.0 * half_span(db))
 }
 
 fn half_span(side: f32) -> f32 {
-    if side < 0.0 { -EQ_MIN_DB } else { EQ_MAX_DB }
+    if side < 0.0 {
+        -MIN_GAIN_DB
+    } else {
+        MAX_GAIN_DB
+    }
 }
 
 struct Endpoint {
@@ -509,8 +512,8 @@ mod tests {
     fn unity_gain_sits_at_the_middle_of_the_knob_travel() {
         assert_eq!(knob_from_db(0.0), 0.5);
         assert_eq!(db_from_knob(0.5), 0.0);
-        assert_eq!(db_from_knob(0.0), EQ_MIN_DB);
-        assert_eq!(db_from_knob(1.0), EQ_MAX_DB);
+        assert_eq!(db_from_knob(0.0), MIN_GAIN_DB);
+        assert_eq!(db_from_knob(1.0), MAX_GAIN_DB);
     }
 
     #[kithara::test]

--- a/crates/kithara-app/src/gui/ui/endpoints.rs
+++ b/crates/kithara-app/src/gui/ui/endpoints.rs
@@ -1,29 +1,7 @@
-use kithara::audio::effects::eq::{MAX_GAIN_DB, MIN_GAIN_DB};
 use kithara_ui::{
     ids::EndpointId,
     registry::{EndpointCategory, EndpointDesc, EndpointRegistry, ValueKind},
 };
-
-/// EQ knob travel in dB: knob `0.0` is [`MIN_GAIN_DB`], knob `0.5` is unity,
-/// knob `1.0` is [`MAX_GAIN_DB`]. The range belongs to the EQ band itself, so
-/// the knob asks `kithara-audio` for it rather than keeping its own copy.
-pub(in crate::gui) fn db_from_knob(knob: f32) -> f32 {
-    let offset = knob.clamp(0.0, 1.0) - 0.5;
-    2.0 * offset * half_span(offset)
-}
-
-pub(in crate::gui) fn knob_from_db(db: f32) -> f32 {
-    let db = db.clamp(MIN_GAIN_DB, MAX_GAIN_DB);
-    0.5 + db / (2.0 * half_span(db))
-}
-
-fn half_span(side: f32) -> f32 {
-    if side < 0.0 {
-        -MIN_GAIN_DB
-    } else {
-        MAX_GAIN_DB
-    }
-}
 
 struct Endpoint {
     scopes: &'static [&'static str],
@@ -497,34 +475,5 @@ impl EndpointRegistry for Registry {
             .iter()
             .find(|entry| entry.endpoint.category == category && entry.endpoint.id == id.0)
             .map(|entry| &entry.desc)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use kithara_test_utils::kithara;
-
-    use super::*;
-
-    const STEPS: usize = 256;
-
-    #[kithara::test]
-    fn unity_gain_sits_at_the_middle_of_the_knob_travel() {
-        assert_eq!(knob_from_db(0.0), 0.5);
-        assert_eq!(db_from_knob(0.5), 0.0);
-        assert_eq!(db_from_knob(0.0), MIN_GAIN_DB);
-        assert_eq!(db_from_knob(1.0), MAX_GAIN_DB);
-    }
-
-    #[kithara::test]
-    fn reading_back_a_written_gain_lands_on_the_same_knob_position() {
-        for step in 0..=STEPS {
-            let knob = step as f32 / STEPS as f32;
-            let round_trip = knob_from_db(db_from_knob(knob));
-            assert!(
-                (round_trip - knob).abs() < 1e-6,
-                "knob {knob} came back as {round_trip}"
-            );
-        }
     }
 }

--- a/crates/kithara-app/src/gui/ui/events.rs
+++ b/crates/kithara-app/src/gui/ui/events.rs
@@ -1,3 +1,4 @@
+use kithara::audio::effects::eq::GainDb;
 use kithara_ui::render::{
     ControlAction, DEFAULT_ZOOM, DragPhase, UiEvent, WindowCommand, zoom_in, zoom_out,
 };
@@ -5,7 +6,6 @@ use num_traits::cast::AsPrimitive;
 
 use super::{
     cache::{DeckLayout, ViewCache},
-    endpoints::db_from_knob,
     scope::{MICRO_DECK, deck_index, eq_band},
 };
 use crate::{
@@ -281,7 +281,7 @@ fn deck_id(state: &Kithara, index: usize) -> Option<DeckId> {
 }
 
 fn eq_msg(band: usize, knob: f64) -> DeckMsg {
-    DeckMsg::EqBandChanged(band, db_from_knob(knob.as_()))
+    DeckMsg::EqBandChanged(band, GainDb::at_knob(knob.as_()))
 }
 
 #[cfg(test)]

--- a/crates/kithara-app/src/gui/update.rs
+++ b/crates/kithara-app/src/gui/update.rs
@@ -2,7 +2,7 @@ use iced::{
     Task, window,
     window::{Direction, Mode},
 };
-use kithara::audio::EqBandConfig;
+use kithara::audio::{EqBandConfig, effects::eq::GainDb};
 use kithara_ui::render::{WindowCommand, WindowEdge};
 use tracing::{error, warn};
 
@@ -23,7 +23,7 @@ struct EqModeChange<'a> {
     controller: &'a StateController,
     previous: Vec<EqBandConfig>,
     next: Vec<EqBandConfig>,
-    gains: Vec<f32>,
+    gains: Vec<GainDb>,
 }
 
 pub(crate) fn update(state: &mut Kithara, message: Message) -> Task<Message> {

--- a/crates/kithara-app/src/state.rs
+++ b/crates/kithara-app/src/state.rs
@@ -1,5 +1,6 @@
 use kithara::{
     abr::AbrHandle,
+    audio::effects::eq::GainDb,
     events::{AbrMode, BpmInfo, DjEvent, Event, MediaTime, PlayerEvent, SlotId, VariantInfo},
     play::StretchControls,
     prelude::EngineLoadSnapshot,
@@ -35,7 +36,7 @@ pub struct UiState {
     pub selected_variant: Option<usize>,
     pub track_name: String,
     pub abr_variants: Vec<AbrVariant>,
-    pub eq_bands: Vec<f32>,
+    pub eq_bands: Vec<GainDb>,
     pub tracks: Vec<TrackEntry>,
     pub abr_mode_is_auto: bool,
     pub is_seeking: bool,
@@ -64,7 +65,7 @@ impl UiState {
             position: queue.position_seconds().unwrap_or(0.0),
             duration: queue.duration_seconds().unwrap_or(0.0),
             volume: queue.volume(),
-            eq_bands: vec![0.0; queue.eq_band_count()],
+            eq_bands: vec![GainDb::default(); queue.eq_band_count()],
             analysis: None,
             beat_marks: Arc::from(Vec::new()),
             downbeat_marks: Arc::from(Vec::new()),
@@ -356,9 +357,9 @@ fn spawn_listener(
 
 /// Push the desired EQ gains down to the engine. Calls for bands with no
 /// active slot are no-ops; the master EQ persists once a slot accepts them.
-fn reapply_eq(queue: &Queue, eq_bands: &[f32]) {
+fn reapply_eq(queue: &Queue, eq_bands: &[GainDb]) {
     for (band, &gain) in eq_bands.iter().enumerate() {
-        let _ = queue.set_eq_gain(band, gain);
+        let _ = queue.set_eq_gain(band, f32::from(gain));
     }
 }
 

--- a/crates/kithara-audio/Cargo.toml
+++ b/crates/kithara-audio/Cargo.toml
@@ -98,6 +98,7 @@ delegate = { workspace = true }
 derive_more = { workspace = true }
 fast-interleave = { workspace = true }
 fieldwork = { workspace = true }
+firewheel-core = { workspace = true }
 num-traits = { workspace = true }
 portable-atomic = { workspace = true }
 realfft = { workspace = true, optional = true }

--- a/crates/kithara-audio/src/effects/eq/band.rs
+++ b/crates/kithara-audio/src/effects/eq/band.rs
@@ -1,6 +1,8 @@
 use bon::Builder;
 use num_traits::cast::AsPrimitive;
 
+use super::GainDb;
+
 struct Consts;
 
 impl Consts {
@@ -13,12 +15,6 @@ impl Consts {
     const Q_REFERENCE_BANDS: f32 = 10.0;
     const Q_SCALE_FACTOR: f32 = 1.4;
 }
-
-/// Maximum EQ band gain in dB.
-pub const MAX_GAIN_DB: f32 = 6.0;
-
-/// Minimum EQ band gain in dB. At this value the band is fully killed.
-pub const MIN_GAIN_DB: f32 = -24.0;
 
 /// The type of biquad filter used for an EQ band.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -52,14 +48,15 @@ pub struct EqBandConfig {
     #[builder(default = Consts::DEFAULT_FREQ)]
     frequency: f32,
     #[builder(default)]
-    gain_db: f32,
+    #[field(get(copy))]
+    gain_db: GainDb,
     #[builder(default = std::f32::consts::FRAC_1_SQRT_2)]
     q_factor: f32,
 }
 
 impl EqBandConfig {
-    pub const fn set_gain_db(&mut self, gain_db: f32) {
-        self.gain_db = gain_db.clamp(MIN_GAIN_DB, MAX_GAIN_DB);
+    pub const fn set_gain_db(&mut self, gain_db: GainDb) {
+        self.gain_db = gain_db;
     }
 }
 
@@ -142,7 +139,11 @@ mod tests {
                         .windows(2)
                         .all(|pair| pair[1].frequency() > pair[0].frequency())
                 );
-                assert!(bands.iter().all(|band| band.gain_db().abs() < f32::EPSILON));
+                assert!(
+                    bands
+                        .iter()
+                        .all(|band| f32::from(band.gain_db()).abs() < f32::EPSILON)
+                );
             }
             _ => {}
         }
@@ -176,11 +177,11 @@ mod tests {
     }
 
     #[kithara::test]
-    fn set_gain_db_clamps_to_public_range() {
+    fn a_band_cannot_hold_a_gain_outside_the_range() {
         let mut band = EqBandConfig::default();
-        band.set_gain_db(100.0);
-        assert_eq!(band.gain_db(), MAX_GAIN_DB);
-        band.set_gain_db(-100.0);
-        assert_eq!(band.gain_db(), MIN_GAIN_DB);
+        band.set_gain_db(GainDb::from(100.0));
+        assert_eq!(band.gain_db(), GainDb::MAX);
+        band.set_gain_db(GainDb::from(-100.0));
+        assert_eq!(band.gain_db(), GainDb::MIN);
     }
 }

--- a/crates/kithara-audio/src/effects/eq/effect.rs
+++ b/crates/kithara-audio/src/effects/eq/effect.rs
@@ -1,6 +1,6 @@
 use kithara_decode::PcmChunk;
 
-use super::{EqBandConfig, IsolatorEq};
+use super::{EqBandConfig, GainDb, IsolatorEq};
 use crate::AudioEffect;
 
 pub struct EqEffect {
@@ -32,7 +32,7 @@ impl EqEffect {
             .enumerate()
             .map(|(index, band)| {
                 let mut band = *band;
-                band.set_gain_db(self.eq_l.target_gain(index).unwrap_or(0.0));
+                band.set_gain_db(self.eq_l.target_gain(index).unwrap_or_default());
                 band
             })
             .collect()
@@ -45,12 +45,12 @@ impl EqEffect {
             fn is_smoothing(&self) -> bool;
             /// Get the target gain for a specific band.
             #[must_use]
-            pub fn target_gain(&self, band_index: usize) -> Option<f32>;
+            pub fn target_gain(&self, band_index: usize) -> Option<GainDb>;
         }
     }
 
-    /// Set the gain for a specific band (clamped to min/max dB).
-    pub fn set_gain(&mut self, band_index: usize, gain_db: f32) {
+    /// Set the gain for a specific band.
+    pub fn set_gain(&mut self, band_index: usize, gain_db: GainDb) {
         self.eq_l.set_gain(band_index, gain_db);
         self.eq_r.set_gain(band_index, gain_db);
     }
@@ -151,23 +151,23 @@ mod tests {
         let bands = generate_log_spaced_bands(3);
         let mut eq = EqEffect::new(bands, 44100, 2);
 
-        eq.set_gain(0, 100.0);
-        assert!((eq.target_gain(0).unwrap() - MAX_GAIN_DB).abs() < f32::EPSILON);
+        eq.set_gain(0, GainDb::from(100.0));
+        assert_eq!(eq.target_gain(0).unwrap(), GainDb::MAX);
 
-        eq.set_gain(0, -100.0);
-        assert!((eq.target_gain(0).unwrap() - MIN_GAIN_DB).abs() < f32::EPSILON);
+        eq.set_gain(0, GainDb::from(-100.0));
+        assert_eq!(eq.target_gain(0).unwrap(), GainDb::MIN);
 
-        eq.set_gain(0, 3.0);
-        assert!((eq.target_gain(0).unwrap() - 3.0).abs() < f32::EPSILON);
+        eq.set_gain(0, GainDb::from(3.0));
+        assert_eq!(eq.target_gain(0).unwrap(), GainDb::from(3.0));
     }
 
     #[kithara::test]
     fn eq_set_gain_out_of_bounds_band_is_noop() {
         let bands = generate_log_spaced_bands(3);
         let mut eq = EqEffect::new(bands, 44100, 2);
-        eq.set_gain(99, 5.0);
+        eq.set_gain(99, GainDb::from(5.0));
         for i in 0..3 {
-            assert!(eq.target_gain(i).unwrap().abs() < f32::EPSILON);
+            assert_eq!(eq.target_gain(i).unwrap(), GainDb::DEFAULT);
         }
     }
 
@@ -176,7 +176,7 @@ mod tests {
         let bands = generate_log_spaced_bands(3);
         let mut eq = EqEffect::new(bands, 44100, 2);
 
-        eq.set_gain(0, 6.0);
+        eq.set_gain(0, GainDb::MAX);
         let spec = EqFixture::spec(2, 44100);
         let pcm = vec![0.5f32; 256];
         let chunk = test_chunk(spec, pcm);
@@ -185,9 +185,10 @@ mod tests {
         eq.reset();
 
         for i in 0..3 {
-            assert!(
-                eq.target_gain(i).unwrap().abs() < f32::EPSILON,
-                "target should be 0 after reset"
+            assert_eq!(
+                eq.target_gain(i).unwrap(),
+                GainDb::DEFAULT,
+                "target should be unity after reset"
             );
         }
     }
@@ -197,7 +198,7 @@ mod tests {
         let bands = vec![EqBandConfig::builder().frequency(1000.0).build()];
         let spec = EqFixture::spec(1, 44100);
         let mut eq = EqEffect::new(bands, spec.sample_rate.get(), spec.channels);
-        eq.set_gain(0, MIN_GAIN_DB);
+        eq.set_gain(0, GainDb::MIN);
         converge_smoother(&mut eq, spec);
 
         let gain = measure_sine_gain(&mut eq, 1000.0, spec);
@@ -212,7 +213,7 @@ mod tests {
         let bands = generate_log_spaced_bands(3);
         let spec = EqFixture::spec(1, 44100);
         let mut eq = EqEffect::new(bands, spec.sample_rate.get(), spec.channels);
-        eq.set_gain(0, MIN_GAIN_DB);
+        eq.set_gain(0, GainDb::MIN);
         converge_smoother(&mut eq, spec);
 
         let gain_bass = measure_sine_gain(&mut eq, 40.0, spec);
@@ -232,7 +233,7 @@ mod tests {
         let bands = generate_log_spaced_bands(3);
         let spec = EqFixture::spec(1, 44100);
         let mut eq = EqEffect::new(bands, spec.sample_rate.get(), spec.channels);
-        eq.set_gain(2, MIN_GAIN_DB);
+        eq.set_gain(2, GainDb::MIN);
         converge_smoother(&mut eq, spec);
 
         let gain_treble = measure_sine_gain(&mut eq, 15000.0, spec);
@@ -250,7 +251,7 @@ mod tests {
         let spec = EqFixture::spec(1, 44100);
         let mut eq = EqEffect::new(bands, spec.sample_rate.get(), spec.channels);
         for i in 0..3 {
-            eq.set_gain(i, MIN_GAIN_DB);
+            eq.set_gain(i, GainDb::MIN);
         }
         converge_smoother(&mut eq, spec);
 
@@ -268,7 +269,7 @@ mod tests {
         let bands = generate_log_spaced_bands(3);
         let spec = EqFixture::spec(1, 44100);
         let mut eq = EqEffect::new(bands, spec.sample_rate.get(), spec.channels);
-        eq.set_gain(0, MAX_GAIN_DB);
+        eq.set_gain(0, GainDb::MAX);
         converge_smoother(&mut eq, spec);
 
         let gain_bass = measure_sine_gain(&mut eq, 40.0, spec);
@@ -283,7 +284,7 @@ mod tests {
         let bands = generate_log_spaced_bands(3);
         let spec = EqFixture::spec(1, 44100);
         let mut eq = EqEffect::new(bands, spec.sample_rate.get(), spec.channels);
-        eq.set_gain(2, MAX_GAIN_DB);
+        eq.set_gain(2, GainDb::MAX);
         converge_smoother(&mut eq, spec);
 
         let gain_treble = measure_sine_gain(&mut eq, 15000.0, spec);
@@ -299,7 +300,7 @@ mod tests {
         let mut eq = EqEffect::new(bands, 44100, 2);
 
         assert!(!eq.is_smoothing(), "should not be smoothing initially");
-        eq.set_gain(0, 6.0);
+        eq.set_gain(0, GainDb::MAX);
         assert!(eq.is_smoothing(), "should be smoothing after set_gain");
     }
 
@@ -308,7 +309,7 @@ mod tests {
         let bands = generate_log_spaced_bands(3);
         let spec = EqFixture::spec(1, 44100);
         let mut eq = EqEffect::new(bands, spec.sample_rate.get(), spec.channels);
-        eq.set_gain(0, 6.0);
+        eq.set_gain(0, GainDb::MAX);
 
         converge_smoother(&mut eq, spec);
 
@@ -330,7 +331,7 @@ mod tests {
         let chunk = test_chunk(spec, warmup);
         let _ = eq.process(chunk);
 
-        eq.set_gain(0, MAX_GAIN_DB);
+        eq.set_gain(0, GainDb::MAX);
 
         let signal: Vec<f32> = (0u16..4096)
             .map(|i| (2.0 * PI * 1000.0 * f32::from(i + 4096) / 44100.0).sin())
@@ -362,7 +363,7 @@ mod tests {
         let spec = EqFixture::spec(channels, 44100);
         let mut eq = EqEffect::new(bands, spec.sample_rate.get(), spec.channels);
         if let Some((band, gain_db)) = gain {
-            eq.set_gain(band, gain_db);
+            eq.set_gain(band, GainDb::from(gain_db));
         }
 
         let pcm = vec![0.5f32; sample_len];
@@ -387,9 +388,9 @@ mod tests {
 
         for round in 0..100 {
             let gain = if round % 2 == 0 {
-                MAX_GAIN_DB
+                GainDb::MAX
             } else {
-                MIN_GAIN_DB
+                GainDb::MIN
             };
             for band in 0..10 {
                 eq.set_gain(band, gain);
@@ -409,7 +410,7 @@ mod tests {
         let bands = generate_log_spaced_bands(3);
         let spec = EqFixture::spec(1, 44100);
         let mut eq = EqEffect::new(bands, spec.sample_rate.get(), spec.channels);
-        eq.set_gain(0, 6.0);
+        eq.set_gain(0, GainDb::MAX);
         converge_smoother(&mut eq, spec);
 
         let mut pcm = vec![0.5f32; 256];
@@ -432,12 +433,15 @@ mod tests {
 
         for round in 0..200 {
             let gain = if round % 2 == 0 {
-                MAX_GAIN_DB
+                GainDb::MAX
             } else {
-                MIN_GAIN_DB
+                GainDb::MIN
             };
+            // The range is asymmetric, so the opposite of the floor is not
+            // the ceiling: it clamps back down to it.
+            let opposite = GainDb::from(-f32::from(gain));
             eq.set_gain(0, gain);
-            eq.set_gain(1, -gain);
+            eq.set_gain(1, opposite);
             eq.set_gain(2, gain);
 
             let pcm: Vec<f32> = (0u16..512).map(|i| (f32::from(i) * 0.3).sin()).collect();
@@ -466,7 +470,7 @@ mod tests {
         let mut eq = IsolatorEq::new(&bands, 44100);
         assert!(eq.bypass_active(), "precondition: fresh EQ is in bypass");
 
-        eq.set_gain(0, 3.0);
+        eq.set_gain(0, GainDb::from(3.0));
 
         assert!(
             !eq.bypass_active(),
@@ -481,11 +485,11 @@ mod tests {
         let spec = EqFixture::spec(1, 44100);
         let mut eq_effect = EqEffect::new(bands, spec.sample_rate.get(), spec.channels);
 
-        eq_effect.set_gain(0, 6.0);
+        eq_effect.set_gain(0, GainDb::MAX);
         converge_smoother(&mut eq_effect, spec);
         assert!(!eq_effect.eq_l.bypass_active());
 
-        eq_effect.set_gain(0, 0.0);
+        eq_effect.set_gain(0, GainDb::default());
         converge_smoother(&mut eq_effect, spec);
         converge_smoother(&mut eq_effect, spec);
 
@@ -519,13 +523,13 @@ mod tests {
         let mut eq_effect = EqEffect::new(bands, spec.sample_rate.get(), spec.channels);
 
         for i in 0..3 {
-            eq_effect.set_gain(i, MIN_GAIN_DB);
+            eq_effect.set_gain(i, GainDb::MIN);
         }
         converge_smoother(&mut eq_effect, spec);
 
         assert!(
             eq_effect.eq_l.silence_active(),
-            "all bands at MIN_GAIN_DB after smoother converges must activate \
+            "all bands at the floor of the range after the smoother converges must \
              the silence fast path so the filter chain is skipped entirely"
         );
     }
@@ -535,7 +539,7 @@ mod tests {
         let bands = generate_log_spaced_bands(3);
         let mut eq = IsolatorEq::new(&bands, 44100);
         for i in 0..3 {
-            eq.set_gain(i, MIN_GAIN_DB);
+            eq.set_gain(i, GainDb::MIN);
             eq.force_current_gain(i, 0.0);
         }
         assert!(eq.silence_active(), "precondition: silence is active");
@@ -556,16 +560,16 @@ mod tests {
         let bands = generate_log_spaced_bands(3);
         let mut eq = IsolatorEq::new(&bands, 44100);
         for i in 0..3 {
-            eq.set_gain(i, MIN_GAIN_DB);
+            eq.set_gain(i, GainDb::MIN);
             eq.force_current_gain(i, 0.0);
         }
         assert!(eq.silence_active(), "precondition: silence is active");
 
-        eq.set_gain(1, -3.0);
+        eq.set_gain(1, GainDb::from(-3.0));
 
         assert!(
             !eq.silence_active(),
-            "raising any band above MIN_GAIN_DB must disable silence so the \
+            "raising any band above the floor must disable silence so the \
              filter chain re-engages via smoother ramp-up"
         );
     }

--- a/crates/kithara-audio/src/effects/eq/effect.rs
+++ b/crates/kithara-audio/src/effects/eq/effect.rs
@@ -540,7 +540,7 @@ mod tests {
         let mut eq = IsolatorEq::new(&bands, 44100);
         for i in 0..3 {
             eq.set_gain(i, GainDb::MIN);
-            eq.force_current_gain(i, 0.0);
+            eq.settle_gain(i);
         }
         assert!(eq.silence_active(), "precondition: silence is active");
 
@@ -561,7 +561,7 @@ mod tests {
         let mut eq = IsolatorEq::new(&bands, 44100);
         for i in 0..3 {
             eq.set_gain(i, GainDb::MIN);
-            eq.force_current_gain(i, 0.0);
+            eq.settle_gain(i);
         }
         assert!(eq.silence_active(), "precondition: silence is active");
 

--- a/crates/kithara-audio/src/effects/eq/gain.rs
+++ b/crates/kithara-audio/src/effects/eq/gain.rs
@@ -5,8 +5,6 @@ use super::GainDb;
 struct Consts;
 
 impl Consts {
-    const DB_DIVISOR: f32 = 20.0;
-    const LOG_FREQ_BASE: f32 = 10.0;
     const MS_PER_SEC: f32 = 1000.0;
     const SMOOTH_BLOCK_SIZE: usize = 32;
     const SMOOTH_CONVERGENCE_THRESHOLD: f32 = 0.0001;
@@ -21,7 +19,7 @@ struct GainState {
 
 impl GainState {
     fn new(gain_db: GainDb) -> Self {
-        let linear = db_to_linear(f32::from(gain_db));
+        let linear = gain_db.linear();
         Self {
             target_db: gain_db,
             target_linear: linear,
@@ -35,7 +33,7 @@ impl GainState {
             return;
         }
         self.target_db = gain_db;
-        self.target_linear = db_to_linear(db);
+        self.target_linear = gain_db.linear();
     }
 
     #[inline]
@@ -115,9 +113,7 @@ impl GainBank {
 
     pub(crate) fn reset(&mut self) {
         for gain in &mut self.gains {
-            gain.target_db = GainDb::default();
-            gain.target_linear = 1.0;
-            gain.current_linear = 1.0;
+            *gain = GainState::new(GainDb::default());
         }
         self.block_counter = 0;
         self.refresh_fastpath();
@@ -147,38 +143,9 @@ impl GainBank {
     }
 }
 
-#[inline]
-fn db_to_linear(db: f32) -> f32 {
-    if db <= f32::from(GainDb::MIN) {
-        0.0
-    } else {
-        Consts::LOG_FREQ_BASE.powf(db / Consts::DB_DIVISOR)
-    }
-}
-
 fn compute_smooth_coeff(sample_rate: f32) -> f32 {
     let tau = Consts::SMOOTH_TIME_MS / Consts::MS_PER_SEC;
     let block_size_f32: f32 = Consts::SMOOTH_BLOCK_SIZE.as_();
     let effective_rate = sample_rate / block_size_f32;
     1.0 - (-1.0 / (tau * effective_rate)).exp()
-}
-
-#[cfg(test)]
-mod tests {
-    use kithara_test_utils::kithara;
-
-    use super::*;
-
-    #[kithara::test]
-    fn db_to_linear_kill_at_min() {
-        assert!(db_to_linear(f32::from(GainDb::MIN)).abs() < f32::EPSILON);
-        assert!(db_to_linear(-30.0).abs() < f32::EPSILON);
-    }
-
-    #[kithara::test]
-    #[case::unity_at_zero(0.0, 1.0, 0.001)]
-    #[case::boost_at_6db(6.0, 2.0, 0.02)]
-    fn db_to_linear_maps_to_gain(#[case] db: f32, #[case] expected: f32, #[case] eps: f32) {
-        assert!((db_to_linear(db) - expected).abs() < eps);
-    }
 }

--- a/crates/kithara-audio/src/effects/eq/gain.rs
+++ b/crates/kithara-audio/src/effects/eq/gain.rs
@@ -1,6 +1,6 @@
 use num_traits::cast::AsPrimitive;
 
-use super::{MAX_GAIN_DB, MIN_GAIN_DB};
+use super::GainDb;
 
 struct Consts;
 
@@ -15,13 +15,13 @@ impl Consts {
 
 struct GainState {
     current_linear: f32,
-    target_db: f32,
+    target_db: GainDb,
     target_linear: f32,
 }
 
 impl GainState {
-    fn new(gain_db: f32) -> Self {
-        let linear = db_to_linear(gain_db);
+    fn new(gain_db: GainDb) -> Self {
+        let linear = db_to_linear(f32::from(gain_db));
         Self {
             target_db: gain_db,
             target_linear: linear,
@@ -29,13 +29,13 @@ impl GainState {
         }
     }
 
-    fn set_target(&mut self, gain_db: f32) {
-        let clamped = gain_db.clamp(MIN_GAIN_DB, MAX_GAIN_DB);
-        if (clamped - self.target_db).abs() < f32::EPSILON {
+    fn set_target(&mut self, gain_db: GainDb) {
+        let db = f32::from(gain_db);
+        if (db - f32::from(self.target_db)).abs() < f32::EPSILON {
             return;
         }
-        self.target_db = clamped;
-        self.target_linear = db_to_linear(clamped);
+        self.target_db = gain_db;
+        self.target_linear = db_to_linear(db);
     }
 
     #[inline]
@@ -62,7 +62,7 @@ pub(crate) struct GainBank {
 }
 
 impl GainBank {
-    pub(crate) fn new(gains_db: impl Iterator<Item = f32>, sample_rate: f32) -> Self {
+    pub(crate) fn new(gains_db: impl Iterator<Item = GainDb>, sample_rate: f32) -> Self {
         let gains = gains_db.map(GainState::new).collect();
         let mut bank = Self {
             gains,
@@ -93,7 +93,7 @@ impl GainBank {
             pub(crate) const fn len(&self) -> usize;
             #[expr($.map(|state| state.target_db))]
             #[call(get)]
-            pub(crate) fn target(&self, band: usize) -> Option<f32>;
+            pub(crate) fn target(&self, band: usize) -> Option<GainDb>;
         }
     }
 
@@ -115,7 +115,7 @@ impl GainBank {
 
     pub(crate) fn reset(&mut self) {
         for gain in &mut self.gains {
-            gain.target_db = 0.0;
+            gain.target_db = GainDb::default();
             gain.target_linear = 1.0;
             gain.current_linear = 1.0;
         }
@@ -123,7 +123,7 @@ impl GainBank {
         self.refresh_fastpath();
     }
 
-    pub(crate) fn set(&mut self, band: usize, gain_db: f32) {
+    pub(crate) fn set(&mut self, band: usize, gain_db: GainDb) {
         if let Some(state) = self.gains.get_mut(band) {
             state.set_target(gain_db);
         }
@@ -149,7 +149,7 @@ impl GainBank {
 
 #[inline]
 fn db_to_linear(db: f32) -> f32 {
-    if db <= MIN_GAIN_DB {
+    if db <= f32::from(GainDb::MIN) {
         0.0
     } else {
         Consts::LOG_FREQ_BASE.powf(db / Consts::DB_DIVISOR)
@@ -171,7 +171,7 @@ mod tests {
 
     #[kithara::test]
     fn db_to_linear_kill_at_min() {
-        assert!(db_to_linear(MIN_GAIN_DB).abs() < f32::EPSILON);
+        assert!(db_to_linear(f32::from(GainDb::MIN)).abs() < f32::EPSILON);
         assert!(db_to_linear(-30.0).abs() < f32::EPSILON);
     }
 

--- a/crates/kithara-audio/src/effects/eq/gain.rs
+++ b/crates/kithara-audio/src/effects/eq/gain.rs
@@ -1,3 +1,6 @@
+use std::{num::NonZeroU32, ops::Index};
+
+use firewheel_core::dsp::filter::smoothing_filter::{SmoothingFilter, SmoothingFilterCoeff};
 use num_traits::cast::AsPrimitive;
 
 use super::GainDb;
@@ -5,66 +8,85 @@ use super::GainDb;
 struct Consts;
 
 impl Consts {
-    const MS_PER_SEC: f32 = 1000.0;
+    const SETTLE_EPSILON: f32 = 0.0001;
     const SMOOTH_BLOCK_SIZE: usize = 32;
-    const SMOOTH_CONVERGENCE_THRESHOLD: f32 = 0.0001;
-    const SMOOTH_TIME_MS: f32 = 10.0;
+    const SMOOTH_SECONDS: f32 = 0.01;
 }
 
-struct GainState {
-    current_linear: f32,
-    target_db: GainDb,
+#[derive(fieldwork::Fieldwork)]
+#[fieldwork(opt_in, get)]
+struct SmoothedGain {
+    filter: SmoothingFilter,
+    #[field(get(copy), vis = "pub(crate)")]
+    target: GainDb,
     target_linear: f32,
 }
 
-impl GainState {
-    fn new(gain_db: GainDb) -> Self {
-        let linear = gain_db.linear();
+impl SmoothedGain {
+    fn new(target: GainDb) -> Self {
+        let linear = target.linear();
         Self {
-            target_db: gain_db,
+            filter: SmoothingFilter::new(linear),
+            target,
             target_linear: linear,
-            current_linear: linear,
         }
     }
 
-    fn set_target(&mut self, gain_db: GainDb) {
-        let db = f32::from(gain_db);
-        if (db - f32::from(self.target_db)).abs() < f32::EPSILON {
+    fn current(&self) -> f32 {
+        self.filter.z1
+    }
+
+    #[cfg(test)]
+    fn is_smoothing(&self) -> bool {
+        !self.filter.has_settled(self.target_linear)
+    }
+
+    fn set_target(&mut self, target: GainDb) {
+        if target == self.target {
             return;
         }
-        self.target_db = gain_db;
-        self.target_linear = gain_db.linear();
+        self.target = target;
+        self.target_linear = target.linear();
+    }
+
+    /// Jump to the target without the ramp.
+    #[cfg(test)]
+    fn settle(&mut self) {
+        self.filter = SmoothingFilter::new(self.target_linear);
+    }
+
+    /// Whether this gain is aimed at `target` and has arrived. The fast paths
+    /// need both: a band on its way to unity still has to run the filters.
+    fn settled_at(&self, target: GainDb) -> bool {
+        self.target == target && self.filter.has_settled(self.target_linear)
     }
 
     #[inline]
-    fn smooth(&mut self, coeff: f32) {
-        let diff = self.target_linear - self.current_linear;
-        if diff.abs() < Consts::SMOOTH_CONVERGENCE_THRESHOLD {
-            self.current_linear = self.target_linear;
-        } else {
-            self.current_linear = coeff.mul_add(diff, self.current_linear);
-        }
+    fn smooth(&mut self, coeff: SmoothingFilterCoeff) {
+        self.filter.process(self.target_linear, coeff);
+        self.filter
+            .settle(self.target_linear, Consts::SETTLE_EPSILON);
     }
 }
 
 #[derive(fieldwork::Fieldwork)]
 #[fieldwork(opt_in, get)]
 pub(crate) struct GainBank {
-    gains: Vec<GainState>,
+    gains: Vec<SmoothedGain>,
     #[field(get, vis = "pub(crate)")]
     bypass_active: bool,
     #[field(get, vis = "pub(crate)")]
     silence_active: bool,
-    smooth_coeff: f32,
+    coeff: SmoothingFilterCoeff,
     block_counter: usize,
 }
 
 impl GainBank {
     pub(crate) fn new(gains_db: impl Iterator<Item = GainDb>, sample_rate: f32) -> Self {
-        let gains = gains_db.map(GainState::new).collect();
+        let gains = gains_db.map(SmoothedGain::new).collect();
         let mut bank = Self {
             gains,
-            smooth_coeff: compute_smooth_coeff(sample_rate),
+            coeff: smoothing_coeff(sample_rate),
             block_counter: 0,
             bypass_active: false,
             silence_active: false,
@@ -73,55 +95,50 @@ impl GainBank {
         bank
     }
 
-    #[cfg(test)]
-    pub(crate) fn force_current(&mut self, band: usize, linear: f32) {
-        self.gains[band].current_linear = linear;
-        self.refresh_fastpath();
-    }
-
-    #[cfg(test)]
-    pub(crate) fn is_smoothing(&self) -> bool {
-        self.gains.iter().any(|gain| {
-            (gain.target_linear - gain.current_linear).abs() > Consts::SMOOTH_CONVERGENCE_THRESHOLD
-        })
+    fn all_settled_at(&self, target: GainDb) -> bool {
+        !self.gains.is_empty() && self.gains.iter().all(|gain| gain.settled_at(target))
     }
 
     delegate::delegate! {
         to self.gains {
+            #[cfg(test)]
+            #[expr($.any(SmoothedGain::is_smoothing))]
+            #[call(iter)]
+            pub(crate) fn is_smoothing(&self) -> bool;
             pub(crate) const fn len(&self) -> usize;
-            #[expr($.map(|state| state.target_db))]
+            #[expr($.current())]
+            #[call(index)]
+            pub(crate) fn linear(&self, band: usize) -> f32;
+            #[expr($.map(SmoothedGain::target))]
             #[call(get)]
             pub(crate) fn target(&self, band: usize) -> Option<GainDb>;
         }
     }
 
-    pub(crate) fn linear(&self, band: usize) -> f32 {
-        self.gains[band].current_linear
-    }
-
     fn refresh_fastpath(&mut self) {
-        self.bypass_active = !self.gains.is_empty()
-            && self.gains.iter().all(|gain| {
-                (gain.target_linear - 1.0).abs() < f32::EPSILON
-                    && (gain.current_linear - 1.0).abs() < f32::EPSILON
-            });
-        self.silence_active = !self.gains.is_empty()
-            && self.gains.iter().all(|gain| {
-                gain.target_linear.abs() < f32::EPSILON && gain.current_linear.abs() < f32::EPSILON
-            });
+        self.bypass_active = self.all_settled_at(GainDb::default());
+        self.silence_active = self.all_settled_at(GainDb::MIN);
     }
 
     pub(crate) fn reset(&mut self) {
         for gain in &mut self.gains {
-            *gain = GainState::new(GainDb::default());
+            *gain = SmoothedGain::new(GainDb::default());
         }
         self.block_counter = 0;
         self.refresh_fastpath();
     }
 
     pub(crate) fn set(&mut self, band: usize, gain_db: GainDb) {
-        if let Some(state) = self.gains.get_mut(band) {
-            state.set_target(gain_db);
+        if let Some(gain) = self.gains.get_mut(band) {
+            gain.set_target(gain_db);
+        }
+        self.refresh_fastpath();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn settle(&mut self, band: usize) {
+        if let Some(gain) = self.gains.get_mut(band) {
+            gain.settle();
         }
         self.refresh_fastpath();
     }
@@ -133,19 +150,44 @@ impl GainBank {
         }
         self.block_counter = 0;
         for gain in &mut self.gains {
-            gain.smooth(self.smooth_coeff);
+            gain.smooth(self.coeff);
         }
         self.refresh_fastpath();
     }
 
     pub(crate) fn update_sample_rate(&mut self, sample_rate: f32) {
-        self.smooth_coeff = compute_smooth_coeff(sample_rate);
+        self.coeff = smoothing_coeff(sample_rate);
     }
 }
 
-fn compute_smooth_coeff(sample_rate: f32) -> f32 {
-    let tau = Consts::SMOOTH_TIME_MS / Consts::MS_PER_SEC;
-    let block_size_f32: f32 = Consts::SMOOTH_BLOCK_SIZE.as_();
-    let effective_rate = sample_rate / block_size_f32;
-    1.0 - (-1.0 / (tau * effective_rate)).exp()
+/// Coefficients for a smoother that steps once per [`Consts::SMOOTH_BLOCK_SIZE`]
+/// samples. What shapes the curve is how many steps fit in the smoothing
+/// window, so dividing the window by the block size gives the same curve as
+/// dividing the rate by it - and it leaves the rate an exact integer.
+fn smoothing_coeff(sample_rate: f32) -> SmoothingFilterCoeff {
+    let block_size: f32 = Consts::SMOOTH_BLOCK_SIZE.as_();
+    let rate: u32 = sample_rate.max(1.0).as_();
+    let rate = NonZeroU32::new(rate).unwrap_or(NonZeroU32::MIN);
+    SmoothingFilterCoeff::new(rate, Consts::SMOOTH_SECONDS / block_size)
+}
+
+#[cfg(test)]
+mod tests {
+    use kithara_test_utils::kithara;
+
+    use super::*;
+
+    /// `IsolatorEq::new` takes a plain `u32`, so a caller can hand the bank a
+    /// rate no filter can be built from. The band still has to arrive.
+    #[kithara::test]
+    fn a_bank_built_at_an_unusable_sample_rate_still_reaches_its_target() {
+        let mut bank = GainBank::new([GainDb::default()].into_iter(), 0.0);
+        bank.set(0, GainDb::MAX);
+
+        for _ in 0..Consts::SMOOTH_BLOCK_SIZE * Consts::SMOOTH_BLOCK_SIZE {
+            bank.tick();
+        }
+
+        assert_eq!(bank.linear(0), GainDb::MAX.linear());
+    }
 }

--- a/crates/kithara-audio/src/effects/eq/gain_db.rs
+++ b/crates/kithara-audio/src/effects/eq/gain_db.rs
@@ -1,5 +1,12 @@
 use kithara_platform::ranged;
 
+struct Consts;
+
+impl Consts {
+    const DB_DIVISOR: f32 = 20.0;
+    const DB_LOG_BASE: f32 = 10.0;
+}
+
 ranged!(
     /// Gain of one EQ band, in dB. `0.0` is unity and [`GainDb::MIN`] kills the
     /// band. The range is asymmetric on purpose: cutting stays useful far past
@@ -23,6 +30,16 @@ impl GainDb {
     pub fn knob(self) -> f32 {
         let db = f32::from(self);
         0.5 + db / (2.0 * Self::half_span(db))
+    }
+
+    /// This gain as a linear amplitude. The floor of the range means the band
+    /// is off, so it maps to exact zero rather than to the very small number
+    /// the dB curve gives there.
+    pub(crate) fn linear(self) -> f32 {
+        if self == Self::MIN {
+            return 0.0;
+        }
+        Consts::DB_LOG_BASE.powf(f32::from(self) / Consts::DB_DIVISOR)
     }
 
     fn half_span(side: f32) -> f32 {
@@ -78,5 +95,28 @@ mod tests {
     fn a_knob_past_its_travel_is_held_at_the_end() {
         assert_eq!(GainDb::at_knob(2.0), GainDb::MAX);
         assert_eq!(GainDb::at_knob(-1.0), GainDb::MIN);
+    }
+
+    #[kithara::test]
+    fn the_floor_of_the_range_is_exact_silence() {
+        assert_eq!(GainDb::MIN.linear(), 0.0);
+    }
+
+    /// A request below the floor is held at the floor, so it kills the band
+    /// too rather than landing on the dB curve's value for it.
+    #[kithara::test]
+    fn a_gain_under_the_floor_is_exact_silence_as_well() {
+        assert_eq!(GainDb::from(-30.0).linear(), 0.0);
+    }
+
+    #[kithara::test]
+    #[case::unity_at_zero(0.0, 1.0, 0.001)]
+    #[case::boost_at_6db(6.0, 2.0, 0.02)]
+    fn a_gain_in_db_maps_onto_its_amplitude(
+        #[case] db: f32,
+        #[case] expected: f32,
+        #[case] eps: f32,
+    ) {
+        assert!((GainDb::from(db).linear() - expected).abs() < eps);
     }
 }

--- a/crates/kithara-audio/src/effects/eq/gain_db.rs
+++ b/crates/kithara-audio/src/effects/eq/gain_db.rs
@@ -1,0 +1,82 @@
+use kithara_platform::ranged;
+
+ranged!(
+    /// Gain of one EQ band, in dB. `0.0` is unity and [`GainDb::MIN`] kills the
+    /// band. The range is asymmetric on purpose: cutting stays useful far past
+    /// the point where boosting only clips.
+    pub struct GainDb(f32, -24.0, 6.0, 0.0)
+);
+
+impl GainDb {
+    /// The gain a knob sitting at `knob` asks for: `0.0` is [`Self::MIN`],
+    /// `0.5` is unity, `1.0` is [`Self::MAX`]. Each half of the travel is
+    /// scaled against its own end, so unity stays in the middle of the knob
+    /// even though the range around it is not symmetric.
+    #[must_use]
+    pub fn at_knob(knob: f32) -> Self {
+        let offset = knob.clamp(0.0, 1.0) - 0.5;
+        Self::from(2.0 * offset * Self::half_span(offset))
+    }
+
+    /// The knob position this gain sits at. Inverse of [`Self::at_knob`].
+    #[must_use]
+    pub fn knob(self) -> f32 {
+        let db = f32::from(self);
+        0.5 + db / (2.0 * Self::half_span(db))
+    }
+
+    fn half_span(side: f32) -> f32 {
+        if side < 0.0 {
+            -f32::from(Self::MIN)
+        } else {
+            f32::from(Self::MAX)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use kithara_test_utils::kithara;
+
+    use super::*;
+
+    #[kithara::test]
+    fn the_middle_of_the_knob_is_unity() {
+        assert_eq!(GainDb::at_knob(0.5), GainDb::DEFAULT);
+    }
+
+    #[kithara::test]
+    fn unity_sits_in_the_middle_of_the_knob() {
+        assert_eq!(GainDb::default().knob(), 0.5);
+    }
+
+    #[kithara::test]
+    fn the_bottom_of_the_knob_is_the_floor_of_the_range() {
+        assert_eq!(GainDb::at_knob(0.0), GainDb::MIN);
+    }
+
+    #[kithara::test]
+    fn the_top_of_the_knob_is_the_ceiling_of_the_range() {
+        assert_eq!(GainDb::at_knob(1.0), GainDb::MAX);
+    }
+
+    /// The two halves are scaled separately, so the mapping is only usable if
+    /// it survives a round trip at every position, not just at the three ends.
+    #[kithara::test]
+    fn a_knob_position_survives_the_round_trip() {
+        for step in 0..=20u8 {
+            let knob = f32::from(step) / 20.0;
+            let round_trip = GainDb::at_knob(knob).knob();
+            assert!(
+                (round_trip - knob).abs() < 1e-6,
+                "knob {knob} came back as {round_trip}"
+            );
+        }
+    }
+
+    #[kithara::test]
+    fn a_knob_past_its_travel_is_held_at_the_end() {
+        assert_eq!(GainDb::at_knob(2.0), GainDb::MAX);
+        assert_eq!(GainDb::at_knob(-1.0), GainDb::MIN);
+    }
+}

--- a/crates/kithara-audio/src/effects/eq/isolator.rs
+++ b/crates/kithara-audio/src/effects/eq/isolator.rs
@@ -36,12 +36,12 @@ impl IsolatorEq {
             #[cfg(test)]
             pub(crate) fn bypass_active(&self) -> bool;
             #[cfg(test)]
-            #[call(force_current)]
-            pub(crate) fn force_current_gain(&mut self, band: usize, linear: f32);
-            #[cfg(test)]
             pub(crate) fn is_smoothing(&self) -> bool;
             #[call(set)]
             pub fn set_gain(&mut self, band: usize, gain_db: GainDb);
+            #[cfg(test)]
+            #[call(settle)]
+            pub(crate) fn settle_gain(&mut self, band: usize);
             #[cfg(test)]
             pub(crate) fn silence_active(&self) -> bool;
         }

--- a/crates/kithara-audio/src/effects/eq/isolator.rs
+++ b/crates/kithara-audio/src/effects/eq/isolator.rs
@@ -1,7 +1,7 @@
 use kithara_decode::sanitize_sample;
 use num_traits::cast::AsPrimitive;
 
-use super::{EqBandConfig, filter::CrossoverFilters, gain::GainBank};
+use super::{EqBandConfig, GainDb, filter::CrossoverFilters, gain::GainBank};
 
 /// Single-channel isolator crossover EQ.
 pub struct IsolatorEq {
@@ -32,7 +32,7 @@ impl IsolatorEq {
             pub const fn band_count(&self) -> usize;
             #[must_use]
             #[call(target)]
-            pub fn target_gain(&self, band: usize) -> Option<f32>;
+            pub fn target_gain(&self, band: usize) -> Option<GainDb>;
             #[cfg(test)]
             pub(crate) fn bypass_active(&self) -> bool;
             #[cfg(test)]
@@ -41,7 +41,7 @@ impl IsolatorEq {
             #[cfg(test)]
             pub(crate) fn is_smoothing(&self) -> bool;
             #[call(set)]
-            pub fn set_gain(&mut self, band: usize, gain_db: f32);
+            pub fn set_gain(&mut self, band: usize, gain_db: GainDb);
             #[cfg(test)]
             pub(crate) fn silence_active(&self) -> bool;
         }
@@ -100,7 +100,7 @@ mod tests {
         let bands = super::super::band::generate_log_spaced_bands(3);
         let mut eq = IsolatorEq::new(&bands, SAMPLE_RATE);
         for band in 0..bands.len() {
-            eq.set_gain(band, 6.0);
+            eq.set_gain(band, GainDb::MAX);
         }
 
         let _ = eq.process_sample(1.0);

--- a/crates/kithara-audio/src/effects/eq/mod.rs
+++ b/crates/kithara-audio/src/effects/eq/mod.rs
@@ -2,8 +2,10 @@ mod band;
 mod effect;
 mod filter;
 mod gain;
+mod gain_db;
 mod isolator;
 
-pub use band::{EqBandConfig, FilterKind, MAX_GAIN_DB, MIN_GAIN_DB, generate_log_spaced_bands};
+pub use band::{EqBandConfig, FilterKind, generate_log_spaced_bands};
 pub use effect::EqEffect;
+pub use gain_db::GainDb;
 pub use isolator::IsolatorEq;

--- a/crates/kithara-platform/CONTEXT.md
+++ b/crates/kithara-platform/CONTEXT.md
@@ -86,6 +86,19 @@ and under `flash` it is the virtual clock. `web_time` is internal to this crate 
 `std::time`, `web_time`, `tokio::time`), `arch.no-direct-thread-wait` (blocking thread waits),
 `arch.no-implicit-clock` (hidden clock reads in library code).
 
+## Ranged Values
+
+`ranged!` declares a float newtype that cannot hold a value outside its range: the type
+carries `MIN`, `MAX` and `DEFAULT` as values of itself, and the only way in is `From`,
+which clamps. `NaN` is in no range and yields `DEFAULT` rather than propagating through
+every later comparison.
+
+It exists so a bound crosses a crate boundary as a type rather than as a pair of loose
+constants a caller has to import and remember to clamp against. The owning crate declares
+the type next to the code that defines the range; every other crate imports the type.
+Plain `f32` stays at ABI and RT-message boundaries (FFI, `firewheel` diffable nodes),
+which convert once at the door.
+
 ## Feature Flags
 
 All off by default. `flash`, `loom`, `no-block` are native and test-only, referenced by no

--- a/crates/kithara-platform/src/common/mod.rs
+++ b/crates/kithara-platform/src/common/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod cancel;
 pub(crate) mod error;
 pub(crate) mod gate;
 pub(crate) mod maybe_send;
+pub(crate) mod ranged;
 pub(crate) mod thread_id;
 pub(crate) mod time;
 pub mod traits;

--- a/crates/kithara-platform/src/common/ranged.rs
+++ b/crates/kithara-platform/src/common/ranged.rs
@@ -1,0 +1,116 @@
+/// Declare a newtype whose value is kept inside a fixed range.
+///
+/// The generated type stores one float, carries its own bounds as `MIN` /
+/// `MAX` and its fallback as `DEFAULT` — all three values of the type itself —
+/// and is built through `From`, which clamps. A caller imports the type
+/// instead of a pair of loose bounds constants, and cannot hold a value the
+/// range does not allow.
+///
+/// `NaN` is in no range, so it yields `DEFAULT` rather than propagating.
+///
+/// ```
+/// kithara_platform::ranged!(
+///     /// Fraction of the way through a fade.
+///     pub struct Progress(f32, 0.0, 1.0, 0.0)
+/// );
+///
+/// assert_eq!(Progress::from(2.0), Progress::MAX);
+/// assert_eq!(Progress::default(), Progress::DEFAULT);
+/// assert_eq!(f32::from(Progress::from(0.25)), 0.25);
+/// ```
+#[macro_export]
+macro_rules! ranged {
+    (
+        $(#[$meta:meta])*
+        $vis:vis struct $name:ident($t:ty, $min:expr, $max:expr, $default:expr)
+    ) => {
+        $(#[$meta])*
+        #[derive(Clone, Copy, PartialEq, PartialOrd)]
+        $vis struct $name($t);
+
+        impl $name {
+            /// Lowest value this type can hold.
+            pub const MIN: Self = Self($min);
+            /// Highest value this type can hold.
+            pub const MAX: Self = Self($max);
+            /// Value a default-constructed instance carries, and the answer to
+            /// a `NaN` input.
+            pub const DEFAULT: Self = Self($default);
+
+            fn clamp(value: $t) -> $t {
+                if value.is_nan() {
+                    Self::DEFAULT.0
+                } else {
+                    value.clamp(Self::MIN.0, Self::MAX.0)
+                }
+            }
+        }
+
+        impl Default for $name {
+            fn default() -> Self {
+                Self::DEFAULT
+            }
+        }
+
+        impl From<$t> for $name {
+            fn from(value: $t) -> Self {
+                Self(Self::clamp(value))
+            }
+        }
+
+        impl From<$name> for $t {
+            fn from(value: $name) -> Self {
+                value.0
+            }
+        }
+
+        impl ::core::fmt::Debug for $name {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                write!(f, "{}({})", stringify!($name), self.0)
+            }
+        }
+
+        impl ::core::fmt::Display for $name {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                ::core::fmt::Display::fmt(&self.0, f)
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use kithara_test_utils::kithara;
+
+    crate::ranged!(
+        /// Asymmetric on purpose: the two ends have to be read separately.
+        pub struct Probe(f32, -24.0, 6.0, 0.0)
+    );
+
+    #[kithara::test]
+    fn a_value_above_the_range_lands_on_the_ceiling() {
+        assert_eq!(Probe::from(100.0), Probe::MAX);
+    }
+
+    #[kithara::test]
+    fn a_value_below_the_range_lands_on_the_floor() {
+        assert_eq!(Probe::from(-100.0), Probe::MIN);
+    }
+
+    #[kithara::test]
+    fn a_value_inside_the_range_is_kept_exactly() {
+        assert_eq!(f32::from(Probe::from(-3.5)), -3.5);
+    }
+
+    /// `NaN` compares false against both bounds, so clamping alone would carry
+    /// it through and poison every comparison downstream of it.
+    #[kithara::test]
+    fn a_nan_becomes_the_default() {
+        assert_eq!(Probe::from(f32::NAN), Probe::DEFAULT);
+    }
+
+    #[kithara::test]
+    fn the_default_value_is_the_declared_one() {
+        assert_eq!(Probe::default(), Probe::DEFAULT);
+    }
+}

--- a/crates/kithara-play/src/api/equalizer.rs
+++ b/crates/kithara-play/src/api/equalizer.rs
@@ -21,6 +21,7 @@ pub trait Equalizer: MaybeSend + MaybeSync + 'static {
     /// Reset all bands to 0 dB.
     fn reset(&self) -> Result<(), PlayError>;
 
-    /// Set the gain in dB for the given band index (clamped to -24..+6 dB).
+    /// Set the gain in dB for the given band index. The value is clamped
+    /// into `kithara_audio`'s EQ gain range on the way in.
     fn set_gain(&self, band: usize, gain_db: f32) -> Result<(), PlayError>;
 }

--- a/crates/kithara-play/src/bridge/eq.rs
+++ b/crates/kithara-play/src/bridge/eq.rs
@@ -1,14 +1,11 @@
 use core::{fmt, sync::atomic::Ordering};
 
 use arc_swap::ArcSwap;
-use kithara_audio::effects::eq::{MAX_GAIN_DB, MIN_GAIN_DB};
+use kithara_audio::effects::eq::GainDb;
 use kithara_platform::sync::Arc;
 use portable_atomic::AtomicF32;
 
 use crate::error::PlayError;
-
-pub(crate) const EQ_MAX_GAIN_DB: f32 = MAX_GAIN_DB;
-pub(crate) const EQ_MIN_GAIN_DB: f32 = MIN_GAIN_DB;
 
 #[derive(Clone)]
 pub struct SharedEq {
@@ -27,7 +24,7 @@ impl fmt::Debug for SharedEq {
 impl SharedEq {
     #[must_use]
     pub fn new(bands: usize) -> Self {
-        let gains = (0..bands).map(|_| AtomicF32::new(0.0)).collect();
+        let gains = (0..bands).map(|_| AtomicF32::new(unity())).collect();
         Self {
             gains: Arc::new(ArcSwap::from_pointee(gains)),
         }
@@ -44,11 +41,11 @@ impl SharedEq {
 
     pub(crate) fn reset(&self) {
         for gain in self.gains.load().iter() {
-            gain.store(0.0, Ordering::Relaxed);
+            gain.store(unity(), Ordering::Relaxed);
         }
     }
 
-    pub(crate) fn set_gain(&self, band: usize, gain_db: f32) -> Result<f32, PlayError> {
+    pub(crate) fn set_gain(&self, band: usize, gain_db: GainDb) -> Result<(), PlayError> {
         let gains = self.gains.load();
         let Some(current) = gains.get(band) else {
             return Err(PlayError::EqBandOutOfRange {
@@ -56,22 +53,30 @@ impl SharedEq {
                 bands: gains.len(),
             });
         };
-        let clamped = gain_db.clamp(EQ_MIN_GAIN_DB, EQ_MAX_GAIN_DB);
-        current.store(clamped, Ordering::Relaxed);
-        Ok(clamped)
+        current.store(f32::from(gain_db), Ordering::Relaxed);
+        Ok(())
     }
 
     pub(crate) fn snapshot(&self) -> Vec<f32> {
         self.gains.load().iter().map(load_gain).collect()
     }
 
-    pub(crate) fn replace(&self, gains: &[f32]) {
+    pub(crate) fn replace(&self, gains: &[GainDb]) {
         self.gains.store(Arc::new(band_array(gains)));
     }
 }
 
-fn band_array(gains: &[f32]) -> Vec<AtomicF32> {
-    gains.iter().copied().map(AtomicF32::new).collect()
+fn band_array(gains: &[GainDb]) -> Vec<AtomicF32> {
+    gains
+        .iter()
+        .copied()
+        .map(f32::from)
+        .map(AtomicF32::new)
+        .collect()
+}
+
+fn unity() -> f32 {
+    f32::from(GainDb::default())
 }
 
 fn load_gain(gain: &AtomicF32) -> f32 {
@@ -88,13 +93,13 @@ mod tests {
     fn a_handle_clone_sees_the_replacement_band_array() {
         let eq = SharedEq::new(3);
         let handle = eq.clone();
-        eq.set_gain(1, 4.0).unwrap();
+        eq.set_gain(1, GainDb::from(4.0)).unwrap();
         assert_eq!(handle.snapshot(), vec![0.0, 4.0, 0.0]);
 
-        eq.replace(&[-6.0, -2.0, 2.0, 5.0]);
+        eq.replace(&[-6.0f32, -2.0, 2.0, 5.0].map(GainDb::from));
         assert_eq!(handle.len(), 4);
         assert_eq!(handle.gain(2), Some(2.0));
-        assert_eq!(handle.set_gain(3, 1.0).unwrap(), 1.0);
+        handle.set_gain(3, GainDb::from(1.0)).unwrap();
         assert_eq!(eq.snapshot(), vec![-6.0, -2.0, 2.0, 1.0]);
     }
 }

--- a/crates/kithara-play/src/bridge/mod.rs
+++ b/crates/kithara-play/src/bridge/mod.rs
@@ -6,7 +6,6 @@ pub mod protocol;
 
 pub use channels::{MixTapWriter, NodeInputs, SlotControl, slot_channels};
 pub use eq::SharedEq;
-pub(crate) use eq::{EQ_MAX_GAIN_DB, EQ_MIN_GAIN_DB};
 pub use metrics::{RtMetrics, RtMetricsSnapshot};
 pub use playback::{PlaybackShared, PlaybackSnapshot};
 pub use protocol::{

--- a/crates/kithara-play/src/player/flow/control.rs
+++ b/crates/kithara-play/src/player/flow/control.rs
@@ -1,4 +1,4 @@
-use kithara_audio::EqBandConfig;
+use kithara_audio::{EqBandConfig, effects::eq::GainDb};
 use kithara_events::RouteDescription;
 
 use super::super::core::PlayerImpl;
@@ -79,8 +79,11 @@ impl PlayerImpl {
             .engine
             .slot_eq(slot_id)
             .ok_or(PlayError::SlotNotFound(slot_id))?;
-        let clamped = eq.set_gain(band, gain_db)?;
-        self.core.engine.set_master_eq_gain(band, clamped)
+        let gain_db = GainDb::from(gain_db);
+        eq.set_gain(band, gain_db)?;
+        self.core
+            .engine
+            .set_master_eq_gain(band, f32::from(gain_db))
     }
 
     delegate::delegate! {

--- a/crates/kithara-play/src/rt/eq.rs
+++ b/crates/kithara-play/src/rt/eq.rs
@@ -11,10 +11,8 @@ use firewheel::{
         ProcBuffers, ProcExtra, ProcInfo, ProcStreamCtx, ProcessStatus,
     },
 };
-use kithara_audio::{EqBandConfig, IsolatorEq};
+use kithara_audio::{EqBandConfig, IsolatorEq, effects::eq::GainDb};
 use kithara_test_utils::kithara;
-
-use crate::bridge::{EQ_MAX_GAIN_DB, EQ_MIN_GAIN_DB};
 
 #[derive(Diff, Patch, Debug, Clone, Copy, PartialEq)]
 pub(crate) struct MasterEqBand {
@@ -36,7 +34,7 @@ impl MasterEqNode {
             .iter()
             .map(|band| MasterEqBand {
                 frequency: band.frequency(),
-                gain_db: band.gain_db(),
+                gain_db: f32::from(band.gain_db()),
                 q_factor: band.q_factor(),
                 kind: band.kind() as u8,
             })
@@ -48,9 +46,9 @@ impl MasterEqNode {
         }
     }
 
-    pub(crate) fn set_gain(&mut self, index: usize, gain_db: f32) {
+    pub(crate) fn set_gain(&mut self, index: usize, gain_db: GainDb) {
         if let Some(band) = self.bands.get_mut(index) {
-            band.gain_db = gain_db.clamp(EQ_MIN_GAIN_DB, EQ_MAX_GAIN_DB);
+            band.gain_db = f32::from(gain_db);
         }
     }
 }
@@ -90,8 +88,8 @@ impl MasterEqProcessor {
         let mut eq_r = IsolatorEq::new(&bands, sample_rate.get());
 
         for (i, band) in params.bands.iter().enumerate() {
-            eq_l.set_gain(i, band.gain_db);
-            eq_r.set_gain(i, band.gain_db);
+            eq_l.set_gain(i, GainDb::from(band.gain_db));
+            eq_r.set_gain(i, GainDb::from(band.gain_db));
         }
 
         Self {
@@ -104,8 +102,8 @@ impl MasterEqProcessor {
 
     fn sync_gains(&mut self) {
         for (i, band) in self.params.bands.iter().enumerate() {
-            self.eq_l.set_gain(i, band.gain_db);
-            self.eq_r.set_gain(i, band.gain_db);
+            self.eq_l.set_gain(i, GainDb::from(band.gain_db));
+            self.eq_r.set_gain(i, GainDb::from(band.gain_db));
         }
     }
 }
@@ -118,7 +116,7 @@ fn bands_from_params(params: &MasterEqNode) -> Vec<EqBandConfig> {
             EqBandConfig::builder()
                 .frequency(b.frequency)
                 .q_factor(b.q_factor)
-                .gain_db(b.gain_db)
+                .gain_db(GainDb::from(b.gain_db))
                 .kind(b.kind.into())
                 .build()
         })

--- a/crates/kithara-play/src/session/graph.rs
+++ b/crates/kithara-play/src/session/graph.rs
@@ -2,7 +2,7 @@ use firewheel::{
     FirewheelCtx, Volume, backend::AudioBackend, diff::Memo,
     dsp::volume::amp_to_linear_volume_clamped, node::NodeID, nodes::volume::VolumeNode,
 };
-use kithara_audio::EqBandConfig;
+use kithara_audio::{EqBandConfig, effects::eq::GainDb};
 use tracing::{debug, warn};
 
 use super::{
@@ -141,7 +141,7 @@ pub(super) mod lifecycle {
         }
         let mut master_eq = MasterEqNode::new(&player.eq_layout);
         for (band, gain) in player.shared_eq.snapshot().into_iter().enumerate() {
-            master_eq.set_gain(band, gain);
+            master_eq.set_gain(band, GainDb::from(gain));
         }
         let master_eq_memo = Memo::new(master_eq.clone());
         let master_eq_id = fw_ctx.add_node(master_eq, None);
@@ -465,7 +465,7 @@ pub(super) mod controls {
                 bands: memo.bands.len(),
             });
         }
-        memo.set_gain(band, gain_db);
+        memo.set_gain(band, GainDb::from(gain_db));
         let mut queue = fw_ctx.event_queue(master_eq_id);
         memo.update_memo(&mut queue);
         Ok(())
@@ -775,7 +775,7 @@ mod tests {
         let previous_volume = state.players[0].master_volume_node_id;
         let mut layout = generate_log_spaced_bands(4);
         for (band, gain) in layout.iter_mut().zip([-6.0, -3.0, 1.5, 4.0]) {
-            band.set_gain_db(gain);
+            band.set_gain_db(GainDb::from(gain));
         }
 
         assert!(matches!(

--- a/crates/kithara-play/src/session/state.rs
+++ b/crates/kithara-play/src/session/state.rs
@@ -2,7 +2,7 @@ use firewheel::{
     FirewheelConfig, FirewheelCtx, backend::AudioBackend, channel_config::ChannelCount, diff::Memo,
     node::NodeID, nodes::volume::VolumeNode,
 };
-use kithara_audio::EqBandConfig;
+use kithara_audio::{EqBandConfig, effects::eq::GainDb};
 use kithara_bufpool::PcmPool;
 use kithara_events::EventBus;
 use tracing::{debug, warn};
@@ -72,10 +72,7 @@ impl PlayerState {
     }
 }
 
-pub(super) fn prepare_eq_layout(mut eq_layout: Vec<EqBandConfig>) -> (Vec<EqBandConfig>, Vec<f32>) {
-    for band in &mut eq_layout {
-        band.set_gain_db(band.gain_db());
-    }
+pub(super) fn prepare_eq_layout(eq_layout: Vec<EqBandConfig>) -> (Vec<EqBandConfig>, Vec<GainDb>) {
     let gains = eq_layout.iter().map(EqBandConfig::gain_db).collect();
     (eq_layout, gains)
 }

--- a/tests/tests/kithara_audio/dsp_properties.rs
+++ b/tests/tests/kithara_audio/dsp_properties.rs
@@ -6,7 +6,7 @@ use std::{
 use kithara::{
     audio::{
         AudioEffect, EqEffect, PeakLimiter,
-        effects::eq::{MAX_GAIN_DB, MIN_GAIN_DB, generate_log_spaced_bands},
+        effects::eq::{GainDb, generate_log_spaced_bands},
     },
     bufpool::PcmPool,
     decode::{PcmChunk, PcmMeta, PcmSpec},
@@ -26,10 +26,10 @@ const INTERMEDIATE_RATE: u16 = 44_100;
 const LIMITER_CEILING: f32 = 0.98;
 const LIMITER_RELEASE_MS: f32 = 50.0;
 
-const EQ_GAIN_PATHS: [(&str, f32); 3] = [
-    ("flat", 0.0),
-    ("boosted", MAX_GAIN_DB),
-    ("killed", MIN_GAIN_DB),
+const EQ_GAIN_PATHS: [(&str, GainDb); 3] = [
+    ("flat", GainDb::DEFAULT),
+    ("boosted", GainDb::MAX),
+    ("killed", GainDb::MIN),
 ];
 
 const SETTLE_FRAMES: usize = 9_600;
@@ -67,7 +67,7 @@ fn render(signal: &dyn SignalFn, sample_rate: u16, frames: usize) -> Vec<f32> {
         .collect()
 }
 
-fn eq_with_gain(gain_db: f32, band_count: usize, channels: u16) -> EqEffect {
+fn eq_with_gain(gain_db: GainDb, band_count: usize, channels: u16) -> EqEffect {
     let bands = generate_log_spaced_bands(band_count);
     let mut eq = EqEffect::new(bands, u32::from(HOST_RATE), channels);
     for band in 0..band_count {
@@ -132,10 +132,10 @@ fn non_finite_report(label: &str, samples: &[f32]) -> Vec<String> {
 }
 
 #[kithara::test]
-#[case::flat(0.0)]
-#[case::boosted(MAX_GAIN_DB)]
-#[case::killed(MIN_GAIN_DB)]
-fn eq_maps_silence_to_exact_silence(#[case] gain_db: f32) {
+#[case::flat(GainDb::DEFAULT)]
+#[case::boosted(GainDb::MAX)]
+#[case::killed(GainDb::MIN)]
+fn eq_maps_silence_to_exact_silence(#[case] gain_db: GainDb) {
     let pool = pcm_pool();
     let spec = host_spec(2);
     let mut eq = eq_with_gain(gain_db, 5, spec.channels);
@@ -164,7 +164,7 @@ fn limiter_maps_silence_to_exact_silence() {
 #[kithara::test]
 fn master_chain_maps_silence_to_exact_silence() {
     let pool = pcm_pool();
-    let mut eq = eq_with_gain(MAX_GAIN_DB, 5, 2);
+    let mut eq = eq_with_gain(GainDb::MAX, 5, 2);
     let mut limiter = limiter_with_ceiling(LIMITER_CEILING);
 
     let output = master_chain(&mut eq, &mut limiter, &pool, vec![0.0f32; 4_096]);
@@ -181,7 +181,7 @@ fn master_chain_maps_silence_to_exact_silence() {
 fn eq_at_zero_db_is_bit_exact_identity(#[case] channels: u16, #[case] band_count: usize) {
     let pool = pcm_pool();
     let spec = host_spec(channels);
-    let mut eq = eq_with_gain(0.0, band_count, channels);
+    let mut eq = eq_with_gain(GainDb::default(), band_count, channels);
     let input = render(&SineWave(440.0), HOST_RATE, 8_192 * usize::from(channels));
 
     let output = process_eq(&mut eq, &pool, spec, input.clone());
@@ -196,11 +196,11 @@ fn eq_at_zero_db_is_bit_exact_identity(#[case] channels: u16, #[case] band_count
 fn eq_returns_to_bit_exact_identity_after_a_gain_round_trip() {
     let pool = pcm_pool();
     let spec = host_spec(2);
-    let mut eq = eq_with_gain(0.0, 3, spec.channels);
+    let mut eq = eq_with_gain(GainDb::default(), 3, spec.channels);
 
-    eq.set_gain(0, MAX_GAIN_DB);
+    eq.set_gain(0, GainDb::MAX);
     settle(&mut eq, &pool, spec);
-    eq.set_gain(0, 0.0);
+    eq.set_gain(0, GainDb::default());
     settle(&mut eq, &pool, spec);
     settle(&mut eq, &pool, spec);
 
@@ -237,7 +237,7 @@ fn limiter_below_ceiling_is_bit_exact_identity(#[case] ceiling: f32) {
 #[kithara::test]
 fn master_chain_at_unity_is_bit_exact_identity() {
     let pool = pcm_pool();
-    let mut eq = eq_with_gain(0.0, 5, 2);
+    let mut eq = eq_with_gain(GainDb::default(), 5, 2);
     let mut limiter = limiter_with_ceiling(LIMITER_CEILING);
 
     let sine = render(&SineWave(440.0), HOST_RATE, 8_192);


### PR DESCRIPTION
## Summary

Batch 4 of the programme that moves hardcoded policy parameters into the config
each crate already owns (batch 1: #218, batch 2: #222, batch 3: #224). This one
is `kithara-app`, plus a range that had an owner but no type.

Smaller than the earlier batches on purpose: the remaining library crates —
`hls`, `play`, `decode`, `ffi`, and most of `audio` — have their parameters
sitting in files currently held by #199, #118 and #223. Taking them now would
mean writing into someone else's open diff. See *Risks / follow-ups* for what is
waiting on what.

## Behavior / scope

**Two app knobs into `AppConfig`.** `WAVEFORM_MAX_BUCKETS = 96_000` (the ceiling
on how much waveform a long track may store) and `DEFAULT_EQ_BANDS = 3` (the
band count every deck's player graph is built with) were private constants next
to a config that already carries the crossfade, the track list and the probe
method. Both become fields with the same values as defaults.

The bucket cap is now threaded to `AnalysisController::new` instead of read out
of the air, which also puts it into `analysis_fingerprint` as a value rather
than as a literal. That fingerprint is the cache key of the durable analysis
blob, so a cap that can move has to move it too — a test pins that two caps give
two fingerprints. The controller tests pass their own small cap, so nothing
re-reads the number the config now owns.

**The EQ gain range is a type now, not a pair of constants.** `app`'s knob
declared its own `EQ_MIN_DB` / `EQ_MAX_DB` beside `kithara-audio`'s
`MIN_GAIN_DB` / `MAX_GAIN_DB`, so the first commit here pointed the knob at the
owner. That fixed the duplicate but kept the shape that caused it: a bound
crossing a crate boundary as two loose floats, with each consumer writing its
own clamp — and writing it differently. `kithara-play` re-exported the pair
under new names and clamped the same value twice on its way down; the app
clamped on the read path and not on the write path.

`kithara-platform` gains `ranged!`, which declares a float newtype that cannot
hold a value outside its range: `MIN`, `MAX` and `DEFAULT` are values of the
type itself and the only way in is `From`, which clamps. `NaN` belongs to no
range, so it yields `DEFAULT` instead of riding through every later comparison.

`kithara-audio` uses it for `GainDb` and drops both constants. `EqBandConfig`,
`EqEffect`, `IsolatorEq` and the gain bank take the type, so `set_gain_db` and
`GainState::set_target` no longer clamp and the tests that pinned the clamp
assert on values instead of on a tolerance around them. The knob mapping moves
in with the range it depends on: `GainDb::at_knob` / `GainDb::knob` are the
app's old `db_from_knob` / `knob_from_db`, which needed the two constants to
know where each half of the travel ends.

`kithara-play` and `kithara-app` import the type instead. `PlayerImpl::set_eq_gain`
converts once at the door and feeds the same value to both sinks;
`UiState::eq_bands` is `Vec<GainDb>`. Plain `f32` stays at three boundaries that
cannot hold the type and each converts where the value crosses: the FFI ABI,
`MasterEqBand` (a `firewheel` `Diff`/`Patch` node whose fields must be plain
floats), and the session command protocol.

One dead line fell out: `prepare_eq_layout` re-set every band's gain to itself
purely to trigger the clamp inside the old setter.

With the range owned by a type, `db_to_linear` follows it: both callers already
held a `GainDb` and the function already had to ask the type where its floor
was, so it is `GainDb::linear` now. In its new home the floor check is
`self == Self::MIN` rather than an inequality against a float, because holding a
value under the floor is not expressible — `From` clamps it there. The `10.0` it
raises is the base of the dB curve, not the log base of the frequency grid it
was named after in `gain.rs`, so it reads `DB_LOG_BASE`. `GainBank::reset` stops
writing `1.0` into two fields by hand and assigns
`GainState::new(GainDb::default())` instead.

**The EQ smoother is firewheel's now, not ours.** `GainState` carried a
hand-written one-pole: a coefficient from `1 - exp(-1 / (tau * rate))`, a step
of `coeff.mul_add(diff, current)`, and a snap once the step landed inside an
absolute threshold. `firewheel` ships exactly that filter, `kithara-play`
already smooths its fades and its render gate with it, and the workspace has
been building it all along as a dependency of `firewheel` - `kithara-audio` was
the only place still writing its own.

`firewheel-core`'s `SmoothingFilter` and `SmoothingFilterCoeff` replace it. The
curve is identical by construction: firewheel's `z1 = target*a0 + z1*b1` with
`b1 = exp(-1 / (secs * rate))` is our step with our coefficient. The filter
still advances once per 32 samples, so the coefficient divides the smoothing
window by the block size rather than the rate by it - same curve, and the rate
stays the exact integer `SmoothingFilterCoeff` wants.

`GainState` becomes `SmoothedGain` and holds its own invariants at last.
`GainBank` used to reach into its private fields from six places; it asks now -
`current`, `target`, `set_target`, `settle`, `settled_at`, `smooth`. The fast
paths read better for it: `refresh_fastpath` is
`all_settled_at(GainDb::default())` for bypass and `all_settled_at(GainDb::MIN)`
for silence, which is the contract in the words the contract is written in,
with no float literals left in it.

Two things change shape rather than behaviour. The settle threshold is
firewheel's `|target| * eps + eps` instead of our flat `eps`, so a band ramping
toward a large boost settles a block or two sooner; every gain still lands on
its target exactly, which is what the fast paths test for. And the test-only
`force_current(band, linear)` is `settle(band)`: both call sites passed the
value the band was already aimed at, so what they wanted was "skip the ramp",
not "put the band somewhere else".

**The magic-number rule stops flagging a named default.**
`style.no-magic-numbers` exempts `const` and `static` items, which is why these
parameters were constants to begin with. Moving one onto a config field
rewrites it as `#[builder(default = N)]` — an attribute the rule did not exempt
— so a value the rule itself pushed into a `const` came back as a warning the
moment it landed where it belongs: +8 hits in batch 1, +7 in batch 3, +2 here.
The rule's own message asks for the number to be extracted into a named
constant, and a builder default is named, by the field it defaults.
`#[builder(...)]` and `#[serde(...)]` attributes are now exempt in both the
integer and the float branch. `ranged!(pub struct GainDb(f32, -24.0, 6.0, 0.0))`
is the same case for the same reason — that line is where `-24.0` gets the name
`GainDb::MIN` — so float literals inside a `ranged!` invocation are exempt too.
Only the float branch needs that one: the integer branch already exempts every
macro invocation.

## Validation

- `just test` — 4018 passed, 0 failed, 26 skipped (176 s); 4007 before. The
  eleven new tests are the six on `GainDb` plus five on `ranged!`, less the two
  the app's knob helpers took with them, plus one net from the `linear` move
  (the two `db_to_linear` tests became three, because a request under the floor
  and the floor itself are separate properties) and one for the smoother's
  unusable-rate path.
- `just test run eq_` — 65 passed, 0 failed, over the smoother swap: the ramp,
  the convergence, the discontinuity check, both fast paths and the
  `dsp_properties` suite all hold without a test edit.
- `just lint fast` — clean over the final tree (the commit hook runs it, and
  the last commit's run saw every change in this branch).
- The builder/serde exemption measured on one tree, rule as the only variable:
  1125 hits over `crates/` before, 1085 after. Every removed hit sits inside a
  `#[builder(` attribute; none appear.
- After the `GainDb` work the same scan reads 1084. The knob arithmetic moved
  from `app` to `audio` and keeps its four hits; the two bounds it used to sit
  beside are a `ranged!` declaration now and are exempt, as they were when they
  were `pub const`.

## Surface impact

- New `AppConfig` fields `waveform_max_buckets` and `eq_bands`, both defaulted;
  no caller has to change.
- `AnalysisController::new` takes the cap as a fourth argument (crate-private).
- New `kithara_platform::ranged!`, exported at the crate root.
- New dependency edge `kithara-audio -> firewheel-core`, for the smoother.
  `firewheel-core` is firewheel's shared-types crate: no backends, `std` only,
  and already in the build graph under `kithara-play`'s `firewheel`. It is an
  external crate, so `direction.toml`'s crate layering is untouched.
- `kithara_audio::effects::eq::{MIN_GAIN_DB, MAX_GAIN_DB}` are gone, replaced by
  `GainDb`. `EqBandConfig::gain_db` / `set_gain_db`, `EqEffect::{set_gain,
  target_gain}` and `IsolatorEq::{set_gain, target_gain}` change type with it.
- `kithara-play`'s `Equalizer` trait and every FFI entry point keep `f32`: they
  are ABI surface, and they convert on the way in.
- No gate moves with the rule change: `style.no-magic-numbers` is
  warning-severity and nothing in `lint fast`, `lint full` or CI passes
  ast-grep `--strict`, which is the only switch that promotes a warning to a
  failure.

## Risks / follow-ups

- Still held by open PRs, and queued for the next batches: `hls`
  (`READER_REAIM_INTERVAL`, the deferred-bus capacity — #199 holds
  `stream/coord.rs`), `decode` (`READER_READ_AHEAD_BYTES`, whose
  `reader_profile` callers sit in audio files #199 holds), `play`
  (`player/config.rs`, `resource/config.rs` — #118, #223) and `ffi` (the
  wasm/native divergence needs `web/worker.rs`, held by #118).
- `audio`'s scheduler park/burst budgets and the renderer gate poll interval
  are no longer blocked, but they are not in this batch either — they belong
  with `play` and `decode`, and taking one crate of that batch alone would
  split a review that reads better whole.
- `ranged!` ships with only the arm this branch needs: float, clamping `From`,
  no arithmetic operators and no fallible strict constructor. An integer arm is
  a straightforward addition when a caller wants one, and adding it later costs
  nothing that guessing at it now would save.
- The attribute exemption is attribute-wide, so a literal that appears in a
  `#[builder(...)]` attribute for some reason other than a default — a `with`
  closure, say — is exempt too. Narrowing it to the `default` argument would
  mean matching inside the attribute's token tree; the whole-attribute form is
  the one the rule file's existing exemptions are written in.
- No `#[serde(...)]` in the workspace carries a bare numeric literal today, so
  that half of the exemption removes nothing now and is there for the same
  reason as the builder half.
- Not moved and deliberately so: the app's tempo range and step and the GUI
  tick intervals. They are read deep in iced view and read code that carries no
  config, so making them configurable is plumbing churn in the demo GUI rather
  than a knob anyone can reach today.


