### PR TITLE
fix(tests,audio,stream): stress all-green — loom gate rendezvous and RT byte-space polls off the control mutex

### DIFF
--- a/crates/kithara-audio/CONTEXT.md
+++ b/crates/kithara-audio/CONTEXT.md
@@ -111,7 +111,24 @@ mutator of track state through `update_state`. Sub-owners never take
 `DecodeCtx`, `RouteCtx`) and return decision values for the coordinator to apply.
 
 - `SharedStream<T>` — byte-space ground truth (position, len, phase, byte map,
-  anchors, init range). No other owner clones byte-range policy.
+  anchors, init range). No other owner clones byte-range policy. Every RT
+  byte-space call — `phase`/`phase_at`, `position`/`set_position`, `len`,
+  `byte_map`, `probe_seek` — answers from the source's narrow `SourceProbe`
+  handle, and the fixed-at-open handles (`abr_handle`,
+  `format_change_segment_range`, `peer_wake`) from clones resolved once in
+  `SharedStream::new`; none of them take the control mutex. Off-RT holders (a
+  construction reader parked in `Stream::read`, a consumer query) hold that
+  mutex across waits, and a contended acquire on the forbid-blocking produce
+  core is an RTSan violation (`sched_yield` in `parking_lot`'s contended
+  path). The probe answers from the source's self-synchronizing state and
+  must not take locks a reader wait can hold. Three calls still lock on RT
+  frames — `probe_read` (steady-state `Read`), `media_info`, and
+  `seek_time_anchor` — which is safe only because the sole off-RT holder
+  that parks under the mutex is the replacement rebuild reader, and it
+  exists exclusively while the FSM sits in `RebuildingDecoder`, a phase
+  whose tick touches none of those calls. The same window is the only time
+  the off-RT reader moves the byte cursor, which keeps `probe_seek`'s
+  non-atomic load→resolve→store single-writer.
 - `ActiveDecode` — the authoritative active `DecoderGeneration`, the optional
   `IncomingDecode`, the always-on `PcmBlender`, the effect chain, the EOF drain.
   Each `DecoderGeneration` owns its decoder facts, base offset, install epoch,

--- a/crates/kithara-audio/CONTEXT.md
+++ b/crates/kithara-audio/CONTEXT.md
@@ -160,6 +160,14 @@ stages per step: seek preemption (`preempt_target`), skipped while
 change (`start_route_change_recreate_if_needed`), skipped in
 recreate/rebuild/terminal phases; then the phase's own `step`.
 
+`AtEof` has exactly two owners, both semantic (PCM/timeline), never byte-space:
+the decode path's exhausted finalization (`decode/step.rs`) and a seek landing
+at-or-past `duration` (`SeekTransition::AtEof`). Byte-space `SourcePhase::Eof`
+is a readiness answer, not an end of track — the demuxer may still hold
+buffered frames past the last byte (a seek into the final segment parks the
+reader at the stream total with the tail undecoded) — so wait states resume
+into their `WaitContext` on it, exactly like `Ready`.
+
 `update_state` publishes the phase to the shared `Activity` PLAYING flag: every
 non-terminal phase keeps it set (the downloader peer's `priority()` reads it, and
 buffering / mid-seek / rebuild windows are still "listened to"); `AtEof` and

--- a/crates/kithara-audio/src/pipeline/stream/shared.rs
+++ b/crates/kithara-audio/src/pipeline/stream/shared.rs
@@ -5,11 +5,13 @@ use std::{
 };
 
 use delegate::delegate;
+use kithara_abr::AbrHandle;
 use kithara_platform::sync::{Arc, Mutex};
 use kithara_stream::{
-    Activity, ByteMap, ConstructionGate, MediaInfo, OpenedReader, PlayheadWrite, SeekControl,
-    SeekObserve, SourcePhase, SourceSeekAnchor, Stream, StreamResult, StreamType, WaitOutcome,
-    WorkerWake,
+    Activity, ByteMap, ConstructionGate, DeferredWake, MediaInfo, OpenedReader, PlayheadWrite,
+    SeekControl, SeekObserve, SourcePhase, SourceProbe, SourceSeekAnchor, Stream, StreamResult,
+    StreamType, VariantControl, WaitOutcome, WorkerWake, format_change_segment_range,
+    resolve_seek_target,
 };
 
 use super::offset::OffsetReader;
