### PR TITLE
fix(audio,stream): serve RT byte-space polls off the control mutex

### DIFF
--- a/crates/kithara-audio/CONTEXT.md
+++ b/crates/kithara-audio/CONTEXT.md
@@ -111,7 +111,24 @@ mutator of track state through `update_state`. Sub-owners never take
 `DecodeCtx`, `RouteCtx`) and return decision values for the coordinator to apply.
 
 - `SharedStream<T>` — byte-space ground truth (position, len, phase, byte map,
-  anchors, init range). No other owner clones byte-range policy.
+  anchors, init range). No other owner clones byte-range policy. Every RT
+  byte-space call — `phase`/`phase_at`, `position`/`set_position`, `len`,
+  `byte_map`, `probe_seek` — answers from the source's narrow `SourceProbe`
+  handle, and the fixed-at-open handles (`abr_handle`,
+  `format_change_segment_range`, `peer_wake`) from clones resolved once in
+  `SharedStream::new`; none of them take the control mutex. Off-RT holders (a
+  construction reader parked in `Stream::read`, a consumer query) hold that
+  mutex across waits, and a contended acquire on the forbid-blocking produce
+  core is an RTSan violation (`sched_yield` in `parking_lot`'s contended
+  path). The probe answers from the source's self-synchronizing state and
+  must not take locks a reader wait can hold. Three calls still lock on RT
+  frames — `probe_read` (steady-state `Read`), `media_info`, and
+  `seek_time_anchor` — which is safe only because the sole off-RT holder
+  that parks under the mutex is the replacement rebuild reader, and it
+  exists exclusively while the FSM sits in `RebuildingDecoder`, a phase
+  whose tick touches none of those calls. The same window is the only time
+  the off-RT reader moves the byte cursor, which keeps `probe_seek`'s
+  non-atomic load→resolve→store single-writer.
 - `ActiveDecode` — the authoritative active `DecoderGeneration`, the optional
   `IncomingDecode`, the always-on `PcmBlender`, the effect chain, the EOF drain.
   Each `DecoderGeneration` owns its decoder facts, base offset, install epoch,

--- a/crates/kithara-audio/src/pipeline/stream/shared.rs
+++ b/crates/kithara-audio/src/pipeline/stream/shared.rs
@@ -5,11 +5,13 @@ use std::{
 };
 
 use delegate::delegate;
+use kithara_abr::AbrHandle;
 use kithara_platform::sync::{Arc, Mutex};
 use kithara_stream::{
-    Activity, ByteMap, ConstructionGate, MediaInfo, OpenedReader, PlayheadWrite, SeekControl,
-    SeekObserve, SourcePhase, SourceSeekAnchor, Stream, StreamResult, StreamType, WaitOutcome,
-    WorkerWake,
+    Activity, ByteMap, ConstructionGate, DeferredWake, MediaInfo, OpenedReader, PlayheadWrite,
+    SeekControl, SeekObserve, SourcePhase, SourceProbe, SourceSeekAnchor, Stream, StreamResult,
+    StreamType, VariantControl, WaitOutcome, WorkerWake, format_change_segment_range,
+    resolve_seek_target,
 };
 
 use super::offset::OffsetReader;
