### PR TITLE
fix(queue,play): stop advancing the queue on a background slot's end

### DIFF
--- a/crates/kithara-events/src/play.rs
+++ b/crates/kithara-events/src/play.rs
@@ -339,6 +339,7 @@ pub enum PlayerEvent {
     ItemDidFail {
         src: Arc<str>,
         item_id: Option<Arc<str>>,
+        from_current_item: bool,
     },
     /// Leading track entered the prefetch window — arm the next slot.
     PrefetchRequested,

--- a/crates/kithara-events/src/play.rs
+++ b/crates/kithara-events/src/play.rs
@@ -317,9 +317,18 @@ pub enum PlayerEvent {
     /// promoted the next track. `item_id` is the optional caller-side
     /// item identifier (FFI bindings tag tracks with stable UUIDs;
     /// internal callers may leave it `None`).
+    ///
+    /// `from_current_item` is the player's own answer to "was this the
+    /// track the listener was hearing?". The player walks every active
+    /// slot, so a preloaded successor or a lingering predecessor that
+    /// decodes ahead publishes its own end while the current track is
+    /// seconds old; only the player knows which slot is current, and
+    /// `src` alone cannot be compared against a queue entry reliably.
+    /// Auto-advance must key on this flag, not on `src`.
     ItemDidPlayToEnd {
         src: Arc<str>,
         item_id: Option<Arc<str>>,
+        from_current_item: bool,
     },
     /// A track aborted mid-stream because the underlying decoder /
     /// source reported a non-recoverable error. Distinct from

--- a/crates/kithara-ffi/src/core/convert.rs
+++ b/crates/kithara-ffi/src/core/convert.rs
@@ -833,6 +833,7 @@ mod tests {
         let event = PlayerEvent::ItemDidFail {
             src: "src".into(),
             item_id: Some("7".into()),
+            from_current_item: true,
         };
 
         assert!(matches!(

--- a/crates/kithara-ffi/src/native/bridge/event_bridge.rs
+++ b/crates/kithara-ffi/src/native/bridge/event_bridge.rs
@@ -759,6 +759,7 @@ mod tests {
             .publish(Event::Player(PlayerEvent::ItemDidPlayToEnd {
                 src: Arc::from(format!("test://memory/{}", id.as_u64())),
                 item_id: None,
+                from_current_item: true,
             }));
 
         let cancel = CancelToken::root();

--- a/crates/kithara-play/CONTEXT.md
+++ b/crates/kithara-play/CONTEXT.md
@@ -93,6 +93,15 @@ The `PlayerEvent` / `ItemEvent` / `EngineEvent` / `SessionEvent` / `DjEvent` enu
 `SessionDuckingMode` is owned by this crate and maps `Off` / `Soft` / `Hard` to session-output
 gains `1.0` / `0.4` / `0.2`.
 
+**`ItemDidPlayToEnd` carries which slot ended.** `process_notifications` drains *every* active
+slot, so a preloaded successor or a lingering predecessor decoding ahead publishes its own natural
+end while the current track is seconds old. Only this crate knows which slot the phase holds, so
+the event carries the answer as `from_current_item` (`slot() == Some(ended_slot)`), taken in
+`dispatch_notification` before `finalize_handover_if_armed` can move the phase. Consumers must key
+auto-advance on that flag, never on `src`: `src` identifies a rendered resource, not a queue entry.
+With a crossfade the incoming slot was already promoted by `commit_next`, so the outgoing end
+reports `false` and the queue advances on its own pre-arm instead.
+
 ## Queue Auto-Advance
 
 `PlayerImpl` exposes a handover API for external orchestrators and internal tests:

--- a/crates/kithara-play/CONTEXT.md
+++ b/crates/kithara-play/CONTEXT.md
@@ -93,14 +93,15 @@ The `PlayerEvent` / `ItemEvent` / `EngineEvent` / `SessionEvent` / `DjEvent` enu
 `SessionDuckingMode` is owned by this crate and maps `Off` / `Soft` / `Hard` to session-output
 gains `1.0` / `0.4` / `0.2`.
 
-**`ItemDidPlayToEnd` carries which slot ended.** `process_notifications` drains *every* active
-slot, so a preloaded successor or a lingering predecessor decoding ahead publishes its own natural
-end while the current track is seconds old. Only this crate knows which slot the phase holds, so
-the event carries the answer as `from_current_item` (`slot() == Some(ended_slot)`), taken in
-`dispatch_notification` before `finalize_handover_if_armed` can move the phase. Consumers must key
-auto-advance on that flag, never on `src`: `src` identifies a rendered resource, not a queue entry.
-With a crossfade the incoming slot was already promoted by `commit_next`, so the outgoing end
-reports `false` and the queue advances on its own pre-arm instead.
+**`ItemDidPlayToEnd` and `ItemDidFail` carry which slot stopped.** `process_notifications` drains
+*every* active slot, so a preloaded successor or a lingering predecessor decoding ahead publishes
+its own end — natural or failed — while the current track is seconds old. Only this crate knows
+which slot the phase holds, so both events carry the answer as `from_current_item` (`slot() ==
+Some(stopped_slot)`), taken in `dispatch_notification` before `finalize_handover_if_armed` can move
+the phase. Consumers must key auto-advance on that flag, never on `src`: `src` identifies a
+rendered resource, not a queue entry. With a crossfade the incoming slot was already promoted by
+`commit_next`, so the outgoing end reports `false` and the queue advances on its own pre-arm
+instead.
 
 ## Queue Auto-Advance
 

--- a/crates/kithara-play/src/player/flow/notify.rs
+++ b/crates/kithara-play/src/player/flow/notify.rs
@@ -206,9 +206,8 @@ impl PlayerImpl {
     }
 }
 
-/// `from_current_item` answers whether the ending slot is the one the
-/// phase currently holds; it is carried only by
-/// [`PlayerEvent::ItemDidPlayToEnd`].
+/// `from_current_item` answers whether the stopping slot is the one the
+/// phase currently holds.
 pub(crate) fn player_event_from_notification(
     notification: PlayerNotification,
     from_current_item: bool,
@@ -229,7 +228,11 @@ pub(crate) fn player_event_from_notification(
             src,
             item_id,
             ..
-        } => Some(PlayerEvent::ItemDidFail { src, item_id }),
+        } => Some(PlayerEvent::ItemDidFail {
+            src,
+            item_id,
+            from_current_item,
+        }),
         _ => None,
     }
 }
@@ -324,6 +327,26 @@ mod tests {
             event,
             Some(PlayerEvent::ItemDidPlayToEnd {
                 from_current_item: true,
+                ..
+            })
+        ));
+    }
+
+    #[kithara::test]
+    fn failed_playback_stopped_notification_carries_the_current_item_answer() {
+        let event = player_event_from_notification(
+            PlayerNotification::PlaybackStopped {
+                src: Arc::from("track.mp3"),
+                item_id: None,
+                reason: TrackPlaybackStopReason::Failed,
+                seek_epoch: 0,
+            },
+            false,
+        );
+        assert!(matches!(
+            event,
+            Some(PlayerEvent::ItemDidFail {
+                from_current_item: false,
                 ..
             })
         ));

--- a/crates/kithara-play/src/player/flow/notify.rs
+++ b/crates/kithara-play/src/player/flow/notify.rs
@@ -35,6 +35,7 @@ impl Notifier<'_> {
             );
             return;
         }