@@ -53,6 +55,17 @@ impl DemandCell {
 /// - `StreamAudioSource` to check `media_info()` for format changes
 pub(crate) struct SharedStream<T: StreamType> {
     inner: Arc<Mutex<Stream<T>>>,
+    /// Narrow byte-space handle. RT polls — phase, cursor, length, byte
+    /// map — answer from here and never take `inner`: off-RT holders (a
+    /// construction reader parked in `Stream::read`, a consumer query)
+    /// hold that mutex across waits, and any contended acquire blocks the
+    /// forbid-blocking produce core.
+    probe: Arc<dyn SourceProbe>,
+    /// Fixed-at-open handles the produce core reaches without `inner`;
+    /// resolved once in [`Self::new`] before the stream enters the mutex.
+    abr: Option<AbrHandle>,
+    variants: Option<Arc<dyn VariantControl>>,
+    peer_wake: Option<Arc<DeferredWake>>,
     demand: Arc<DemandCell>,
     /// Construction mode for one decoder reader. Coordinator clones carry no
     /// gate; every opened reader receives a fresh gate so an off-RT rebuild
@@ -62,11 +75,94 @@ pub(crate) struct SharedStream<T: StreamType> {
 
 impl<T: StreamType> SharedStream<T> {
     pub(crate) fn new(stream: Stream<T>) -> Self {
+        let probe = stream.probe();
+        let abr = stream.abr_handle();
+        let variants = stream.variant_control();
+        let peer_wake = stream.peer_wake();
         Self {
             inner: Arc::new(Mutex::new(stream)),
+            probe,
+            abr,
+            variants,
+            peer_wake,
             demand: Arc::default(),
             construction_gate: None,
         }
+    }
+
+    /// Overall source readiness at current position — answered by the
+    /// narrow [`SourceProbe`], never the control mutex.
+    pub(crate) fn phase(&self) -> SourcePhase {
+        self.probe.phase()
+    }
+
+    /// Point-in-time readiness for a specific byte range — same contract
+    /// as [`Self::phase`].
+    pub(crate) fn phase_at(&self, range: Range<u64>) -> SourcePhase {
+        self.probe.phase_at(range)
+    }
+
+    /// Current read position — the source's atomic cursor via the probe.
+    pub(crate) fn position(&self) -> u64 {
+        self.probe.position()
+    }
+
+    /// Absolute byte cursor set — forwards to the inner source's atomic,
+    /// used post-seek when the audio FSM lands at a known byte position.
+    pub(crate) fn set_position(&self, pos: u64) {
+        self.probe.set_position(pos);
+    }
+
+    /// Total length if known — answered by the probe.
+    pub(crate) fn len(&self) -> Option<u64> {
+        self.probe.len()
+    }
+
+    /// Optional byte-map handle — answered by the probe; the decoder
+    /// factory uses it to activate the segment-by-segment fMP4 path.
+    pub(crate) fn byte_map(&self) -> Option<Arc<dyn ByteMap>> {
+        self.probe.byte_map()
+    }
+
+    /// Runtime ABR handle — `Some` for adaptive sources (HLS).
+    pub(crate) fn abr_handle(&self) -> Option<AbrHandle> {
+        self.abr.clone()
+    }
+
+    /// Header byte range for decoder recreate after a format change — via
+    /// the fixed variant-control handle; same answer as
+    /// [`Stream::format_change_segment_range`].
+    pub(crate) fn format_change_segment_range(&self) -> StreamResult<Range<u64>> {
+        format_change_segment_range(self.variants.as_deref())
+    }
+
+    /// The reader→peer wake handle — `Some` for segmented sources (HLS)
+    /// that push a downloader peer.
+    pub(crate) fn peer_wake(&self) -> Option<Arc<DeferredWake>> {
+        self.peer_wake.clone()
+    }
+
+    /// Real-time on-core seek (FSM recreate/boundary, decoder
+    /// `OffsetReader`): cursor math + cursor set through the probe, no
+    /// lock and no `prime_seek_range` spin on the forbid-blocking produce
+    /// core — the same [`resolve_seek_target`] math as the off-RT
+    /// [`Seek::seek`]. The load→resolve→store is not atomic: it relies on
+    /// the single-cursor-writer invariant — the produce core owns the
+    /// cursor except while it is parked in `RebuildingDecoder`, the only
+    /// window where the off-RT rebuild reader moves it instead.
+    ///
+    /// # Errors
+    ///
+    /// See [`resolve_seek_target`].
+    pub(crate) fn probe_seek(&self, pos: SeekFrom) -> io::Result<u64> {
+        let new_pos = resolve_seek_target(pos, self.probe.position(), self.probe.len())?;
+        self.probe.set_position(new_pos);
+        // The reader cursor moved on the produce core: arm the peer so it
+        // re-targets fetches around the new position. The shell flushes it.
+        if let Some(ref wake) = self.peer_wake {
+            wake.arm();
+        }
+        Ok(new_pos)
     }
 
     /// Record `range` as the window a parked decoder poll waits on.
@@ -115,6 +211,10 @@ impl<T: StreamType> SharedStream<T> {
     fn with_construction_gate(&self, construction_gate: ConstructionGate) -> Self {
         Self {
             inner: Arc::clone(&self.inner),
+            probe: Arc::clone(&self.probe),
+            abr: self.abr.clone(),
+            variants: self.variants.clone(),
+            peer_wake: self.peer_wake.clone(),
             demand: Arc::clone(&self.demand),
             construction_gate: Some(construction_gate),
         }
@@ -122,22 +222,10 @@ impl<T: StreamType> SharedStream<T> {
 
     delegate! {
         to self.inner.lock() {
-            pub(crate) fn position(&self) -> u64;
-            /// Absolute byte cursor set — forwards to the inner source's
-            /// atomic, used post-seek when the audio FSM lands at a
-            /// known byte position.
-            pub(crate) fn set_position(&self, pos: u64);
-            pub(crate) fn len(&self) -> Option<u64>;
             pub(crate) fn media_info(&self) -> Option<MediaInfo>;
-            pub(crate) fn abr_handle(&self) -> Option<kithara_abr::AbrHandle>;
-            pub(crate) fn format_change_segment_range(&self) -> StreamResult<Range<u64>>;
             pub(crate) fn seek_time_anchor(&self, position: kithara_platform::time::Duration) -> Result<Option<SourceSeekAnchor>, io::Error>;
             /// Build a fresh reader-side event-sink instance from the inner source.
             pub(crate) fn take_reader_event_sink(&self) -> Option<kithara_stream::BoxedEventSink>;
-            /// Pull a clone of the optional byte-map handle from the
-            /// inner source. Used by the decoder factory to activate the
-            /// segment-by-segment fMP4 path on HLS.
-            pub(crate) fn byte_map(&self) -> Option<Arc<dyn ByteMap>>;
             pub(crate) fn seek_prepare(&self) -> Option<Arc<dyn kithara_stream::SeekPrepare>>;
             /// Narrow mutating playhead handle.
             pub(crate) fn playhead_write(&self) -> Arc<dyn PlayheadWrite>;
@@ -147,28 +235,15 @@ impl<T: StreamType> SharedStream<T> {
             pub(crate) fn seek_observe(&self) -> Arc<dyn SeekObserve>;
             /// Narrow activity handle.
             pub(crate) fn activity(&self) -> Arc<dyn Activity>;
-            /// Overall source readiness at current position.
-            pub(crate) fn phase(&self) -> SourcePhase;
-            /// Point-in-time readiness for a specific byte range.
-            pub(crate) fn phase_at(&self, range: Range<u64>) -> SourcePhase;
             /// Zero-budget readiness probe that also files `range` as reader
             /// demand with the source — the channel dispatch budgets follow.
             /// See [`Stream::probe_wait`].
             pub(crate) fn probe_wait(&self, range: Range<u64>) -> StreamResult<WaitOutcome>;
-            /// The reader→peer wake handle — `Some` for segmented sources
-            /// (HLS) that push a downloader peer. The FSM arms it on the
-            /// produce core (seek-apply / finalize); the scheduler shell
-            /// flushes it off the forbid-blocking path.
-            pub(crate) fn peer_wake(&self) -> Option<Arc<kithara_stream::DeferredWake>>;
             /// Install the audio worker's data-arrival wake on the inner
             /// source. Segmented sources (HLS) fire it from their off-RT
             /// write/settle sites; no-op for non-segmented sources. Set once,
             /// after the worker exists.
             pub(crate) fn set_worker_wake(&self, wake: Arc<dyn WorkerWake>);
-            /// Real-time on-core seek (FSM recreate/boundary, decoder
-            /// `OffsetReader`): position math + cursor set, no `prime_seek_range`
-            /// spin on the forbid-blocking produce core. See [`Stream::probe_seek`].
-            pub(crate) fn probe_seek(&self, pos: SeekFrom) -> io::Result<u64>;
         }
     }
 }
@@ -177,6 +252,10 @@ impl<T: StreamType> Clone for SharedStream<T> {
     fn clone(&self) -> Self {
         Self {
             inner: Arc::clone(&self.inner),
+            probe: Arc::clone(&self.probe),
+            abr: self.abr.clone(),
+            variants: self.variants.clone(),
+            peer_wake: self.peer_wake.clone(),
             demand: Arc::clone(&self.demand),
             construction_gate: self.construction_gate.clone(),
         }

--- a/crates/kithara-audio/src/pipeline/stream/shared.rs
+++ b/crates/kithara-audio/src/pipeline/stream/shared.rs
@@ -90,43 +90,38 @@ impl<T: StreamType> SharedStream<T> {
         }
     }
 
-    /// Overall source readiness at current position — answered by the
-    /// narrow [`SourceProbe`], never the control mutex.
-    pub(crate) fn phase(&self) -> SourcePhase {
-        self.probe.phase()
-    }
-
-    /// Point-in-time readiness for a specific byte range — same contract
-    /// as [`Self::phase`].
-    pub(crate) fn phase_at(&self, range: Range<u64>) -> SourcePhase {
-        self.probe.phase_at(range)
-    }
-
-    /// Current read position — the source's atomic cursor via the probe.
-    pub(crate) fn position(&self) -> u64 {
-        self.probe.position()
-    }
-
-    /// Absolute byte cursor set — forwards to the inner source's atomic,
-    /// used post-seek when the audio FSM lands at a known byte position.
-    pub(crate) fn set_position(&self, pos: u64) {
-        self.probe.set_position(pos);
-    }
-
-    /// Total length if known — answered by the probe.
-    pub(crate) fn len(&self) -> Option<u64> {
-        self.probe.len()
-    }
-
-    /// Optional byte-map handle — answered by the probe; the decoder
-    /// factory uses it to activate the segment-by-segment fMP4 path.
-    pub(crate) fn byte_map(&self) -> Option<Arc<dyn ByteMap>> {
-        self.probe.byte_map()
-    }
-
-    /// Runtime ABR handle — `Some` for adaptive sources (HLS).
-    pub(crate) fn abr_handle(&self) -> Option<AbrHandle> {
-        self.abr.clone()
+    delegate! {
+        // Byte-space polls answered by the narrow probe, never the control
+        // mutex: RT-safe on the forbid-blocking produce core.
+        to self.probe {
+            /// Overall source readiness at current position.
+            pub(crate) fn phase(&self) -> SourcePhase;
+            /// Point-in-time readiness for a specific byte range — same
+            /// contract as [`Self::phase`].
+            pub(crate) fn phase_at(&self, range: Range<u64>) -> SourcePhase;
+            /// Current read position — the source's atomic cursor.
+            pub(crate) fn position(&self) -> u64;
+            /// Absolute byte cursor set — forwards to the inner source's
+            /// atomic, used post-seek when the audio FSM lands at a known
+            /// byte position.
+            pub(crate) fn set_position(&self, pos: u64);
+            /// Total length if known.
+            pub(crate) fn len(&self) -> Option<u64>;
+            /// Optional byte-map handle; the decoder factory uses it to
+            /// activate the segment-by-segment fMP4 path.
+            pub(crate) fn byte_map(&self) -> Option<Arc<dyn ByteMap>>;
+        }
+        to self.abr {
+            /// Runtime ABR handle — `Some` for adaptive sources (HLS).
+            #[call(clone)]
+            pub(crate) fn abr_handle(&self) -> Option<AbrHandle>;
+        }
+        to self.peer_wake {
+            /// The reader→peer wake handle — `Some` for segmented sources
+            /// (HLS) that push a downloader peer.
+            #[call(clone)]
+            pub(crate) fn peer_wake(&self) -> Option<Arc<DeferredWake>>;
+        }
     }
 
     /// Header byte range for decoder recreate after a format change — via
@@ -134,12 +129,6 @@ impl<T: StreamType> SharedStream<T> {
     /// [`Stream::format_change_segment_range`].
     pub(crate) fn format_change_segment_range(&self) -> StreamResult<Range<u64>> {
         format_change_segment_range(self.variants.as_deref())
-    }
-
-    /// The reader→peer wake handle — `Some` for segmented sources (HLS)
-    /// that push a downloader peer.
-    pub(crate) fn peer_wake(&self) -> Option<Arc<DeferredWake>> {
-        self.peer_wake.clone()
     }
 
     /// Real-time on-core seek (FSM recreate/boundary, decoder

--- a/crates/kithara-audio/src/pipeline/track/seek.rs
+++ b/crates/kithara-audio/src/pipeline/track/seek.rs
@@ -3,7 +3,7 @@ use kithara_stream::{SourcePhase, StreamType};
 use tracing::trace;
 
 use super::{
-    AtEof, CurrentFsm, Decoding, Failed, RecreatingDecoder, TrackFailure, TrackStep,
+    CurrentFsm, Decoding, Failed, RecreatingDecoder, TrackFailure, TrackStep,
     decode::{DecodeStep, decode_step},
     fsm::apply_seek_transition,
     phase::{Track, TrackPhase, sealed},
@@ -279,19 +279,14 @@ impl Track<WaitingForSource> {
             return TrackStep::Blocked(reason);
         }
 
-        match phase {
-            SourcePhase::Cancelled => {
-                src.update_state(Track::<Failed>::new(TrackFailure::SourceCancelled).erase());
-                return TrackStep::Failed;
-            }
-            SourcePhase::Eof => {
-                src.update_state(Track::<AtEof>::new(()).erase());
-                return TrackStep::Eof;
-            }
-            _ => {}
+        if phase == SourcePhase::Cancelled {
+            src.update_state(Track::<Failed>::new(TrackFailure::SourceCancelled).erase());
+            return TrackStep::Failed;
         }
 
-        // Source ready — resume into the phase that initiated the wait.
+        // Source ready — resume into the phase that initiated the wait. `Eof`
+        // resumes like `Ready`: byte-space EOF is not end of PCM, only the
+        // decode path finalizes `AtEof` (see CONTEXT.md, "Track FSM").
         match context {
             WaitContext::Playback => src.update_state(Track::<Decoding>::new(()).erase()),
             WaitContext::Seek(ctx) => src.update_state(Track::<SeekRequested>::new(ctx).erase()),

--- a/crates/kithara-audio/src/pipeline/track/tests/gate.rs
+++ b/crates/kithara-audio/src/pipeline/track/tests/gate.rs
@@ -1,12 +1,20 @@
-use std::ops::Range;
+use std::{
+    io::{Read, SeekFrom},
+    ops::Range,
+};
 
-use kithara_platform::sync::{Arc, Mutex};
-use kithara_stream::{SourcePhase, Stream};
+use kithara_platform::{
+    sync::{Arc, Mutex},
+    thread,
+};
+use kithara_stream::{DeferredWake, SourcePhase, Stream};
 use kithara_test_utils::kithara;
 
 use super::rebuild::{TestConfig, TestControl, TestSource, TestStream, media_info};
 use crate::pipeline::{
-    decode::gate::source_phase_for_wait_context, stream::shared::SharedStream, track::WaitContext,
+    decode::gate::{ReadinessGate, source_phase_for_wait_context},
+    stream::shared::SharedStream,
+    track::WaitContext,
 };
 
 async fn shared_with_phase(
@@ -71,6 +79,85 @@ async fn repeated_parked_polls_coalesce_into_one_probe() {
         vec![2000..4096],
         "coalesced flush must file the latest armed window exactly once"
     );
+}
+
+/// RT gate polls answer while a construction read holds the control mutex.
+/// The real off-RT holder is a construction reader parked inside
+/// `Stream::read` → `Source::wait_range(range, None)` with the mutex held;
+/// a gate poll that touched that mutex would block the forbid-blocking
+/// produce core behind the park (RTSan: `sched_yield` in `parking_lot`'s
+/// contended acquire). The regression mode is this test hanging on the
+/// poll until the harness watchdog fires.
+#[kithara::test(tokio)]
+async fn a_readiness_poll_answers_while_a_construction_read_holds_the_mutex() {
+    let wake = Arc::new(DeferredWake::default());
+    let source = TestSource::new(Arc::new(TestControl::new(media_info(0))))
+        .with_peer_wake(Arc::clone(&wake));
+    *source.phase_handle().lock() = SourcePhase::Waiting;
+    let phase = source.phase_handle();
+    let park = source.park_handle();
+    let stream = match Stream::<TestStream>::new(TestConfig { source }).await {
+        Ok(stream) => stream,
+        Err(error) => panic!("test stream construction failed: {error}"),
+    };
+    let shared = SharedStream::new(stream);
+
+    park.arm();
+    let opened = shared.open_initial_reader();
+    let Some(gate) = opened.construction_gate() else {
+        panic!("initial reader must carry a construction gate");
+    };
+    gate.arm();
+    let mut reader = opened.into_inner();
+    let holder = thread::spawn_named("construction-read-holder", move || {
+        let mut buf = [0u8; 64];
+        reader.read(&mut buf)
+    });
+    park.wait_entered();
+
+    assert!(
+        !ReadinessGate::new(None).source_is_ready(&shared),
+        "a waiting source must poll as not-ready without touching the held control mutex"
+    );
+    assert_eq!(
+        source_phase_for_wait_context(&shared, &WaitContext::Playback),
+        SourcePhase::Waiting,
+        "the wait-context poll must answer from the probe while the mutex is held"
+    );
+    assert!(
+        shared.abr_handle().is_none(),
+        "the fixed-at-open ABR handle must answer (None here) while the mutex is held"
+    );
+    assert_eq!(
+        shared.format_change_segment_range().ok(),
+        Some(0..32),
+        "the fixed variant-control handle must serve the mock's format range while the mutex is held"
+    );
+    let pos = match shared.probe_seek(SeekFrom::Start(64)) {
+        Ok(pos) => pos,
+        Err(error) => {
+            panic!("the on-core probe seek must resolve while the mutex is held: {error}")
+        }
+    };
+    assert_eq!(pos, 64);
+    assert_eq!(
+        shared.position(),
+        64,
+        "probe_seek must move the probe cursor"
+    );
+    assert!(
+        wake.flush(),
+        "probe_seek must arm the peer wake for the shell to flush"
+    );
+
+    // Teardown: EOF lets the released construction read return instead of
+    // re-parking on the still-waiting phase.
+    *phase.lock() = SourcePhase::Eof;
+    park.release();
+    holder
+        .join()
+        .expect("holder thread must exit cleanly")
+        .expect("released construction read must complete");
 }
 
 /// A ready poll is a snapshot, not a wait: it must not arm demand, or the

--- a/crates/kithara-audio/src/pipeline/track/tests/mod.rs
+++ b/crates/kithara-audio/src/pipeline/track/tests/mod.rs
@@ -3,3 +3,4 @@ mod rebuild;
 mod splice;
 mod state;
 mod transition;
+mod wait;

--- a/crates/kithara-audio/src/pipeline/track/tests/rebuild.rs
+++ b/crates/kithara-audio/src/pipeline/track/tests/rebuild.rs
@@ -860,6 +860,7 @@ pub(super) struct RouteFixture {
     pub(super) control: Arc<TestControl>,
     pub(super) drops: Arc<Mutex<Vec<u64>>>,
     pub(super) host_sample_rate: Arc<AtomicU32>,
+    pub(super) phase: Arc<Mutex<SourcePhase>>,
     pub(super) source: StreamAudioSource<TestStream>,
 }
 
@@ -983,6 +984,25 @@ pub(super) async fn route_signal_source_with_effects(
     .await
 }
 
+pub(super) async fn route_signal_source_with_eof(
+    initial_host_rate: u32,
+    chunks_before_eof: usize,
+) -> RouteFixture {
+    route_source(
+        RouteParams {
+            chunks_before_eof: Some(chunks_before_eof),
+            gapless: None,
+            incoming_chunks_before_eof: None,
+            active_timeline_gap: 0,
+            incoming_timeline_gap: 0,
+            initial_host_rate,
+            segmented: false,
+        },
+        Vec::new(),
+    )
+    .await
+}
+
 pub(super) async fn route_signal_source_with_gapless(
     initial_host_rate: u32,
     gapless: GaplessInfo,
@@ -1051,12 +1071,14 @@ async fn route_source(params: RouteParams, effects: Vec<Box<dyn AudioEffect>>) -
     let active_timeline_gap = params.active_timeline_gap;
     let incoming_timeline_gap = params.incoming_timeline_gap;
     let segmented = params.segmented;
+    let test_source = if segmented {
+        TestSource::segmented(control.clone())
+    } else {
+        TestSource::new(control.clone())
+    };
+    let phase = test_source.phase_handle();
     let stream = match Stream::<TestStream>::new(TestConfig {
-        source: if segmented {
-            TestSource::segmented(control.clone())
-        } else {
-            TestSource::new(control.clone())
-        },
+        source: test_source,
     })
     .await
     {
@@ -1132,6 +1154,7 @@ async fn route_source(params: RouteParams, effects: Vec<Box<dyn AudioEffect>>) -
         control,
         drops,
         host_sample_rate,
+        phase,
         source: StreamAudioSource::new(shared_stream, parts),
     }
 }

--- a/crates/kithara-audio/src/pipeline/track/tests/rebuild.rs
+++ b/crates/kithara-audio/src/pipeline/track/tests/rebuild.rs
@@ -16,18 +16,18 @@ use kithara_events::{
     AudioEvent, DecoderChangeCause, DecoderEvent, DeferredBus, Event, EventBus, TrackFailureKind,
 };
 use kithara_platform::{
-    sync::{Arc, Mutex},
+    sync::{Arc, Condvar, Mutex},
     time::Duration,
     tokio::runtime::Handle as RuntimeHandle,
 };
 use kithara_storage::WaitOutcome;
 use kithara_stream::{
-    Activity, AudioCodec, ByteMap, ChunkPosition, ContainerFormat, MediaInfo, OpenedReader,
-    OpenedVariantReader, PlayheadRead, PlayheadState, PlayheadWrite, PrerollHint, ReadOutcome,
-    ReaderProfile, SeekControl, SeekObserve, SeekState, SegmentDescriptor, Source, SourceError,
-    SourcePhase, SourceSeekAnchor, Stream, StreamError, StreamResult, StreamType, VariantControl,
-    VariantPromotion, VariantReaderPlan, VariantReaderTake, VariantTransition, VariantTransitionId,
-    WorkerWake,
+    Activity, AudioCodec, ByteMap, ChunkPosition, ContainerFormat, DeferredWake, MediaInfo,
+    OpenedReader, OpenedVariantReader, PlayheadRead, PlayheadState, PlayheadWrite, PrerollHint,
+    ReadOutcome, ReaderProfile, SeekControl, SeekObserve, SeekState, SegmentDescriptor, Source,
+    SourceError, SourcePhase, SourceProbe, SourceSeekAnchor, Stream, StreamError, StreamResult,
+    StreamType, VariantControl, VariantPromotion, VariantReaderPlan, VariantReaderTake,
+    VariantTransition, VariantTransitionId, WorkerWake,
 };
 use kithara_test_utils::kithara;
 
@@ -521,9 +521,62 @@ impl VariantControl for TestControl {
     }
 }
 
+/// Optional park inside `wait_range`, letting a test hold the stream's
+/// control mutex the way a real construction read does: `Stream::read`
+/// enters `Source::wait_range` under the `SharedStream` mutex and stays
+/// there until data lands. Disarmed by default — no other test changes.
+#[derive(Default)]
+pub(super) struct WaitPark {
+    armed: AtomicBool,
+    state: Mutex<WaitParkState>,
+    condvar: Condvar,
+}
+
+#[derive(Default)]
+struct WaitParkState {
+    entered: bool,
+    released: bool,
+}
+
+impl WaitPark {
+    pub(super) fn arm(&self) {
+        self.armed.store(true, Ordering::Release);
+    }
+
+    /// Block until the holder is inside `wait_range` — i.e. the control
+    /// mutex is held by a parked blocking read.
+    pub(super) fn wait_entered(&self) {
+        let mut state = self.state.lock();
+        while !state.entered {
+            state = self.condvar.wait(state);
+        }
+    }
+
+    pub(super) fn release(&self) {
+        let mut state = self.state.lock();
+        state.released = true;
+        drop(state);
+        self.condvar.notify_all();
+    }
+
+    fn enter_if_armed(&self) {
+        if !self.armed.load(Ordering::Acquire) {
+            return;
+        }
+        let mut state = self.state.lock();
+        state.entered = true;
+        self.condvar.notify_all();
+        while !state.released {
+            state = self.condvar.wait(state);
+        }
+    }
+}
+
 pub(super) struct TestSource {
     byte_map: Arc<TestByteMap>,
     control: Arc<TestControl>,
+    park: Arc<WaitPark>,
+    peer: Option<Arc<DeferredWake>>,
     phase: Arc<Mutex<SourcePhase>>,
     playhead: Arc<PlayheadState>,
     position: Arc<AtomicU64>,
@@ -536,6 +589,8 @@ impl TestSource {
         Self {
             control,
             byte_map: Arc::new(TestByteMap),
+            park: Arc::new(WaitPark::default()),
+            peer: None,
             phase: Arc::new(Mutex::new(SourcePhase::Ready)),
             playhead: Arc::new(PlayheadState::new()),
             position: Arc::new(AtomicU64::new(0)),
@@ -544,9 +599,21 @@ impl TestSource {
         }
     }
 
+    /// Attach a reader→peer wake, as segmented sources vend one. Opt-in:
+    /// a `Some` peer changes `Stream`'s read-path unit clamping, so only
+    /// tests pinning the peer-wake contract install it.
+    pub(super) fn with_peer_wake(mut self, wake: Arc<DeferredWake>) -> Self {
+        self.peer = Some(wake);
+        self
+    }
+
     fn segmented(control: Arc<TestControl>) -> Self {
         control.enable_byte_map();
         Self::new(control)
+    }
+
+    pub(super) fn park_handle(&self) -> Arc<WaitPark> {
+        Arc::clone(&self.park)
     }
 
     pub(super) fn phase_handle(&self) -> Arc<Mutex<SourcePhase>> {
@@ -558,9 +625,52 @@ impl TestSource {
     }
 }
 
+/// Byte-space probe sharing the test source's scripted cells — the same
+/// phase, cursor, and byte-map gating as the `Source` impl below.
+struct SharedPhaseProbe {
+    phase: Arc<Mutex<SourcePhase>>,
+    position: Arc<AtomicU64>,
+    control: Arc<TestControl>,
+    byte_map: Arc<TestByteMap>,
+}
+
+impl SourceProbe for SharedPhaseProbe {
+    fn phase(&self) -> SourcePhase {
+        *self.phase.lock()
+    }
+
+    fn phase_at(&self, _range: Range<u64>) -> SourcePhase {
+        *self.phase.lock()
+    }
+
+    fn position(&self) -> u64 {
+        self.position.load(Ordering::Acquire)
+    }
+
+    fn set_position(&self, pos: u64) {
+        self.position.store(pos, Ordering::Release);
+    }
+
+    fn len(&self) -> Option<u64> {
+        Some(4096)
+    }
+
+    fn byte_map(&self) -> Option<Arc<dyn ByteMap>> {
+        if self.control.byte_map_enabled.load(Ordering::Acquire) {
+            Some(self.byte_map.clone() as Arc<dyn ByteMap>)
+        } else {
+            None
+        }
+    }
+}
+
 impl Source for TestSource {
     fn activity(&self) -> Arc<dyn Activity> {
         Arc::clone(&self.seek) as Arc<dyn Activity>
+    }
+
+    fn peer_wake(&self) -> Option<Arc<DeferredWake>> {
+        self.peer.clone()
     }
 
     fn advance(&self, n: u64) {
@@ -585,6 +695,15 @@ impl Source for TestSource {
 
     fn phase_at(&self, _range: Range<u64>) -> SourcePhase {
         *self.phase.lock()
+    }
+
+    fn probe(&self) -> Arc<dyn SourceProbe> {
+        Arc::new(SharedPhaseProbe {
+            phase: Arc::clone(&self.phase),
+            position: Arc::clone(&self.position),
+            control: Arc::clone(&self.control),
+            byte_map: Arc::clone(&self.byte_map),
+        })
     }
 
     fn playhead_read(&self) -> Arc<dyn PlayheadRead> {
@@ -624,6 +743,7 @@ impl Source for TestSource {
         range: Range<u64>,
         _timeout: Option<Duration>,
     ) -> StreamResult<WaitOutcome> {
+        self.park.enter_if_armed();
         self.waits.lock().push(range);
         match *self.phase.lock() {
             SourcePhase::Ready => Ok(WaitOutcome::Ready),

--- a/crates/kithara-audio/src/pipeline/track/tests/splice.rs
+++ b/crates/kithara-audio/src/pipeline/track/tests/splice.rs
@@ -16,8 +16,8 @@ use kithara_storage::WaitOutcome;
 use kithara_stream::{
     Activity, AudioCodec, ByteMap, ChunkPosition, ContainerFormat, MediaInfo, PlayheadRead,
     PlayheadState, PlayheadWrite, ReadOutcome, ReaderProfile, SeekControl, SeekObserve, SeekState,
-    SegmentDescriptor, Source, SourceError, SourcePhase, SourceSeekAnchor, Stream, StreamError,
-    StreamResult, StreamType, VariantControl, VariantPromotion, VariantReaderPlan,
+    SegmentDescriptor, Source, SourceError, SourcePhase, SourceProbe, SourceSeekAnchor, Stream,
+    StreamError, StreamResult, StreamType, VariantControl, VariantPromotion, VariantReaderPlan,
     VariantReaderTake, VariantTransition, WorkerWake,
 };
 use kithara_test_utils::kithara;
@@ -230,6 +230,39 @@ impl SpliceSource {
     }
 }
 
+/// Always-ready byte-space probe sharing `SpliceSource`'s cells — same
+/// phase, cursor, length, and byte map as the `Source` impl below.
+struct ReadyProbe {
+    position: Arc<AtomicU64>,
+    state: Arc<SpliceState>,
+}
+
+impl SourceProbe for ReadyProbe {
+    fn phase(&self) -> SourcePhase {
+        SourcePhase::Ready
+    }
+
+    fn phase_at(&self, _range: Range<u64>) -> SourcePhase {
+        SourcePhase::Ready
+    }
+
+    fn position(&self) -> u64 {
+        self.position.load(Ordering::Acquire)
+    }
+
+    fn set_position(&self, pos: u64) {
+        self.position.store(pos, Ordering::Release);
+    }
+
+    fn len(&self) -> Option<u64> {
+        Some(u64::try_from(self.state.active_layout().blob.len()).expect("blob length fits u64"))
+    }
+
+    fn byte_map(&self) -> Option<Arc<dyn ByteMap>> {
+        Some(Arc::clone(&self.state) as Arc<dyn ByteMap>)
+    }
+}
+
 impl Source for SpliceSource {
     fn activity(&self) -> Arc<dyn Activity> {
         Arc::clone(&self.seek) as Arc<dyn Activity>
@@ -253,6 +286,13 @@ impl Source for SpliceSource {
 
     fn phase_at(&self, _range: Range<u64>) -> SourcePhase {
         SourcePhase::Ready
+    }
+
+    fn probe(&self) -> Arc<dyn SourceProbe> {
+        Arc::new(ReadyProbe {
+            position: Arc::clone(&self.position),
+            state: Arc::clone(&self.state),
+        })
     }
 
     fn playhead_read(&self) -> Arc<dyn PlayheadRead> {

--- a/crates/kithara-audio/src/pipeline/track/tests/wait.rs
+++ b/crates/kithara-audio/src/pipeline/track/tests/wait.rs
@@ -1,0 +1,116 @@
+use kithara_platform::time::Duration;
+use kithara_stream::SourcePhase;
+use kithara_test_utils::kithara;
+
+use super::rebuild::{
+    Consts, RouteFixture, produced_data, route_signal_source, route_signal_source_with_eof,
+};
+use crate::{
+    pipeline::{
+        seek::{ResumeState, SeekContext},
+        track::{
+            CurrentFsm, Track, TrackStep, WaitContext, WaitState, WaitingForSource, WaitingReason,
+        },
+    },
+    renderer::AudioWorkerSource,
+};
+
+/// Park the track in `WaitingForSource(Playback)` the way a transient
+/// not-ready source does, then flip the source to byte-space EOF.
+fn park_playback_at_byte_eof(fixture: &mut RouteFixture) {
+    *fixture.phase.lock() = SourcePhase::Waiting;
+    assert!(
+        matches!(
+            fixture.source.step_track(),
+            TrackStep::Blocked(WaitingReason::Waiting)
+        ),
+        "a waiting source must park the decoding track"
+    );
+    *fixture.phase.lock() = SourcePhase::Eof;
+}
+
+/// A byte-space EOF from the source must not end the track while the decoder
+/// can still produce PCM. A seek into the last segment leaves the reader at
+/// the stream total with frames still buffered in the demuxer; a transient
+/// un-published layout parks the track for one tick, and the next poll sees
+/// `SourcePhase::Eof`. Latching `AtEof` from that wait drops the buffered
+/// tail (the `live_real_stream_random_seek_prefix_regression` flake) — only
+/// the decode path may finalize natural EOF.
+#[kithara::test(tokio)]
+async fn byte_eof_resumes_decoding_while_the_decoder_still_produces() {
+    let mut fixture = route_signal_source(Consts::SAMPLE_RATE).await;
+    park_playback_at_byte_eof(&mut fixture);
+
+    assert!(
+        matches!(fixture.source.step_track(), TrackStep::StateChanged),
+        "byte-space EOF must resume the wait into the decode path"
+    );
+    let TrackStep::Produced(fetch) = fixture.source.step_track() else {
+        panic!("the resumed track must produce PCM from the buffered decoder");
+    };
+    assert!(
+        produced_data(fetch).meta.frames > 0,
+        "the resumed decode must yield audible PCM"
+    );
+}
+
+/// With the decoder itself drained, the same parked byte-EOF still ends the
+/// track — through the decode path's exhausted finalization, not a wait
+/// shortcut (the first step resumes instead of reporting `Eof`).
+#[kithara::test(tokio)]
+async fn byte_eof_still_ends_a_drained_decoder_through_the_decode_path() {
+    let mut fixture = route_signal_source_with_eof(Consts::SAMPLE_RATE, 0).await;
+    park_playback_at_byte_eof(&mut fixture);
+
+    assert!(
+        matches!(fixture.source.step_track(), TrackStep::StateChanged),
+        "byte-space EOF must resume the wait, not shortcut to Eof"
+    );
+    for _ in 0..8 {
+        match fixture.source.step_track() {
+            TrackStep::Eof => {
+                assert!(matches!(fixture.source.state, CurrentFsm::AtEof(_)));
+                return;
+            }
+            TrackStep::Failed => {
+                panic!("a drained decoder at byte EOF must finalize as EOF, not fail")
+            }
+            _ => fixture.source.flush_deferred(),
+        }
+    }
+    panic!("a drained decoder at byte EOF must still finalize the track");
+}
+
+/// The post-seek wait is the context that actually holds the flake's tail: a
+/// byte-space EOF while awaiting the first post-seek chunk must resume into
+/// `AwaitingResume` and decode that tail, not end the track.
+#[kithara::test(tokio)]
+async fn byte_eof_resumes_a_post_seek_wait_into_the_tail() {
+    let mut fixture = route_signal_source(Consts::SAMPLE_RATE).await;
+    fixture.source.update_state(
+        Track::<WaitingForSource>::new(WaitState {
+            context: WaitContext::PostSeek(ResumeState {
+                seek: SeekContext {
+                    epoch: 0,
+                    target: Duration::ZERO,
+                },
+                ..Default::default()
+            }),
+            reason: WaitingReason::Waiting,
+        })
+        .erase(),
+    );
+    *fixture.phase.lock() = SourcePhase::Eof;
+
+    assert!(
+        matches!(fixture.source.step_track(), TrackStep::StateChanged),
+        "byte-space EOF must resume the post-seek wait"
+    );
+    let TrackStep::Produced(fetch) = fixture.source.step_track() else {
+        panic!("the post-seek tail must decode after a byte-space EOF resume");
+    };
+    assert!(
+        produced_data(fetch).meta.frames > 0,
+        "the post-seek resume must yield audible PCM"
+    );
+}

--- a/crates/kithara-file/CONTEXT.md
+++ b/crates/kithara-file/CONTEXT.md
@@ -51,12 +51,19 @@ peer precisely so the peer re-targets around the new position.
   first; the earlier span still has to land for the resource to commit, so it is filled next. Drop
   the cursor lookup and a forward seek waits for the whole skipped span; drop the byte-0 lookup and
   a seeked-over span never lands and the resource never commits.
-- A fetch streams forward from where it started, so a cursor that sits inside the fetch's span but
-  past its write offset can no longer be served by it — that fetch would deliver the whole skipped
-  span first. The peer cancels it. Cancellation relinquishes the writer epoch, the completion path
-  wakes the peer, and the next plan re-elects a writer and anchors on the new cursor. A fetch whose
-  span ends before the cursor is a backfill: it starts behind the cursor by construction and never
-  promised it anything, so it runs to completion.
+- A fetch streams forward from where it started, so a cursor that sits inside the fetch's span
+  past the bytes it has landed can no longer be served by it — that fetch would deliver the whole
+  skipped span first. The peer cancels it. Stored bytes decide where the fetch has got to (the
+  first gap at or after its start), not a write offset the fetch publishes: that offset lands
+  after `write_at`, and the landing is what wakes the reader, so a reader that consumed the bytes
+  in between sat ahead of the offset without being ahead of the fetch and got its own fetch
+  cancelled. Cancellation relinquishes the writer epoch, the completion path wakes the peer, and
+  the next plan re-elects a writer and anchors on the new cursor. A fetch whose span ends before
+  the cursor is a backfill: it starts behind the cursor by construction and never promised it
+  anything, so it runs to completion.
+- A plan that finds no gap over a known extent commits the resource from the peer. A cancelled
+  fetch relinquishes without committing, and when it had already landed everything its replacement
+  has nothing to fetch; parking there would leave every consumer waiting on a complete resource.
 - The cursor steers nothing until the resource extent is known, and nothing once it sits outside
   it. A range request needs an extent: before the first response answers how long the resource is,
   a cursor past the end is indistinguishable from one inside it, and anchoring there would both ask

--- a/crates/kithara-file/src/session/inner.rs
+++ b/crates/kithara-file/src/session/inner.rs
@@ -6,8 +6,10 @@ use std::{
     task::{Wake, Waker},
 };
 
-use kithara_assets::{AssetReader, ReadSide, ResourceLease};
-use kithara_events::{AudioCodecKind, ContainerKind, EventBus, FileEvent, TotalBytesSource};
+use kithara_assets::{AssetReader, ReadSide, ResourceLease, WriterEpoch};
+use kithara_events::{
+    AudioCodecKind, ContainerKind, EventBus, FileError, FileEvent, TotalBytesSource,
+};
 use kithara_net::Headers;
 use kithara_platform::{
     CancelToken,
@@ -255,6 +257,27 @@ impl FileInner {
         );
         self.mark_complete();
         true
+    }
+
+    /// Commit the epoch once every byte up to `final_len` has landed.
+    /// Returns whether the resource committed through this epoch.
+    pub(crate) fn commit_if_complete(&self, epoch: &WriterEpoch, final_len: u64) -> bool {
+        if self.asset.reader.next_gap(0, final_len).is_some() {
+            return false;
+        }
+        match epoch.commit(Some(final_len)).current() {
+            Some(Ok(())) => {
+                self.observe_committed();
+                true
+            }
+            Some(Err(error)) => {
+                self.source.bus.publish(FileEvent::Error {
+                    error: FileError::Io(error.to_string()),
+                });
+                false
+            }
+            None => false,
+        }
     }
 
     /// One-shot fragmented-mp4 parse from the fully cached file bytes.

--- a/crates/kithara-file/src/session/peer.rs
+++ b/crates/kithara-file/src/session/peer.rs
@@ -40,8 +40,8 @@ struct Inflight {
     cancel: CancelToken,
     /// End of the span this fetch was planned to deliver, if bounded.
     end_exclusive: Option<u64>,
-    /// Live write cursor: how far this fetch has landed bytes.
-    offset: Arc<AtomicU64>,
+    /// Where this fetch started streaming; it lands bytes forward from here.
+    start: u64,
 }
 
 struct WriterSnapshot {
@@ -130,7 +130,7 @@ impl FilePeer {
         *self.inflight.lock() = Some(Inflight {
             cancel: fetch_cancel.clone(),
             end_exclusive,
-            offset: Arc::clone(&offset),
+            start,
         });
 
         let weak_for_complete = Arc::downgrade(inner);
@@ -230,26 +230,23 @@ impl FilePeer {
     }
 
     /// Whether the peer has to park on a fetch that is already running, having
-    /// first cancelled that fetch if the reader cursor has overtaken it. A
-    /// fetch streams forward from where it started, so a cursor that sits
-    /// inside its span but ahead of its write offset can only be served by a
-    /// new request — this one would deliver the whole skipped span first. The
-    /// completion path releases the writer and the next plan anchors on the new
-    /// cursor. A fetch whose span ends before the cursor is a backfill and is
-    /// left alone: it never promised the cursor anything, and neither is a
-    /// fetch the cursor cannot steer, which would be cancelled for a
-    /// replacement anchored right back where it started.
+    /// first cancelled that fetch if the reader cursor sits inside its span
+    /// past the bytes it has landed. Stored bytes decide, not a write offset
+    /// the fetch publishes. See CONTEXT.md "Fetch targeting".
     fn park_on_running_fetch(&self, inner: &Arc<FileInner>) -> bool {
-        let cursor = steering_cursor(&inner.source.coord);
-        let Some(overtaken) = self.inflight.lock().as_ref().map(|fetch| {
-            cursor
-                .filter(|cursor| fetch.end_exclusive.is_none_or(|end| *cursor < end))
-                .filter(|cursor| *cursor > fetch.offset.load(Ordering::Acquire))
-                .map(|_| fetch.cancel.clone())
-        }) else {
+        let Some((cancel, end_exclusive, start)) = self
+            .inflight
+            .lock()
+            .as_ref()
+            .map(|fetch| (fetch.cancel.clone(), fetch.end_exclusive, fetch.start))
+        else {
             return false;
         };
-        if let Some(cancel) = overtaken {
+        let frontier = landed_frontier(&inner.asset.reader, start, end_exclusive);
+        let overtaken = steering_cursor(&inner.source.coord)
+            .filter(|cursor| end_exclusive.is_none_or(|end| *cursor < end))
+            .is_some_and(|cursor| cursor > frontier);
+        if overtaken {
             cancel.cancel();
         }
         true
@@ -279,6 +276,11 @@ impl FilePeer {
         let upper = total.map_or(writer.watermark, |total| total.min(writer.watermark));
         let cursor = steering_cursor(&inner.source.coord);
         let Some(gap) = next_gap_from_cursor(&inner.asset.reader, cursor, upper) else {
+            // A relinquished fetch may have landed everything; its replacement
+            // has nothing to fetch.
+            if total.is_some_and(|total| inner.commit_if_complete(&writer.epoch, total)) {
+                return PeerAction::Done;
+            }
             return PeerAction::Pending;
         };
         let end_exclusive = (total.is_some() || writer.watermark != u64::MAX).then_some(gap.end);
@@ -314,6 +316,13 @@ fn next_gap_from_cursor(
     cursor
         .and_then(|cursor| reader.next_gap(cursor, upper))
         .or_else(|| reader.next_gap(0, upper))
+}
+
+/// How far a fetch streaming forward from `start` has landed bytes: the first
+/// byte still missing at or after `start`, or the end of its span.
+fn landed_frontier(reader: &AssetReader, start: u64, end_exclusive: Option<u64>) -> u64 {
+    let end = end_exclusive.unwrap_or(u64::MAX);
+    reader.next_gap(start, end).map_or(end, |gap| gap.start)
 }
 
 /// The reader cursor, when it is allowed to steer fetching. A range request

--- a/crates/kithara-file/src/session/peer/response.rs
+++ b/crates/kithara-file/src/session/peer/response.rs
@@ -4,7 +4,7 @@ use std::{
     sync::atomic::{AtomicBool, AtomicU64, Ordering},
 };
 
-use kithara_assets::{ReadSide, WriterEpoch};
+use kithara_assets::WriterEpoch;
 use kithara_events::{FileError, FileEvent, TotalBytesSource};
 use kithara_net::{Headers, NetError, Retryability};
 use kithara_platform::{
@@ -97,18 +97,6 @@ impl FileInner {
         true
     }
 
-    fn commit_completed_epoch(&self, epoch: &WriterEpoch, final_len: u64) {
-        if let Some(result) = epoch.commit(Some(final_len)).current() {
-            if let Err(error) = result {
-                self.source.bus.publish(FileEvent::Error {
-                    error: FileError::Io(error.to_string()),
-                });
-            } else {
-                self.observe_committed();
-            }
-        }
-    }
-
     pub(super) fn complete_fetch(&self, epoch: &WriterEpoch, completion: FetchCompletion<'_>) {
         if completion.invalid_response && !matches!(completion.error, Some(NetError::Cancelled)) {
             self.fail_current_epoch(
@@ -144,13 +132,9 @@ impl FileInner {
         if !epoch.is_current() {
             return;
         }
-        let Some(final_len) = self.resolved_final_len(completion) else {
-            return;
-        };
-        if self.asset.reader.next_gap(0, final_len).is_some() {
-            return;
+        if let Some(final_len) = self.resolved_final_len(completion) {
+            self.commit_if_complete(epoch, final_len);
         }
-        self.commit_completed_epoch(epoch, final_len);
     }
 
     fn resolved_final_len(&self, completion: FetchCompletion<'_>) -> Option<u64> {

--- a/crates/kithara-file/src/session/peer/tests/seek.rs
+++ b/crates/kithara-file/src/session/peer/tests/seek.rs
@@ -106,6 +106,81 @@ fn a_settled_fetch_wakes_the_parked_peer() {
     assert!(wake.count() > parked);
 }
 
+/// The write offset a fetch publishes lags the bytes it lands: the storage
+/// wakes the reader inside `write_at`, the offset is stored after. A reader
+/// that consumed those bytes in between sits ahead of the offset without being
+/// ahead of the fetch, so the fetch is not overtaken and must keep running.
+#[kithara::test]
+fn a_reader_consuming_landed_bytes_does_not_cancel_the_fetch() {
+    let (_store, _key, inner, writer) = fresh_session(None);
+    inner.source.coord.set_total_bytes(Some(4096));
+    let epoch = writer.epoch();
+    let peer = FilePeer::new(&inner, Some(writer));
+    let mut cx = Context::from_waker(Waker::noop());
+
+    let Poll::Ready(Some(fetches)) = Peer::poll_next(&peer, &mut cx) else {
+        panic!("a resource missing every byte must start a fetch");
+    };
+    let running = fetches[0]
+        .cancel()
+        .expect("a peer fetch carries its own cancel")
+        .clone();
+
+    assert!(matches!(
+        epoch.write_at(0, &[0u8; 512]),
+        WriterOutcome::Current(Ok(()))
+    ));
+    inner.source.coord.set_position(256);
+
+    assert!(matches!(Peer::poll_next(&peer, &mut cx), Poll::Pending));
+    assert!(!running.is_cancelled());
+}
+
+/// A cancelled fetch relinquishes without committing and its replacement is
+/// planned from the resource it left behind. When it had already landed
+/// everything, the plan finds no gap: the writer commits instead of parking,
+/// or every consumer waits on a resource that is complete.
+#[kithara::test]
+fn a_writer_with_nothing_left_to_fetch_commits() {
+    let (store, key, inner, writer) = fresh_session(None);
+    inner.source.coord.set_total_bytes(Some(4));
+    assert!(matches!(
+        writer.epoch().write_at(0, b"done"),
+        WriterOutcome::Current(Ok(()))
+    ));
+
+    let peer = make_peer(&inner, Some(writer));
+    let lease = inner.resource_lease.as_ref().expect("session lease");
+
+    assert!(matches!(peer.next_action(&inner, lease), PeerAction::Done));
+    assert_ready_bytes(&store, &key, b"done");
+}
+
+/// A plan bounded by the demand watermark can run out of gaps while bytes
+/// beyond it are still missing. That is a wait for demand, not a complete
+/// resource: committing there would truncate it.
+#[kithara::test]
+fn a_plan_bounded_by_demand_does_not_commit_a_partial_resource() {
+    let (store, key, inner, writer) = fresh_session(Some(512));
+    inner.source.coord.set_total_bytes(Some(4096));
+    assert!(matches!(
+        writer.epoch().write_at(0, &[0u8; 512]),
+        WriterOutcome::Current(Ok(()))
+    ));
+
+    let peer = make_peer(&inner, Some(writer));
+    let lease = inner.resource_lease.as_ref().expect("session lease");
+
+    assert!(matches!(
+        peer.next_action(&inner, lease),
+        PeerAction::Pending
+    ));
+    assert!(matches!(
+        store.resource_state(&key).expect("resource state"),
+        AssetResourceState::Active
+    ));
+}
+
 /// A backfill fetch starts behind the cursor by construction — it fills what an
 /// earlier seek skipped. The cursor being ahead of it is the normal case, not a
 /// reason to cancel it, or the peer would kill every backfill it starts.

--- a/crates/kithara-file/src/session/source.rs
+++ b/crates/kithara-file/src/session/source.rs
@@ -6,9 +6,10 @@ use kithara_events::{EventBus, TotalBytesSource};
 use kithara_platform::{CancelToken, sync::Arc, time::Duration};
 use kithara_storage::{ResourceStatus, StorageError, WaitOutcome};
 use kithara_stream::{
-    Activity, AudioCodec, MediaInfo, NotReadyCause, PendingReason, PlayheadRead, PlayheadWrite,
-    ReadOutcome, SeekControl, SeekObserve, SegmentDescriptor, SourceError as StreamSourceError,
-    SourcePhase, StreamError, StreamResult, WorkerWake, dl::PeerHandle,
+    Activity, AudioCodec, ByteMap, MediaInfo, NotReadyCause, PendingReason, PlayheadRead,
+    PlayheadWrite, ReadOutcome, SeekControl, SeekObserve, SegmentDescriptor,
+    SourceError as StreamSourceError, SourcePhase, SourceProbe, StreamError, StreamResult,
+    WorkerWake, dl::PeerHandle,
 };
 use tracing::trace;
 use url::Url;
@@ -82,12 +83,6 @@ impl FileSource {
         }
     }
 
-    fn known_len(&self) -> Option<u64> {
-        self.coord
-            .total_bytes()
-            .or_else(|| self.inner.asset.reader.len())
-    }
-
     /// Create a source for a local/cached file (no downloads needed).
     ///
     /// `cancel` is a child of the file config master so a track drop
@@ -132,16 +127,6 @@ impl FileSource {
             inner,
             peer_handle: None,
         }
-    }
-
-    fn readable_part(&self, range: Range<u64>) -> Option<Range<u64>> {
-        let Some(total) = self.known_len() else {
-            return Some(range);
-        };
-        if total > 0 && range.start >= total {
-            return None;
-        }
-        Some(range.start..range.end.min(total))
     }
 
     /// Pin the Downloader peer registration to this source's lifetime.
@@ -198,51 +183,109 @@ impl FileSource {
     }
 }
 
-impl kithara_stream::Source for FileSource {
-    fn byte_map(&self) -> Option<Arc<dyn kithara_stream::ByteMap>> {
-        self.inner.segment_index.get()?;
-        Some(Arc::new(FileByteMap {
-            inner: Arc::clone(&self.inner),
-        }))
+/// Phase snapshots live on the shared inner: it owns the terminal state and
+/// the cached-range view, and (per its own contract) is Mutex-free — so the
+/// narrow [`SourceProbe`] handle the forbid-blocking audio core polls without
+/// the stream's control-plane lock answers from here.
+impl FileInner {
+    pub(crate) fn phase(&self) -> SourcePhase {
+        let pos = self.source.coord.position();
+        self.phase_at(pos..pos.saturating_add(1))
     }
 
-    fn len(&self) -> Option<u64> {
-        self.known_len()
+    pub(crate) fn phase_at(&self, range: Range<u64>) -> SourcePhase {
+        if self.source.cancel.is_cancelled() {
+            return SourcePhase::Cancelled;
+        }
+        self.refresh_unmanaged_terminal();
+        if self.terminal_state() == FileTerminalState::Cancelled {
+            return SourcePhase::Cancelled;
+        }
+        let Some(readable) = self.readable_part(range) else {
+            return match self.terminal_state() {
+                FileTerminalState::Committed => SourcePhase::Eof,
+                FileTerminalState::Cancelled => SourcePhase::Cancelled,
+                FileTerminalState::Active | FileTerminalState::Failed => SourcePhase::Waiting,
+            };
+        };
+        let contains = readable.is_empty() || self.asset.reader.contains_range(readable);
+        if contains {
+            return SourcePhase::Ready;
+        }
+
+        if self.source.coord.seek_obs().is_flushing() {
+            return SourcePhase::Seeking;
+        }
+        SourcePhase::Waiting
+    }
+
+    pub(crate) fn known_len(&self) -> Option<u64> {
+        self.source
+            .coord
+            .total_bytes()
+            .or_else(|| self.asset.reader.len())
+    }
+
+    fn readable_part(&self, range: Range<u64>) -> Option<Range<u64>> {
+        let Some(total) = self.known_len() else {
+            return Some(range);
+        };
+        if total > 0 && range.start >= total {
+            return None;
+        }
+        Some(range.start..range.end.min(total))
+    }
+}
+
+/// Narrow byte-space handle over the shared inner. Wraps the `Arc` because
+/// vending the byte map needs an owning handle to the inner's lazy segment
+/// index; every answer comes from the inner's Mutex-free state.
+struct FileProbe {
+    inner: Arc<FileInner>,
+}
+
+/// Segment-map handle over the shared inner, vended once the lazy segment
+/// index exists — the one body behind `Source::byte_map` and
+/// `SourceProbe::byte_map`.
+fn file_byte_map(inner: &Arc<FileInner>) -> Option<Arc<dyn ByteMap>> {
+    inner.segment_index.get()?;
+    Some(Arc::new(FileByteMap {
+        inner: Arc::clone(inner),
+    }))
+}
+
+impl SourceProbe for FileProbe {
+    delegate::delegate! {
+        to self.inner {
+            fn phase(&self) -> SourcePhase;
+            fn phase_at(&self, range: Range<u64>) -> SourcePhase;
+            #[call(known_len)]
+            fn len(&self) -> Option<u64>;
+        }
+        to self.inner.source.coord {
+            fn position(&self) -> u64;
+            fn set_position(&self, pos: u64);
+        }
+    }
+
+    fn byte_map(&self) -> Option<Arc<dyn ByteMap>> {
+        file_byte_map(&self.inner)
+    }
+}
+
+impl kithara_stream::Source for FileSource {
+    fn byte_map(&self) -> Option<Arc<dyn ByteMap>> {
+        file_byte_map(&self.inner)
     }
 
     fn media_info(&self) -> Option<MediaInfo> {
         self.inner.content_type_info.get().cloned()
     }
 
-    fn phase(&self) -> SourcePhase {
-        let pos = self.coord.position();
-        self.phase_at(pos..pos.saturating_add(1))
-    }
-
-    fn phase_at(&self, range: Range<u64>) -> SourcePhase {
-        if self.inner.source.cancel.is_cancelled() {
-            return SourcePhase::Cancelled;
-        }
-        self.inner.refresh_unmanaged_terminal();
-        if self.inner.terminal_state() == FileTerminalState::Cancelled {
-            return SourcePhase::Cancelled;
-        }
-        let Some(readable) = self.readable_part(range) else {
-            return match self.inner.terminal_state() {
-                FileTerminalState::Committed => SourcePhase::Eof,
-                FileTerminalState::Cancelled => SourcePhase::Cancelled,
-                FileTerminalState::Active | FileTerminalState::Failed => SourcePhase::Waiting,
-            };
-        };
-        let contains = readable.is_empty() || self.inner.asset.reader.contains_range(readable);
-        if contains {
-            return SourcePhase::Ready;
-        }
-
-        if self.coord.seek_obs().is_flushing() {
-            return SourcePhase::Seeking;
-        }
-        SourcePhase::Waiting
+    fn probe(&self) -> Arc<dyn SourceProbe> {
+        Arc::new(FileProbe {
+            inner: Arc::clone(&self.inner),
+        })
     }
 
     #[cfg_attr(feature = "perf", hotpath::measure)]
@@ -325,6 +368,12 @@ impl kithara_stream::Source for FileSource {
             fn seek_observe(&self) -> Arc<dyn SeekObserve>;
             fn set_position(&self, pos: u64);
         }
+        to self.inner {
+            #[call(known_len)]
+            fn len(&self) -> Option<u64>;
+            fn phase(&self) -> SourcePhase;
+            fn phase_at(&self, range: Range<u64>) -> SourcePhase;
+        }
     }
 }
 
@@ -343,7 +392,7 @@ impl FileByteMap {
     }
 }
 
-impl kithara_stream::ByteMap for FileByteMap {
+impl ByteMap for FileByteMap {
     delegate::delegate! {
         to self {
             #[expr($.map_or(0..0, FileSegmentIndex::init_range))]

--- a/crates/kithara-hls/CONTEXT.md
+++ b/crates/kithara-hls/CONTEXT.md
@@ -93,6 +93,34 @@ Retired and recovering fetches re-enter the plan in plan order (`requeue_planned
 insert): dispatch caps read the queue head, and a far look-ahead entry parked at the front would
 wall off every nearer segment behind it.
 
+Command priority is stamped at emit against the reader position of that moment, and the
+`Downloading` claim dedupes re-emission — so a prefetch stamped `Low` cannot be re-issued as
+`High` when the reader later catches up with it. The escalation goes through the slot instead.
+`wait_range` is the single filing site of a parked read (the RT `try_read` / `probe_wait` probe
+and the off-RT `Read` park both land there): on a not-ready range it walks the same fetches as
+the wait-phase query and calls `note_reader_demand()` on every claimed slot the read still needs
+bytes from — the whole span, not the first gap, so the downloader serves them concurrently
+rather than one round trip each. `phase_at` stays a pure query: tracing fields, error
+formatting, and the transition's incoming-session probe observe it and must not arm scheduling.
+The readiness poll of a session under construction (`reader_is_ready` → `poll_range`) parks the
+same way, including the `wait_end` filing, but files no demand: it is not a read, the incoming
+variant's fetches are owed already, and escalating its leftover look-ahead would put it back in
+front of the audible variant. The note is set only while the slot is `DOWNLOADING` (a planned
+slot is owed, and the owed dispatch stamps it `High` at emit) and cleared by every terminal
+transition, so a fresh claim starts unescalated and a read still parked re-files on its next
+wait. The `(flags, reader_demand)` pair is not one atomic: a note that saw `DOWNLOADING` just
+before the settle, or a walk whose layout read was torn, can leave a stale note on the next
+claim. Clearing on claim instead would drop a legitimate note; the stale note only escalates
+one fetch, which is the tolerable side. The in-flight command's live demand probe (built in
+`build_cmd`) reads it back, and the downloader's `reschedule` walks the command past
+later-stamped urgent work. `reader_demand` lives beside the flag byte for the same reason as
+`acquire_failures` — a bit inside it would break the claim CAS. It is written by the same filing
+as `ReaderRuntime::wait_end` but owned per slot: the command holds only its slot state, a
+byte-space end alone cannot tell which fetch a read waits on, and the escalation outlives the
+wait that filed it until that fetch settles. Without this, an urgent down-switch starves the
+audible variant's demanded bytes behind the whole construction window and the ring drains dry
+(the UrgentDownSwitch hang).
+
 A fetch cancelled in flight settles back toward the plan it was popped from, gated by the plan
 revision. The revision supersedes on every rebuild — including the short-circuit rebuild that
 changes nothing, because that rebuild still claims plan ownership. A claim captures the revision

--- a/crates/kithara-hls/src/segment/state.rs
+++ b/crates/kithara-hls/src/segment/state.rs
@@ -1,6 +1,6 @@
 use std::sync::{
     Weak,
-    atomic::{AtomicU8, Ordering},
+    atomic::{AtomicBool, AtomicU8, Ordering},
 };
 
 use bitflags::bitflags;
@@ -57,6 +57,12 @@ pub(crate) struct SegmentSlotState {
     /// requeue — that is the whole point — and is cleared the moment an
     /// acquire succeeds.
     acquire_failures: AtomicU8,
+    /// Whether a parked read needs the in-flight fetch's bytes. Set only
+    /// while `DOWNLOADING`, cleared by every terminal transition, read back
+    /// by the command's live demand probe. Kept beside the flags for the
+    /// same reason as `acquire_failures`: a bit packed in there would break
+    /// the claim CAS.
+    reader_demand: AtomicBool,
 }
 
 impl SegmentSlotState {
@@ -64,19 +70,21 @@ impl SegmentSlotState {
         SlotFlags::from_bits_truncate(self.flags.load(Ordering::Acquire))
     }
 
+    fn settle(&self, state: SlotFlags) {
+        self.flags.store(state.bits(), Ordering::Release);
+        self.reader_demand.store(false, Ordering::Release);
+    }
+
     pub(crate) fn mark_failed(&self) {
-        self.flags
-            .store(SlotFlags::FAILED.bits(), Ordering::Release);
+        self.settle(SlotFlags::FAILED);
     }
 
     pub(crate) fn mark_loaded(&self) {
-        self.flags
-            .store(SlotFlags::LOADED.bits(), Ordering::Release);
+        self.settle(SlotFlags::LOADED);
     }
 
     pub(crate) fn mark_missing(&self) {
-        self.flags
-            .store(SlotFlags::empty().bits(), Ordering::Release);
+        self.settle(SlotFlags::empty());
     }
 
     /// Mark the in-flight fetch slow (the `on_slow` hook fired). Idempotent;
@@ -86,10 +94,25 @@ impl SegmentSlotState {
             .fetch_or(SlotFlags::SLOW.bits(), Ordering::AcqRel);
     }
 
+    /// File a parked read on the in-flight fetch. A slot that is not
+    /// `DOWNLOADING` is left alone: a planned one is owed, and the owed
+    /// dispatch stamps it `High` at emit.
+    pub(crate) fn note_reader_demand(&self) {
+        if self.is_downloading() {
+            self.reader_demand.store(true, Ordering::Release);
+        }
+    }
+
+    /// True while a parked read needs the current in-flight fetch's bytes.
+    pub(crate) fn is_reader_demanded(&self) -> bool {
+        self.is_downloading() && self.reader_demand.load(Ordering::Acquire)
+    }
+
     pub(crate) fn missing() -> Arc<Self> {
         Arc::new(Self {
             flags: AtomicU8::new(SlotFlags::empty().bits()),
             acquire_failures: AtomicU8::new(0),
+            reader_demand: AtomicBool::new(false),
         })
     }
 

--- a/crates/kithara-hls/src/stream/coord.rs
+++ b/crates/kithara-hls/src/stream/coord.rs
@@ -15,8 +15,9 @@ use kithara_storage::WaitOutcome;
 use kithara_stream::{
     Activity, ByteMap, DeferredWake, MediaInfo, PlayheadRead, PlayheadState, PlayheadWrite,
     ReadOutcome, ReaderProfile, SeekControl, SeekObserve, SeekPrepare, SeekState,
-    SegmentDescriptor, SourceError, SourcePhase, SourceSeekAnchor, StreamError, StreamResult,
-    VariantControl, VariantPromotion, VariantReaderPlan, VariantReaderTake, VariantTransition,
+    SegmentDescriptor, SourceError, SourcePhase, SourceProbe, SourceSeekAnchor, StreamError,
+    StreamResult, VariantControl, VariantPromotion, VariantReaderPlan, VariantReaderTake,
+    VariantTransition,
 };
 use kithara_test_utils::kithara;
 
@@ -483,6 +484,40 @@ pub(super) fn variant_switch_target_time(
             .unwrap_or_else(|| playhead_read.position());
     }
     landing.unwrap_or_else(|| playhead_read.position())
+}
+
+/// Narrow byte-space handle: the coord is the single owner of phase,
+/// cursor, length, and layout, so the forbid-blocking audio core reads
+/// them here without the stream mutex. Wraps the `Arc` because the byte
+/// map IS the coord — vending it is an allocation-free `Arc` clone.
+pub(crate) struct HlsProbe {
+    coord: Arc<HlsCoord>,
+}
+
+impl HlsProbe {
+    pub(crate) fn new(coord: Arc<HlsCoord>) -> Self {
+        Self { coord }
+    }
+}
+
+impl SourceProbe for HlsProbe {
+    delegate! {
+        to self.coord {
+            fn phase_at(&self, range: Range<u64>) -> SourcePhase;
+            fn position(&self) -> u64;
+            fn set_position(&self, pos: u64);
+            fn len(&self) -> Option<u64>;
+        }
+    }
+
+    fn phase(&self) -> SourcePhase {
+        let pos = self.coord.position();
+        self.coord.phase_at(pos..pos.saturating_add(1))
+    }
+
+    fn byte_map(&self) -> Option<Arc<dyn ByteMap>> {
+        Some(Arc::clone(&self.coord) as Arc<dyn ByteMap>)
+    }
 }
 
 /// `VariantControl` exposes the cross-variant fence/format-change surface

--- a/crates/kithara-hls/src/stream/source.rs
+++ b/crates/kithara-hls/src/stream/source.rs
@@ -9,10 +9,11 @@ use kithara_platform::{CancelScope, sync::Arc, time::Duration};
 use kithara_storage::WaitOutcome;
 use kithara_stream::{
     Activity, BoxedEventSink, ByteMap, DeferredWake, MediaInfo, PlayheadRead, PlayheadWrite,
-    ReadOutcome, SeekControl, SeekObserve, SeekPrepare, Source, SourcePhase, StreamResult,
+    ReadOutcome, SeekControl, SeekObserve, SeekPrepare, Source, SourcePhase, SourceProbe,
+    StreamResult,
 };
 
-use super::coord::HlsCoord;
+use super::coord::{HlsCoord, HlsProbe};
 use crate::{peer::HlsPeer, reader::HlsReaderEventSink};
 
 /// HLS source: thin façade over [`HlsCoord`].
@@ -130,6 +131,10 @@ impl Source for HlsSource {
             self.coord.seek_epoch_handle(),
         );
         Some(Box::new(sink))
+    }
+
+    fn probe(&self) -> Arc<dyn SourceProbe> {
+        Arc::new(HlsProbe::new(Arc::clone(&self.coord)))
     }
 
     fn variant_control(&self) -> Option<Arc<dyn kithara_stream::VariantControl>> {

--- a/crates/kithara-hls/src/variant/io/fetch.rs
+++ b/crates/kithara-hls/src/variant/io/fetch.rs
@@ -1,7 +1,7 @@
 use kithara_assets::{AcquisitionResult, ReadSide, ResourceAcquisition, WriteSide};
 use kithara_platform::{CancelToken, sync::Arc};
 use kithara_storage::ResourceStatus;
-use kithara_stream::dl::{FetchCmd, OnCompleteFn, OnSlowFn, WriterFn};
+use kithara_stream::dl::{DemandFn, FetchCmd, OnCompleteFn, OnSlowFn, WriterFn};
 use url::Url;
 
 use super::HlsVariant;
@@ -57,6 +57,8 @@ impl HlsVariant {
             // WHY: Stalled-escape reconciliation has no reader progress to wake it.
             slow_signal.wake_peer();
         });
+        let demand_slot = slot.handle.slot_state();
+        let demand: DemandFn = Box::new(move || demand_slot.is_reader_demanded());
         let mut inner_writer = slot.writer();
         // WHY: Readers and the audio worker need byte-arrival wakes before terminal settle.
         let writer_fn: WriterFn = Box::new(move |chunk: &[u8]| {
@@ -72,6 +74,7 @@ impl HlsVariant {
                 .maybe_headers(self.profile.headers.clone())
                 .writer(writer_fn)
                 .on_slow(on_slow)
+                .demand(demand)
                 .on_complete(OnCompleteFn::from(slot))
                 .build(),
         )

--- a/crates/kithara-hls/src/variant/io/read.rs
+++ b/crates/kithara-hls/src/variant/io/read.rs
@@ -197,12 +197,27 @@ impl HlsVariant {
     }
 
     fn range_wait_phase(&self, range: &Range<u64>) -> SourcePhase {
+        self.range_wait_phase_with(range, |_| {})
+    }
+
+    /// Wait phase of `range`; `on_demand` sees every planned or in-flight
+    /// fetch the range still needs bytes from. The query itself is pure —
+    /// only the wait filing in `wait_range` passes a writing visitor.
+    pub(super) fn range_wait_phase_with(
+        &self,
+        range: &Range<u64>,
+        on_demand: impl FnMut(PlannedFetch),
+    ) -> SourcePhase {
         self.layout
-            .try_published(|| Some(self.range_wait_phase_published(range)))
+            .try_published(|| Some(self.range_wait_phase_published(range, on_demand)))
             .unwrap_or(SourcePhase::WaitingDemand)
     }
 
-    fn range_wait_phase_published(&self, range: &Range<u64>) -> SourcePhase {
+    fn range_wait_phase_published(
+        &self,
+        range: &Range<u64>,
+        mut on_demand: impl FnMut(PlannedFetch),
+    ) -> SourcePhase {
         let total = self.total_bytes();
         let uses_seek_alias = self.seek_alias_at(range.start).is_some();
         let clamp_alias_to_eof = uses_seek_alias
@@ -211,6 +226,7 @@ impl HlsVariant {
         if !uses_seek_alias && total > 0 && range.start >= total && !self.sizes_complete() {
             let head = self.download_head();
             return if self.segment_has_demand(head) {
+                on_demand(PlannedFetch::Segment(head));
                 SourcePhase::WaitingDemand
             } else {
                 SourcePhase::Waiting
@@ -238,6 +254,7 @@ impl HlsVariant {
                 if !self.init_has_demand() {
                     return SourcePhase::Waiting;
                 }
+                on_demand(PlannedFetch::Init);
                 waiting_on_demand = true;
             }
             cursor = slice_end;
@@ -262,6 +279,7 @@ impl HlsVariant {
                 if !self.segment_has_demand(seg_idx) {
                     return SourcePhase::Waiting;
                 }
+                on_demand(PlannedFetch::Segment(seg_idx));
                 waiting_on_demand = true;
             }
             cursor = slice_end;

--- a/crates/kithara-hls/src/variant/io/read_data.rs
+++ b/crates/kithara-hls/src/variant/io/read_data.rs
@@ -7,7 +7,10 @@ use kithara_test_utils::kithara;
 use tracing::trace;
 
 use super::{HlsVariant, read::RangeGate};
-use crate::{HlsError, segment::PlannedFetch};
+use crate::{
+    HlsError,
+    segment::{PlannedFetch, Segment},
+};
 
 impl HlsVariant {
     #[kithara::hang_watchdog]
@@ -127,11 +130,26 @@ impl HlsVariant {
         self.segment_downloading(seg_idx) || self.fetch_is_planned(PlannedFetch::Segment(seg_idx))
     }
 
-    #[kithara::hang_watchdog]
     pub(crate) fn wait_range(
         &self,
         range: Range<u64>,
         _timeout: Option<Duration>,
+    ) -> StreamResult<WaitOutcome> {
+        self.wait_range_with(range, |planned| self.note_fetch_demand(planned))
+    }
+
+    /// Readiness poll of a session under construction. Parks like a wait but
+    /// files no demand: the poll is not a read, and an incoming variant's
+    /// fetches are owed already.
+    pub(crate) fn poll_range(&self, range: Range<u64>) -> StreamResult<WaitOutcome> {
+        self.wait_range_with(range, |_| {})
+    }
+
+    #[kithara::hang_watchdog]
+    fn wait_range_with(
+        &self,
+        range: Range<u64>,
+        on_demand: impl FnMut(PlannedFetch),
     ) -> StreamResult<WaitOutcome> {
         let stable_pending = match self.range_gate(&range) {
             Some(RangeGate::Eof) => {
@@ -155,13 +173,27 @@ impl HlsVariant {
             return Err(StreamError::Source(HlsError::SegmentUnavailable.into()));
         }
         self.flow.reader.note_wait(range.end);
+        let phase = self.range_wait_phase_with(&range, on_demand);
         trace!(
             variant = self.variant,
             start = range.start,
             end = range.end,
+            ?phase,
             "wait_range: range not ready (budget exceeded)"
         );
         Err(StreamError::Source(HlsError::WaitBudgetExceeded.into()))
+    }
+
+    /// File the parked read on a fetch it needs bytes from, so the in-flight
+    /// command's demand probe escalates it in the downloader queue.
+    fn note_fetch_demand(&self, planned: PlannedFetch) {
+        let state = match planned {
+            PlannedFetch::Init => self.segments.init.as_ref().map(Segment::state),
+            PlannedFetch::Segment(idx) => self.segments.get(idx as usize).map(Segment::state),
+        };
+        if let Some(state) = state {
+            state.note_reader_demand();
+        }
     }
 
     fn wrap(written: usize) -> ReadOutcome {

--- a/crates/kithara-hls/src/variant/profile.rs
+++ b/crates/kithara-hls/src/variant/profile.rs
@@ -174,7 +174,7 @@ impl HlsVariant {
     }
 
     fn reader_range_is_ready(&self, range: Range<u64>) -> StreamResult<bool> {
-        match self.wait_range(range, Some(Duration::ZERO)) {
+        match self.poll_range(range) {
             Ok(WaitOutcome::Ready | WaitOutcome::Eof) => Ok(true),
             Ok(WaitOutcome::Interrupted)
             | Err(StreamError::Source(SourceError::WaitBudgetExceeded)) => Ok(false),

--- a/crates/kithara-hls/src/variant/tests.rs
+++ b/crates/kithara-hls/src/variant/tests.rs
@@ -29,8 +29,8 @@ use super::{HlsVariant, PlanConfig, PlanCtx, SizeDemand, VariantParts, segment_p
 use crate::{
     playlist::{PlaylistState, SegmentState, VariantState},
     segment::{
-        InitSegment, MediaSegment, PlannedFetch, Segment, SegmentContent, SegmentSize,
-        SegmentSlotState,
+        Downloading, FetchClaim, InitSegment, MediaSegment, PlannedFetch, Segment, SegmentContent,
+        SegmentSize, SegmentSlotState,
     },
     signal::SizeSignal,
     stream::HlsSession,
@@ -1421,6 +1421,112 @@ fn phase_at_reports_waiting_demand_for_queued_segment() {
     push_planned(&v, 0);
 
     assert_eq!(v.phase_at(0..16), SourcePhase::WaitingDemand);
+}
+
+fn claim_segment_zero(v: &Arc<HlsVariant>, ctx: &PlanCtx) -> FetchClaim<Downloading> {
+    v.segments()[0]
+        .state()
+        .try_claim(
+            PlannedFetch::Segment(0),
+            v.flow.queue.revision(),
+            Arc::downgrade(v),
+            ctx.signal.clone(),
+        )
+        .expect("segment claim")
+}
+
+#[kithara::test]
+fn a_parked_wait_files_demand_on_the_claimed_segment() {
+    let ctx = test_ctx(3);
+    let v = make_var(0, 0, &[100, 100], &ctx);
+    let _claim = claim_segment_zero(&v, &ctx);
+    assert!(
+        !v.segments()[0].state().is_reader_demanded(),
+        "an in-flight fetch nobody waits on must not be escalated"
+    );
+
+    assert!(v.wait_range(0..16, None).is_err(), "the range is not ready");
+
+    assert!(
+        v.segments()[0].state().is_reader_demanded(),
+        "the wait parking on the claimed segment must escalate its fetch"
+    );
+}
+
+#[kithara::test]
+fn a_phase_query_leaves_demand_unfiled() {
+    let ctx = test_ctx(3);
+    let v = make_var(0, 0, &[100, 100], &ctx);
+    let _claim = claim_segment_zero(&v, &ctx);
+
+    assert_eq!(v.phase_at(0..16), SourcePhase::WaitingDemand);
+
+    assert!(
+        !v.segments()[0].state().is_reader_demanded(),
+        "a phase query observes the slot; only a parked wait escalates it"
+    );
+}
+
+#[kithara::test]
+fn a_settled_slot_answers_no_demand() {
+    let ctx = test_ctx(3);
+    let v = make_var(0, 0, &[100, 100], &ctx);
+    let claim = claim_segment_zero(&v, &ctx);
+    assert!(v.wait_range(0..16, None).is_err(), "the range is not ready");
+
+    claim.into_missing();
+
+    assert!(
+        !v.segments()[0].state().is_reader_demanded(),
+        "a settled slot has no in-flight fetch left to escalate"
+    );
+
+    let _claim = claim_segment_zero(&v, &ctx);
+
+    assert!(
+        !v.segments()[0].state().is_reader_demanded(),
+        "the settle must clear the filing: a fresh claim starts unescalated"
+    );
+}
+
+#[kithara::test]
+fn a_readiness_poll_leaves_demand_unfiled() {
+    let ctx = test_ctx(3);
+    let v = make_var(0, 0, &[100, 100], &ctx);
+    let profile = ReaderProfile::new(
+        ReaderInput::Incremental,
+        ReaderWarmup::None,
+        NonZeroU64::new(16).expect("non-zero read ahead"),
+    );
+    let preparation = v
+        .prepare_reader(profile, Duration::ZERO)
+        .expect("reader preparation");
+    let _claim = claim_segment_zero(&v, &ctx);
+
+    assert!(
+        !v.reader_is_ready(&preparation).expect("readiness poll"),
+        "the claimed segment is not loaded"
+    );
+
+    assert!(
+        !v.segments()[0].state().is_reader_demanded(),
+        "a readiness poll is not a read; only a parked wait escalates the fetch"
+    );
+}
+
+#[kithara::test]
+fn a_planned_segment_is_owed_not_escalated() {
+    let ctx = test_ctx(3);
+    let v = make_var(0, 0, &[100, 100], &ctx);
+    push_planned(&v, 0);
+    assert!(v.wait_range(0..16, None).is_err(), "the range is not ready");
+
+    let _claim = claim_segment_zero(&v, &ctx);
+
+    assert!(
+        !v.segments()[0].state().is_reader_demanded(),
+        "a wait parked before the claim must not carry into the fresh fetch: the owed dispatch stamps it High at emit"
+    );
 }
 
 fn exact_seek_session() -> (Arc<HlsVariant>, HlsSession, u64) {

--- a/crates/kithara-platform/CONTEXT.md
+++ b/crates/kithara-platform/CONTEXT.md
@@ -172,7 +172,13 @@ independent of scheduling: runs are deterministic and every timed wait collapses
 - `thread::spawn`, `thread::spawn_named`, and platform `task::spawn_blocking` reset the credit on
   entry (a reused pool thread must not inherit a stale credit) and own the exit decrement via an
   RAII participant after the closure returns *or unwinds*. A consumer running a wrapped wait on a
-  blocking pool thread must spawn through platform `task::spawn_blocking`.
+  blocking pool thread must spawn through platform `task::spawn_blocking`. Both spawn forms
+  reserve the child's slot synchronously on the spawning thread, before the OS thread exists.
+- A test body that never runs a wrapped wait stays `None` — invisible to the engine. Every peer a
+  timed waiter depends on must therefore be spawned (its slot reserved) BEFORE the waiter can
+  park: a waiter parked in a spawn→spawn gap is the only credit, and the clock jumps its whole
+  backstop before the peer exists (`tests/tests/loom.rs`,
+  `thread_gate_refreshes_waiter_after_thread_handoff`).
 - A wrapped wait does register-deadline (or a deadline-less entry for an untimed condvar wait),
   wait accounting, and advance-rule evaluation in ONE critical section under the engine lock,
   closing the wake-to-re-register race. Lock order is always domain → engine; wakes fire only after

--- a/crates/kithara-stream/CONTEXT.md
+++ b/crates/kithara-stream/CONTEXT.md
@@ -124,6 +124,21 @@ releases the command's claim — the HLS segment slot and the non-`Clone` `Asset
 in it — so a dropped closure strands a `<canonical>.tmp` that no one will ever write.
 Imperative `execute`/`batch` commands carry no claim: their oneshot is the completion signal.
 
+Scheduling routes each queued command into a 2×2 priority slot map keyed by
+`(peer.priority(), command priority)`; the urgent slots (`High` peer or command)
+drain fully before the demand slots each loop pass. A command's stamped priority
+reflects the reader position at *emit* time, so `FetchCmd` also carries an
+optional `DemandFn` — a live probe answering whether a reader currently blocks
+on this command's bytes. `Registry::reschedule` (every loop pass) re-asks both
+the peer priority and the demand probe, and an escalation moves the command to
+the *front* of its more urgent slot: a prefetch the playhead caught up with
+overtakes work stamped more urgent after it, instead of starving behind an
+entire construction window while a reader waits (the UrgentDownSwitch hang).
+Demand probes must be cheap, lock-free reads — they run on the download loop.
+`reschedule` rebuilds every slot in one pass rather than patching by index, since a
+slot can be both source and destination of the same pass. `RequestEnqueued` carries
+the stamped priority; an escalation is a `reschedule` trace line, not a bus event.
+
 `DownloaderConfig::for_client(client)` carries `abr_settings` for the shared ABR
 controller, `demand_throttle`, `soft_timeout` (2s — publishes
 `DownloaderEvent::LoadSlow` on the peer's bus without aborting the request),

--- a/crates/kithara-stream/CONTEXT.md
+++ b/crates/kithara-stream/CONTEXT.md
@@ -62,6 +62,19 @@ underran worker re-ticks the instant bytes land); sources whose data is always
 resident have neither. `take_reader_event_sink` must return a **fresh** sink on
 every call — decoder recreation (ABR / format change) needs a clean state cursor.
 
+`probe` is the narrow byte-space handle (`SourceProbe`): phase, cursor
+(`position`/`set_position`), `len`, and `byte_map` behind an `Arc`, so a caller
+that keeps `Stream` behind a mutex (the audio worker's shared stream) serves its
+real-time polls and cursor moves without that lock — an off-thread holder parked
+in a blocking `read`/`seek` would otherwise turn the poll into a wait.
+Implementations answer from self-synchronizing state (HLS: the coord; file: the
+shared inner) and must not take locks a reader wait can hold — the file probe's
+`phase_at` and `len` may take the storage gate lock on the uncommitted path, a
+short acquire the storage wait releases before parking, never one held across a
+wait. `resolve_seek_target` is the shared cursor math: `Stream::seek` and the
+probe-side `probe_seek` resolve a `SeekFrom` against the same position/length
+answers.
+
 ## End-of-stream contract
 
 `Stream::try_read` surfaces `StreamReadOutcome::Eof` only from a `Source` proving

--- a/crates/kithara-stream/src/dl/cmd.rs
+++ b/crates/kithara-stream/src/dl/cmd.rs
@@ -32,6 +32,13 @@ pub type OnCompleteFn = Box<dyn FnOnce(u64, Option<&Headers>, Option<&NetError>)
 /// same point that publishes [`DownloaderEvent::LoadSlow`](kithara_events::DownloaderEvent::LoadSlow).
 pub type OnSlowFn = Box<dyn FnOnce() + Send>;
 
+/// Per-command live demand probe: does a reader currently block on this
+/// command's bytes? The scheduler re-polls it on every loop pass and
+/// treats `true` as [`RequestPriority::High`]. It runs on the download
+/// loop, so it must be a lock-free read and must not re-enter the
+/// downloader.
+pub type DemandFn = Box<dyn Fn() -> bool + Send>;
+
 /// Optional response-header validator for a single `FetchCmd`.
 ///
 /// Invoked with the response headers after a successful HTTP response.
@@ -69,6 +76,8 @@ pub struct FetchCmd {
     pub(crate) on_slow: Option<OnSlowFn>,
     /// Scheduling priority for proactive peer fetches.
     pub(crate) priority: Option<RequestPriority>,
+    /// Live demand probe; `None` when the peer cannot tell.
+    pub(crate) demand: Option<DemandFn>,
     /// Optional byte range (HTTP Range request).
     pub(crate) range: Option<RangeSpec>,
     /// Optional per-request response validator.
@@ -103,6 +112,12 @@ impl FetchCmd {
     #[must_use]
     pub const fn priority(&self) -> Option<RequestPriority> {
         self.priority
+    }
+
+    /// Whether a reader currently blocks on this command's bytes, per the
+    /// live [`DemandFn`] probe. `false` when no probe was attached.
+    pub(crate) fn is_demanded(&self) -> bool {
+        self.demand.as_ref().is_some_and(|probe| probe())
     }
 
     /// URL this command fetches.

--- a/crates/kithara-stream/src/dl/mod.rs
+++ b/crates/kithara-stream/src/dl/mod.rs
@@ -14,7 +14,9 @@ mod response;
 #[cfg(test)]
 mod tests;
 
-pub use cmd::{FetchCmd, OnCompleteFn, OnResponseFn, OnSlowFn, WriterFn, reject_html_response};
+pub use cmd::{
+    DemandFn, FetchCmd, OnCompleteFn, OnResponseFn, OnSlowFn, WriterFn, reject_html_response,
+};
 pub use config::DownloaderConfig;
 pub use downloader::Downloader;
 pub use kithara_events::{RequestMethod, RequestPriority};

--- a/crates/kithara-stream/src/dl/peer.rs
+++ b/crates/kithara-stream/src/dl/peer.rs
@@ -110,6 +110,17 @@ pub(super) struct InternalCmd {
     pub(super) response: ResponseTarget,
 }
 
+impl InternalCmd {
+    /// Scheduling priority as of *now*: the stamped priority, escalated to
+    /// `High` while the live demand probe reports a blocked reader.
+    pub(super) fn effective_priority(&self) -> RequestPriority {
+        if self.cmd.is_demanded() {
+            return RequestPriority::High;
+        }
+        self.priority
+    }
+}
+
 /// Shared per-peer state. Cancel fires when the last clone is dropped.
 #[derive(bon::Builder)]
 pub(super) struct PeerInner {

--- a/crates/kithara-stream/src/dl/registry.rs
+++ b/crates/kithara-stream/src/dl/registry.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::VecDeque,
     future::{Future, pending, poll_fn},
+    mem::take,
     sync::atomic::Ordering,
     task::Poll,
 };
@@ -16,6 +17,7 @@ use kithara_platform::{
 };
 use kithara_test_utils::kithara;
 use thunderdome::{Arena, Index};
+use tracing::trace;
 
 use super::{
     batch::BatchGroup,
@@ -177,7 +179,7 @@ impl Registry {
             }
             while let Poll::Ready(Some(mut cmd)) = entry.cmd_rx.poll_recv(cx) {
                 let peer_prio = entry.peer.priority();
-                let slot = slot_index(peer_prio, cmd.priority);
+                let slot = slot_index(peer_prio, cmd.effective_priority());
                 cmd.peer = Some(idx);
                 let entry_slot = SlotEntry {
                     cmd,
@@ -212,7 +214,6 @@ impl Registry {
                             None => CancelGroup::new(vec![entry.peer_cancel.child()]),
                         };
                         let cmd_prio = cmd.priority.unwrap_or(RequestPriority::Low);
-                        let slot = slot_index(peer_prio, cmd_prio);
                         let request_id = inner.next_request_id();
                         let enqueued_at = Instant::now();
                         let internal = InternalCmd {
@@ -226,6 +227,7 @@ impl Registry {
                             bus: bus.clone(),
                             peer_id: entry.peer_id,
                         };
+                        let slot = slot_index(peer_prio, internal.effective_priority());
                         let entry_slot = SlotEntry {
                             cmd: internal,
                             peer_cancel: entry.peer_cancel.clone(),
@@ -264,49 +266,63 @@ impl Registry {
                 .peer
                 .and_then(|peer| self.peers.get(peer))
                 .map_or(RequestPriority::Low, |peer| peer.peer.priority());
-            let slot = slot_index(peer_priority, entry.cmd.priority);
+            let slot = slot_index(peer_priority, entry.cmd.effective_priority());
             self.slots[slot].push_front(entry);
         }
     }
 
-    /// Check `peer.priority()` for each command in slots,
-    /// move to the correct slot if priority changed.
+    /// Re-ask `peer.priority()` and the command's live demand probe for
+    /// each queued command, and move it to the correct slot when either
+    /// answer changed. An escalation goes to the *front* of its new slot:
+    /// a reader now blocks on those bytes, and the point is overtaking the
+    /// queue that starved it. A demotion goes to the back.
+    ///
+    /// Each slot is rebuilt in one pass rather than patched by index: a
+    /// slot can be both a source and a destination in the same pass, and
+    /// a `push_front` shifts every index recorded before it.
     pub(super) fn reschedule(&mut self) {
-        let mut moves: Vec<(usize, usize, usize)> = Vec::new();
-        let mut cancels: Vec<(usize, usize)> = Vec::new();
+        let mut escalated: Vec<(usize, SlotEntry)> = Vec::new();
+        let mut demoted: Vec<(usize, SlotEntry)> = Vec::new();
 
         for slot_idx in 0..SLOT_COUNT {
-            for (i, slot_entry) in self.slots[slot_idx].iter().enumerate() {
+            for slot_entry in take(&mut self.slots[slot_idx]) {
                 let cmd = &slot_entry.cmd;
                 let Some(peer_idx) = cmd.peer else {
+                    self.slots[slot_idx].push_back(slot_entry);
                     continue;
                 };
                 let Some(entry) = self.peers.get(peer_idx) else {
-                    cancels.push((slot_idx, i));
+                    let SlotEntry { cmd, peer_cancel } = slot_entry;
+                    super::batch::deliver_cancelled_with_event(cmd, &peer_cancel);
                     continue;
                 };
-                let correct_slot = slot_index(entry.peer.priority(), cmd.priority);
-                if correct_slot != slot_idx {
-                    moves.push((slot_idx, i, correct_slot));
+                let correct_slot = slot_index(entry.peer.priority(), cmd.effective_priority());
+                if correct_slot == slot_idx {
+                    self.slots[slot_idx].push_back(slot_entry);
+                } else if correct_slot < slot_idx {
+                    trace!(
+                        request_id = ?cmd.request_id,
+                        url = %cmd.cmd.url,
+                        from_slot = slot_idx,
+                        to_slot = correct_slot,
+                        demanded = cmd.cmd.is_demanded(),
+                        "reschedule: queued fetch escalated"
+                    );
+                    escalated.push((correct_slot, slot_entry));
+                } else {
+                    demoted.push((correct_slot, slot_entry));
                 }
             }
         }
 
-        cancels.sort_by_key(|entry| std::cmp::Reverse(entry.1));
-        for (slot_idx, i) in cancels {
-            if let Some(slot_entry) = self.slots[slot_idx].remove(i) {
-                let SlotEntry { cmd, peer_cancel } = slot_entry;
-                super::batch::deliver_cancelled_with_event(cmd, &peer_cancel);
-            }
+        for (slot, slot_entry) in demoted {
+            self.slots[slot].push_back(slot_entry);
         }
-
-        moves.sort_by_key(|entry| std::cmp::Reverse(entry.1));
-        for (from_slot, i, to_slot) in moves {
-            if let Some(slot_entry) = self.slots[from_slot].remove(i) {
-                self.slots[to_slot].push_back(slot_entry);
-                if to_slot <= 1 {
-                    self.urgent_notify.notify_one();
-                }
+        // WHY: Reverse keeps scan order among entries escalated into one slot.
+        for (slot, slot_entry) in escalated.into_iter().rev() {
+            self.slots[slot].push_front(slot_entry);
+            if slot <= 1 {
+                self.urgent_notify.notify_one();
             }
         }
     }

--- a/crates/kithara-stream/src/dl/tests.rs
+++ b/crates/kithara-stream/src/dl/tests.rs
@@ -1,7 +1,7 @@
 use std::{
     convert::Infallible,
     net::SocketAddr,
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
     task::{Context, Poll},
 };
 
@@ -28,7 +28,10 @@ use kithara_platform::{
 use kithara_test_utils::kithara;
 use url::Url;
 
-use super::{BodyStream, Downloader, DownloaderConfig, FetchCmd, Peer, RequestPriority};
+use super::{
+    BodyStream, DemandFn, Downloader, DownloaderConfig, FetchCmd, Peer, RequestPriority,
+    cmd::{FetchCmdBuilder, fetch_cmd_builder},
+};
 use crate::{Activity, SeekState};
 
 const CONCURRENCY_TEST_TIMEOUT_SECS: u64 = 30;
@@ -1317,6 +1320,156 @@ async fn active_peer_completes_before_preload_under_contention() {
         "active peer must dominate the first quarter of completions: \
          got {active_in_first_quarter}/{}",
         first_quarter.len()
+    );
+}
+
+type NamedLog = Arc<Mutex<Vec<&'static str>>>;
+
+/// A command whose completion appends `name` to the log and releases the gate.
+fn logged_cmd(
+    url: &Url,
+    log: &NamedLog,
+    gate: &Arc<CompletionGate>,
+    name: &'static str,
+) -> FetchCmdBuilder<
+    fetch_cmd_builder::SetOnComplete<fetch_cmd_builder::SetWriter<fetch_cmd_builder::SetMethod>>,
+> {
+    let log = Arc::clone(log);
+    let gate = Arc::clone(gate);
+    FetchCmd::get(url.clone())
+        .writer(Box::new(|_chunk: &[u8]| Ok(())))
+        .on_complete(Box::new(
+            move |_bytes, _headers: Option<&ResponseHeaders>, _err: Option<&FetchError>| {
+                log.lock().push(name);
+                gate.complete();
+            },
+        ))
+}
+
+fn demand_probe(flag: &Arc<AtomicBool>) -> DemandFn {
+    let probe = Arc::clone(flag);
+    Box::new(move || probe.load(Ordering::Acquire))
+}
+
+/// One fetch in flight at a time over a slow-body server: the lead
+/// command's `on_response` fires before the queue moves again, so a
+/// flag it flips is what the next scheduler pass sees.
+async fn one_slot_downloader() -> (Downloader, Url) {
+    const PER_REQUEST_BODY_DELAY_MS: u64 = 100;
+
+    let url = spawn_slow_body_server(PER_REQUEST_BODY_DELAY_MS).await;
+    let config = DownloaderConfig {
+        max_concurrent: 1,
+        ..test_config()
+    };
+    (Downloader::new(config), url)
+}
+
+/// Emits one pre-built batch, then stays quiet so the queue order alone
+/// decides completion order.
+async fn run_one_batch(dl: &Downloader, gate: &Arc<CompletionGate>, batch: Vec<FetchCmd>) {
+    let peer = Arc::new(QueuedPeer {
+        cancel: CancelToken::never(),
+        cmds: Mutex::new(Some(batch)),
+        yielded: Notify::default(),
+    });
+    let handle = dl.register(peer as Arc<dyn Peer>);
+    gate.wait().await;
+    drop(handle);
+}
+
+/// A prefetch is stamped `Low` against the reader position at emit time;
+/// when the reader then parks on its bytes, the live demand probe must
+/// walk it past urgent work stamped after it — otherwise the audible
+/// track starves behind an entire construction window (the
+/// UrgentDownSwitch hang: v0's demanded bytes queued behind all of v1).
+#[kithara::test(tokio, timeout(Duration::from_secs(30)))]
+async fn a_demanded_prefetch_overtakes_later_stamped_urgent_work() {
+    let (dl, url) = one_slot_downloader().await;
+    let gate = CompletionGate::new(5);
+    let log: NamedLog = Arc::new(Mutex::new(Vec::new()));
+    let demand = Arc::new(AtomicBool::new(false));
+    let arm = Arc::clone(&demand);
+
+    run_one_batch(
+        &dl,
+        &gate,
+        vec![
+            logged_cmd(&url, &log, &gate, "lead")
+                .on_response(Box::new(move |_headers: &ResponseHeaders| {
+                    arm.store(true, Ordering::Release);
+                }))
+                .priority(RequestPriority::High)
+                .build(),
+            logged_cmd(&url, &log, &gate, "prefetch")
+                .demand(demand_probe(&demand))
+                .build(),
+            logged_cmd(&url, &log, &gate, "urgent-1")
+                .priority(RequestPriority::High)
+                .build(),
+            logged_cmd(&url, &log, &gate, "urgent-2")
+                .priority(RequestPriority::High)
+                .build(),
+            logged_cmd(&url, &log, &gate, "urgent-3")
+                .priority(RequestPriority::High)
+                .build(),
+        ],
+    )
+    .await;
+
+    let order = log.lock().clone();
+    assert_eq!(order.len(), 5, "every cmd must complete exactly once");
+    assert_eq!(order[0], "lead", "the in-flight fetch finishes first");
+    assert_eq!(
+        order[1], "prefetch",
+        "the demanded prefetch must overtake urgent work stamped after it: {order:?}"
+    );
+}
+
+/// One scheduler pass can demote and escalate through the same slot. The
+/// command whose demand dropped yields to the queue, and the newly
+/// demanded one takes the front — neither may be confused for the other.
+#[kithara::test(tokio, timeout(Duration::from_secs(30)))]
+async fn a_dropped_demand_yields_to_a_newly_demanded_command() {
+    let (dl, url) = one_slot_downloader().await;
+    let gate = CompletionGate::new(5);
+    let log: NamedLog = Arc::new(Mutex::new(Vec::new()));
+    let stale = Arc::new(AtomicBool::new(true));
+    let fresh = Arc::new(AtomicBool::new(false));
+    let (drop_stale, arm_fresh) = (Arc::clone(&stale), Arc::clone(&fresh));
+
+    run_one_batch(
+        &dl,
+        &gate,
+        vec![
+            logged_cmd(&url, &log, &gate, "lead")
+                .on_response(Box::new(move |_headers: &ResponseHeaders| {
+                    drop_stale.store(false, Ordering::Release);
+                    arm_fresh.store(true, Ordering::Release);
+                }))
+                .priority(RequestPriority::High)
+                .build(),
+            logged_cmd(&url, &log, &gate, "stale")
+                .demand(demand_probe(&stale))
+                .build(),
+            logged_cmd(&url, &log, &gate, "filler-1").build(),
+            logged_cmd(&url, &log, &gate, "filler-2").build(),
+            logged_cmd(&url, &log, &gate, "fresh")
+                .demand(demand_probe(&fresh))
+                .build(),
+        ],
+    )
+    .await;
+
+    let order = log.lock().clone();
+    assert_eq!(order.len(), 5, "every cmd must complete exactly once");
+    assert_eq!(
+        order[1], "fresh",
+        "the newly demanded command takes the front: {order:?}"
+    );
+    assert_eq!(
+        order[4], "stale",
+        "the command whose demand dropped yields to the queue: {order:?}"
     );
 }
 

--- a/crates/kithara-stream/src/lib.rs
+++ b/crates/kithara-stream/src/lib.rs
@@ -40,11 +40,11 @@ pub use reader::{
 pub use seek_state::{Activity, SeekControl, SeekObserve, SeekState};
 pub use source::{
     ByteMap, NotReadyCause, PendingReason, ReadOutcome, SeekPrepare, SegmentDescriptor, Source,
-    SourcePhase, SourceSeekAnchor, VariantControl,
+    SourcePhase, SourceProbe, SourceSeekAnchor, VariantControl,
 };
 pub use stream::{
     Stream, StreamPending, StreamReadError, StreamReadOutcome, StreamSeekPastEof, StreamType,
-    VariantChangeError,
+    VariantChangeError, format_change_segment_range, resolve_seek_target,
 };
 pub use transition::{
     OutgoingDisposition, VariantPromotion, VariantTransition, VariantTransitionId,

--- a/crates/kithara-stream/src/source.rs
+++ b/crates/kithara-stream/src/source.rs
@@ -82,6 +82,46 @@ pub enum SourcePhase {
     WaitingMetadata,
 }
 
+/// Narrow view of the source's byte space, served off the control mutex.
+///
+/// Phase, cursor, length, and byte map are non-blocking `&self` snapshots
+/// on [`Source`], but reaching them through a `Mutex<Stream>` turns each
+/// query into a lock acquisition — off-limits on the forbid-blocking audio
+/// produce core, where any contended acquire (a construction read or a
+/// consumer query holding the control mutex) blocks the real-time tick.
+/// Callers on that core take this handle once at open and answer every
+/// byte-space question without touching the stream's control-plane mutex.
+/// Implementations answer from self-synchronizing state and must not take
+/// locks a reader wait can hold.
+pub trait SourceProbe: Send + Sync + 'static {
+    /// Overall source readiness at the current position.
+    fn phase(&self) -> SourcePhase;
+
+    /// Point-in-time readiness for a specific byte range.
+    fn phase_at(&self, range: Range<u64>) -> SourcePhase;
+
+    /// Current read position — the same atomic cursor as
+    /// [`Source::position`].
+    fn position(&self) -> u64;
+
+    /// Absolute byte-position set — the same atomic cursor as
+    /// [`Source::set_position`].
+    fn set_position(&self, pos: u64);
+
+    /// Total length if known — the same answer as [`Source::len`].
+    fn len(&self) -> Option<u64>;
+
+    /// Whether the source currently reports zero bytes — the same
+    /// convention as [`Source::is_empty`].
+    fn is_empty(&self) -> bool {
+        self.len().is_none_or(|n| n == 0)
+    }
+
+    /// Optional byte-map handle — the same answer as [`Source::byte_map`],
+    /// including its over-time `None` → `Some` transition.
+    fn byte_map(&self) -> Option<Arc<dyn ByteMap>>;
+}
+
 /// Reason a [`ReadOutcome::Pending`] was returned — i.e. why the source
 /// did not make progress this call. Each variant maps to a distinct
 /// caller action; there is no overlap and no string-matching required.
@@ -260,6 +300,13 @@ pub trait Source: MaybeSend + MaybeSync + 'static {
     /// Returns the current [`SourcePhase`] without blocking. Used internally
     /// by `wait_range()` implementations for fast-path dispatch.
     fn phase_at(&self, range: Range<u64>) -> SourcePhase;
+
+    /// Narrow byte-space handle serving the same snapshots as
+    /// [`Source::phase_at`], [`Source::position`], [`Source::len`], and
+    /// [`Source::byte_map`] without going through the stream's control-plane
+    /// lock. The forbid-blocking audio produce core answers every byte-space
+    /// question through this handle only.
+    fn probe(&self) -> Arc<dyn SourceProbe>;
 
     /// Narrow read-only handle to the playhead position and total duration.
     fn playhead_read(&self) -> Arc<dyn PlayheadRead>;
@@ -512,10 +559,41 @@ pub trait ByteMap: Send + Sync + 'static {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
     use kithara_test_utils::kithara;
 
     use super::*;
     use crate::{PlayheadState, SeekState};
+
+    /// Constant-phase probe for the minimal test sources below; shares the
+    /// source's cursor cell and mirrors its `len`.
+    struct FixedPhase {
+        phase: SourcePhase,
+        len: Option<u64>,
+        position: Arc<AtomicU64>,
+    }
+
+    impl SourceProbe for FixedPhase {
+        fn phase(&self) -> SourcePhase {
+            self.phase
+        }
+        fn phase_at(&self, _range: Range<u64>) -> SourcePhase {
+            self.phase
+        }
+        fn position(&self) -> u64 {
+            self.position.load(Ordering::Acquire)
+        }
+        fn set_position(&self, pos: u64) {
+            self.position.store(pos, Ordering::Release);
+        }
+        fn len(&self) -> Option<u64> {
+            self.len
+        }
+        fn byte_map(&self) -> Option<Arc<dyn ByteMap>> {
+            None
+        }
+    }
 
     #[kithara::test]
     fn test_source_trait_object_safety() {
@@ -529,8 +607,6 @@ mod tests {
 
     #[kithara::test]
     fn phase_default_delegates_to_phase_at() {
-        use std::sync::atomic::{AtomicU64, Ordering};
-
         struct ReadySource {
             seek: Arc<SeekState>,
             playhead: Arc<PlayheadState>,
@@ -565,6 +641,13 @@ mod tests {
             fn phase_at(&self, _range: Range<u64>) -> SourcePhase {
                 SourcePhase::Ready
             }
+            fn probe(&self) -> Arc<dyn SourceProbe> {
+                Arc::new(FixedPhase {
+                    phase: SourcePhase::Ready,
+                    len: Some(100),
+                    position: Arc::clone(&self.position),
+                })
+            }
             fn len(&self) -> Option<u64> {
                 Some(100)
             }
@@ -597,8 +680,6 @@ mod tests {
     /// - `activity().is_playing()` toggles correctly.
     #[kithara::test]
     fn narrow_source_accessors_seam() {
-        use std::sync::atomic::{AtomicU64, Ordering};
-
         struct MinimalSource {
             seek: Arc<SeekState>,
             playhead: Arc<PlayheadState>,
@@ -632,6 +713,13 @@ mod tests {
             }
             fn phase_at(&self, _range: Range<u64>) -> SourcePhase {
                 SourcePhase::Waiting
+            }
+            fn probe(&self) -> Arc<dyn SourceProbe> {
+                Arc::new(FixedPhase {
+                    phase: SourcePhase::Waiting,
+                    len: None,
+                    position: Arc::clone(&self.position),
+                })
             }
             fn len(&self) -> Option<u64> {
                 None

--- a/crates/kithara-stream/src/stream.rs
+++ b/crates/kithara-stream/src/stream.rs
@@ -234,14 +234,9 @@ impl<T: StreamType> Stream<T> {
     ///
     /// # Errors
     ///
-    /// `Err(SourceError::FormatChangeNotApplicable)` for non-HLS sources
-    /// or HLS variants activated with `served_from > 0` (init prefix
-    /// unreachable via Stream reads).
+    /// See [`format_change_segment_range`].
     pub fn format_change_segment_range(&self) -> StreamResult<Range<u64>> {
-        self.source.variant_control().map_or(
-            Err(StreamError::Source(SourceError::FormatChangeNotApplicable)),
-            |vc| vc.format_change_segment_range(),
-        )
+        format_change_segment_range(self.source.variant_control().as_deref())
     }
 
     pub fn is_empty(&self) -> Option<bool> {
@@ -271,6 +266,12 @@ impl<T: StreamType> Stream<T> {
             pub fn phase(&self) -> SourcePhase;
             /// Point-in-time readiness for a specific byte range.
             pub fn phase_at(&self, range: Range<u64>) -> SourcePhase;
+            /// Narrow byte-space handle — the same snapshots as
+            /// [`Stream::phase_at`] / [`Stream::position`] / [`Stream::len`] /
+            /// [`Stream::byte_map`] for callers that must not take the lock a
+            /// shared stream wrapper puts around `Stream`.
+            #[must_use]
+            pub fn probe(&self) -> Arc<dyn crate::SourceProbe>;
             /// Get current media info if known.
             pub fn media_info(&self) -> Option<MediaInfo>;
             /// Runtime ABR handle — `Some` for adaptive sources (HLS).
@@ -580,61 +581,68 @@ impl<T: StreamType> Stream<T> {
         self.source.wait_range(range, Some(Duration::ZERO))
     }
 
-    /// Real-time on-core seek: resolve + cursor set, with NO `prime_seek_range`
-    /// spin — no `yield_now`/`notify_one` on the forbid-blocking produce core.
-    /// The audio worker (the FSM's recreate/boundary seeks and the decoder's
-    /// `OffsetReader`) seeks through this; the off-RT [`Seek::seek`] adapter
-    /// primes inline instead. The seeked range's readiness is discovered by the
-    /// next `probe_read` (park-on-not-ready), and the armed peer wake — flushed
-    /// by the shell — drives the fetch.
-    ///
-    /// # Errors
-    ///
-    /// See [`Self::resolve_seek_target`].
-    pub fn probe_seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
-        let new_pos = self.resolve_seek_target(pos, self.source.len())?;
-        self.source.set_position(new_pos);
-        // The reader cursor moved on the produce core: arm the peer so it
-        // re-targets fetches around the new position. The shell flushes it.
-        self.arm_peer_wake();
-        Ok(new_pos)
-    }
-
-    /// Resolve a [`SeekFrom`] to an absolute, clamped byte target — the shared
-    /// math behind the off-RT [`Seek::seek`] and the on-core [`Self::probe_seek`].
+    /// Resolve a [`SeekFrom`] against the live cursor — the shared math
+    /// behind the off-RT [`Seek::seek`] and the on-core probe seek
+    /// (the audio worker's shared-stream wrapper).
     ///
     /// `len` is the known source length, resolved by the caller (`seek` primes
-    /// to discover it; `probe_seek` uses the current value); `SeekFrom::End`
-    /// errors when it is `None`. `Current` is relative to the live cursor.
+    /// to discover it; a probe seek uses the current value).
     ///
     /// # Errors
     ///
-    /// `Unsupported` for `SeekFrom::End` without a known length; `InvalidInput`
-    /// for a negative resulting offset.
+    /// See [`resolve_seek_target`].
     fn resolve_seek_target(&self, pos: SeekFrom, len: Option<u64>) -> io::Result<u64> {
-        let new_pos: i128 = match pos {
-            SeekFrom::Start(p) => i128::from(p),
-            SeekFrom::Current(delta) => {
-                i128::from(self.source.position()).saturating_add(i128::from(delta))
-            }
-            SeekFrom::End(delta) => {
-                let Some(len) = len else {
-                    return Err(IoError::new(
-                        ErrorKind::Unsupported,
-                        "seek from end requires known length",
-                    ));
-                };
-                i128::from(len).saturating_add(i128::from(delta))
-            }
-        };
-        if new_pos < 0 {
-            return Err(IoError::new(
-                ErrorKind::InvalidInput,
-                "negative seek position",
-            ));
-        }
-        Ok(u64::try_from(new_pos).unwrap_or(u64::MAX))
+        resolve_seek_target(pos, self.source.position(), len)
     }
+}
+
+/// Resolve a [`SeekFrom`] to an absolute, clamped byte target. `position` is
+/// the live cursor (`Current` is relative to it); `SeekFrom::End` errors when
+/// `len` is `None`. Shared by [`Stream`]'s seek adapters and lock-free
+/// wrappers that seek through a [`crate::SourceProbe`].
+///
+/// # Errors
+///
+/// `Unsupported` for `SeekFrom::End` without a known length; `InvalidInput`
+/// for a negative resulting offset.
+pub fn resolve_seek_target(pos: SeekFrom, position: u64, len: Option<u64>) -> io::Result<u64> {
+    let new_pos: i128 = match pos {
+        SeekFrom::Start(p) => i128::from(p),
+        SeekFrom::Current(delta) => i128::from(position).saturating_add(i128::from(delta)),
+        SeekFrom::End(delta) => {
+            let Some(len) = len else {
+                return Err(IoError::new(
+                    ErrorKind::Unsupported,
+                    "seek from end requires known length",
+                ));
+            };
+            i128::from(len).saturating_add(i128::from(delta))
+        }
+    };
+    if new_pos < 0 {
+        return Err(IoError::new(
+            ErrorKind::InvalidInput,
+            "negative seek position",
+        ));
+    }
+    Ok(u64::try_from(new_pos).unwrap_or(u64::MAX))
+}
+
+/// Header byte range for decoder recreate after a format change — the one
+/// mapping from an optional [`VariantControl`] to the typed answer. Shared
+/// by [`Stream::format_change_segment_range`] and lock-free wrappers that
+/// hold the variant-control handle directly.
+///
+/// # Errors
+///
+/// `Err(SourceError::FormatChangeNotApplicable)` for sources without a
+/// variant surface (non-HLS) or HLS variants activated with
+/// `served_from > 0` (init prefix unreachable via Stream reads).
+pub fn format_change_segment_range(vc: Option<&dyn VariantControl>) -> StreamResult<Range<u64>> {
+    vc.map_or(
+        Err(StreamError::Source(SourceError::FormatChangeNotApplicable)),
+        VariantControl::format_change_segment_range,
+    )
 }
 
 impl<T: StreamType> Read for Stream<T> {
@@ -766,7 +774,9 @@ mod tests {
     use kithara_test_utils::kithara;
 
     use super::*;
-    use crate::{PlayheadRead, PlayheadState, ReadOutcome, SeekState, Source, SourcePhase};
+    use crate::{
+        PlayheadRead, PlayheadState, ReadOutcome, SeekState, Source, SourcePhase, SourceProbe,
+    };
 
     /// Test helper — script entry that maps to either `Bytes(N)` (with
     /// the source slicing actual `data`) or a terminal `Eof`. Pending
@@ -782,6 +792,36 @@ mod tests {
         let nz = NonZeroUsize::new(count)
             .expect("BUG: ScriptSource::bytes invariant — count must be > 0");
         ReadOutcome::Bytes(nz)
+    }
+
+    /// Constant-phase probe for the scripted test sources below; shares the
+    /// source's cursor cell and mirrors its `len`. The byte map is not
+    /// scripted — nothing in these tests reads it through the probe.
+    struct FixedProbe {
+        phase: SourcePhase,
+        len: Option<u64>,
+        position: Arc<AtomicU64>,
+    }
+
+    impl SourceProbe for FixedProbe {
+        fn phase(&self) -> SourcePhase {
+            self.phase
+        }
+        fn phase_at(&self, _range: Range<u64>) -> SourcePhase {
+            self.phase
+        }
+        fn position(&self) -> u64 {
+            self.position.load(Ordering::Acquire)
+        }
+        fn set_position(&self, pos: u64) {
+            self.position.store(pos, Ordering::Release);
+        }
+        fn len(&self) -> Option<u64> {
+            self.len
+        }
+        fn byte_map(&self) -> Option<Arc<dyn crate::ByteMap>> {
+            None
+        }
     }
 
     struct ScriptSource {
@@ -861,6 +901,14 @@ mod tests {
 
         fn phase_at(&self, _range: Range<u64>) -> SourcePhase {
             SourcePhase::Waiting
+        }
+
+        fn probe(&self) -> Arc<dyn SourceProbe> {
+            Arc::new(FixedProbe {
+                phase: SourcePhase::Waiting,
+                len: Some(self.data.len() as u64),
+                position: Arc::clone(&self.position),
+            })
         }
 
         fn playhead_read(&self) -> Arc<dyn PlayheadRead> {
@@ -1024,6 +1072,14 @@ mod tests {
             SourcePhase::Ready
         }
 
+        fn probe(&self) -> Arc<dyn SourceProbe> {
+            Arc::new(FixedProbe {
+                phase: SourcePhase::Ready,
+                len: Some(4),
+                position: Arc::clone(&self.position),
+            })
+        }
+
         fn playhead_read(&self) -> Arc<dyn PlayheadRead> {
             Arc::clone(&self.playhead) as Arc<dyn PlayheadRead>
         }
@@ -1146,39 +1202,6 @@ mod tests {
         assert!(
             !wake.flush(),
             "the consumer path notifies immediately — nothing is left armed"
-        );
-    }
-
-    #[kithara::test]
-    fn probe_seek_moves_cursor_and_arms_without_priming() {
-        // On-core seek: set the cursor and arm the peer (the shell flushes),
-        // with NO prime_seek_range spin — so it returns immediately even when
-        // the target range is not ready (the wait script is never consulted).
-        let wake = Arc::new(DeferredWake::default());
-        let source = ScriptSource::new(
-            Arc::new(SeekState::new()),
-            [WaitOutcome::Interrupted, WaitOutcome::Interrupted],
-            [],
-            vec![0u8; 100],
-        )
-        .with_peer_wake(Arc::clone(&wake));
-        let mut stream = Stream::<DummyType> { source };
-
-        let started = Instant::now();
-        let pos = stream
-            .probe_seek(SeekFrom::Start(42))
-            .expect("absolute on-core seek within range");
-        let elapsed = started.elapsed();
-
-        assert_eq!(pos, 42);
-        assert_eq!(stream.source.position(), 42, "cursor moved to the target");
-        assert!(
-            elapsed < Duration::from_millis(2),
-            "probe_seek must not prime/spin (the consumer Seek would); took {elapsed:?}"
-        );
-        assert!(
-            wake.flush(),
-            "probe_seek armed the peer wake on the produce core; the shell flushes it"
         );
     }
 

--- a/tests/fuzz/fuzz_targets/stream_read_seek.rs
+++ b/tests/fuzz/fuzz_targets/stream_read_seek.rs
@@ -15,11 +15,43 @@ use kithara::{
     platform::{time::Duration, tokio::runtime::Builder},
     storage::WaitOutcome,
     stream::{
-        Activity, PlayheadRead, PlayheadState, PlayheadWrite, ReadOutcome, SeekControl,
-        SeekObserve, SeekState, Source, SourcePhase, Stream, StreamResult, StreamType,
+        Activity, ByteMap, PlayheadRead, PlayheadState, PlayheadWrite, ReadOutcome, SeekControl,
+        SeekObserve, SeekState, Source, SourcePhase, SourceProbe, Stream, StreamResult, StreamType,
     },
 };
 use libfuzzer_sys::fuzz_target;
+
+/// Always-ready byte-space probe sharing the fuzz source's cursor and length.
+struct ReadyProbe {
+    len: u64,
+    position: Arc<AtomicU64>,
+}
+
+impl SourceProbe for ReadyProbe {
+    fn phase(&self) -> SourcePhase {
+        SourcePhase::Ready
+    }
+
+    fn phase_at(&self, _range: Range<u64>) -> SourcePhase {
+        SourcePhase::Ready
+    }
+
+    fn position(&self) -> u64 {
+        self.position.load(Ordering::Acquire)
+    }
+
+    fn set_position(&self, pos: u64) {
+        self.position.store(pos, Ordering::Release);
+    }
+
+    fn len(&self) -> Option<u64> {
+        Some(self.len)
+    }
+
+    fn byte_map(&self) -> Option<Arc<dyn ByteMap>> {
+        None
+    }
+}
 
 #[derive(Debug)]
 enum WaitStep {
@@ -171,6 +203,13 @@ impl Source for ScriptSource {
 
     fn phase_at(&self, _range: Range<u64>) -> SourcePhase {
         SourcePhase::Ready
+    }
+
+    fn probe(&self) -> Arc<dyn SourceProbe> {
+        Arc::new(ReadyProbe {
+            len: self.data.len() as u64,
+            position: Arc::clone(&self.position),
+        })
     }
 
     fn len(&self) -> Option<u64> {

--- a/tests/src/memory_source.rs
+++ b/tests/src/memory_source.rs
@@ -11,8 +11,9 @@ use kithara::{
     platform::{sync::Arc, time::Duration},
     storage::WaitOutcome,
     stream::{
-        Activity, PlayheadRead, PlayheadState, PlayheadWrite, ReadOutcome, SeekControl,
-        SeekObserve, SeekState, Source, SourceError, SourcePhase, Stream, StreamResult, StreamType,
+        Activity, ByteMap, PlayheadRead, PlayheadState, PlayheadWrite, ReadOutcome, SeekControl,
+        SeekObserve, SeekState, Source, SourceError, SourcePhase, SourceProbe, Stream,
+        StreamResult, StreamType,
     },
 };
 
@@ -20,6 +21,59 @@ use kithara::{
 #[derive(Debug, thiserror::Error)]
 #[error("memory source error")]
 pub struct MemorySourceError;
+
+/// Constant-length byte-space probe shared by the fixed-size test sources:
+/// `Eof` at or past the known total, `Ready` otherwise — mirroring each
+/// source's own `phase_at`. `None` total never reaches `Eof`. `reported`
+/// mirrors the source's `len()` answer, which may hide the actual total
+/// (`MemorySource::without_len`).
+pub struct LenPhaseProbe {
+    total: Option<u64>,
+    reported: Option<u64>,
+    position: Arc<AtomicU64>,
+}
+
+impl LenPhaseProbe {
+    #[must_use]
+    pub fn new(total: Option<u64>, reported: Option<u64>, position: Arc<AtomicU64>) -> Self {
+        Self {
+            total,
+            reported,
+            position,
+        }
+    }
+}
+
+impl SourceProbe for LenPhaseProbe {
+    fn phase(&self) -> SourcePhase {
+        let pos = self.position.load(Ordering::Acquire);
+        self.phase_at(pos..pos.saturating_add(1))
+    }
+
+    fn phase_at(&self, range: Range<u64>) -> SourcePhase {
+        if self.total.is_some_and(|total| range.start >= total) {
+            SourcePhase::Eof
+        } else {
+            SourcePhase::Ready
+        }
+    }
+
+    fn position(&self) -> u64 {
+        self.position.load(Ordering::Acquire)
+    }
+
+    fn set_position(&self, pos: u64) {
+        self.position.store(pos, Ordering::Release);
+    }
+
+    fn len(&self) -> Option<u64> {
+        self.reported
+    }
+
+    fn byte_map(&self) -> Option<Arc<dyn ByteMap>> {
+        None
+    }
+}
 
 /// In-memory source for testing Source-based readers.
 ///
@@ -74,6 +128,14 @@ impl Source for MemorySource {
         } else {
             SourcePhase::Ready
         }
+    }
+
+    fn probe(&self) -> Arc<dyn SourceProbe> {
+        Arc::new(LenPhaseProbe::new(
+            Some(self.data.len() as u64),
+            self.len(),
+            Arc::clone(&self.position),
+        ))
     }
 
     fn position(&self) -> u64 {

--- a/tests/src/signal_source.rs
+++ b/tests/src/signal_source.rs
@@ -12,11 +12,12 @@ use kithara::{
     stream::{
         Activity, AudioCodec, ContainerFormat, MediaInfo, PlayheadRead, PlayheadState,
         PlayheadWrite, ReadOutcome, SeekControl, SeekObserve, SeekState, Source, SourceError,
-        SourcePhase, Stream, StreamResult, StreamType,
+        SourcePhase, SourceProbe, Stream, StreamResult, StreamType,
     },
 };
 
 use crate::{
+    memory_source::LenPhaseProbe,
     signal_pcm::{SignalPcm, signal},
     wav::WavHeader,
 };
@@ -87,6 +88,14 @@ impl<S: signal::SignalFn + Sync> Source for SignalSource<S> {
         } else {
             SourcePhase::Ready
         }
+    }
+
+    fn probe(&self) -> Arc<dyn SourceProbe> {
+        Arc::new(LenPhaseProbe::new(
+            self.total_byte_len(),
+            self.total_byte_len(),
+            Arc::clone(&self.position),
+        ))
     }
 
     fn position(&self) -> u64 {

--- a/tests/tests/kithara_file/seek_issues_range_request.rs
+++ b/tests/tests/kithara_file/seek_issues_range_request.rs
@@ -52,17 +52,25 @@ struct RangeState {
     first_range_start: Arc<AtomicU64>,
 }
 
-fn range_start(headers: &HeaderMap) -> Option<u64> {
+/// `bytes=start-end` bounds, the inclusive end absent for an open-ended range.
+fn range_bounds(headers: &HeaderMap) -> Option<(u64, Option<u64>)> {
     let value = headers.get(header::RANGE)?.to_str().ok()?;
-    let (start, _) = value.strip_prefix("bytes=")?.split_once('-')?;
-    start.parse().ok()
+    let (start, end) = value.strip_prefix("bytes=")?.split_once('-')?;
+    let end = if end.is_empty() {
+        None
+    } else {
+        Some(end.parse().ok()?)
+    };
+    Some((start.parse().ok()?, end))
 }
 
 /// The head request stalls after a short prefix and never completes, so the
-/// only way to serve a forward seek is a second, ranged request.
+/// only way to serve a forward seek is a second, ranged request. A ranged
+/// request is served exactly as bounded: the backfill of the skipped span asks
+/// for a closed range, and the client rejects a `206` that overshoots it.
 async fn serve(State(state): State<RangeState>, headers: HeaderMap) -> Response {
     let bytes = body();
-    let Some(start) = range_start(&headers).filter(|start| *start > 0) else {
+    let Some((start, end)) = range_bounds(&headers).filter(|(start, _)| *start > 0) else {
         let prefix = Bytes::copy_from_slice(&bytes[..HEAD_PREFIX]);
         let body = Body::from_stream(
             stream::iter(vec![Ok::<_, Infallible>(prefix)]).chain(stream::pending()),
@@ -82,16 +90,21 @@ async fn serve(State(state): State<RangeState>, headers: HeaderMap) -> Response 
         Ordering::SeqCst,
     );
     let start = usize::try_from(start).expect("range start fits usize");
-    let tail = &bytes[start..];
+    let end = end.map_or(TOTAL - 1, |end| {
+        usize::try_from(end)
+            .expect("range end fits usize")
+            .min(TOTAL - 1)
+    });
+    let span = &bytes[start..=end];
     Response::builder()
         .status(StatusCode::PARTIAL_CONTENT)
-        .header(header::CONTENT_LENGTH, tail.len().to_string())
+        .header(header::CONTENT_LENGTH, span.len().to_string())
         .header(
             header::CONTENT_RANGE,
-            format!("bytes {start}-{}/{TOTAL}", TOTAL - 1),
+            format!("bytes {start}-{end}/{TOTAL}"),
         )
         .header(header::CONTENT_TYPE, "audio/mpeg")
-        .body(Body::from(Bytes::copy_from_slice(tail)))
+        .body(Body::from(Bytes::copy_from_slice(span)))
         .expect("ranged response")
 }
 

--- a/tests/tests/kithara_stream/reader_seek_overflow.rs
+++ b/tests/tests/kithara_stream/reader_seek_overflow.rs
@@ -13,8 +13,8 @@ use kithara::{
     platform::{sync::Arc, time::Duration, tokio::runtime::Runtime},
     storage::WaitOutcome,
     stream::{
-        Activity, PlayheadRead, PlayheadState, PlayheadWrite, ReadOutcome, SeekControl,
-        SeekObserve, SeekState, Source, SourcePhase, Stream, StreamResult, StreamType,
+        Activity, ByteMap, PlayheadRead, PlayheadState, PlayheadWrite, ReadOutcome, SeekControl,
+        SeekObserve, SeekState, Source, SourcePhase, SourceProbe, Stream, StreamResult, StreamType,
     },
 };
 
@@ -103,8 +103,47 @@ impl Source for MockSource {
         SourcePhase::Ready
     }
 
+    fn probe(&self) -> Arc<dyn SourceProbe> {
+        Arc::new(ReadyProbe {
+            len: self.reported_len,
+            position: Arc::clone(&self.position),
+        })
+    }
+
     fn len(&self) -> Option<u64> {
         Some(self.reported_len)
+    }
+}
+
+/// Always-ready byte-space probe sharing `MockSource`'s cursor and length.
+struct ReadyProbe {
+    len: u64,
+    position: Arc<AtomicU64>,
+}
+
+impl SourceProbe for ReadyProbe {
+    fn phase(&self) -> SourcePhase {
+        SourcePhase::Ready
+    }
+
+    fn phase_at(&self, _range: Range<u64>) -> SourcePhase {
+        SourcePhase::Ready
+    }
+
+    fn position(&self) -> u64 {
+        self.position.load(Ordering::Acquire)
+    }
+
+    fn set_position(&self, pos: u64) {
+        self.position.store(pos, Ordering::Release);
+    }
+
+    fn len(&self) -> Option<u64> {
+        Some(self.len)
+    }
+
+    fn byte_map(&self) -> Option<Arc<dyn ByteMap>> {
+        None
     }
 }
 

--- a/tests/tests/loom.rs
+++ b/tests/tests/loom.rs
@@ -17,8 +17,9 @@ use kithara::platform::{
 /// published after the waiter's snapshot wakes that waiter; a correct gate
 /// returns as soon as the signal lands, so this deadline never becomes runtime.
 /// Under the flash engine the deadline is virtual: the clock jumps straight to
-/// it whenever every engine-visible thread is parked, so any thread the waiter
-/// depends on must be spawned with `thread::spawn_named` to stay visible.
+/// it the moment no counted participant is left running. The test body itself
+/// is NOT counted, so every peer a waiter depends on must be spawned (its slot
+/// reserved) BEFORE the waiter can park — otherwise the jump fires in the gap.
 #[cfg(feature = "flash")]
 const SIGNAL_BACKSTOP: Duration = Duration::from_secs(5);
 
@@ -128,18 +129,23 @@ fn thread_gate_refreshes_waiter_after_thread_handoff() {
     assert!(matches!(first.join(), Ok(true)));
 
     let (snapshot_tx, snapshot_rx) = mpsc::channel();
+    // Spawn the signaller FIRST: the spawn reserves its engine slot on this
+    // (engine-invisible) thread, so from here until the signal there is always
+    // a counted participant and the clock cannot burn the backstop while the
+    // rendezvous is still assembling. With the waiter spawned first, it can
+    // park inside the spawn→spawn gap where nothing is counted, and the jump
+    // fires the backstop before the signaller even exists.
     let second_gate = Arc::clone(&gate);
+    let signaller = thread::spawn_named("threadgate-handoff-signaller", move || {
+        assert_eq!(snapshot_rx.recv(), Ok(()));
+        gate.signal();
+    });
     let second = thread::spawn(move || {
         let since = second_gate.current();
         if snapshot_tx.send(()).is_err() {
             return false;
         }
         second_gate.wait_timeout(since, SIGNAL_BACKSTOP)
-    });
-
-    let signaller = thread::spawn_named("threadgate-handoff-signaller", move || {
-        assert_eq!(snapshot_rx.recv(), Ok(()));
-        gate.signal();
     });
     assert!(matches!(second.join(), Ok(true)));
     assert!(signaller.join().is_ok());

--- a/tests/tests/loom.rs
+++ b/tests/tests/loom.rs
@@ -129,12 +129,13 @@ fn thread_gate_refreshes_waiter_after_thread_handoff() {
     assert!(matches!(first.join(), Ok(true)));
 
     let (snapshot_tx, snapshot_rx) = mpsc::channel();
-    // Spawn the signaller FIRST: the spawn reserves its engine slot on this
-    // (engine-invisible) thread, so from here until the signal there is always
-    // a counted participant and the clock cannot burn the backstop while the
-    // rendezvous is still assembling. With the waiter spawned first, it can
-    // park inside the spawn→spawn gap where nothing is counted, and the jump
-    // fires the backstop before the signaller even exists.
+    // Spawn the signaller FIRST: `spawn_named` reserves its engine slot on
+    // this (engine-invisible) thread, so the waiter is never the last credit
+    // holder while parked on the backstop — the send's `notify_one` bumps
+    // `active` for the woken signaller under the core lock before the waiter's
+    // own park drops its credit. Waiter first, and it parks with nothing
+    // counted: the clock jumps the whole backstop before the signaller exists.
+    // See `kithara-platform/CONTEXT.md`, "Quiescence engine".
     let second_gate = Arc::clone(&gate);
     let signaller = thread::spawn_named("threadgate-handoff-signaller", move || {
         assert_eq!(snapshot_rx.recv(), Ok(()));


### PR DESCRIPTION
# Stress all-green: fixes from stress run №4

One PR for the defects surfaced by the full-suite stress run №4 on `main` (50×6). Fixes land as separate commits; remaining defects from the same run will be appended here.

## 1. loom: `thread_gate_refreshes_waiter_after_thread_handoff` flake (`b411acfeb` + docs)

Kept flaking (~1/50 on stress lanes, wall time ~150ms, assertion at the `second.join()` check) even after the signaller moved to `spawn_named` in #199. All three archived hang dumps show the identical engine state: the virtual clock jumped by exactly the 5s `SIGNAL_BACKSTOP`, `active=1`.

**Root cause:** the window is between the two spawns, not in how the signaller is spawned. The test body is not a counted engine participant, so after `thread::spawn(second)` the waiter thread can claim its slot, send the snapshot (the notify hits nobody — the signaller does not exist yet), and park in the gate, dropping the last active credit. The engine then sees a lone timed waiter with nothing running and legitimately jumps the backstop before the test body ever reaches the signaller spawn.

**Fix:** spawn the signaller first. Its engine slot is reserved on the parent thread before the waiter thread exists, so in every interleaving a counted credit survives until `gate.signal()`, and the clock cannot burn the backstop while the rendezvous is still assembling.

**Validation:** farm stress run 32899435320 on this fix — target test 100/100 green on both reproduction lanes (flash-on, no-block) against the 1/50 baseline; full CI green including all RTSan lanes.

## 2. audio/stream: RTSan `sched_yield` on the RT produce tick (`420901a80`)

Stress run №4 rtsan-hls lane aborted with an RTSan `sched_yield` on the produce tick. The audio worker's gate frames (`source_is_ready`, `source_phase_forward`, `seek_landing_end`, `recreate_ready_range`, `source_park`, `post_seek_anchor_offset`) reached the source through `SharedStream`'s `Mutex<Stream>` — `position()`, `len()`, `byte_map()`, `abr_handle()`, `format_change_segment_range()` alongside `phase_at` in the same RT frames. The off-RT holder is a construction reader parked in `Stream::read` → `Source::wait_range(range, None)` **under that mutex**; a contended acquire on the produce core goes through `parking_lot`'s `lock_slow` → `sched_yield` → RTSan abort.

**Fix:**
- New narrow trait `SourceProbe` in `kithara-stream` (`phase`, `phase_at`, `position`, `set_position`, `len`, `byte_map`) — an `Arc` handle answering from the source's self-synchronizing state; implementations must not take locks a reader wait can hold. Production owners: `HlsProbe` (over `Arc<HlsCoord>`) and `FileProbe` (over `Arc<FileInner>`).
- `SharedStream::new` resolves `probe`, `abr_handle`, `variant_control`, and `peer_wake` once, before the stream enters the mutex; every RT byte-space call, including the new lock-free `probe_seek`, answers without `inner.lock()`.
- `resolve_seek_target` and `format_change_segment_range` become free fns with one owner each; the caller-less `Stream::probe_seek` and the `hold_control_lock` test seam are removed.
- The contract test pins the property with a real holder: a construction read (armed `ConstructionGate` → blocking `Stream::read`) parks in `Source::wait_range` via a `WaitPark` rendezvous while the real gate entry points (`source_is_ready`, `source_phase_for_wait_context`) plus `abr_handle` / `format_change_segment_range` / `probe_seek` answer under the genuinely held mutex. Regression mode is a hang caught by the harness watchdog.
- CONTEXT.md (kithara-stream, kithara-audio) documents the probe contract, the three remaining lock sites on RT frames (`probe_read`, `media_info`, `seek_time_anchor`) with the `RebuildingDecoder`-only exclusion window that keeps them safe, and the single-cursor-writer invariant behind `probe_seek`.

**Validation:** `just fmt` / `just lint fast` green; full `just test` 4050/4050 on the fix revision and re-run on this combined branch; guardian architecture review Accept (re-review after an initial Reject); targeted farm stress run 32906531105 (rtsan lanes at count=100 + `phase_continuity` reproduction filter) running on the fix revision — same diff as the commit here.

## 3. audio: byte-space EOF ended the track past the decode path (`fdd3ea23b`)

Stress run №4's remaining failure: `live_real_stream_random_seek_prefix_regression_hls`, "HLS rng-prefix read stopped early at idx=74" (1/50, flash-on lane only; the isolated farm reproduction 32912094469 at 3×100 stayed green — the defect needs full-suite contention).

**Root cause:** `WaitingForSource::step` had a `SourcePhase::Eof => AtEof + TrackStep::Eof` branch (alive since the #113 refactor): byte-space source EOF terminated the track outside the decode path. Seek 74 (217.81s) landed in the final segment, parking the reader at the stream total while the fMP4 demuxer still held the undecoded tail (~104 frames, ~2.4s). The trigger: a transient un-published layout (re-mint under the write lock while a settle parks behind the live seek tail) answered one readiness poll with `WaitingDemand`, parking the track for a tick; the next poll saw byte EOF and latched `AtEof` under the correct post-`Applied` epoch, so the strict epoch validator passed the bogus natural EOF through to the consumer.

**Fix:** the branch is gone — byte-space EOF resumes the stored `WaitContext` exactly like `Ready` (the readiness gate already counted `Eof` as ready); natural EOF stays owned by the decode path's exhausted finalization. CONTEXT.md now pins the `AtEof` ownership invariant: exactly two owners, both semantic — decode-path exhaustion and `SeekTransition::AtEof`.

**Validation:** new track wait tests — the resume-while-the-decoder-still-produces pin was red before the fix; the drained-decoder and post-seek-wait companions assert the resume path too. Full `just test` 4052/4052 with the fix; guardian review Notes with no blockers, confirming no livelock across all five `WaitContext` arms under a permanent `Eof` phase. Full-suite farm stress run 32917682726 on the fix revision (the same contention that reproduced the 1/50): the target test is **0/50 on every lane** (was 1/50 on flash-on), and all three stress-run-№4 defects are gone (loom thread_gate 0/50, rtsan `phase_continuity` 0/50, `prefix_regression` 0/50; all rtsan lanes clean, no-block lane fully green). The run itself concluded red with 9 known-flake names / 13 attempts — inside the historical baseline band (3-16 attempts), clustered on two narrow iteration windows (20-27 flash-on, 36-41 flash-off), the classic host-contention signature; no failure signature touches the EOF/wait path (the one flash-on `flac_fmp4` hang never reached a byte-EOF mint per the divergence table).

**Accepted behavior changes (from review):** a decoder recreate at `offset >= total` now surfaces `RecreateFailed` instead of silently latching `AtEof`; a degenerate permanent-`Eof`-with-`Pending`-demuxer oscillation is caught by the hang watchdog instead of silently truncating the track.

## 4. stream/hls: a parked reader's fetch kept its emit-time priority (urgent down-switch hang) (`126fbc926`)

The all-green queue's most frequent remaining hang: `stress_seek_abr_audio_flac_fmp4` (also `concurrent_hls_instances_n4_auto_abr`, `abr_auto_switch_during_playback`), 1-3/50 per lane under full-suite contention, always with `abr_pending=DownSwitch{0→1, UrgentDownSwitch}`. The hang-detector endpoint differs per lane (`ring.rs:209` recv timeout on flash-off, `cursor::read` on no-block — the 2/50 in run 32927352059 on `main`) but the flight recorder is the same in every dump: the outgoing variant-0 reader parks on a tail span (`byte_offset=306651`, segment 8 of 538630 bytes; ~25KB across segments 8-13) while `prime_incoming` ticks hundreds of times without a promotion. Present since at least run 32473824553 (20 Aug) — not a regression of this PR.

**Root cause:** the timeline of the run-32917682726 attempt (junit log) shows the parked span cost ~3.06s instead of the ~0.6-1.2s the test server's 500ms `DelayRule` charges for it: no settle at all between 05.41 and 06.11, then the variant-0 tail lands in one batch only after the variant-1 construction stream runs dry, and the promotion (06.4165) misses the 3s detector by 60ms. The segments 8-13 commands had been emitted earlier as *prefetch* with `RequestPriority::Low` (`dispatch_from` stamps High only for what is owed at emit time). A command's priority was frozen at emit: the live `Downloading` claim on the slot dedupes any re-emit (`dispatch_owed` gets "requeue refused"), and `Registry::reschedule` re-read only the *peer* priority. Every variant-1 construction fetch is High (`!audible → owed`), so they FIFO-overtook the reader's bytes for the whole construction window. Product impact: ≥3s of silence on an urgent down-switch.

**Fix (supply side only — the promotion contract by the outgoing frontier is untouched):**
- `kithara-stream` `dl`: `FetchCmd` carries an optional `DemandFn` — a lock-free probe answering "does a parked read need these bytes". `InternalCmd::effective_priority()` escalates to High while the probe says yes; slot routing asks it at enqueue, on requeue, and in `Registry::reschedule` on every loop pass. `reschedule` now rebuilds every slot in one pass (escalations `push_front`, demotions `push_back`) instead of patching by recorded index — the first-pass review caught that a `push_front` shifts the indices recorded before it, so a same-pass demotion could evict the wrong entry (pinned).
- `kithara-hls`: `HlsVariant::wait_range` — the single park/filing site for both the RT `try_read` / `probe_wait` probe and the off-RT `Read` park — walks the fetches the not-ready range still needs and calls `note_reader_demand()` on every *claimed* slot among them (the whole span, so the downloader serves them concurrently). `phase_at` stays a pure query (tracing fields, error formatting and the transition's incoming-session probe observe it; pinned as non-arming), and the transition's readiness poll (`reader_is_ready`) goes through a new `poll_range` that parks the same way but files nothing — it is not a read, and escalating an incoming variant's leftover look-ahead would put it back in front of the audible one (pinned). `SegmentSlotState` gains `reader_demand: AtomicBool` beside `flags` (not a `SlotFlags` bit — `try_claim` CASes flags against zero); it is set only while `DOWNLOADING` (a planned slot is owed and the owed dispatch already stamps High) and cleared by every terminal transition so a fresh claim starts unescalated (pinned). `build_cmd` attaches the probe for init and media fetches alike.
- CONTEXT.md of both crates document the live-priority contract, the filing site, the non-filing readiness poll, the atomic-placement constraint, the tolerated stale-note window of the non-atomic `(flags, reader_demand)` pair, and why `ReaderRuntime::wait_end` cannot serve as the probe source (byte-space end only; the command holds just its slot; different clear owner).

**Validation:** pins — `kithara-stream` `dl::tests::a_demanded_prefetch_overtakes_later_stamped_urgent_work` (RED with `effective_priority` neutered) and `a_dropped_demand_yields_to_a_newly_demanded_command` (RED on the index-patching `reschedule`: `["lead","stale","fresh",…]`); `kithara-hls` `a_parked_wait_files_demand_on_the_claimed_segment`, `a_phase_query_leaves_demand_unfiled`, `a_readiness_poll_leaves_demand_unfiled` (RED with the poll routed through `wait_range`), `a_settled_slot_answers_no_demand` (RED without the clear in `settle`), `a_planned_segment_is_owed_not_escalated`. `just fmt` / `just lint fast` clean (0 regressions); full `just test` 4060/4060 on the fix commit and 4069/4069 on the merged head `45b42f2d7` (zvuk `main` 23b85b70a merged in, clean); two guardian passes (`rust-architecture-guardian`): the first rejected the index-patching `reschedule` and a filing side effect in `phase_at`, the second flagged the readiness-poll leak — all closed, final verdict Accept-with-notes with the notes folded in. Full-suite farm stress (50×6) on `cedaaed00` (this fix + `main` 23b85b70a + the fixture fix below): run 32972149357 (dispatched 2026-08-26 13:05 UTC, farm idle). Verdict from its stress-report artifact: the target hang cluster is **0/50 on every lane** (`stress_seek_abr_audio_flac_fmp4`, `concurrent_hls_instances_n4_auto_abr`, `abr_auto_switch_during_playback` all absent from the failure table), flash-off and all three RTSan lanes fully green, and every other name from the previous `main` run (32927352059: 9 attempts / 7 names / 3 red lanes) is gone too. The run concluded red on exactly **one** name — 5 attempts / 1 name / 2 lanes — `kithara_file::shared_download::follower_joins_active_download_without_second_get`, a `main` 23b85b70a defect that had never run on Linux; root-caused and fixed in §6.

## 5. test(file): the seek range-request fixture ignored the requested end (`cedaaed00`)

Merging `main` 23b85b70a ("Serve a forward seek with a range request") turned both Linux test lanes of the fork CI red on `a_forward_seek_is_served_by_a_range_request` (run 32963594669, 2/2 lanes, 0.45s, `partial response for range bytes=64-3071 ... returned content-range bytes 64-4095/4096`). That test had never run on Linux: the zvuk hosted CI for 23b85b70a is `skipped`, and `just test` on macOS is green.

**Root cause:** the test's axum fixture answered every ranged request with the whole tail (`Content-Range: bytes {start}-4095/4096`, body to EOF) whatever end the client asked for. The product path is fine: after the seek fetch (`bytes=3072-4095`) lands, `FilePeer` backfills the skipped span with a closed range (`bytes=64-3071`); `kithara-net` rightly rejects the overshooting `206`, the resource is marked failed, and the reader's `read_exact` under the cursor loses the race with that failure (the seek itself had already succeeded — the panic is at the read, line 130, not the seek). The race is load-dependent: filtered stress 50×6 in isolation is 150/150 on both pure `main` (32966914973) and this branch's merged head (32966926155); under full-suite CI load it lost 2/2 on this branch and won 2/2 on a pure-`main` probe (32965451265) — four samples, not an attribution, and no mechanism connects the downloader change to the file path (`FilePeer` runs one fetch at a time and sets no demand probe).

**Fix:** the fixture honours `bytes=start-end` and serves exactly that span. Test green locally; fork CI on `cedaaed00` (run 32970575839) fully green, both Linux test lanes included.

## 6. file: the peer cancelled its own healthy fetch; a complete plan never committed (`d1ae20788`)

The one red name of stress run 32972149357: `follower_joins_active_download_without_second_get`, 3/50 flash-on and 2/50 no-block (0/50 flash-off), two endpoints — `whole-file read must complete: … resource failed: ranged response did not identify the requested interval at offset 60` (offset 60 = the body length) and a 10s wall timeout. Absent from every earlier run; the test exercises `main` 23b85b70a's cursor-steered `FilePeer`, which had never run on Linux.

**Root cause (flight recorder, identical in all five dumps):** the single full GET lands all 60 bytes (`set_download_pos value=60`), *then* the fetch is aborted (`abort_request was_in_flight=1` — its own cancel token). The new overtake check in `park_on_running_fetch` compares the reader cursor with the fetch's write offset, but `FetchWriter::write` publishes the offset *after* `epoch.write_at` lands the bytes, and the landing is what wakes the reader (the follower's look-ahead reads wake every peer on the lease): a reader that consumed the bytes in between sits ahead of the stale offset without being ahead of the fetch, and the peer kills a healthy fetch. Downstream, two more holes of the same commit turned the cancel into the two endpoints: (a) a cancelled fetch relinquishes without committing, the writer re-plans, finds no gap, parks — and the follower waits forever on a resource nobody commits (timeout); (b) when the follower wins the writer instead, its session has never seen a response, its extent is unknown, and it plans `bytes=60-` past the end — the fixture answers 200, `response_contract` rejects it, the resource fails for both consumers (panic).

**Fix:**
- Stored bytes are the authority on where a fetch has got to: `Inflight` carries the fetch `start` instead of a clone of the write-offset atomic, and `park_on_running_fetch` cancels only when the cursor sits inside the span *past the first gap at or after that start* (`landed_frontier` via `AssetReader::next_gap`). The in-flight snapshot is taken and the mutex dropped before the storage query. Legitimate seek-overtake and backfill behaviour is unchanged (all five pre-existing seek pins pass), including a seek onto an island of stored bytes past the frontier, which still cancels at the seek.
- A plan that finds no gap over a known extent commits from the peer: `FileInner::commit_if_complete` (in `session/inner.rs`, next to `observe_committed`) is now the single commit path shared by `finalize_fetch` and `next_action`; the `next_gap(0, final_len)` re-check keeps a plan bounded by the demand watermark from committing a truncated resource.
- CONTEXT.md (kithara-file) documents both; the code comments point there.
- (b) is closed by removing its trigger; the underlying "a follower that inherits the writer plans from its own session's extent" is a `main` design gap left as a follow-up (see below).

**Validation:** pins `a_reader_consuming_landed_bytes_does_not_cancel_the_fetch` (cursor 256 over 512 landed bytes with the fetch offset still 0 → fetch cancelled: RED before the fix), `a_writer_with_nothing_left_to_fetch_commits` (`PeerAction::Pending`, resource never committed: RED before the fix) and `a_plan_bounded_by_demand_does_not_commit_a_partial_resource` (the anti-truncation guard); all peer tests and the three shared-download e2e tests green; `just fmt` / `just lint fast` (0 regressions, 0 new) / full `just test` green on the commit; guardian review Accept-with-notes — the notes (frontier from storage instead of a second authority, helper moved to `FileInner`, comments trimmed to the contract, the truncation pin) are folded in. Accepted as-is: the commit now also runs from the peer poll — the same downloader task that already commits from `on_complete`, off the RT path. Farm stress 50×6 on `d1ae20788`: run 32998649595 (6/6 lanes trustworthy; 3911/3854/3935 tests observed on the reproduction lanes) — `follower_joins_active_download_without_second_get` 0/50 on all six lanes, neither endpoint seen anywhere; the §4 cluster stayed at 0/50; rtsan/rtsan-file/rtsan-hls 0 failures; no-block 0/50 across the whole suite. The run was dispatched into a busy window of the one-host farm (four foreign CI/UI runs 18:07–18:58Z, another 19:24–19:50Z): flash-on ran 18:17–18:48Z at load1 65–96 on 32 CPUs (cgroup CPU pressure some/avg60 up to 27 %) and took 12 failed attempts over 9 names, each 1–2/50 and all stamped 18:22–18:47Z (two 5 s sync-timeouts and a gapless length assert within 40 s of each other at 18:32Z); flash-off ran 18:51–19:53Z at load1 2–6 except the 19:24–19:50Z spike (load1 up to 60), and its single failure (`two_tracks_gapless_no_click_with_silence_trim_zero_crossfade`, 19:26:21Z) sits inside that spike; no-block ran 19:56–20:21Z at load1 5–14 and was clean. None of the nine names is new to the farm: `packaged_abr_switch_keeps_player_continuity` is red on fork `main` itself, `file_stream_closes_early_seek_still_works` (1/50 flash-on, the same `Phase 1 timed out`) and the gapless/seamless pair were red in the same shape on the pre-fix `main` run 32927352059, the mp3 preload timeout is an open flake. Verdict: §6 closed by the artifact; the nine names stay on the all-green queue, and the quiet-window 50×6 baseline is still owed.


## 7. refactor(audio): `SharedStream` probe polls through `delegate!` (`bff5d33a6`)

Review catch: `420901a80` took `phase`/`phase_at`/`position`/`set_position`/`len`/`byte_map` out of the `to self.inner.lock()` block (their target became the narrow `SourceProbe`) and wrote them by hand, plus hand-written clone getters for `abr_handle`/`peer_wake`. Now a `to self.probe` block and `to self.abr` / `to self.peer_wake` with `#[call(clone)]`; only `format_change_segment_range` (free function over a field) and `probe_seek` (cursor math) stay manual. No behaviour change. `derivable_delegation` cannot see this shape: an impl with a non-simple delegate target (`self.inner.lock()`) is skipped whole (`NON_SIMPLE_DELEGATE_TARGET`). `just fmt` / `just check` / `just lint fast` (0 regressions, 0 new); full `just test` 4072/4072.

## Follow-ups (non-blocking, from review)

- `main` 23b85b70a: a follower that takes over the writer role plans from its own session's `total_bytes` (unknown until it sees a response itself), so after any legitimate cancel it can ask for bytes past a known extent; the resource extent needs one owner shared by every consumer of the lease.

- Probe↔source equivalence tests for `HlsProbe`/`FileProbe`.
- Dedup of near-identical test probe types (`LenPhaseProbe` already generalizes the shape).

https://claude.ai/code/session_01JNGdteLNoCmkat4JDgDGE6