@@ -53,6 +55,17 @@ impl DemandCell {
 /// - `StreamAudioSource` to check `media_info()` for format changes
 pub(crate) struct SharedStream<T: StreamType> {
     inner: Arc<Mutex<Stream<T>>>,
+    /// Narrow byte-space handle. RT polls — phase, cursor, length, byte
+    /// map — answer from here and never take `inner`: off-RT holders (a
+    /// construction reader parked in `Stream::read`, a consumer query)
+    /// hold that mutex across waits, and any contended acquire blocks the
+    /// forbid-blocking produce core.
+    probe: Arc<dyn SourceProbe>,
+    /// Fixed-at-open handles the produce core reaches without `inner`;
+    /// resolved once in [`Self::new`] before the stream enters the mutex.
+    abr: Option<AbrHandle>,
+    variants: Option<Arc<dyn VariantControl>>,
+    peer_wake: Option<Arc<DeferredWake>>,
     demand: Arc<DemandCell>,
     /// Construction mode for one decoder reader. Coordinator clones carry no
     /// gate; every opened reader receives a fresh gate so an off-RT rebuild
@@ -62,11 +75,94 @@ pub(crate) struct SharedStream<T: StreamType> {
 
 impl<T: StreamType> SharedStream<T> {
     pub(crate) fn new(stream: Stream<T>) -> Self {
+        let probe = stream.probe();
+        let abr = stream.abr_handle();
+        let variants = stream.variant_control();
+        let peer_wake = stream.peer_wake();
         Self {
             inner: Arc::new(Mutex::new(stream)),
+            probe,
+            abr,
+            variants,
+            peer_wake,
             demand: Arc::default(),
             construction_gate: None,
         }
+    }
+
+    /// Overall source readiness at current position — answered by the
+    /// narrow [`SourceProbe`], never the control mutex.
+    pub(crate) fn phase(&self) -> SourcePhase {
+        self.probe.phase()
+    }
+
+    /// Point-in-time readiness for a specific byte range — same contract
+    /// as [`Self::phase`].
+    pub(crate) fn phase_at(&self, range: Range<u64>) -> SourcePhase {
+        self.probe.phase_at(range)
+    }
+
+    /// Current read position — the source's atomic cursor via the probe.
+    pub(crate) fn position(&self) -> u64 {
+        self.probe.position()
+    }
+
+    /// Absolute byte cursor set — forwards to the inner source's atomic,
+    /// used post-seek when the audio FSM lands at a known byte position.
+    pub(crate) fn set_position(&self, pos: u64) {
+        self.probe.set_position(pos);
+    }
+
+    /// Total length if known — answered by the probe.
+    pub(crate) fn len(&self) -> Option<u64> {
+        self.probe.len()
+    }
+
+    /// Optional byte-map handle — answered by the probe; the decoder
+    /// factory uses it to activate the segment-by-segment fMP4 path.
+    pub(crate) fn byte_map(&self) -> Option<Arc<dyn ByteMap>> {
+        self.probe.byte_map()
+    }
+
+    /// Runtime ABR handle — `Some` for adaptive sources (HLS).
+    pub(crate) fn abr_handle(&self) -> Option<AbrHandle> {
+        self.abr.clone()
+    }
+
+    /// Header byte range for decoder recreate after a format change — via
+    /// the fixed variant-control handle; same answer as
+    /// [`Stream::format_change_segment_range`].
+    pub(crate) fn format_change_segment_range(&self) -> StreamResult<Range<u64>> {
+        format_change_segment_range(self.variants.as_deref())
+    }
+
+    /// The reader→peer wake handle — `Some` for segmented sources (HLS)
+    /// that push a downloader peer.
+    pub(crate) fn peer_wake(&self) -> Option<Arc<DeferredWake>> {
+        self.peer_wake.clone()
+    }
+
+    /// Real-time on-core seek (FSM recreate/boundary, decoder
+    /// `OffsetReader`): cursor math + cursor set through the probe, no
+    /// lock and no `prime_seek_range` spin on the forbid-blocking produce
+    /// core — the same [`resolve_seek_target`] math as the off-RT
+    /// [`Seek::seek`]. The load→resolve→store is not atomic: it relies on
+    /// the single-cursor-writer invariant — the produce core owns the
+    /// cursor except while it is parked in `RebuildingDecoder`, the only
+    /// window where the off-RT rebuild reader moves it instead.
+    ///
+    /// # Errors
+    ///
+    /// See [`resolve_seek_target`].
+    pub(crate) fn probe_seek(&self, pos: SeekFrom) -> io::Result<u64> {
+        let new_pos = resolve_seek_target(pos, self.probe.position(), self.probe.len())?;
+        self.probe.set_position(new_pos);
+        // The reader cursor moved on the produce core: arm the peer so it
+        // re-targets fetches around the new position. The shell flushes it.
+        if let Some(ref wake) = self.peer_wake {
+            wake.arm();
+        }
+        Ok(new_pos)
     }
 
     /// Record `range` as the window a parked decoder poll waits on.
@@ -115,6 +211,10 @@ impl<T: StreamType> SharedStream<T> {
     fn with_construction_gate(&self, construction_gate: ConstructionGate) -> Self {
         Self {
             inner: Arc::clone(&self.inner),
+            probe: Arc::clone(&self.probe),
+            abr: self.abr.clone(),
+            variants: self.variants.clone(),
+            peer_wake: self.peer_wake.clone(),
             demand: Arc::clone(&self.demand),
             construction_gate: Some(construction_gate),
         }
@@ -122,22 +222,10 @@ impl<T: StreamType> SharedStream<T> {
 
     delegate! {
         to self.inner.lock() {
-            pub(crate) fn position(&self) -> u64;
-            /// Absolute byte cursor set — forwards to the inner source's
-            /// atomic, used post-seek when the audio FSM lands at a
-            /// known byte position.
-            pub(crate) fn set_position(&self, pos: u64);
-            pub(crate) fn len(&self) -> Option<u64>;
             pub(crate) fn media_info(&self) -> Option<MediaInfo>;
-            pub(crate) fn abr_handle(&self) -> Option<kithara_abr::AbrHandle>;
-            pub(crate) fn format_change_segment_range(&self) -> StreamResult<Range<u64>>;
             pub(crate) fn seek_time_anchor(&self, position: kithara_platform::time::Duration) -> Result<Option<SourceSeekAnchor>, io::Error>;
             /// Build a fresh reader-side event-sink instance from the inner source.
             pub(crate) fn take_reader_event_sink(&self) -> Option<kithara_stream::BoxedEventSink>;
-            /// Pull a clone of the optional byte-map handle from the
-            /// inner source. Used by the decoder factory to activate the
-            /// segment-by-segment fMP4 path on HLS.
-            pub(crate) fn byte_map(&self) -> Option<Arc<dyn ByteMap>>;
             pub(crate) fn seek_prepare(&self) -> Option<Arc<dyn kithara_stream::SeekPrepare>>;
             /// Narrow mutating playhead handle.
             pub(crate) fn playhead_write(&self) -> Arc<dyn PlayheadWrite>;
@@ -147,28 +235,15 @@ impl<T: StreamType> SharedStream<T> {
             pub(crate) fn seek_observe(&self) -> Arc<dyn SeekObserve>;
             /// Narrow activity handle.
             pub(crate) fn activity(&self) -> Arc<dyn Activity>;
-            /// Overall source readiness at current position.
-            pub(crate) fn phase(&self) -> SourcePhase;
-            /// Point-in-time readiness for a specific byte range.
-            pub(crate) fn phase_at(&self, range: Range<u64>) -> SourcePhase;
             /// Zero-budget readiness probe that also files `range` as reader
             /// demand with the source — the channel dispatch budgets follow.
             /// See [`Stream::probe_wait`].
             pub(crate) fn probe_wait(&self, range: Range<u64>) -> StreamResult<WaitOutcome>;
-            /// The reader→peer wake handle — `Some` for segmented sources
-            /// (HLS) that push a downloader peer. The FSM arms it on the
-            /// produce core (seek-apply / finalize); the scheduler shell
-            /// flushes it off the forbid-blocking path.
-            pub(crate) fn peer_wake(&self) -> Option<Arc<kithara_stream::DeferredWake>>;
             /// Install the audio worker's data-arrival wake on the inner
             /// source. Segmented sources (HLS) fire it from their off-RT
             /// write/settle sites; no-op for non-segmented sources. Set once,
             /// after the worker exists.
             pub(crate) fn set_worker_wake(&self, wake: Arc<dyn WorkerWake>);
-            /// Real-time on-core seek (FSM recreate/boundary, decoder
-            /// `OffsetReader`): position math + cursor set, no `prime_seek_range`
-            /// spin on the forbid-blocking produce core. See [`Stream::probe_seek`].
-            pub(crate) fn probe_seek(&self, pos: SeekFrom) -> io::Result<u64>;
         }
     }
 }
@@ -177,6 +252,10 @@ impl<T: StreamType> Clone for SharedStream<T> {
     fn clone(&self) -> Self {
         Self {
             inner: Arc::clone(&self.inner),
+            probe: Arc::clone(&self.probe),
+            abr: self.abr.clone(),
+            variants: self.variants.clone(),
+            peer_wake: self.peer_wake.clone(),
             demand: Arc::clone(&self.demand),
             construction_gate: self.construction_gate.clone(),
         }

--- a/crates/kithara-audio/src/pipeline/track/tests/gate.rs
+++ b/crates/kithara-audio/src/pipeline/track/tests/gate.rs
@@ -1,12 +1,20 @@
-use std::ops::Range;
+use std::{
+    io::{Read, SeekFrom},
+    ops::Range,
+};
 
-use kithara_platform::sync::{Arc, Mutex};
-use kithara_stream::{SourcePhase, Stream};
+use kithara_platform::{
+    sync::{Arc, Mutex},
+    thread,
+};
+use kithara_stream::{DeferredWake, SourcePhase, Stream};
 use kithara_test_utils::kithara;
 
 use super::rebuild::{TestConfig, TestControl, TestSource, TestStream, media_info};
 use crate::pipeline::{
-    decode::gate::source_phase_for_wait_context, stream::shared::SharedStream, track::WaitContext,
+    decode::gate::{ReadinessGate, source_phase_for_wait_context},
+    stream::shared::SharedStream,
+    track::WaitContext,
 };
 
 async fn shared_with_phase(
@@ -71,6 +79,85 @@ async fn repeated_parked_polls_coalesce_into_one_probe() {
         vec![2000..4096],
         "coalesced flush must file the latest armed window exactly once"
     );
+}
+
+/// RT gate polls answer while a construction read holds the control mutex.
+/// The real off-RT holder is a construction reader parked inside
+/// `Stream::read` → `Source::wait_range(range, None)` with the mutex held;
+/// a gate poll that touched that mutex would block the forbid-blocking
+/// produce core behind the park (RTSan: `sched_yield` in `parking_lot`'s
+/// contended acquire). The regression mode is this test hanging on the
+/// poll until the harness watchdog fires.
+#[kithara::test(tokio)]
+async fn a_readiness_poll_answers_while_a_construction_read_holds_the_mutex() {
+    let wake = Arc::new(DeferredWake::default());
+    let source = TestSource::new(Arc::new(TestControl::new(media_info(0))))
+        .with_peer_wake(Arc::clone(&wake));
+    *source.phase_handle().lock() = SourcePhase::Waiting;
+    let phase = source.phase_handle();
+    let park = source.park_handle();
+    let stream = match Stream::<TestStream>::new(TestConfig { source }).await {
+        Ok(stream) => stream,
+        Err(error) => panic!("test stream construction failed: {error}"),
+    };
+    let shared = SharedStream::new(stream);
+
+    park.arm();
+    let opened = shared.open_initial_reader();
+    let Some(gate) = opened.construction_gate() else {
+        panic!("initial reader must carry a construction gate");
+    };
+    gate.arm();
+    let mut reader = opened.into_inner();
+    let holder = thread::spawn_named("construction-read-holder", move || {
+        let mut buf = [0u8; 64];
+        reader.read(&mut buf)
+    });
+    park.wait_entered();
+
+    assert!(
+        !ReadinessGate::new(None).source_is_ready(&shared),
+        "a waiting source must poll as not-ready without touching the held control mutex"
+    );
+    assert_eq!(
+        source_phase_for_wait_context(&shared, &WaitContext::Playback),
+        SourcePhase::Waiting,
+        "the wait-context poll must answer from the probe while the mutex is held"
+    );
+    assert!(
+        shared.abr_handle().is_none(),
+        "the fixed-at-open ABR handle must answer (None here) while the mutex is held"
+    );
+    assert_eq!(
+        shared.format_change_segment_range().ok(),
+        Some(0..32),
+        "the fixed variant-control handle must serve the mock's format range while the mutex is held"
+    );
+    let pos = match shared.probe_seek(SeekFrom::Start(64)) {
+        Ok(pos) => pos,
+        Err(error) => {
+            panic!("the on-core probe seek must resolve while the mutex is held: {error}")
+        }
+    };
+    assert_eq!(pos, 64);
+    assert_eq!(
+        shared.position(),
+        64,
+        "probe_seek must move the probe cursor"
+    );
+    assert!(
+        wake.flush(),
+        "probe_seek must arm the peer wake for the shell to flush"
+    );
+
+    // Teardown: EOF lets the released construction read return instead of
+    // re-parking on the still-waiting phase.
+    *phase.lock() = SourcePhase::Eof;
+    park.release();
+    holder
+        .join()
+        .expect("holder thread must exit cleanly")
+        .expect("released construction read must complete");
 }
 
 /// A ready poll is a snapshot, not a wait: it must not arm demand, or the

--- a/crates/kithara-audio/src/pipeline/track/tests/rebuild.rs
+++ b/crates/kithara-audio/src/pipeline/track/tests/rebuild.rs
@@ -16,18 +16,18 @@ use kithara_events::{
     AudioEvent, DecoderChangeCause, DecoderEvent, DeferredBus, Event, EventBus, TrackFailureKind,
 };
 use kithara_platform::{
-    sync::{Arc, Mutex},
+    sync::{Arc, Condvar, Mutex},
     time::Duration,
     tokio::runtime::Handle as RuntimeHandle,
 };
 use kithara_storage::WaitOutcome;
 use kithara_stream::{
-    Activity, AudioCodec, ByteMap, ChunkPosition, ContainerFormat, MediaInfo, OpenedReader,
-    OpenedVariantReader, PlayheadRead, PlayheadState, PlayheadWrite, PrerollHint, ReadOutcome,
-    ReaderProfile, SeekControl, SeekObserve, SeekState, SegmentDescriptor, Source, SourceError,
-    SourcePhase, SourceSeekAnchor, Stream, StreamError, StreamResult, StreamType, VariantControl,
-    VariantPromotion, VariantReaderPlan, VariantReaderTake, VariantTransition, VariantTransitionId,
-    WorkerWake,
+    Activity, AudioCodec, ByteMap, ChunkPosition, ContainerFormat, DeferredWake, MediaInfo,
+    OpenedReader, OpenedVariantReader, PlayheadRead, PlayheadState, PlayheadWrite, PrerollHint,
+    ReadOutcome, ReaderProfile, SeekControl, SeekObserve, SeekState, SegmentDescriptor, Source,
+    SourceError, SourcePhase, SourceProbe, SourceSeekAnchor, Stream, StreamError, StreamResult,
+    StreamType, VariantControl, VariantPromotion, VariantReaderPlan, VariantReaderTake,
+    VariantTransition, VariantTransitionId, WorkerWake,
 };
 use kithara_test_utils::kithara;
 
@@ -521,9 +521,62 @@ impl VariantControl for TestControl {
     }
 }
 
+/// Optional park inside `wait_range`, letting a test hold the stream's
+/// control mutex the way a real construction read does: `Stream::read`
+/// enters `Source::wait_range` under the `SharedStream` mutex and stays
+/// there until data lands. Disarmed by default — no other test changes.
+#[derive(Default)]
+pub(super) struct WaitPark {
+    armed: AtomicBool,
+    state: Mutex<WaitParkState>,
+    condvar: Condvar,
+}
+
+#[derive(Default)]
+struct WaitParkState {
+    entered: bool,
+    released: bool,
+}
+
+impl WaitPark {
+    pub(super) fn arm(&self) {
+        self.armed.store(true, Ordering::Release);
+    }
+
+    /// Block until the holder is inside `wait_range` — i.e. the control
+    /// mutex is held by a parked blocking read.
+    pub(super) fn wait_entered(&self) {
+        let mut state = self.state.lock();
+        while !state.entered {
+            state = self.condvar.wait(state);
+        }
+    }
+
+    pub(super) fn release(&self) {
+        let mut state = self.state.lock();
+        state.released = true;
+        drop(state);
+        self.condvar.notify_all();
+    }
+
+    fn enter_if_armed(&self) {
+        if !self.armed.load(Ordering::Acquire) {
+            return;
+        }
+        let mut state = self.state.lock();
+        state.entered = true;
+        self.condvar.notify_all();
+        while !state.released {
+            state = self.condvar.wait(state);
+        }
+    }
+}
+
 pub(super) struct TestSource {
     byte_map: Arc<TestByteMap>,
     control: Arc<TestControl>,
+    park: Arc<WaitPark>,
+    peer: Option<Arc<DeferredWake>>,
     phase: Arc<Mutex<SourcePhase>>,
     playhead: Arc<PlayheadState>,
     position: Arc<AtomicU64>,
@@ -536,6 +589,8 @@ impl TestSource {
         Self {
             control,
             byte_map: Arc::new(TestByteMap),
+            park: Arc::new(WaitPark::default()),
+            peer: None,
             phase: Arc::new(Mutex::new(SourcePhase::Ready)),
             playhead: Arc::new(PlayheadState::new()),
             position: Arc::new(AtomicU64::new(0)),
@@ -544,9 +599,21 @@ impl TestSource {
         }
     }
 
+    /// Attach a reader→peer wake, as segmented sources vend one. Opt-in:
+    /// a `Some` peer changes `Stream`'s read-path unit clamping, so only
+    /// tests pinning the peer-wake contract install it.
+    pub(super) fn with_peer_wake(mut self, wake: Arc<DeferredWake>) -> Self {
+        self.peer = Some(wake);
+        self
+    }
+
     fn segmented(control: Arc<TestControl>) -> Self {
         control.enable_byte_map();
         Self::new(control)
+    }
+
+    pub(super) fn park_handle(&self) -> Arc<WaitPark> {
+        Arc::clone(&self.park)
     }
 
     pub(super) fn phase_handle(&self) -> Arc<Mutex<SourcePhase>> {
@@ -558,9 +625,52 @@ impl TestSource {
     }
 }
 
+/// Byte-space probe sharing the test source's scripted cells — the same
+/// phase, cursor, and byte-map gating as the `Source` impl below.
+struct SharedPhaseProbe {
+    phase: Arc<Mutex<SourcePhase>>,
+    position: Arc<AtomicU64>,
+    control: Arc<TestControl>,
+    byte_map: Arc<TestByteMap>,
+}
+
+impl SourceProbe for SharedPhaseProbe {
+    fn phase(&self) -> SourcePhase {
+        *self.phase.lock()
+    }
+
+    fn phase_at(&self, _range: Range<u64>) -> SourcePhase {
+        *self.phase.lock()
+    }
+
+    fn position(&self) -> u64 {
+        self.position.load(Ordering::Acquire)
+    }
+
+    fn set_position(&self, pos: u64) {
+        self.position.store(pos, Ordering::Release);
+    }
+
+    fn len(&self) -> Option<u64> {
+        Some(4096)
+    }
+
+    fn byte_map(&self) -> Option<Arc<dyn ByteMap>> {
+        if self.control.byte_map_enabled.load(Ordering::Acquire) {
+            Some(self.byte_map.clone() as Arc<dyn ByteMap>)
+        } else {
+            None
+        }
+    }
+}
+
 impl Source for TestSource {
     fn activity(&self) -> Arc<dyn Activity> {
         Arc::clone(&self.seek) as Arc<dyn Activity>
+    }
+
+    fn peer_wake(&self) -> Option<Arc<DeferredWake>> {
+        self.peer.clone()
     }
 
     fn advance(&self, n: u64) {
@@ -585,6 +695,15 @@ impl Source for TestSource {
 
     fn phase_at(&self, _range: Range<u64>) -> SourcePhase {
         *self.phase.lock()
+    }
+
+    fn probe(&self) -> Arc<dyn SourceProbe> {
+        Arc::new(SharedPhaseProbe {
+            phase: Arc::clone(&self.phase),
+            position: Arc::clone(&self.position),
+            control: Arc::clone(&self.control),
+            byte_map: Arc::clone(&self.byte_map),
+        })
     }
 
     fn playhead_read(&self) -> Arc<dyn PlayheadRead> {
@@ -624,6 +743,7 @@ impl Source for TestSource {
         range: Range<u64>,
         _timeout: Option<Duration>,
     ) -> StreamResult<WaitOutcome> {
+        self.park.enter_if_armed();
         self.waits.lock().push(range);
         match *self.phase.lock() {
             SourcePhase::Ready => Ok(WaitOutcome::Ready),

--- a/crates/kithara-audio/src/pipeline/track/tests/splice.rs
+++ b/crates/kithara-audio/src/pipeline/track/tests/splice.rs
@@ -16,8 +16,8 @@ use kithara_storage::WaitOutcome;
 use kithara_stream::{
     Activity, AudioCodec, ByteMap, ChunkPosition, ContainerFormat, MediaInfo, PlayheadRead,
     PlayheadState, PlayheadWrite, ReadOutcome, ReaderProfile, SeekControl, SeekObserve, SeekState,
-    SegmentDescriptor, Source, SourceError, SourcePhase, SourceSeekAnchor, Stream, StreamError,
-    StreamResult, StreamType, VariantControl, VariantPromotion, VariantReaderPlan,
+    SegmentDescriptor, Source, SourceError, SourcePhase, SourceProbe, SourceSeekAnchor, Stream,
+    StreamError, StreamResult, StreamType, VariantControl, VariantPromotion, VariantReaderPlan,
     VariantReaderTake, VariantTransition, WorkerWake,
 };
 use kithara_test_utils::kithara;
@@ -230,6 +230,39 @@ impl SpliceSource {
     }
 }
 
+/// Always-ready byte-space probe sharing `SpliceSource`'s cells — same
+/// phase, cursor, length, and byte map as the `Source` impl below.
+struct ReadyProbe {
+    position: Arc<AtomicU64>,
+    state: Arc<SpliceState>,
+}
+
+impl SourceProbe for ReadyProbe {
+    fn phase(&self) -> SourcePhase {
+        SourcePhase::Ready
+    }
+
+    fn phase_at(&self, _range: Range<u64>) -> SourcePhase {
+        SourcePhase::Ready
+    }
+
+    fn position(&self) -> u64 {
+        self.position.load(Ordering::Acquire)
+    }
+
+    fn set_position(&self, pos: u64) {
+        self.position.store(pos, Ordering::Release);
+    }
+
+    fn len(&self) -> Option<u64> {
+        Some(u64::try_from(self.state.active_layout().blob.len()).expect("blob length fits u64"))
+    }
+
+    fn byte_map(&self) -> Option<Arc<dyn ByteMap>> {
+        Some(Arc::clone(&self.state) as Arc<dyn ByteMap>)
+    }
+}
+
 impl Source for SpliceSource {
     fn activity(&self) -> Arc<dyn Activity> {
         Arc::clone(&self.seek) as Arc<dyn Activity>
@@ -253,6 +286,13 @@ impl Source for SpliceSource {
 
     fn phase_at(&self, _range: Range<u64>) -> SourcePhase {
         SourcePhase::Ready
+    }
+
+    fn probe(&self) -> Arc<dyn SourceProbe> {
+        Arc::new(ReadyProbe {
+            position: Arc::clone(&self.position),
+            state: Arc::clone(&self.state),
+        })
     }
 
     fn playhead_read(&self) -> Arc<dyn PlayheadRead> {

--- a/crates/kithara-file/src/session/source.rs
+++ b/crates/kithara-file/src/session/source.rs
@@ -6,9 +6,10 @@ use kithara_events::{EventBus, TotalBytesSource};
 use kithara_platform::{CancelToken, sync::Arc, time::Duration};
 use kithara_storage::{ResourceStatus, StorageError, WaitOutcome};
 use kithara_stream::{
-    Activity, AudioCodec, MediaInfo, NotReadyCause, PendingReason, PlayheadRead, PlayheadWrite,
-    ReadOutcome, SeekControl, SeekObserve, SegmentDescriptor, SourceError as StreamSourceError,
-    SourcePhase, StreamError, StreamResult, WorkerWake, dl::PeerHandle,
+    Activity, AudioCodec, ByteMap, MediaInfo, NotReadyCause, PendingReason, PlayheadRead,
+    PlayheadWrite, ReadOutcome, SeekControl, SeekObserve, SegmentDescriptor,
+    SourceError as StreamSourceError, SourcePhase, SourceProbe, StreamError, StreamResult,
+    WorkerWake, dl::PeerHandle,
 };
 use tracing::trace;
 use url::Url;
@@ -82,12 +83,6 @@ impl FileSource {
         }
     }
 
-    fn known_len(&self) -> Option<u64> {
-        self.coord
-            .total_bytes()
-            .or_else(|| self.inner.asset.reader.len())
-    }
-
     /// Create a source for a local/cached file (no downloads needed).
     ///
     /// `cancel` is a child of the file config master so a track drop
@@ -132,16 +127,6 @@ impl FileSource {
             inner,
             peer_handle: None,
         }
-    }
-
-    fn readable_part(&self, range: Range<u64>) -> Option<Range<u64>> {
-        let Some(total) = self.known_len() else {
-            return Some(range);
-        };
-        if total > 0 && range.start >= total {
-            return None;
-        }
-        Some(range.start..range.end.min(total))
     }
 
     /// Pin the Downloader peer registration to this source's lifetime.
@@ -198,51 +183,109 @@ impl FileSource {
     }
 }
 
-impl kithara_stream::Source for FileSource {
-    fn byte_map(&self) -> Option<Arc<dyn kithara_stream::ByteMap>> {
-        self.inner.segment_index.get()?;
-        Some(Arc::new(FileByteMap {
-            inner: Arc::clone(&self.inner),
-        }))
+/// Phase snapshots live on the shared inner: it owns the terminal state and
+/// the cached-range view, and (per its own contract) is Mutex-free — so the
+/// narrow [`SourceProbe`] handle the forbid-blocking audio core polls without
+/// the stream's control-plane lock answers from here.
+impl FileInner {
+    pub(crate) fn phase(&self) -> SourcePhase {
+        let pos = self.source.coord.position();
+        self.phase_at(pos..pos.saturating_add(1))
     }
 
-    fn len(&self) -> Option<u64> {
-        self.known_len()
+    pub(crate) fn phase_at(&self, range: Range<u64>) -> SourcePhase {
+        if self.source.cancel.is_cancelled() {
+            return SourcePhase::Cancelled;
+        }
+        self.refresh_unmanaged_terminal();
+        if self.terminal_state() == FileTerminalState::Cancelled {
+            return SourcePhase::Cancelled;
+        }
+        let Some(readable) = self.readable_part(range) else {
+            return match self.terminal_state() {
+                FileTerminalState::Committed => SourcePhase::Eof,
+                FileTerminalState::Cancelled => SourcePhase::Cancelled,
+                FileTerminalState::Active | FileTerminalState::Failed => SourcePhase::Waiting,
+            };
+        };
+        let contains = readable.is_empty() || self.asset.reader.contains_range(readable);
+        if contains {
+            return SourcePhase::Ready;
+        }
+
+        if self.source.coord.seek_obs().is_flushing() {
+            return SourcePhase::Seeking;
+        }
+        SourcePhase::Waiting
+    }
+
+    pub(crate) fn known_len(&self) -> Option<u64> {
+        self.source
+            .coord
+            .total_bytes()
+            .or_else(|| self.asset.reader.len())
+    }
+
+    fn readable_part(&self, range: Range<u64>) -> Option<Range<u64>> {
+        let Some(total) = self.known_len() else {
+            return Some(range);
+        };
+        if total > 0 && range.start >= total {
+            return None;
+        }
+        Some(range.start..range.end.min(total))
+    }
+}
+
+/// Narrow byte-space handle over the shared inner. Wraps the `Arc` because
+/// vending the byte map needs an owning handle to the inner's lazy segment
+/// index; every answer comes from the inner's Mutex-free state.
+struct FileProbe {
+    inner: Arc<FileInner>,
+}
+
+/// Segment-map handle over the shared inner, vended once the lazy segment
+/// index exists — the one body behind `Source::byte_map` and
+/// `SourceProbe::byte_map`.
+fn file_byte_map(inner: &Arc<FileInner>) -> Option<Arc<dyn ByteMap>> {
+    inner.segment_index.get()?;
+    Some(Arc::new(FileByteMap {
+        inner: Arc::clone(inner),
+    }))
+}
+
+impl SourceProbe for FileProbe {
+    delegate::delegate! {
+        to self.inner {
+            fn phase(&self) -> SourcePhase;
+            fn phase_at(&self, range: Range<u64>) -> SourcePhase;
+            #[call(known_len)]
+            fn len(&self) -> Option<u64>;
+        }
+        to self.inner.source.coord {
+            fn position(&self) -> u64;
+            fn set_position(&self, pos: u64);
+        }
+    }
+
+    fn byte_map(&self) -> Option<Arc<dyn ByteMap>> {
+        file_byte_map(&self.inner)
+    }
+}
+
+impl kithara_stream::Source for FileSource {
+    fn byte_map(&self) -> Option<Arc<dyn ByteMap>> {
+        file_byte_map(&self.inner)
     }
 
     fn media_info(&self) -> Option<MediaInfo> {
         self.inner.content_type_info.get().cloned()
     }
 
-    fn phase(&self) -> SourcePhase {
-        let pos = self.coord.position();
-        self.phase_at(pos..pos.saturating_add(1))
-    }
-
-    fn phase_at(&self, range: Range<u64>) -> SourcePhase {
-        if self.inner.source.cancel.is_cancelled() {
-            return SourcePhase::Cancelled;
-        }
-        self.inner.refresh_unmanaged_terminal();
-        if self.inner.terminal_state() == FileTerminalState::Cancelled {
-            return SourcePhase::Cancelled;
-        }
-        let Some(readable) = self.readable_part(range) else {
-            return match self.inner.terminal_state() {
-                FileTerminalState::Committed => SourcePhase::Eof,
-                FileTerminalState::Cancelled => SourcePhase::Cancelled,
-                FileTerminalState::Active | FileTerminalState::Failed => SourcePhase::Waiting,
-            };
-        };
-        let contains = readable.is_empty() || self.inner.asset.reader.contains_range(readable);
-        if contains {
-            return SourcePhase::Ready;
-        }
-
-        if self.coord.seek_obs().is_flushing() {
-            return SourcePhase::Seeking;
-        }
-        SourcePhase::Waiting
+    fn probe(&self) -> Arc<dyn SourceProbe> {
+        Arc::new(FileProbe {
+            inner: Arc::clone(&self.inner),
+        })
     }
 
     #[cfg_attr(feature = "perf", hotpath::measure)]
@@ -325,6 +368,12 @@ impl kithara_stream::Source for FileSource {
             fn seek_observe(&self) -> Arc<dyn SeekObserve>;
             fn set_position(&self, pos: u64);
         }
+        to self.inner {
+            #[call(known_len)]
+            fn len(&self) -> Option<u64>;
+            fn phase(&self) -> SourcePhase;
+            fn phase_at(&self, range: Range<u64>) -> SourcePhase;
+        }
     }
 }
 
@@ -343,7 +392,7 @@ impl FileByteMap {
     }
 }
 
-impl kithara_stream::ByteMap for FileByteMap {
+impl ByteMap for FileByteMap {
     delegate::delegate! {
         to self {
             #[expr($.map_or(0..0, FileSegmentIndex::init_range))]

--- a/crates/kithara-hls/src/stream/coord.rs
+++ b/crates/kithara-hls/src/stream/coord.rs
@@ -15,8 +15,9 @@ use kithara_storage::WaitOutcome;
 use kithara_stream::{
     Activity, ByteMap, DeferredWake, MediaInfo, PlayheadRead, PlayheadState, PlayheadWrite,
     ReadOutcome, ReaderProfile, SeekControl, SeekObserve, SeekPrepare, SeekState,
-    SegmentDescriptor, SourceError, SourcePhase, SourceSeekAnchor, StreamError, StreamResult,
-    VariantControl, VariantPromotion, VariantReaderPlan, VariantReaderTake, VariantTransition,
+    SegmentDescriptor, SourceError, SourcePhase, SourceProbe, SourceSeekAnchor, StreamError,
+    StreamResult, VariantControl, VariantPromotion, VariantReaderPlan, VariantReaderTake,
+    VariantTransition,
 };
 use kithara_test_utils::kithara;
 
@@ -483,6 +484,40 @@ pub(super) fn variant_switch_target_time(
             .unwrap_or_else(|| playhead_read.position());
     }
     landing.unwrap_or_else(|| playhead_read.position())
+}
+
+/// Narrow byte-space handle: the coord is the single owner of phase,
+/// cursor, length, and layout, so the forbid-blocking audio core reads
+/// them here without the stream mutex. Wraps the `Arc` because the byte
+/// map IS the coord — vending it is an allocation-free `Arc` clone.
+pub(crate) struct HlsProbe {
+    coord: Arc<HlsCoord>,
+}
+
+impl HlsProbe {
+    pub(crate) fn new(coord: Arc<HlsCoord>) -> Self {
+        Self { coord }
+    }
+}
+
+impl SourceProbe for HlsProbe {
+    delegate! {
+        to self.coord {
+            fn phase_at(&self, range: Range<u64>) -> SourcePhase;
+            fn position(&self) -> u64;
+            fn set_position(&self, pos: u64);
+            fn len(&self) -> Option<u64>;
+        }
+    }
+
+    fn phase(&self) -> SourcePhase {
+        let pos = self.coord.position();
+        self.coord.phase_at(pos..pos.saturating_add(1))
+    }
+
+    fn byte_map(&self) -> Option<Arc<dyn ByteMap>> {
+        Some(Arc::clone(&self.coord) as Arc<dyn ByteMap>)
+    }
 }
 
 /// `VariantControl` exposes the cross-variant fence/format-change surface

--- a/crates/kithara-hls/src/stream/source.rs
+++ b/crates/kithara-hls/src/stream/source.rs
@@ -9,10 +9,11 @@ use kithara_platform::{CancelScope, sync::Arc, time::Duration};
 use kithara_storage::WaitOutcome;
 use kithara_stream::{
     Activity, BoxedEventSink, ByteMap, DeferredWake, MediaInfo, PlayheadRead, PlayheadWrite,
-    ReadOutcome, SeekControl, SeekObserve, SeekPrepare, Source, SourcePhase, StreamResult,
+    ReadOutcome, SeekControl, SeekObserve, SeekPrepare, Source, SourcePhase, SourceProbe,
+    StreamResult,
 };
 
-use super::coord::HlsCoord;
+use super::coord::{HlsCoord, HlsProbe};
 use crate::{peer::HlsPeer, reader::HlsReaderEventSink};
 
 /// HLS source: thin façade over [`HlsCoord`].
@@ -130,6 +131,10 @@ impl Source for HlsSource {
             self.coord.seek_epoch_handle(),
         );
         Some(Box::new(sink))
+    }
+
+    fn probe(&self) -> Arc<dyn SourceProbe> {
+        Arc::new(HlsProbe::new(Arc::clone(&self.coord)))
     }
 
     fn variant_control(&self) -> Option<Arc<dyn kithara_stream::VariantControl>> {

--- a/crates/kithara-stream/CONTEXT.md
+++ b/crates/kithara-stream/CONTEXT.md
@@ -62,6 +62,19 @@ underran worker re-ticks the instant bytes land); sources whose data is always
 resident have neither. `take_reader_event_sink` must return a **fresh** sink on
 every call — decoder recreation (ABR / format change) needs a clean state cursor.
 
+`probe` is the narrow byte-space handle (`SourceProbe`): phase, cursor
+(`position`/`set_position`), `len`, and `byte_map` behind an `Arc`, so a caller
+that keeps `Stream` behind a mutex (the audio worker's shared stream) serves its
+real-time polls and cursor moves without that lock — an off-thread holder parked
+in a blocking `read`/`seek` would otherwise turn the poll into a wait.
+Implementations answer from self-synchronizing state (HLS: the coord; file: the
+shared inner) and must not take locks a reader wait can hold — the file probe's
+`phase_at` and `len` may take the storage gate lock on the uncommitted path, a
+short acquire the storage wait releases before parking, never one held across a
+wait. `resolve_seek_target` is the shared cursor math: `Stream::seek` and the
+probe-side `probe_seek` resolve a `SeekFrom` against the same position/length
+answers.
+
 ## End-of-stream contract
 
 `Stream::try_read` surfaces `StreamReadOutcome::Eof` only from a `Source` proving

--- a/crates/kithara-stream/src/lib.rs
+++ b/crates/kithara-stream/src/lib.rs
@@ -40,11 +40,11 @@ pub use reader::{
 pub use seek_state::{Activity, SeekControl, SeekObserve, SeekState};
 pub use source::{
     ByteMap, NotReadyCause, PendingReason, ReadOutcome, SeekPrepare, SegmentDescriptor, Source,
-    SourcePhase, SourceSeekAnchor, VariantControl,
+    SourcePhase, SourceProbe, SourceSeekAnchor, VariantControl,
 };
 pub use stream::{
     Stream, StreamPending, StreamReadError, StreamReadOutcome, StreamSeekPastEof, StreamType,
-    VariantChangeError,
+    VariantChangeError, format_change_segment_range, resolve_seek_target,
 };
 pub use transition::{
     OutgoingDisposition, VariantPromotion, VariantTransition, VariantTransitionId,

--- a/crates/kithara-stream/src/source.rs
+++ b/crates/kithara-stream/src/source.rs
@@ -82,6 +82,46 @@ pub enum SourcePhase {
     WaitingMetadata,
 }
 
+/// Narrow view of the source's byte space, served off the control mutex.
+///
+/// Phase, cursor, length, and byte map are non-blocking `&self` snapshots
+/// on [`Source`], but reaching them through a `Mutex<Stream>` turns each
+/// query into a lock acquisition — off-limits on the forbid-blocking audio
+/// produce core, where any contended acquire (a construction read or a
+/// consumer query holding the control mutex) blocks the real-time tick.
+/// Callers on that core take this handle once at open and answer every
+/// byte-space question without touching the stream's control-plane mutex.
+/// Implementations answer from self-synchronizing state and must not take
+/// locks a reader wait can hold.
+pub trait SourceProbe: Send + Sync + 'static {
+    /// Overall source readiness at the current position.
+    fn phase(&self) -> SourcePhase;
+
+    /// Point-in-time readiness for a specific byte range.
+    fn phase_at(&self, range: Range<u64>) -> SourcePhase;
+
+    /// Current read position — the same atomic cursor as
+    /// [`Source::position`].
+    fn position(&self) -> u64;
+
+    /// Absolute byte-position set — the same atomic cursor as
+    /// [`Source::set_position`].
+    fn set_position(&self, pos: u64);
+
+    /// Total length if known — the same answer as [`Source::len`].
+    fn len(&self) -> Option<u64>;
+
+    /// Whether the source currently reports zero bytes — the same
+    /// convention as [`Source::is_empty`].
+    fn is_empty(&self) -> bool {
+        self.len().is_none_or(|n| n == 0)
+    }
+
+    /// Optional byte-map handle — the same answer as [`Source::byte_map`],
+    /// including its over-time `None` → `Some` transition.
+    fn byte_map(&self) -> Option<Arc<dyn ByteMap>>;
+}
+
 /// Reason a [`ReadOutcome::Pending`] was returned — i.e. why the source
 /// did not make progress this call. Each variant maps to a distinct
 /// caller action; there is no overlap and no string-matching required.
@@ -260,6 +300,13 @@ pub trait Source: MaybeSend + MaybeSync + 'static {
     /// Returns the current [`SourcePhase`] without blocking. Used internally
     /// by `wait_range()` implementations for fast-path dispatch.
     fn phase_at(&self, range: Range<u64>) -> SourcePhase;
+
+    /// Narrow byte-space handle serving the same snapshots as
+    /// [`Source::phase_at`], [`Source::position`], [`Source::len`], and
+    /// [`Source::byte_map`] without going through the stream's control-plane
+    /// lock. The forbid-blocking audio produce core answers every byte-space
+    /// question through this handle only.
+    fn probe(&self) -> Arc<dyn SourceProbe>;
 
     /// Narrow read-only handle to the playhead position and total duration.
     fn playhead_read(&self) -> Arc<dyn PlayheadRead>;
@@ -512,10 +559,41 @@ pub trait ByteMap: Send + Sync + 'static {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
     use kithara_test_utils::kithara;
 
     use super::*;
     use crate::{PlayheadState, SeekState};
+
+    /// Constant-phase probe for the minimal test sources below; shares the
+    /// source's cursor cell and mirrors its `len`.
+    struct FixedPhase {
+        phase: SourcePhase,
+        len: Option<u64>,
+        position: Arc<AtomicU64>,
+    }
+
+    impl SourceProbe for FixedPhase {
+        fn phase(&self) -> SourcePhase {
+            self.phase
+        }
+        fn phase_at(&self, _range: Range<u64>) -> SourcePhase {
+            self.phase
+        }
+        fn position(&self) -> u64 {
+            self.position.load(Ordering::Acquire)
+        }
+        fn set_position(&self, pos: u64) {
+            self.position.store(pos, Ordering::Release);
+        }
+        fn len(&self) -> Option<u64> {
+            self.len
+        }
+        fn byte_map(&self) -> Option<Arc<dyn ByteMap>> {
+            None
+        }
+    }
 
     #[kithara::test]
     fn test_source_trait_object_safety() {
@@ -529,8 +607,6 @@ mod tests {
 
     #[kithara::test]
     fn phase_default_delegates_to_phase_at() {
-        use std::sync::atomic::{AtomicU64, Ordering};
-
         struct ReadySource {
             seek: Arc<SeekState>,
             playhead: Arc<PlayheadState>,
@@ -565,6 +641,13 @@ mod tests {
             fn phase_at(&self, _range: Range<u64>) -> SourcePhase {
                 SourcePhase::Ready
             }
+            fn probe(&self) -> Arc<dyn SourceProbe> {
+                Arc::new(FixedPhase {
+                    phase: SourcePhase::Ready,
+                    len: Some(100),
+                    position: Arc::clone(&self.position),
+                })
+            }
             fn len(&self) -> Option<u64> {
                 Some(100)
             }
@@ -597,8 +680,6 @@ mod tests {
     /// - `activity().is_playing()` toggles correctly.
     #[kithara::test]
     fn narrow_source_accessors_seam() {
-        use std::sync::atomic::{AtomicU64, Ordering};
-
         struct MinimalSource {
             seek: Arc<SeekState>,
             playhead: Arc<PlayheadState>,
@@ -632,6 +713,13 @@ mod tests {
             }
             fn phase_at(&self, _range: Range<u64>) -> SourcePhase {
                 SourcePhase::Waiting
+            }
+            fn probe(&self) -> Arc<dyn SourceProbe> {
+                Arc::new(FixedPhase {
+                    phase: SourcePhase::Waiting,
+                    len: None,
+                    position: Arc::clone(&self.position),
+                })
             }
             fn len(&self) -> Option<u64> {
                 None

--- a/crates/kithara-stream/src/stream.rs
+++ b/crates/kithara-stream/src/stream.rs
@@ -234,14 +234,9 @@ impl<T: StreamType> Stream<T> {
     ///
     /// # Errors
     ///
-    /// `Err(SourceError::FormatChangeNotApplicable)` for non-HLS sources
-    /// or HLS variants activated with `served_from > 0` (init prefix
-    /// unreachable via Stream reads).
+    /// See [`format_change_segment_range`].
     pub fn format_change_segment_range(&self) -> StreamResult<Range<u64>> {
-        self.source.variant_control().map_or(
-            Err(StreamError::Source(SourceError::FormatChangeNotApplicable)),
-            |vc| vc.format_change_segment_range(),
-        )
+        format_change_segment_range(self.source.variant_control().as_deref())
     }
 
     pub fn is_empty(&self) -> Option<bool> {
@@ -271,6 +266,12 @@ impl<T: StreamType> Stream<T> {
             pub fn phase(&self) -> SourcePhase;
             /// Point-in-time readiness for a specific byte range.
             pub fn phase_at(&self, range: Range<u64>) -> SourcePhase;
+            /// Narrow byte-space handle — the same snapshots as
+            /// [`Stream::phase_at`] / [`Stream::position`] / [`Stream::len`] /
+            /// [`Stream::byte_map`] for callers that must not take the lock a
+            /// shared stream wrapper puts around `Stream`.
+            #[must_use]
+            pub fn probe(&self) -> Arc<dyn crate::SourceProbe>;
             /// Get current media info if known.
             pub fn media_info(&self) -> Option<MediaInfo>;
             /// Runtime ABR handle — `Some` for adaptive sources (HLS).
@@ -580,61 +581,68 @@ impl<T: StreamType> Stream<T> {
         self.source.wait_range(range, Some(Duration::ZERO))
     }
 
-    /// Real-time on-core seek: resolve + cursor set, with NO `prime_seek_range`
-    /// spin — no `yield_now`/`notify_one` on the forbid-blocking produce core.
-    /// The audio worker (the FSM's recreate/boundary seeks and the decoder's
-    /// `OffsetReader`) seeks through this; the off-RT [`Seek::seek`] adapter
-    /// primes inline instead. The seeked range's readiness is discovered by the
-    /// next `probe_read` (park-on-not-ready), and the armed peer wake — flushed
-    /// by the shell — drives the fetch.
-    ///
-    /// # Errors
-    ///
-    /// See [`Self::resolve_seek_target`].
-    pub fn probe_seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
-        let new_pos = self.resolve_seek_target(pos, self.source.len())?;
-        self.source.set_position(new_pos);
-        // The reader cursor moved on the produce core: arm the peer so it
-        // re-targets fetches around the new position. The shell flushes it.
-        self.arm_peer_wake();
-        Ok(new_pos)
-    }
-
-    /// Resolve a [`SeekFrom`] to an absolute, clamped byte target — the shared
-    /// math behind the off-RT [`Seek::seek`] and the on-core [`Self::probe_seek`].
+    /// Resolve a [`SeekFrom`] against the live cursor — the shared math
+    /// behind the off-RT [`Seek::seek`] and the on-core probe seek
+    /// (the audio worker's shared-stream wrapper).
     ///
     /// `len` is the known source length, resolved by the caller (`seek` primes
-    /// to discover it; `probe_seek` uses the current value); `SeekFrom::End`
-    /// errors when it is `None`. `Current` is relative to the live cursor.
+    /// to discover it; a probe seek uses the current value).
     ///
     /// # Errors
     ///
-    /// `Unsupported` for `SeekFrom::End` without a known length; `InvalidInput`
-    /// for a negative resulting offset.
+    /// See [`resolve_seek_target`].
     fn resolve_seek_target(&self, pos: SeekFrom, len: Option<u64>) -> io::Result<u64> {
-        let new_pos: i128 = match pos {
-            SeekFrom::Start(p) => i128::from(p),
-            SeekFrom::Current(delta) => {
-                i128::from(self.source.position()).saturating_add(i128::from(delta))
-            }
-            SeekFrom::End(delta) => {
-                let Some(len) = len else {
-                    return Err(IoError::new(
-                        ErrorKind::Unsupported,
-                        "seek from end requires known length",
-                    ));
-                };
-                i128::from(len).saturating_add(i128::from(delta))
-            }
-        };
-        if new_pos < 0 {
-            return Err(IoError::new(
-                ErrorKind::InvalidInput,
-                "negative seek position",
-            ));
-        }
-        Ok(u64::try_from(new_pos).unwrap_or(u64::MAX))
+        resolve_seek_target(pos, self.source.position(), len)
     }
+}
+
+/// Resolve a [`SeekFrom`] to an absolute, clamped byte target. `position` is
+/// the live cursor (`Current` is relative to it); `SeekFrom::End` errors when
+/// `len` is `None`. Shared by [`Stream`]'s seek adapters and lock-free
+/// wrappers that seek through a [`crate::SourceProbe`].
+///
+/// # Errors
+///
+/// `Unsupported` for `SeekFrom::End` without a known length; `InvalidInput`
+/// for a negative resulting offset.
+pub fn resolve_seek_target(pos: SeekFrom, position: u64, len: Option<u64>) -> io::Result<u64> {
+    let new_pos: i128 = match pos {
+        SeekFrom::Start(p) => i128::from(p),
+        SeekFrom::Current(delta) => i128::from(position).saturating_add(i128::from(delta)),
+        SeekFrom::End(delta) => {
+            let Some(len) = len else {
+                return Err(IoError::new(
+                    ErrorKind::Unsupported,
+                    "seek from end requires known length",
+                ));
+            };
+            i128::from(len).saturating_add(i128::from(delta))
+        }
+    };
+    if new_pos < 0 {
+        return Err(IoError::new(
+            ErrorKind::InvalidInput,
+            "negative seek position",
+        ));
+    }
+    Ok(u64::try_from(new_pos).unwrap_or(u64::MAX))
+}
+
+/// Header byte range for decoder recreate after a format change — the one
+/// mapping from an optional [`VariantControl`] to the typed answer. Shared
+/// by [`Stream::format_change_segment_range`] and lock-free wrappers that
+/// hold the variant-control handle directly.
+///
+/// # Errors
+///
+/// `Err(SourceError::FormatChangeNotApplicable)` for sources without a
+/// variant surface (non-HLS) or HLS variants activated with
+/// `served_from > 0` (init prefix unreachable via Stream reads).
+pub fn format_change_segment_range(vc: Option<&dyn VariantControl>) -> StreamResult<Range<u64>> {
+    vc.map_or(
+        Err(StreamError::Source(SourceError::FormatChangeNotApplicable)),
+        VariantControl::format_change_segment_range,
+    )
 }
 
 impl<T: StreamType> Read for Stream<T> {
@@ -766,7 +774,9 @@ mod tests {
     use kithara_test_utils::kithara;
 
     use super::*;
-    use crate::{PlayheadRead, PlayheadState, ReadOutcome, SeekState, Source, SourcePhase};
+    use crate::{
+        PlayheadRead, PlayheadState, ReadOutcome, SeekState, Source, SourcePhase, SourceProbe,
+    };
 
     /// Test helper — script entry that maps to either `Bytes(N)` (with
     /// the source slicing actual `data`) or a terminal `Eof`. Pending
@@ -782,6 +792,36 @@ mod tests {
         let nz = NonZeroUsize::new(count)
             .expect("BUG: ScriptSource::bytes invariant — count must be > 0");
         ReadOutcome::Bytes(nz)
+    }
+
+    /// Constant-phase probe for the scripted test sources below; shares the
+    /// source's cursor cell and mirrors its `len`. The byte map is not
+    /// scripted — nothing in these tests reads it through the probe.
+    struct FixedProbe {
+        phase: SourcePhase,
+        len: Option<u64>,
+        position: Arc<AtomicU64>,
+    }
+
+    impl SourceProbe for FixedProbe {
+        fn phase(&self) -> SourcePhase {
+            self.phase
+        }
+        fn phase_at(&self, _range: Range<u64>) -> SourcePhase {
+            self.phase
+        }
+        fn position(&self) -> u64 {
+            self.position.load(Ordering::Acquire)
+        }
+        fn set_position(&self, pos: u64) {
+            self.position.store(pos, Ordering::Release);
+        }
+        fn len(&self) -> Option<u64> {
+            self.len
+        }
+        fn byte_map(&self) -> Option<Arc<dyn crate::ByteMap>> {
+            None
+        }
     }
 
     struct ScriptSource {
@@ -861,6 +901,14 @@ mod tests {
 
         fn phase_at(&self, _range: Range<u64>) -> SourcePhase {
             SourcePhase::Waiting
+        }
+
+        fn probe(&self) -> Arc<dyn SourceProbe> {
+            Arc::new(FixedProbe {
+                phase: SourcePhase::Waiting,
+                len: Some(self.data.len() as u64),
+                position: Arc::clone(&self.position),
+            })
         }
 
         fn playhead_read(&self) -> Arc<dyn PlayheadRead> {
@@ -1024,6 +1072,14 @@ mod tests {
             SourcePhase::Ready
         }
 
+        fn probe(&self) -> Arc<dyn SourceProbe> {
+            Arc::new(FixedProbe {
+                phase: SourcePhase::Ready,
+                len: Some(4),
+                position: Arc::clone(&self.position),
+            })
+        }
+
         fn playhead_read(&self) -> Arc<dyn PlayheadRead> {
             Arc::clone(&self.playhead) as Arc<dyn PlayheadRead>
         }
@@ -1146,39 +1202,6 @@ mod tests {
         assert!(
             !wake.flush(),
             "the consumer path notifies immediately — nothing is left armed"
-        );
-    }
-
-    #[kithara::test]
-    fn probe_seek_moves_cursor_and_arms_without_priming() {
-        // On-core seek: set the cursor and arm the peer (the shell flushes),
-        // with NO prime_seek_range spin — so it returns immediately even when
-        // the target range is not ready (the wait script is never consulted).
-        let wake = Arc::new(DeferredWake::default());
-        let source = ScriptSource::new(
-            Arc::new(SeekState::new()),
-            [WaitOutcome::Interrupted, WaitOutcome::Interrupted],
-            [],
-            vec![0u8; 100],
-        )
-        .with_peer_wake(Arc::clone(&wake));
-        let mut stream = Stream::<DummyType> { source };
-
-        let started = Instant::now();
-        let pos = stream
-            .probe_seek(SeekFrom::Start(42))
-            .expect("absolute on-core seek within range");
-        let elapsed = started.elapsed();
-
-        assert_eq!(pos, 42);
-        assert_eq!(stream.source.position(), 42, "cursor moved to the target");
-        assert!(
-            elapsed < Duration::from_millis(2),
-            "probe_seek must not prime/spin (the consumer Seek would); took {elapsed:?}"
-        );
-        assert!(
-            wake.flush(),
-            "probe_seek armed the peer wake on the produce core; the shell flushes it"
         );
     }
 

--- a/tests/fuzz/fuzz_targets/stream_read_seek.rs
+++ b/tests/fuzz/fuzz_targets/stream_read_seek.rs
@@ -15,11 +15,43 @@ use kithara::{
     platform::{time::Duration, tokio::runtime::Builder},
     storage::WaitOutcome,
     stream::{
-        Activity, PlayheadRead, PlayheadState, PlayheadWrite, ReadOutcome, SeekControl,
-        SeekObserve, SeekState, Source, SourcePhase, Stream, StreamResult, StreamType,
+        Activity, ByteMap, PlayheadRead, PlayheadState, PlayheadWrite, ReadOutcome, SeekControl,
+        SeekObserve, SeekState, Source, SourcePhase, SourceProbe, Stream, StreamResult, StreamType,
     },
 };
 use libfuzzer_sys::fuzz_target;
+
+/// Always-ready byte-space probe sharing the fuzz source's cursor and length.
+struct ReadyProbe {
+    len: u64,
+    position: Arc<AtomicU64>,
+}
+
+impl SourceProbe for ReadyProbe {
+    fn phase(&self) -> SourcePhase {
+        SourcePhase::Ready
+    }
+
+    fn phase_at(&self, _range: Range<u64>) -> SourcePhase {
+        SourcePhase::Ready
+    }
+
+    fn position(&self) -> u64 {
+        self.position.load(Ordering::Acquire)
+    }
+
+    fn set_position(&self, pos: u64) {
+        self.position.store(pos, Ordering::Release);
+    }
+
+    fn len(&self) -> Option<u64> {
+        Some(self.len)
+    }
+
+    fn byte_map(&self) -> Option<Arc<dyn ByteMap>> {
+        None
+    }
+}
 
 #[derive(Debug)]
 enum WaitStep {
@@ -171,6 +203,13 @@ impl Source for ScriptSource {
 
     fn phase_at(&self, _range: Range<u64>) -> SourcePhase {
         SourcePhase::Ready
+    }
+
+    fn probe(&self) -> Arc<dyn SourceProbe> {
+        Arc::new(ReadyProbe {
+            len: self.data.len() as u64,
+            position: Arc::clone(&self.position),
+        })
     }
 
     fn len(&self) -> Option<u64> {

--- a/tests/src/memory_source.rs
+++ b/tests/src/memory_source.rs
@@ -11,8 +11,9 @@ use kithara::{
     platform::{sync::Arc, time::Duration},
     storage::WaitOutcome,
     stream::{
-        Activity, PlayheadRead, PlayheadState, PlayheadWrite, ReadOutcome, SeekControl,
-        SeekObserve, SeekState, Source, SourceError, SourcePhase, Stream, StreamResult, StreamType,
+        Activity, ByteMap, PlayheadRead, PlayheadState, PlayheadWrite, ReadOutcome, SeekControl,
+        SeekObserve, SeekState, Source, SourceError, SourcePhase, SourceProbe, Stream,
+        StreamResult, StreamType,
     },
 };
 
@@ -20,6 +21,59 @@ use kithara::{
 #[derive(Debug, thiserror::Error)]
 #[error("memory source error")]
 pub struct MemorySourceError;
+
+/// Constant-length byte-space probe shared by the fixed-size test sources:
+/// `Eof` at or past the known total, `Ready` otherwise — mirroring each
+/// source's own `phase_at`. `None` total never reaches `Eof`. `reported`
+/// mirrors the source's `len()` answer, which may hide the actual total
+/// (`MemorySource::without_len`).
+pub struct LenPhaseProbe {
+    total: Option<u64>,
+    reported: Option<u64>,
+    position: Arc<AtomicU64>,
+}
+
+impl LenPhaseProbe {
+    #[must_use]
+    pub fn new(total: Option<u64>, reported: Option<u64>, position: Arc<AtomicU64>) -> Self {
+        Self {
+            total,
+            reported,
+            position,
+        }
+    }
+}
+
+impl SourceProbe for LenPhaseProbe {
+    fn phase(&self) -> SourcePhase {
+        let pos = self.position.load(Ordering::Acquire);
+        self.phase_at(pos..pos.saturating_add(1))
+    }
+
+    fn phase_at(&self, range: Range<u64>) -> SourcePhase {
+        if self.total.is_some_and(|total| range.start >= total) {
+            SourcePhase::Eof
+        } else {
+            SourcePhase::Ready
+        }
+    }
+
+    fn position(&self) -> u64 {
+        self.position.load(Ordering::Acquire)
+    }
+
+    fn set_position(&self, pos: u64) {
+        self.position.store(pos, Ordering::Release);
+    }
+
+    fn len(&self) -> Option<u64> {
+        self.reported
+    }
+
+    fn byte_map(&self) -> Option<Arc<dyn ByteMap>> {
+        None
+    }
+}
 
 /// In-memory source for testing Source-based readers.
 ///
@@ -74,6 +128,14 @@ impl Source for MemorySource {
         } else {
             SourcePhase::Ready
         }
+    }
+
+    fn probe(&self) -> Arc<dyn SourceProbe> {
+        Arc::new(LenPhaseProbe::new(
+            Some(self.data.len() as u64),
+            self.len(),
+            Arc::clone(&self.position),
+        ))
     }
 
     fn position(&self) -> u64 {

--- a/tests/src/signal_source.rs
+++ b/tests/src/signal_source.rs
@@ -12,11 +12,12 @@ use kithara::{
     stream::{
         Activity, AudioCodec, ContainerFormat, MediaInfo, PlayheadRead, PlayheadState,
         PlayheadWrite, ReadOutcome, SeekControl, SeekObserve, SeekState, Source, SourceError,
-        SourcePhase, Stream, StreamResult, StreamType,
+        SourcePhase, SourceProbe, Stream, StreamResult, StreamType,
     },
 };
 
 use crate::{
+    memory_source::LenPhaseProbe,
     signal_pcm::{SignalPcm, signal},
     wav::WavHeader,
 };
@@ -87,6 +88,14 @@ impl<S: signal::SignalFn + Sync> Source for SignalSource<S> {
         } else {
             SourcePhase::Ready
         }
+    }
+
+    fn probe(&self) -> Arc<dyn SourceProbe> {
+        Arc::new(LenPhaseProbe::new(
+            self.total_byte_len(),
+            self.total_byte_len(),
+            Arc::clone(&self.position),
+        ))
     }
 
     fn position(&self) -> u64 {

--- a/tests/tests/kithara_stream/reader_seek_overflow.rs
+++ b/tests/tests/kithara_stream/reader_seek_overflow.rs
@@ -13,8 +13,8 @@ use kithara::{
     platform::{sync::Arc, time::Duration, tokio::runtime::Runtime},
     storage::WaitOutcome,
     stream::{
-        Activity, PlayheadRead, PlayheadState, PlayheadWrite, ReadOutcome, SeekControl,
-        SeekObserve, SeekState, Source, SourcePhase, Stream, StreamResult, StreamType,
+        Activity, ByteMap, PlayheadRead, PlayheadState, PlayheadWrite, ReadOutcome, SeekControl,
+        SeekObserve, SeekState, Source, SourcePhase, SourceProbe, Stream, StreamResult, StreamType,
     },
 };
 
@@ -103,8 +103,47 @@ impl Source for MockSource {
         SourcePhase::Ready
     }
 
+    fn probe(&self) -> Arc<dyn SourceProbe> {
+        Arc::new(ReadyProbe {
+            len: self.reported_len,
+            position: Arc::clone(&self.position),
+        })
+    }
+
     fn len(&self) -> Option<u64> {
         Some(self.reported_len)
+    }
+}
+
+/// Always-ready byte-space probe sharing `MockSource`'s cursor and length.
+struct ReadyProbe {
+    len: u64,
+    position: Arc<AtomicU64>,
+}
+
+impl SourceProbe for ReadyProbe {
+    fn phase(&self) -> SourcePhase {
+        SourcePhase::Ready
+    }
+
+    fn phase_at(&self, _range: Range<u64>) -> SourcePhase {
+        SourcePhase::Ready
+    }
+
+    fn position(&self) -> u64 {
+        self.position.load(Ordering::Acquire)
+    }
+
+    fn set_position(&self, pos: u64) {
+        self.position.store(pos, Ordering::Release);
+    }
+
+    fn len(&self) -> Option<u64> {
+        Some(self.len)
+    }
+
+    fn byte_map(&self) -> Option<Arc<dyn ByteMap>> {
+        None
     }
 }
 


### PR DESCRIPTION
# fix(audio,stream): serve RT byte-space polls off the control mutex

## Defect

Stress run №4 on `main` (rtsan-hls lane) aborted with an RTSan `sched_yield` on the RT produce tick. Root cause: the audio worker's gate frames (`source_is_ready`, `source_phase_forward`, `seek_landing_end`, `recreate_ready_range`, `source_park`, `post_seek_anchor_offset`) reached the source through `SharedStream`'s `Mutex<Stream>` — not just for `phase_at`, but for `position()`, `len()`, `byte_map()`, `abr_handle()`, and `format_change_segment_range()` in the same RT frames. The off-RT holder is a construction reader parked in `Stream::read` → `Source::wait_range(range, None)` **under that mutex**; any contended acquire on the produce core goes through `parking_lot`'s `lock_slow` → `sched_yield` → RTSan abort.

## Fix

- New narrow trait `SourceProbe` in `kithara-stream` (`phase`, `phase_at`, `position`, `set_position`, `len`, `byte_map`) — an `Arc` handle answering from the source's self-synchronizing state; implementations must not take locks a reader wait can hold. Production owners: `HlsProbe` (over `Arc<HlsCoord>`, arc-swapped sessions) and `FileProbe` (over `Arc<FileInner>`).
- `SharedStream::new` resolves `probe`, `abr_handle`, `variant_control`, and `peer_wake` once, before the stream enters the mutex. Every RT byte-space call — `phase`/`phase_at`, `position`/`set_position`, `len`, `byte_map`, `abr_handle`, `format_change_segment_range`, and the new lock-free `probe_seek` — now answers without `inner.lock()`.
- `resolve_seek_target` extracted as a free fn in `kithara-stream`: `Stream::seek` and `SharedStream::probe_seek` resolve identically. `Stream::probe_seek` (now caller-less) removed. `format_change_segment_range` likewise has one owner (free fn shared by `Stream` and `SharedStream`).
- The `hold_control_lock` test seam is gone. The contract test now uses a real holder: a construction read (armed `ConstructionGate` → blocking `Stream::read`) parks in `Source::wait_range` via a `WaitPark` rendezvous while the test drives the real gate entry points (`source_is_ready`, `source_phase_for_wait_context`) plus `abr_handle` / `format_change_segment_range` / `probe_seek` under the genuinely held mutex. Regression mode is a hang caught by the harness watchdog.
- CONTEXT.md (kithara-stream, kithara-audio) documents the probe contract, the three remaining lock sites on RT frames (`probe_read`, `media_info`, `seek_time_anchor`) and the `RebuildingDecoder`-only exclusion window that keeps them safe, and the single-cursor-writer invariant behind `probe_seek`.

## Validation

- `just fmt`, `just lint fast` green.
- Full `just test`: 4051/4051 passed.
- Guardian architecture review: Accept (re-review after an initial Reject; B1/B2/N1/N3/N4 closed).
- Targeted rtsan-hls stress on this revision: dispatched after push (see PR comments).

## Follow-ups (non-blocking, from review)

- Probe↔source equivalence tests for `HlsProbe`/`FileProbe`.
- Dedup of near-identical test probe types (`LenPhaseProbe` already generalizes the shape).

https://claude.ai/code/session_01NjMEC8QeNE5TCKBjXRGyKA