+        let from_current_item = self.slot() == Some(slot_id);
         let emitted = player_events_from_notification(self, &notification);
         let emitted_any = !emitted.is_empty();
         for event in emitted {
@@ -52,10 +53,12 @@ impl Notifier<'_> {
                 reason: TrackPlaybackStopReason::Eof,
                 ..
             } => {
-                self.handle_track_playback_stopped(notification);
+                self.handle_track_playback_stopped(from_current_item, notification);
             }
             _ => {
-                if let Some(event) = player_event_from_notification(notification.clone()) {
+                if let Some(event) =
+                    player_event_from_notification(notification.clone(), from_current_item)
+                {
                     self.core.engine.bus().publish(event);
                 } else if !emitted_any {
                     tracing::trace!(
@@ -130,8 +133,17 @@ impl Notifier<'_> {
         }
     }
 
-    fn handle_track_playback_stopped(&self, notification: PlayerNotification) {
-        if let Some(event) = player_event_from_notification(notification) {
+    /// `from_current_item` is read before `finalize_handover_if_armed`
+    /// runs, so the phase still names the slot that ended. With a
+    /// crossfade the incoming slot was already promoted by `commit_next`,
+    /// so an outgoing end reports `false` — the queue advanced on the
+    /// pre-arm instead.
+    fn handle_track_playback_stopped(
+        &self,
+        from_current_item: bool,
+        notification: PlayerNotification,
+    ) {
+        if let Some(event) = player_event_from_notification(notification, from_current_item) {
             self.core.engine.bus().publish(event);
         }
 
@@ -194,8 +206,12 @@ impl PlayerImpl {
     }
 }
 
+/// `from_current_item` answers whether the ending slot is the one the
+/// phase currently holds; it is carried only by
+/// [`PlayerEvent::ItemDidPlayToEnd`].
 pub(crate) fn player_event_from_notification(
     notification: PlayerNotification,
+    from_current_item: bool,
 ) -> Option<PlayerEvent> {
     match notification {
         PlayerNotification::PlaybackStopped {
@@ -203,7 +219,11 @@ pub(crate) fn player_event_from_notification(
             src,
             item_id,
             ..
-        } => Some(PlayerEvent::ItemDidPlayToEnd { src, item_id }),
+        } => Some(PlayerEvent::ItemDidPlayToEnd {
+            src,
+            item_id,
+            from_current_item,
+        }),
         PlayerNotification::PlaybackStopped {
             reason: TrackPlaybackStopReason::Failed,
             src,
@@ -255,30 +275,104 @@ fn player_events_from_notification(
 
 #[cfg(test)]
 mod tests {
+    use kithara_events::{Envelope, Event, EventReceiver};
     use kithara_platform::sync::Arc;
     use kithara_test_utils::kithara;
 
     use super::*;
+    use crate::{player::PlayerConfig, session::testing};
+
+    /// A started player holding one slot — the slot the phase calls current.
+    fn player_with_slot() -> (PlayerImpl, SlotId) {
+        let player = PlayerImpl::new(
+            PlayerConfig::test_builder()
+                .session(testing::test_session())
+                .build(),
+        );
+        player
+            .ensure_engine_started()
+            .expect("engine start must succeed");
+        let slot = player.ensure_slot().expect("slot allocation must succeed");
+        (player, slot)
+    }
+
+    fn eof_notification() -> PlayerNotification {
+        PlayerNotification::PlaybackStopped {
+            src: Arc::from("track.mp3"),
+            item_id: None,
+            reason: TrackPlaybackStopReason::Eof,
+            seek_epoch: 0,
+        }
+    }
+
+    fn published_end_flag(rx: &mut EventReceiver) -> Option<bool> {
+        while let Ok(Envelope { event, .. }) = rx.try_recv() {
+            if let Event::Player(PlayerEvent::ItemDidPlayToEnd {
+                from_current_item, ..
+            }) = event
+            {
+                return Some(from_current_item);
+            }
+        }
+        None
+    }
 
     #[kithara::test]
     fn eof_playback_stopped_notification_maps_to_item_end_event() {
-        let event = player_event_from_notification(PlayerNotification::PlaybackStopped {
-            src: Arc::from("track.mp3"),
-            item_id: Some(Arc::from("item-1")),
-            reason: TrackPlaybackStopReason::Eof,
-            seek_epoch: 0,
-        });
-        assert!(matches!(event, Some(PlayerEvent::ItemDidPlayToEnd { .. })));
+        let event = player_event_from_notification(eof_notification(), true);
+        assert!(matches!(
+            event,
+            Some(PlayerEvent::ItemDidPlayToEnd {
+                from_current_item: true,
+                ..
+            })
+        ));
     }
 
     #[kithara::test]
     fn playback_stopped_notification_does_not_map_to_item_end_event() {
-        let event = player_event_from_notification(PlayerNotification::PlaybackStopped {
-            src: Arc::from("track.mp3"),
-            item_id: Some(Arc::from("item-1")),
-            reason: TrackPlaybackStopReason::Stop,
-            seek_epoch: 0,
-        });
+        let event = player_event_from_notification(
+            PlayerNotification::PlaybackStopped {
+                src: Arc::from("track.mp3"),
+                item_id: None,
+                reason: TrackPlaybackStopReason::Stop,
+                seek_epoch: 0,
+            },
+            true,
+        );
         assert!(event.is_none());
+    }
+
+    #[kithara::test]
+    fn end_of_the_held_slot_is_reported_as_the_current_item() {
+        let (player, slot) = player_with_slot();
+        let mut rx = player.subscribe();
+
+        Notifier::new(&player).dispatch_notification(slot, eof_notification());
+
+        assert_eq!(
+            published_end_flag(&mut rx),
+            Some(true),
+            "the slot the phase holds is the item the listener hears"
+        );
+    }
+
+    /// `process_notifications` drains every active slot. An end minted by a
+    /// slot the phase does not hold — a preloaded successor, or a
+    /// predecessor still decoding after a switch — must not be reported as
+    /// the current item, or the queue advances off a track still playing.
+    #[kithara::test]
+    fn end_of_a_background_slot_is_not_reported_as_the_current_item() {
+        let (player, slot) = player_with_slot();
+        let background = SlotId::new(slot.value() + 1);
+        let mut rx = player.subscribe();
+
+        Notifier::new(&player).dispatch_notification(background, eof_notification());
+
+        assert_eq!(
+            published_end_flag(&mut rx),
+            Some(false),
+            "an end from a slot the phase does not hold is not the current item"
+        );
     }
 }

--- a/crates/kithara-queue/CONTEXT.md
+++ b/crates/kithara-queue/CONTEXT.md
@@ -145,7 +145,12 @@ seeking — not from `PlayerImpl::current_index`.
   pos/dur heuristic (advance when `pos >= dur - 1.0s`, else log a spurious crossfade
   fade-out).
 - `ItemDidFail` → status `Failed`, `TrackLoadFailed { auto_skipped: true }`, then
-  `advance_to_next(Transition::None, TrackFailed)`.
+  `advance_to_next(Transition::None, TrackFailed)` — gated on `from_current_item` for
+  the same reason as `ItemDidPlayToEnd`. A background slot's failure is dropped
+  outright rather than flagged against a queue entry: the event carries no track
+  identity beyond `src`, so acting on it would take the wrong entry out of selection
+  for the rest of the session. Load-time failures reach the queue through the loader,
+  not through this path.
 - Both handlers publish `QueueEnded` when `current()` is `None`: a stale EOF after
   queue end must not restart from the first track.
 - `tick()` → `maybe_arm_crossfade`: `should_arm_crossfade` requires `crossfade > 0`,

--- a/crates/kithara-queue/CONTEXT.md
+++ b/crates/kithara-queue/CONTEXT.md
@@ -133,9 +133,17 @@ seeking — not from `PlayerImpl::current_index`.
 - `HandoverRequested` → `advance_loaded_successor`, which selects the successor only
   if it is already `Loaded`. The queue never consumes `PrefetchRequested` and never
   calls `arm_next` / `commit_next`.
-- `ItemDidPlayToEnd`: a non-empty `src` is the authoritative natural-EOF signal →
-  `advance_to_next(Crossfade, NaturalEof)`. An empty `src` falls back to the pos/dur
-  heuristic (advance when `pos >= dur - 1.0s`, else log a spurious crossfade fade-out).
+- `ItemDidPlayToEnd`: `PlayerImpl::process_notifications` walks every active slot, so
+  the event names whichever track hit EOF — a preloaded successor or a lingering
+  predecessor decoding ahead reaches its own end while the current track is seconds
+  old. Advance (`advance_to_next(Crossfade, NaturalEof)`) only when the event carries
+  `from_current_item: true`. That flag is the player's own answer (`slot() ==
+  Some(ended_slot)`), and it is the only trustworthy one: `src` is a rendered resource
+  identifier, not a queue key — `file://` URLs arrive as bare paths and `track_id_for_src`
+  returns the first entry carrying a source, so a duplicated or repeat-all track resolves
+  to a sibling. A `from_current_item: true` event with an empty `src` falls back to the
+  pos/dur heuristic (advance when `pos >= dur - 1.0s`, else log a spurious crossfade
+  fade-out).
 - `ItemDidFail` → status `Failed`, `TrackLoadFailed { auto_skipped: true }`, then
   `advance_to_next(Transition::None, TrackFailed)`.
 - Both handlers publish `QueueEnded` when `current()` is `None`: a stale EOF after

--- a/crates/kithara-queue/src/queue/engine_events.rs
+++ b/crates/kithara-queue/src/queue/engine_events.rs
@@ -144,20 +144,12 @@ impl Queue {
         let _ = self.advance_to_next(Transition::None, AdvanceReason::TrackFailed);
     }
 
-    /// Decide whether `ItemDidPlayToEnd` advances the queue or is
-    /// filtered as a stale crossfade fade-out signal.
-    ///
-    /// `src` identifies the underlying audio source of the track that
-    /// just hit EOF. The player only emits `TrackPlaybackStopped` from
-    /// its natural-EOF path (`handle_eof`), so a non-empty `src` is the
-    /// authoritative end-of-track signal: advance unconditionally
-    /// (subject to crossfade pre-arm consumption).
-    ///
-    /// The empty-`src` arm preserves backward compatibility for
-    /// pre-PR-#64 callers and acts as a defensive fallback when the
-    /// player has not yet wired the src through; it falls back to the
-    /// pos/dur tolerance heuristic to filter spurious events.
-    pub(super) fn handle_item_did_play_to_end(&self, src: &Arc<str>) {
+    /// `from_current_item` is the player's verdict on whether the slot
+    /// that ended is the one being heard. The player walks every active
+    /// slot, so a preloaded successor or a lingering predecessor that
+    /// decodes ahead reports its own end while the current track still
+    /// has minutes left; advancing on that end cuts the current track.
+    pub(super) fn handle_item_did_play_to_end(&self, src: &Arc<str>, from_current_item: bool) {
         let snap = self.player.playback_snapshot();
         let pos = snap.map_or(0.0, |s| s.position());
         let dur = snap.map_or(0.0, |s| s.duration());
@@ -174,6 +166,10 @@ impl Queue {
         if self.consume_armed_advance(ended_id, pos, dur) {
             return;
         }
+        if !from_current_item {
+            debug!(%src, pos, dur, "filtered ItemDidPlayToEnd from a background slot");
+            return;
+        }
         if src.is_empty() {
             self.dispatch_real_or_spurious(pos, dur);
         } else {
@@ -183,8 +179,12 @@ impl Queue {
 
     pub(super) fn process_player_event(&self, ev: &Event) {
         match ev {
-            Event::Player(PlayerEvent::ItemDidPlayToEnd { src, .. }) => {
-                self.handle_item_did_play_to_end(src);
+            Event::Player(PlayerEvent::ItemDidPlayToEnd {
+                src,
+                from_current_item,
+                ..
+            }) => {
+                self.handle_item_did_play_to_end(src, *from_current_item);
             }
             Event::Player(PlayerEvent::ItemDidFail { src, .. }) => {
                 self.handle_item_did_fail(src);

--- a/crates/kithara-queue/src/queue/engine_events.rs
+++ b/crates/kithara-queue/src/queue/engine_events.rs
@@ -113,7 +113,13 @@ impl Queue {
         self.advance_loaded_successor(entry.id, Transition::Crossfade);
     }
 
-    pub(super) fn handle_item_did_fail(&self, src: &Arc<str>) {
+    /// Gated on `from_current_item` for the same reason as
+    /// [`Self::handle_item_did_play_to_end`]: the player reports the slot
+    /// that aborted, not the one being heard. A background slot's failure
+    /// must neither skip the current track nor flag a queue entry — the
+    /// event carries no track identity beyond `src`, and `track_id_for_src`
+    /// resolves it to the first entry with that source.
+    pub(super) fn handle_item_did_fail(&self, src: &Arc<str>, from_current_item: bool) {
         let snap = self.player.playback_snapshot();
         let pos = snap.map_or(0.0, |s| s.position());
         let dur = snap.map_or(0.0, |s| s.duration());
@@ -128,6 +134,10 @@ impl Queue {
         }
         let ended_id = self.track_id_for_src(src);
         if self.consume_armed_advance(ended_id, pos, dur) {
+            return;
+        }
+        if !from_current_item {
+            debug!(%src, pos, dur, "filtered ItemDidFail from a background slot");
             return;
         }
         if let Some(id) = ended_id {
@@ -186,8 +196,12 @@ impl Queue {
             }) => {
                 self.handle_item_did_play_to_end(src, *from_current_item);
             }
-            Event::Player(PlayerEvent::ItemDidFail { src, .. }) => {
-                self.handle_item_did_fail(src);
+            Event::Player(PlayerEvent::ItemDidFail {
+                src,
+                from_current_item,
+                ..
+            }) => {
+                self.handle_item_did_fail(src, *from_current_item);
             }
             Event::Player(PlayerEvent::CurrentItemChanged) => {
                 self.handle_current_item_changed();

--- a/crates/kithara-queue/src/queue/playback.rs
+++ b/crates/kithara-queue/src/queue/playback.rs
@@ -260,6 +260,7 @@ mod tests {
             .publish(Event::Player(PlayerEvent::ItemDidPlayToEnd {
                 src: Arc::from(""),
                 item_id: None,
+                from_current_item: true,
             }));
 
         queue
@@ -285,6 +286,7 @@ mod tests {
             .publish(Event::Player(PlayerEvent::ItemDidPlayToEnd {
                 src: Arc::from(format!("test://memory/{}", b.as_u64())),
                 item_id: None,
+                from_current_item: true,
             }));
 
         queue

--- a/tests/tests/kithara_queue/background_track_eof.rs
+++ b/tests/tests/kithara_queue/background_track_eof.rs
@@ -1,0 +1,156 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+//! `ItemDidPlayToEnd` is published for whichever slot hit EOF, not for
+//! the current one: `PlayerImpl::process_notifications` walks every
+//! active slot. A preloaded successor or a lingering predecessor that
+//! decodes ahead reaches its own end while the current track is seconds
+//! old, and the event names that background track — not the one the
+//! listener is hearing. The player answers which it was in
+//! `from_current_item`; the queue must key auto-advance on that answer.
+
+use std::num::NonZero;
+
+use kithara::{
+    self,
+    decode::PcmSpec,
+    events::{Event, PlayerEvent, TrackId},
+    platform::sync::Arc,
+    queue::{Queue, QueueConfig, Transition},
+};
+use kithara_integration_tests::{
+    audio_mock::TestPcmReader,
+    offline::{OfflinePlayerHarness, OfflinePlayerOptions, resource_from_reader_with_src},
+};
+
+const SAMPLE_RATE: u32 = 44_100;
+const CHANNELS: u16 = 2;
+const BLOCK_FRAMES: usize = 512;
+/// ≈ 0.74 s of rendered audio — far short of `TRACK_SECS`.
+const WARMUP_BLOCKS: usize = 64;
+const TRACK_SECS: f64 = 30.0;
+const LOUD: f32 = 0.80;
+const QUIET: f32 = 0.10;
+
+fn make_fixture() -> (OfflinePlayerHarness, Queue) {
+    let harness = OfflinePlayerHarness::with_sample_rate(
+        OfflinePlayerOptions::builder()
+            .crossfade_duration(0.0)
+            .build(),
+        SAMPLE_RATE,
+    );
+    let config = QueueConfig::builder()
+        .player(Arc::clone(harness.player()))
+        .should_autoplay(false)
+        .build();
+    (harness, Queue::new(config))
+}
+
+/// Load a track whose player-side `src` is its queue URI, the way a real
+/// source arrives: `Queue::track_id_for_src` resolves the EOF back to a
+/// queue entry through that string.
+fn loaded_track(queue: &Queue, value: f32) -> (TrackId, Arc<str>) {
+    let id = queue.register_for_test();
+    let src: Arc<str> = Arc::from(format!("test://memory/{}", id.as_u64()));
+    let spec = PcmSpec {
+        channels: CHANNELS,
+        sample_rate: NonZero::new(SAMPLE_RATE).unwrap(),
+    };
+    queue.complete_load_for_test(
+        id,
+        resource_from_reader_with_src(
+            TestPcmReader::with_value(spec, TRACK_SECS, value),
+            Arc::clone(&src),
+        ),
+    );
+    (id, src)
+}
+
+fn mean_abs(pcm: &[f32]) -> f32 {
+    if pcm.is_empty() {
+        return 0.0;
+    }
+    pcm.iter().map(|s| s.abs()).sum::<f32>() / pcm.len() as f32
+}
+
+fn render_loop(queue: &Queue, harness: &OfflinePlayerHarness, block_budget: usize) -> Vec<f32> {
+    let mut pcm = Vec::new();
+    for _ in 0..block_budget {
+        let _ = queue.tick();
+        pcm.extend(harness.render(BLOCK_FRAMES));
+    }
+    pcm
+}
+
+/// Three loaded tracks, the middle one playing. The first track — never
+/// selected, standing in for the background slot — reports natural EOF.
+fn fixture_with_background_eof() -> (OfflinePlayerHarness, Queue, Arc<str>, TrackId) {
+    let (harness, queue) = make_fixture();
+    let (_stale, stale_src) = loaded_track(&queue, QUIET);
+    let (current, _) = loaded_track(&queue, LOUD);
+    let (_next, _) = loaded_track(&queue, QUIET);
+    (harness, queue, stale_src, current)
+}
+
+/// Field log, 2026-08-26: a background HLS slot hit EOF 5 s after the
+/// current track started and the queue advanced on it, cutting a track
+/// with minutes left. The queue must key the advance on the track that
+/// ended being the current one.
+#[kithara::test(tokio)]
+async fn background_track_eof_does_not_advance_the_queue() {
+    let (harness, queue, stale_src, current) = fixture_with_background_eof();
+
+    queue
+        .select(current, Transition::None)
+        .expect("select the current track");
+    let _ = render_loop(&queue, &harness, WARMUP_BLOCKS);
+
+    harness
+        .player()
+        .bus()
+        .publish(Event::Player(PlayerEvent::ItemDidPlayToEnd {
+            src: stale_src,
+            item_id: None,
+            from_current_item: false,
+        }));
+    let _ = render_loop(&queue, &harness, WARMUP_BLOCKS);
+
+    assert_eq!(
+        queue.current_index(),
+        Some(1),
+        "EOF from a track that is not current must leave the current track selected"
+    );
+}
+
+/// The audible half of the same defect: the listener hears the current
+/// track handed over to the successor while it is still playing.
+#[kithara::test(tokio)]
+async fn background_track_eof_does_not_cut_the_current_track_audio() {
+    let (harness, queue, stale_src, current) = fixture_with_background_eof();
+
+    queue
+        .select(current, Transition::None)
+        .expect("select the current track");
+    let before_pcm = render_loop(&queue, &harness, WARMUP_BLOCKS);
+    let before = mean_abs(&before_pcm[before_pcm.len() / 2..]);
+    assert!(
+        before > 0.005,
+        "the current track must be audible before the background EOF: mean={before}"
+    );
+
+    harness
+        .player()
+        .bus()
+        .publish(Event::Player(PlayerEvent::ItemDidPlayToEnd {
+            src: stale_src,
+            item_id: None,
+            from_current_item: false,
+        }));
+    let after_pcm = render_loop(&queue, &harness, WARMUP_BLOCKS);
+    let after = mean_abs(&after_pcm[after_pcm.len() / 2..]);
+
+    assert!(
+        after > before / 2.0,
+        "the current track must keep sounding through a background track's EOF — \
+         the quieter successor took over instead: before={before}, after={after}"
+    );
+}

--- a/tests/tests/kithara_queue/background_track_failure.rs
+++ b/tests/tests/kithara_queue/background_track_failure.rs
@@ -1,0 +1,171 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+//! The failure twin of [`background_track_eof`]: `ItemDidFail` is
+//! published for whichever slot aborted, and `PlayerImpl::
+//! process_notifications` walks every active slot. A background slot
+//! whose decoder gives up must not skip the track being heard, and must
+//! not mark a queue entry failed on its behalf.
+//!
+//! [`background_track_eof`]: super::background_track_eof
+
+use std::num::NonZero;
+
+use kithara::{
+    self,
+    decode::PcmSpec,
+    events::{Event, PlayerEvent, TrackId, TrackStatus},
+    platform::sync::Arc,
+    queue::{Queue, QueueConfig, Transition},
+};
+use kithara_integration_tests::{
+    audio_mock::TestPcmReader,
+    offline::{OfflinePlayerHarness, OfflinePlayerOptions, resource_from_reader_with_src},
+};
+
+const SAMPLE_RATE: u32 = 44_100;
+const CHANNELS: u16 = 2;
+const BLOCK_FRAMES: usize = 512;
+/// ≈ 0.74 s of rendered audio — far short of `TRACK_SECS`.
+const WARMUP_BLOCKS: usize = 64;
+const TRACK_SECS: f64 = 30.0;
+const LOUD: f32 = 0.80;
+const QUIET: f32 = 0.10;
+
+fn make_fixture() -> (OfflinePlayerHarness, Queue) {
+    let harness = OfflinePlayerHarness::with_sample_rate(
+        OfflinePlayerOptions::builder()
+            .crossfade_duration(0.0)
+            .build(),
+        SAMPLE_RATE,
+    );
+    let config = QueueConfig::builder()
+        .player(Arc::clone(harness.player()))
+        .should_autoplay(false)
+        .build();
+    (harness, Queue::new(config))
+}
+
+fn loaded_track(queue: &Queue, value: f32) -> (TrackId, Arc<str>) {
+    let id = queue.register_for_test();
+    let src: Arc<str> = Arc::from(format!("test://memory/{}", id.as_u64()));
+    let spec = PcmSpec {
+        channels: CHANNELS,
+        sample_rate: NonZero::new(SAMPLE_RATE).unwrap(),
+    };
+    queue.complete_load_for_test(
+        id,
+        resource_from_reader_with_src(
+            TestPcmReader::with_value(spec, TRACK_SECS, value),
+            Arc::clone(&src),
+        ),
+    );
+    (id, src)
+}
+
+fn mean_abs(pcm: &[f32]) -> f32 {
+    if pcm.is_empty() {
+        return 0.0;
+    }
+    pcm.iter().map(|s| s.abs()).sum::<f32>() / pcm.len() as f32
+}
+
+fn render_loop(queue: &Queue, harness: &OfflinePlayerHarness, block_budget: usize) -> Vec<f32> {
+    let mut pcm = Vec::new();
+    for _ in 0..block_budget {
+        let _ = queue.tick();
+        pcm.extend(harness.render(BLOCK_FRAMES));
+    }
+    pcm
+}
+
+/// Three loaded tracks, the middle one playing and warmed up. The first
+/// — never selected, standing in for the background slot — is the one
+/// that will report the failure.
+fn fixture_playing_the_middle_track() -> (OfflinePlayerHarness, Queue, TrackId, Arc<str>) {
+    let (harness, queue) = make_fixture();
+    let (stale, stale_src) = loaded_track(&queue, QUIET);
+    let (current, _) = loaded_track(&queue, LOUD);
+    let (_next, _) = loaded_track(&queue, QUIET);
+
+    queue
+        .select(current, Transition::None)
+        .expect("select the current track");
+    let _ = render_loop(&queue, &harness, WARMUP_BLOCKS);
+
+    (harness, queue, stale, stale_src)
+}
+
+fn publish_background_failure(harness: &OfflinePlayerHarness, src: Arc<str>) {
+    harness
+        .player()
+        .bus()
+        .publish(Event::Player(PlayerEvent::ItemDidFail {
+            src,
+            item_id: None,
+            from_current_item: false,
+        }));
+}
+
+#[kithara::test(tokio)]
+async fn background_track_failure_does_not_advance_the_queue() {
+    let (harness, queue, _stale, stale_src) = fixture_playing_the_middle_track();
+
+    publish_background_failure(&harness, stale_src);
+    let _ = render_loop(&queue, &harness, WARMUP_BLOCKS);
+
+    assert_eq!(
+        queue.current_index(),
+        Some(1),
+        "a failure from a track that is not current must leave the current track selected"
+    );
+}
+
+#[kithara::test(tokio)]
+async fn background_track_failure_does_not_cut_the_current_track_audio() {
+    let (harness, queue) = make_fixture();
+    let (_stale, stale_src) = loaded_track(&queue, QUIET);
+    let (current, _) = loaded_track(&queue, LOUD);
+    let (_next, _) = loaded_track(&queue, QUIET);
+
+    queue
+        .select(current, Transition::None)
+        .expect("select the current track");
+    let before_pcm = render_loop(&queue, &harness, WARMUP_BLOCKS);
+    let before = mean_abs(&before_pcm[before_pcm.len() / 2..]);
+    assert!(
+        before > 0.005,
+        "the current track must be audible before the background failure: mean={before}"
+    );
+
+    publish_background_failure(&harness, stale_src);
+    let after_pcm = render_loop(&queue, &harness, WARMUP_BLOCKS);
+    let after = mean_abs(&after_pcm[after_pcm.len() / 2..]);
+
+    assert!(
+        after > before / 2.0,
+        "the current track must keep sounding through a background track's failure — \
+         the quieter successor took over instead: before={before}, after={after}"
+    );
+}
+
+/// Acting on a background failure also flags a queue entry, taking it out
+/// of selection for the rest of the session — on the strength of a slot
+/// nobody is listening to.
+#[kithara::test(tokio)]
+async fn background_track_failure_does_not_flag_a_queue_entry() {
+    let (harness, queue, stale, stale_src) = fixture_playing_the_middle_track();
+
+    publish_background_failure(&harness, stale_src);
+    let _ = render_loop(&queue, &harness, WARMUP_BLOCKS);
+
+    let status = queue
+        .tracks()
+        .into_iter()
+        .find(|entry| entry.id == stale)
+        .map(|entry| entry.status)
+        .expect("the background entry must still be in the queue");
+    assert!(
+        !matches!(status, TrackStatus::Failed(_)),
+        "a background track's failure must not mark the entry failed: {status:?}"
+    );
+}

--- a/tests/tests/kithara_queue/mod.rs
+++ b/tests/tests/kithara_queue/mod.rs
@@ -6,6 +6,7 @@ use source_helper::app_track_source;
 mod advance_boundary_provenance;
 mod architecture_flow;
 mod auto_advance;
+mod background_track_eof;
 mod cold_seek_middle;
 mod cpal_cold_seek_synthetic;
 mod early_seek_size_withheld_advance;

--- a/tests/tests/kithara_queue/mod.rs
+++ b/tests/tests/kithara_queue/mod.rs
@@ -7,6 +7,7 @@ mod advance_boundary_provenance;
 mod architecture_flow;
 mod auto_advance;
 mod background_track_eof;
+mod background_track_failure;
 mod cold_seek_middle;
 mod cpal_cold_seek_synthetic;
 mod early_seek_size_withheld_advance;


### PR DESCRIPTION
## The bug

A track goes into crossfade seconds after it starts, with minutes left to play.

`PlayerImpl::process_notifications` drains **every** active slot, not just the current one. A preloaded successor, or a predecessor still decoding after a switch, reaches its own end and publishes `ItemDidPlayToEnd` — and `Queue::handle_item_did_play_to_end` advanced on any non-empty `src`, never checking which track had actually ended. `handle_item_did_fail` had the same hole on the failure path.

Field log, two misfires and one correct contrast:

| time | end came from | published | but playing was |
|---|---|---|---|
| 18:32:42 | HLS `variant=3`, `slot_id=2` | `src=hls/master.m3u8 pos=5.99 dur=60.0` | Mp3 on `slot_id=1` since 18:32:36 |
| 18:37:12 | HLS `variant=0`, `slot_id=14` | `src=drm/master.m3u8 pos=5.06 dur=432.93` | Mp3 since 18:37:07 |
| 18:47:29 | the current track | `pos=4.99 dur=205.79` | → `consumed ItemDidPlayToEnd (armed pre-end)` ✓ |

A 432 s track cut at 5.06 s. The only existing guard, `consume_armed_advance`, fires only when a crossfade pre-arm was written, so it missed every advance that arrived via `TrackFailed`, manual next, or seek.

## Why `src` cannot be the gate

The obvious fix — compare the event's `src` against the queue entry's URI — is wrong, and not only in fixtures. `src` identifies a *rendered resource*, not a queue entry:

- `ResourceSrc::parse_src` renders `file://` URLs as bare paths, dropping the scheme.
- `Url::to_string` normalizes.
- `track_id_for_src` returns the *first* entry carrying that source, so a duplicated or repeat-all track resolves to a sibling.

Gating on the string would have silently disabled auto-advance for local files.

## The fix

Slot identity belongs to the player, so the player answers the question on the event. `PlayerEvent::ItemDidPlayToEnd` and `ItemDidFail` carry `from_current_item`, computed in `Notifier::dispatch_notification` as `slot() == Some(slot_id)` — read before `finalize_handover_if_armed` can move the phase. The queue acts only on `true`.

With a crossfade the incoming slot was already promoted by `commit_next`, so the outgoing end reports `false` — correctly: the queue already advanced on its own pre-arm.

A background *failure* is dropped outright rather than flagged against an entry. The event carries no track identity beyond `src`, so acting on it can take the wrong track out of selection for the rest of the session. Load-time failures reach the queue through the loader, not this path.

## Commits

1. `advance only on the current item's end of track` — the `ItemDidPlayToEnd` path.
2. `drop a background slot's failure instead of skipping` — the `ItemDidFail` twin.

## Tests

Written first, and each watched fail for the right reason before the fix:

- `tests/tests/kithara_queue/background_track_eof.rs` — the queue keeps its index, and the current track keeps sounding (`before=0.80 → after=0.10` before the fix).
- `tests/tests/kithara_queue/background_track_failure.rs` — same two properties for a failure, plus: the background entry is not marked `Failed` (before the fix: `Failed("mid-stream engine failure")`).
- `crates/kithara-play/src/player/flow/notify.rs` — producer-side pins that a held slot reports `true` and a background slot reports `false`. RED verified by pinning the producer to a constant: `left: Some(true), right: Some(false)`.

Contracts updated in `crates/kithara-queue/CONTEXT.md` and `crates/kithara-play/CONTEXT.md`.

## Validation

`just test` — 4067 passed, 0 failed. `just check clippy` clean. `just lint fast` — 0 regressions, 0 new. Rebased onto `main` (`23b85b70a`) and re-run green there.

## Noticed, not fixed

Visible in the same log, out of scope here:

- Scheduler nodes accumulate — `slot_id` climbs to 16, with `unregistering` arriving minutes later.
- `variant::layout: minting byte EOF ... sizes_complete=false`.
- `tests/benches/perf_audit.rs` has pre-existing `E0061` errors unrelated to this change.
