### PR TITLE
fix(play): bound transport response and preserve continuity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5597,6 +5597,7 @@ dependencies = [
  "delegate",
  "derive_more",
  "fieldwork",
+ "firewheel-core",
  "kithara-bufpool",
  "kithara-platform",
  "kithara-signal",

--- a/crates/kithara-app/src/wave_cache/persistence.rs
+++ b/crates/kithara-app/src/wave_cache/persistence.rs
@@ -241,7 +241,7 @@ async fn run_actor(
 
         let ack = match result {
             Ok(WriteOutcome::Committed { final_len }) => {
-                analysis_persistence_committed(revision, final_len);
+                probe::probe_event!(analysis_persistence_committed, revision, bytes = final_len);
                 Ok(())
             }
             Ok(WriteOutcome::AlreadyCommitted) => Ok(()),
@@ -465,9 +465,6 @@ fn abort_join<T>(handle: &JoinHandle<T>) {
 
 #[cfg(target_arch = "wasm32")]
 fn abort_join<T>(_handle: &JoinHandle<T>) {}
-
-#[probe::probe(revision, bytes = final_len)]
-fn analysis_persistence_committed(revision: u64, final_len: u64) {}
 
 /// Analysis persistence startup, queue, storage, or archive failure.
 #[derive(Debug)]

--- a/crates/kithara-audio/src/audio/cursor.rs
+++ b/crates/kithara-audio/src/audio/cursor.rs
@@ -456,7 +456,7 @@ mod tests {
     }
 
     #[kithara::test]
-    fn reads_preserve_each_rendered_source_revision() {
+    fn reads_preserve_consecutive_rendered_source_spans_and_revisions() {
         let pools = pools();
         let rate = NonZeroU32::new(48_000).expect("test rate");
         let spec = AudioSpec::new(1, rate);
@@ -481,7 +481,7 @@ mod tests {
             Duration::from_millis(3),
             Duration::from_millis(5),
         );
-        second.meta.frame_offset = 106;
+        second.meta.frame_offset = 1_000;
         second.meta.render_revision = 7;
         let mut changed = timed_chunk(
             &pools,
@@ -490,7 +490,7 @@ mod tests {
             Duration::from_millis(5),
             Duration::from_millis(7),
         );
-        changed.meta.frame_offset = 110;
+        changed.meta.frame_offset = 2_000;
         changed.meta.render_revision = 8;
         data_tx
             .try_push(Fetch::rendered(first, 0, SourceEnd::new(106, rate)))

--- a/crates/kithara-audio/src/audio/ring.rs
+++ b/crates/kithara-audio/src/audio/ring.rs
@@ -39,6 +39,7 @@ pub(super) struct RingConsumer {
     pub(super) validator: EpochValidator,
     pub(super) current_chunk: Option<AudioChunk>,
     pub(super) current_source_span: Option<SourceSpan>,
+    rendered_source_head: Option<SourceEnd>,
     pub(super) preloaded: bool,
     _epoch: Arc<AtomicU64>,
     reader_wake: Arc<ThreadWake>,
@@ -71,6 +72,7 @@ impl RingConsumer {
             phase: ConsumerPhase::Buffering,
             current_chunk: None,
             current_source_span: None,
+            rendered_source_head: None,
             trash_tx: parts.trash_tx,
             reader_wake: parts.reader_wake,
             _epoch: parts.epoch,
@@ -85,6 +87,7 @@ impl RingConsumer {
     pub(super) fn begin_seek_epoch(&mut self, epoch: u64, cursor: &mut ChunkCursor) -> bool {
         self.validator.epoch = epoch;
         self.recycle_current();
+        self.rendered_source_head = None;
         cursor.clear();
         self.phase = ConsumerPhase::SeekPending { epoch };
 
@@ -166,7 +169,7 @@ impl RingConsumer {
             Fetch::Data {
                 data, source_end, ..
             } => {
-                let source_span = source_span(&data, source_end);
+                let source_span = self.source_span(&data, source_end);
                 FetchOutcome::Return(Some((data, source_span)))
             }
         }
@@ -283,7 +286,7 @@ impl RingConsumer {
             Fetch::Data {
                 data, source_end, ..
             } => {
-                self.current_source_span = source_span(&data, source_end);
+                self.current_source_span = self.source_span(&data, source_end);
                 cursor.begin_chunk(&data);
                 self.current_chunk = Some(data);
                 self.phase = ConsumerPhase::Playing;
@@ -300,19 +303,28 @@ impl RingConsumer {
             }
         }
     }
-}
 
-fn source_span(data: &AudioChunk, source_end: Option<SourceEnd>) -> Option<SourceSpan> {
-    let source_end = source_end?;
-    if source_end.sample_rate() != data.meta.spec.sample_rate {
-        return None;
+    fn source_span(
+        &mut self,
+        data: &AudioChunk,
+        source_end: Option<SourceEnd>,
+    ) -> Option<SourceSpan> {
+        let Some(source_end) = source_end else {
+            self.rendered_source_head = None;
+            return None;
+        };
+        if source_end.sample_rate() != data.meta.spec.sample_rate {
+            self.rendered_source_head = None;
+            return None;
+        }
+        let source_start = self
+            .rendered_source_head
+            .filter(|head| head.sample_rate() == source_end.sample_rate())
+            .map_or(data.meta.frame_offset, |head| head.frame());
+        self.rendered_source_head = Some(source_end);
+        SourceSpan::new(source_start, source_end.frame(), source_end.sample_rate())
+            .map(|span| span.with_render_revision(data.meta.render_revision))
     }
-    SourceSpan::new(
-        data.meta.frame_offset,
-        source_end.frame(),
-        source_end.sample_rate(),
-    )
-    .map(|span| span.with_render_revision(data.meta.render_revision))
 }
 
 pub(super) fn create_channels(

--- a/crates/kithara-devtools/src/semver.rs
+++ b/crates/kithara-devtools/src/semver.rs
@@ -68,7 +68,7 @@ fn packages_to_compare<'a>(
 }
 
 fn semver_args<'a>(baseline: &'a str, packages: &[&'a str]) -> Vec<&'a str> {
-    let mut args = vec!["semver-checks", "check-release"];
+    let mut args = vec!["semver-checks", "check-release", "--default-features"];
     for package in packages {
         args.extend(["--package", *package]);
     }
@@ -189,6 +189,7 @@ source = "git+https://github.com/example/firewheel#0000000"
             args.windows(2)
                 .any(|pair| pair == ["--release-type", "minor"])
         );
+        assert!(args.contains(&"--default-features"));
         assert!(!args.contains(&"--workspace"));
     }
 }

--- a/crates/kithara-devtools/src/semver.rs
+++ b/crates/kithara-devtools/src/semver.rs
@@ -197,7 +197,6 @@ source = "git+https://github.com/example/firewheel#0000000"
             args.windows(2)
                 .any(|pair| pair == ["--release-type", "minor"])
         );
-        assert!(args.contains(&"--default-features"));
         assert!(!args.contains(&"--workspace"));
     }
 

--- a/crates/kithara-events/src/audio.rs
+++ b/crates/kithara-events/src/audio.rs
@@ -72,7 +72,7 @@ pub enum AudioEvent {
         seek_epoch: SeekEpoch,
         location: SegmentLocation,
     },
-    /// Seek completed.
+    /// Seek completed at the first committed post-seek output frame.
     SeekComplete {
         position: Duration,
         seek_epoch: SeekEpoch,

--- a/crates/kithara-hls/src/peer.rs
+++ b/crates/kithara-hls/src/peer.rs
@@ -54,7 +54,7 @@ where
     /// after a forward seek it still resolves to the *pre-seek* segment until
     /// the decoder recreate's first read lands (the off-RT `wait_range` is now
     /// event-driven, but a native-backend recreate can still take several
-    /// scheduler polls). [`Self::seek_epoch_reset`] already aimed
+    /// scheduler polls). [`Self::apply_seek_change`] already aimed
     /// `reader_segment` + the fetch plan at this target;
     /// [`Self::apply_boundary_crossing`] honours it as a floor so a stale-low
     /// resolved segment cannot drag the cursor back and re-plan the prefix.
@@ -591,7 +591,7 @@ where
         let resolved = demand_segment.unwrap_or_else(|| u32::try_from(prev).unwrap_or(0));
         // Forward-seek settle floor: while the reader's physical byte cursor
         // still lags behind a just-applied seek target, ignore this poll's
-        // stale-low segment. `seek_epoch_reset` already aimed `reader_segment`
+        // stale-low segment. `apply_seek_change` already aimed `reader_segment`
         // + the fetch plan at the target; without this guard the lagging
         // `resolved` re-keys the cursor backward and `rebuild`s the prefix
         // (re-downloading seg 0..target). Only drop the floor once the reader
@@ -606,7 +606,7 @@ where
             {
                 // Decoder-backoff landing, NOT a lagging cursor. The seek
                 // re-aimed the queue + floor at the time-derived target
-                // (`seek_epoch_reset` → `rebuild_at_time`), but the codec's
+                // (`apply_seek_change` → `rebuild_at_time`), but the codec's
                 // recreate seek backs off by its warmup preroll and parks one
                 // segment earlier (60s target → 54s landing). `set_position`
                 // already put the reader cursor in that landing segment, yet
@@ -665,7 +665,19 @@ where
             return;
         }
         self.last_seek_epoch = cur_seek;
-        self.seek_epoch_reset(coord, ctx);
+        kithara::probe_event!(
+            seek_epoch_reset,
+            seek_epoch = cur_seek,
+            segment_index = self.reader_segment.load(Ordering::Acquire),
+            variant = coord.variant_index()
+        );
+        if let Some(target) = self.seek_obs.target()
+            && let Some(seg) = coord.active().rebuild_at_time(ctx, target)
+        {
+            self.reader_segment.store(seg as usize, Ordering::Release);
+            self.reader_variant = coord.variant_index();
+            self.seek_settle_floor = Some(seg);
+        }
     }
 
     /// Drain the eviction channel into a local buffer so the broadcast
@@ -686,27 +698,6 @@ where
             config: self.config,
             seek_epoch: self.seek_obs.epoch(),
             signal: self.coord.signal(),
-        }
-    }
-
-    /// React to a confirmed seek-epoch bump: reposition the active
-    /// variant at the new target time and sync `reader_segment`.
-    /// Extracted from [`Self::apply_seek_change`] so the actual reset
-    /// work owns a USDT probe (`kithara_hls_probe::seek_epoch_reset`)
-    /// — integration tests key off this probe to detect scheduler
-    /// epoch resets without polling cycles flooding the wire.
-    #[kithara::probe(
-        seek_epoch = self.seek_obs.epoch(),
-        segment_index = self.reader_segment.load(Ordering::Acquire),
-        variant = coord.variant_index()
-    )]
-    fn seek_epoch_reset(&mut self, coord: &HlsCoord<S>, ctx: &PlanCtx<S>) {
-        if let Some(target) = self.seek_obs.target()
-            && let Some(seg) = coord.active().rebuild_at_time(ctx, target)
-        {
-            self.reader_segment.store(seg as usize, Ordering::Release);
-            self.reader_variant = coord.variant_index();
-            self.seek_settle_floor = Some(seg);
         }
     }
 }

--- a/crates/kithara-hls/src/variant/flow/seek.rs
+++ b/crates/kithara-hls/src/variant/flow/seek.rs
@@ -35,7 +35,7 @@ where
 
     /// Resolve a time seek to its byte anchor on the produce core: lock-free
     /// layout reads plus atomic anchor stores. The fetch plan belongs to the
-    /// download peer (`seek_epoch_reset` -> `rebuild_at_time`).
+    /// download peer (`apply_seek_change` -> `rebuild_at_time`).
     pub(crate) fn prepare_seek_time_anchor(
         &self,
         position: Duration,

--- a/crates/kithara-host/src/session/dispatch.rs
+++ b/crates/kithara-host/src/session/dispatch.rs
@@ -123,8 +123,17 @@ where
         Cmd::StartPlayer {
             master_volume,
             player_id,
+            render_quantum_frames,
+            response_budget_frames,
             sample_rate,
-        } => match lifecycle::start_player(state, player_id, sample_rate, master_volume) {
+        } => match lifecycle::start_player(
+            state,
+            player_id,
+            sample_rate,
+            master_volume,
+            render_quantum_frames,
+            response_budget_frames,
+        ) {
             Ok(()) => Reply::Ok,
             Err(err) => Reply::Err(err),
         },
@@ -430,7 +439,10 @@ pub(super) fn trace_stream_info<B: AudioBackend, S>(
 
 #[cfg(test)]
 mod tests {
-    use std::{num::NonZeroU32, sync::atomic::AtomicBool};
+    use std::{
+        num::{NonZeroU32, NonZeroUsize},
+        sync::atomic::AtomicBool,
+    };
 
     use firewheel::{FirewheelCtx, StreamInfo, processor::FirewheelProcessor};
     use kithara_bufpool::testing::{TestPools, pools};
@@ -588,6 +600,17 @@ mod tests {
         }
     }
 
+    fn start_command(player_id: u64, sample_rate: u32) -> Cmd<TestPools> {
+        Cmd::StartPlayer {
+            master_volume: 1.0,
+            player_id,
+            render_quantum_frames: None,
+            response_budget_frames: NonZeroUsize::new(448)
+                .expect("fixture response budget is non-zero"),
+            sample_rate,
+        }
+    }
+
     fn deck(state: &TestState, index: usize) -> &Deck<TestPools> {
         state
             .graph
@@ -654,11 +677,7 @@ mod tests {
         assert!(matches!(
             run_cmd(
                 &mut state,
-                Cmd::StartPlayer {
-                    player_id,
-                    sample_rate: TestState::DEFAULT_SAMPLE_RATE,
-                    master_volume: 1.0,
-                },
+                start_command(player_id, TestState::DEFAULT_SAMPLE_RATE),
             ),
             Reply::Ok
         ));
@@ -876,14 +895,7 @@ mod tests {
             })
         ));
         assert!(matches!(
-            run_cmd(
-                &mut state,
-                Cmd::StartPlayer {
-                    master_volume: 1.0,
-                    player_id,
-                    sample_rate: 48_000,
-                },
-            ),
+            run_cmd(&mut state, start_command(player_id, 48_000),),
             Reply::Ok
         ));
         assert!(matches!(
@@ -917,11 +929,7 @@ mod tests {
         assert!(matches!(
             run_cmd(
                 &mut state,
-                Cmd::StartPlayer {
-                    master_volume: 1.0,
-                    player_id,
-                    sample_rate: TestState::DEFAULT_SAMPLE_RATE,
-                },
+                start_command(player_id, TestState::DEFAULT_SAMPLE_RATE),
             ),
             Reply::Ok
         ));
@@ -933,6 +941,34 @@ mod tests {
     }
 
     #[kithara::test]
+    fn measured_output_block_rejects_player_before_graph_start() {
+        route_loss(RouteLossProbe::reset);
+
+        let mut state = test_state(start_route_loss_stream);
+        state.requested_max_block_frames = NonZeroU32::new(128);
+        let player_id = register_player(&mut state);
+        let command = Cmd::StartPlayer {
+            master_volume: 1.0,
+            player_id,
+            render_quantum_frames: NonZeroUsize::new(64),
+            response_budget_frames: NonZeroUsize::new(441)
+                .expect("fixture response budget is non-zero"),
+            sample_rate: TestState::DEFAULT_SAMPLE_RATE,
+        };
+
+        assert!(matches!(
+            run_cmd(&mut state, command),
+            Reply::Err(SessionError::ResponseBudgetExceeded {
+                max_block_frames: 512,
+                render_quantum_frames: 64,
+                required_frames: 639,
+                budget_frames: 441,
+            })
+        ));
+        assert!(!deck_by_player_id(&state, player_id).started);
+    }
+
+    #[kithara::test]
     fn explicit_audio_route_invalidation_restarts_stream_without_backend_error() {
         route_loss(RouteLossProbe::reset);
 
@@ -940,14 +976,7 @@ mod tests {
         let player_id = register_player(&mut state);
 
         assert!(matches!(
-            run_cmd(
-                &mut state,
-                Cmd::StartPlayer {
-                    master_volume: 1.0,
-                    player_id,
-                    sample_rate: 0,
-                },
-            ),
+            run_cmd(&mut state, start_command(player_id, 0),),
             Reply::Ok
         ));
         assert!(matches!(
@@ -1033,14 +1062,7 @@ mod tests {
         let player_id = register_player(&mut state);
 
         assert!(matches!(
-            run_cmd(
-                &mut state,
-                Cmd::StartPlayer {
-                    master_volume: 1.0,
-                    player_id,
-                    sample_rate: 0,
-                },
-            ),
+            run_cmd(&mut state, start_command(player_id, 0),),
             Reply::Ok
         ));
         assert!(state.ctx.is_some());
@@ -1102,14 +1124,7 @@ mod tests {
         let player_id = register_player(&mut state);
 
         assert!(matches!(
-            run_cmd(
-                &mut state,
-                Cmd::StartPlayer {
-                    master_volume: 1.0,
-                    player_id,
-                    sample_rate: 44_100,
-                },
-            ),
+            run_cmd(&mut state, start_command(player_id, 44_100),),
             Reply::Ok
         ));
         assert_eq!(
@@ -1156,14 +1171,7 @@ mod tests {
 
     fn start_player_cmd(state: &mut TestState, player_id: u64) {
         assert!(matches!(
-            run_cmd(
-                &mut *state,
-                Cmd::StartPlayer {
-                    master_volume: 1.0,
-                    player_id,
-                    sample_rate: 44_100,
-                },
-            ),
+            run_cmd(&mut *state, start_command(player_id, 44_100),),
             Reply::Ok
         ));
     }

--- a/crates/kithara-host/src/session/graph.rs
+++ b/crates/kithara-host/src/session/graph.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroUsize;
+
 use firewheel::{
     FirewheelCtx, Volume, backend::AudioBackend, diff::Memo,
     dsp::volume::amp_to_linear_volume_clamped, node::NodeID, nodes::volume::VolumeNode,
@@ -141,6 +143,8 @@ pub(super) mod lifecycle {
         player_id: PlayerId,
         sample_rate: u32,
         master_volume: f32,
+        render_quantum_frames: Option<NonZeroUsize>,
+        response_budget_frames: NonZeroUsize,
     ) -> Result<(), SessionError>
     where
         B: AudioBackend,
@@ -151,6 +155,7 @@ pub(super) mod lifecycle {
             sample_rate, master_volume, "[KITHARA-ROUTE] starting player"
         );
         ensure_ctx(state, sample_rate)?;
+        validate_response_geometry(state, render_quantum_frames, response_budget_frames)?;
         let idx = player_index(state, player_id)?;
         let Some(session_output_id) = state.session_output_node_id else {
             return Err(graph_state("session output node is not initialised"));
@@ -197,6 +202,41 @@ pub(super) mod lifecycle {
             ?master_volume_id,
             "[KITHARA-ROUTE] player graph started"
         );
+        Ok(())
+    }
+
+    fn validate_response_geometry<B: AudioBackend, S>(
+        state: &SessionState<B, S>,
+        render_quantum_frames: Option<NonZeroUsize>,
+        response_budget_frames: NonZeroUsize,
+    ) -> Result<(), SessionError> {
+        let Some(render_quantum_frames) = render_quantum_frames else {
+            return Ok(());
+        };
+        let max_block_frames = state
+            .ctx
+            .as_ref()
+            .and_then(FirewheelCtx::stream_info)
+            .ok_or(SessionError::NoContext)?
+            .max_block_frames
+            .get();
+        let block_frames = usize::try_from(max_block_frames)
+            .map_err(|_| SessionError::ResponseGeometryOverflow)?;
+        let quantum_frames = render_quantum_frames.get();
+        let preload_chunks = block_frames.div_ceil(quantum_frames);
+        let required_frames = preload_chunks
+            .checked_add(2)
+            .and_then(|chunks| chunks.checked_mul(quantum_frames))
+            .and_then(|frames| frames.checked_sub(1))
+            .ok_or(SessionError::ResponseGeometryOverflow)?;
+        if required_frames > response_budget_frames.get() {
+            return Err(SessionError::ResponseBudgetExceeded {
+                max_block_frames,
+                render_quantum_frames: quantum_frames,
+                required_frames,
+                budget_frames: response_budget_frames.get(),
+            });
+        }
         Ok(())
     }
     pub(in crate::session) fn stop_player<B: AudioBackend, S>(
@@ -858,6 +898,9 @@ mod tests {
             Cmd::StartPlayer {
                 master_volume: 1.0,
                 player_id,
+                render_quantum_frames: None,
+                response_budget_frames: NonZeroUsize::new(448)
+                    .expect("fixture response budget is non-zero"),
                 sample_rate,
             },
         ) {

--- a/crates/kithara-play/README.md
+++ b/crates/kithara-play/README.md
@@ -77,9 +77,10 @@ to the single `decoder` field.
   then release the slot and stop the engine.
 - **Configuration:** `PlayerConfig`, `EngineConfig`, and `ResourceConfig` expose
   builders while their fields remain crate-private.
-- **Tempo and key-lock:** a shared `StretchControls` handle is supplied through
-  `PlayerConfig::builder().timestretch(...)`; speed, key-lock, and backend apply
-  live, mid-track.
+- **Tempo and key-lock:** `PlayerConfig::builder().warp(...)` supplies the
+  resident `WarpConfig`, including its shared `StretchControls`; speed,
+  key-lock, and backend changes apply live, mid-track. Render quantum and rate
+  smoothing remain optional frame-based Warp settings.
 - **Events:** `tokio::sync::broadcast` via `player.subscribe()` /
   `engine.subscribe()` (`PlayerEvent`, `ItemEvent`, `EngineEvent`,
   `SessionEvent`, `DjEvent`).

--- a/crates/kithara-play/src/bridge/protocol.rs
+++ b/crates/kithara-play/src/bridge/protocol.rs
@@ -27,8 +27,6 @@ pub enum PlayerCmd {
     SetFadeDuration(f32),
     /// Update the prefetch lead time.
     SetPrefetchDuration(f32),
-    /// Update the requested playback-rate target for all active tracks.
-    SetPlaybackRate(f32),
 }
 
 impl fmt::Debug for PlayerCmd {
@@ -56,7 +54,6 @@ impl fmt::Debug for PlayerCmd {
             Self::SetPaused(p) => f.debug_tuple("SetPaused").field(p).finish(),
             Self::SetFadeDuration(d) => f.debug_tuple("SetFadeDuration").field(d).finish(),
             Self::SetPrefetchDuration(d) => f.debug_tuple("SetPrefetchDuration").field(d).finish(),
-            Self::SetPlaybackRate(r) => f.debug_tuple("SetPlaybackRate").field(r).finish(),
         }
     }
 }

--- a/crates/kithara-play/src/engine/config.rs
+++ b/crates/kithara-play/src/engine/config.rs
@@ -1,4 +1,7 @@
-use std::{fmt, num::NonZeroU32};
+use std::{
+    fmt,
+    num::{NonZeroU32, NonZeroUsize},
+};
 
 use bon::Builder;
 use kithara_bufpool::PoolRegion;
@@ -15,6 +18,10 @@ use crate::{
 #[builder(state_mod(vis = "pub"))]
 #[non_exhaustive]
 pub struct EngineConfig<S> {
+    /// Player-owned response contract used to validate session geometry.
+    pub(crate) response_budget_frames: NonZeroUsize,
+    /// Optional resident Warp render quantum supplied by the owning player.
+    pub(crate) render_quantum_frames: Option<NonZeroUsize>,
     /// Stable synchronization identity of the owning player.
     pub(crate) grid_id: BeatGridId,
     /// Master cancel token for the engine. The worker scheduler derives a
@@ -42,6 +49,8 @@ pub struct EngineConfig<S> {
 impl<S> Clone for EngineConfig<S> {
     fn clone(&self) -> Self {
         Self {
+            response_budget_frames: self.response_budget_frames,
+            render_quantum_frames: self.render_quantum_frames,
             grid_id: self.grid_id,
             cancel: self.cancel.clone(),
             session: self.session.clone(),
@@ -61,6 +70,8 @@ impl<S> fmt::Debug for EngineConfig<S> {
             .field("channels", &self.channels)
             .field("sample_rate", &self.sample_rate)
             .field("max_slots", &self.max_slots)
+            .field("response_budget_frames", &self.response_budget_frames)
+            .field("render_quantum_frames", &self.render_quantum_frames)
             .field("pools", &self.pools)
             .finish_non_exhaustive()
     }

--- a/crates/kithara-play/src/engine/core.rs
+++ b/crates/kithara-play/src/engine/core.rs
@@ -382,7 +382,12 @@ impl<S> EngineImpl<S> {
 
         let player_id = self.ensure_player_id()?;
         let master_volume = self.master_volume.load(Ordering::Relaxed);
-        self.session.start_player(player_id, master_volume)?;
+        self.session.start_player(
+            player_id,
+            master_volume,
+            self.config.render_quantum_frames,
+            self.config.response_budget_frames,
+        )?;
 
         self.running.store(true, Ordering::Release);
 

--- a/crates/kithara-play/src/player/config.rs
+++ b/crates/kithara-play/src/player/config.rs
@@ -1,4 +1,7 @@
-use std::{fmt, num::NonZeroU32};
+use std::{
+    fmt,
+    num::{NonZeroU32, NonZeroUsize},
+};
 
 use bon::Builder;
 use kithara_abr::AbrController;
@@ -20,9 +23,15 @@ fn allocate_grid_id() -> BeatGridId {
     id
 }
 
+const DEFAULT_RESPONSE_BUDGET_FRAMES: NonZeroUsize = match NonZeroUsize::new(448) {
+    Some(frames) => frames,
+    None => unreachable!(),
+};
+
 /// Configuration for the player.
-#[derive(Builder)]
+#[derive(Builder, fieldwork::Fieldwork)]
 #[builder(state_mod(vis = "pub"))]
+#[fieldwork(opt_in, get)]
 #[non_exhaustive]
 pub struct PlayerConfig<S> {
     /// Stable synchronization-group identity owned by this player.
@@ -31,6 +40,10 @@ pub struct PlayerConfig<S> {
     /// Per-deck Warp resources and live temporal controls.
     #[builder(default = WarpConfig::builder().build())]
     pub(crate) warp: WarpConfig,
+    /// Maximum accepted control-to-presented-audio response in output frames.
+    #[builder(default = DEFAULT_RESPONSE_BUDGET_FRAMES)]
+    #[field(get, copy)]
+    pub(crate) response_budget_frames: NonZeroUsize,
     /// Explicit shared playback worker. Its pools and cancellation lifetime
     /// are configured once in [`crate::PlayWorkerConfig`].
     pub(crate) worker: PlayWorker<S>,
@@ -80,6 +93,7 @@ impl<S> Clone for PlayerConfig<S> {
         Self {
             grid_id: self.grid_id,
             warp: self.warp.clone(),
+            response_budget_frames: self.response_budget_frames,
             worker: self.worker.clone(),
             gapless_mode: self.gapless_mode,
             block_on_underrun: self.block_on_underrun,
@@ -102,6 +116,7 @@ impl<S> fmt::Debug for PlayerConfig<S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("PlayerConfig")
             .field("warp", &self.warp)
+            .field("response_budget_frames", &self.response_budget_frames)
             .field("gapless_mode", &self.gapless_mode)
             .field("eq_layout", &self.eq_layout)
             .field("auto_advance_enabled", &self.auto_advance_enabled)
@@ -111,5 +126,24 @@ impl<S> fmt::Debug for PlayerConfig<S> {
             .field("max_slots", &self.max_slots)
             .field("worker", &self.worker)
             .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use kithara_test_utils::kithara;
+
+    use super::*;
+    use crate::{PlayWorkerConfig, test_pools::pools};
+
+    #[kithara::test(native)]
+    fn default_response_budget_matches_product_contract() {
+        let worker = PlayWorker::new(PlayWorkerConfig::builder(pools()).build());
+        let config = PlayerConfig::builder()
+            .sample_rate(NonZeroU32::new(44_100).expect("fixture rate is non-zero"))
+            .worker(worker)
+            .build();
+
+        assert_eq!(config.response_budget_frames().get(), 448);
     }
 }

--- a/crates/kithara-play/src/player/core.rs
+++ b/crates/kithara-play/src/player/core.rs
@@ -1,6 +1,8 @@
 mod lifecycle;
 mod player;
 
+use std::num::NonZeroUsize;
+
 use delegate::delegate;
 use kithara_bufpool::{HasPool, PoolRegion};
 use kithara_decode::GaplessMode;
@@ -33,6 +35,7 @@ pub(crate) struct PlayerCore<S> {
     pub(crate) engine_load: Arc<EngineLoad>,
 
     pub(crate) warp: WarpConfig,
+    pub(crate) response_budget_frames: NonZeroUsize,
     /// Undelivered resources unregister before the worker owner drops.
     pub(crate) items: ItemQueue,
     /// Host lifecycle explicitly detaches the engine session lane before the

--- a/crates/kithara-play/src/player/core/player.rs
+++ b/crates/kithara-play/src/player/core/player.rs
@@ -67,6 +67,8 @@ impl<S> PlayerImpl<S> {
             .grid_id(config.grid_id)
             .max_slots(config.max_slots)
             .sample_rate(config.sample_rate)
+            .response_budget_frames(config.response_budget_frames)
+            .maybe_render_quantum_frames(config.warp.render_quantum_frames())
             .pools(pools)
             .maybe_session(config.session.clone())
             .cancel(cancel.clone())
@@ -86,6 +88,7 @@ impl<S> PlayerImpl<S> {
             engine_load: Arc::new(EngineLoad::default()),
             params,
             warp: config.warp,
+            response_budget_frames: config.response_budget_frames,
             gapless_mode: config.gapless_mode,
             block_on_underrun: config.block_on_underrun,
             status: Mutex::default(),

--- a/crates/kithara-play/src/player/flow/control.rs
+++ b/crates/kithara-play/src/player/flow/control.rs
@@ -5,7 +5,6 @@ use kithara_warp::{RenderSnapshot, StretchControls};
 use super::super::core::PlayerRuntime;
 use crate::{
     api::{RouteChangeReason, SessionEvent, SlotId},
-    bridge::PlayerCmd,
     effects::eq::{EqBandConfig, GainDb},
     error::PlayError,
     player::state::phase::PlayerPhaseKind,
@@ -24,7 +23,7 @@ impl<S> PlayerRuntime<S> {
         )
     )]
     fn rate_requested(&self, target: f32, request_revision: u64, snapshot: &RenderSnapshot) {
-        let _ = self.send_to_slot(PlayerCmd::SetPlaybackRate(target));
+        self.core.worker.wake();
     }
 
     /// Ensure we have an active slot, allocating one if needed.
@@ -139,7 +138,7 @@ impl<S> PlayerRuntime<S> {
         if let Some(snapshot) = snapshot {
             self.rate_requested(target, revision, &snapshot);
         } else {
-            let _ = self.send_to_slot(PlayerCmd::SetPlaybackRate(target));
+            self.core.worker.wake();
         }
     }
 

--- a/crates/kithara-play/src/player/flow/control.rs
+++ b/crates/kithara-play/src/player/flow/control.rs
@@ -1,6 +1,6 @@
 use kithara_events::RouteDescription;
 use kithara_test_macros as kithara;
-use kithara_warp::{RenderSnapshot, StretchControls};
+use kithara_warp::StretchControls;
 
 use super::super::core::PlayerRuntime;
 use crate::{
@@ -11,21 +11,6 @@ use crate::{
 };
 
 impl<S> PlayerRuntime<S> {
-    #[kithara::probe(
-        request_revision,
-        target_rate_bits = target.to_bits(),
-        session_epoch = u64::from(snapshot.context().session_epoch()),
-        transport_revision = snapshot.context().transport_revision().map_or(0, u64::from),
-        session_frame = i64::from(snapshot.context().output_frames().end),
-        session_beat_bits = snapshot.context().session_beats().map_or(
-            f64::NAN.to_bits(),
-            |beats| f64::from(beats.end).to_bits()
-        )
-    )]
-    fn rate_requested(&self, target: f32, request_revision: u64, snapshot: &RenderSnapshot) {
-        self.core.worker.wake();
-    }
-
     /// Ensure we have an active slot, allocating one if needed.
     pub fn ensure_slot(&self) -> Result<SlotId, PlayError> {
         if let Some(id) = self.slot() {
@@ -136,10 +121,20 @@ impl<S> PlayerRuntime<S> {
             .slot()
             .and_then(|slot| self.core.engine.slot_render_snapshot(slot));
         if let Some(snapshot) = snapshot {
-            self.rate_requested(target, revision, &snapshot);
-        } else {
-            self.core.worker.wake();
+            kithara::probe_event!(
+                rate_requested,
+                request_revision = revision,
+                target_rate_bits = target.to_bits(),
+                session_epoch = u64::from(snapshot.context().session_epoch()),
+                transport_revision = snapshot.context().transport_revision().map_or(0, u64::from),
+                session_frame = i64::from(snapshot.context().output_frames().end),
+                session_beat_bits = snapshot
+                    .context()
+                    .session_beats()
+                    .map_or(f64::NAN.to_bits(), |beats| f64::from(beats.end).to_bits())
+            );
         }
+        self.core.worker.wake();
     }
 
     /// Set volume, clamped to `0.0..=1.0`.

--- a/crates/kithara-play/src/player/flow/prepare.rs
+++ b/crates/kithara-play/src/player/flow/prepare.rs
@@ -1,4 +1,4 @@
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, NonZeroUsize};
 
 use kithara_audio::{AudioDecoderConfig, DecoderResamplerSettings, ResamplerOptions};
 use kithara_bufpool::HasPool;
@@ -31,13 +31,18 @@ where
         let warp = self.player.core.warp.clone();
         let host_sample_rate = NonZeroU32::new(self.player.core.engine.master_sample_rate())
             .or_else(|| NonZeroU32::new(self.player.core.engine.configured_sample_rate()));
+        let stream_shape = self.player.core.engine.stream_shape()?;
+        let output_buffer_frames = warp
+            .render_quantum_frames()
+            .map(|_| {
+                let shape = stream_shape.ok_or(crate::session::SessionError::NoContext)?;
+                NonZeroUsize::try_from(shape.max_block_frames)
+                    .map_err(|_| PlayError::Internal("session output block exceeds usize".into()))
+            })
+            .transpose()?;
         let resampler = match config.decoder.resampler().cloned() {
             Some(settings) => Some(settings),
-            None => self
-                .player
-                .core
-                .engine
-                .stream_shape()?
+            None => stream_shape
                 .map(|shape| {
                     let chunk_size =
                         usize::try_from(shape.max_block_frames.get()).map_err(|_| {
@@ -63,6 +68,9 @@ where
             worker: Some(self.player.core.worker.clone()),
             consumer_wake_mode: Some(self.player.core.engine.consumer_wake_mode()),
             block_on_underrun: self.player.core.block_on_underrun,
+            output_buffer_frames,
+            response_budget_frames: output_buffer_frames
+                .map(|_| self.player.core.response_budget_frames),
             host_sample_rate,
             decoder,
             warp,

--- a/crates/kithara-play/src/player/flow/prepare.rs
+++ b/crates/kithara-play/src/player/flow/prepare.rs
@@ -7,7 +7,37 @@ use kithara_platform::sync::Arc;
 #[cfg(test)]
 use super::super::core::PlayerImpl;
 use super::super::core::PlayerRuntime;
-use crate::{PlayError, resource::ResourceConfig};
+use crate::{PlayError, resource::ResourceConfig, rt::StreamShape, session::SessionError};
+
+fn playback_buffers(
+    shape: StreamShape,
+    quantum: NonZeroUsize,
+    budget: NonZeroUsize,
+) -> Result<(NonZeroUsize, NonZeroUsize), SessionError> {
+    let output_frames = usize::try_from(shape.max_block_frames.get())
+        .map_err(|_| SessionError::ResponseGeometryOverflow)?;
+    let preload = output_frames.div_ceil(quantum.get());
+    let ring = preload
+        .checked_add(1)
+        .ok_or(SessionError::ResponseGeometryOverflow)?;
+    let required_frames = ring
+        .checked_add(1)
+        .and_then(|chunks| chunks.checked_mul(quantum.get()))
+        .and_then(|frames| frames.checked_sub(1))
+        .ok_or(SessionError::ResponseGeometryOverflow)?;
+    if required_frames > budget.get() {
+        return Err(SessionError::ResponseBudgetExceeded {
+            max_block_frames: shape.max_block_frames.get(),
+            render_quantum_frames: quantum.get(),
+            required_frames,
+            budget_frames: budget.get(),
+        });
+    }
+    Ok((
+        NonZeroUsize::new(preload).ok_or(SessionError::ResponseGeometryOverflow)?,
+        NonZeroUsize::new(ring).ok_or(SessionError::ResponseGeometryOverflow)?,
+    ))
+}
 
 struct ConfigPrep<'a, S> {
     player: &'a PlayerRuntime<S>,
@@ -32,14 +62,15 @@ where
         let host_sample_rate = NonZeroU32::new(self.player.core.engine.master_sample_rate())
             .or_else(|| NonZeroU32::new(self.player.core.engine.configured_sample_rate()));
         let stream_shape = self.player.core.engine.stream_shape()?;
-        let output_buffer_frames = warp
-            .render_quantum_frames()
-            .map(|_| {
-                let shape = stream_shape.ok_or(crate::session::SessionError::NoContext)?;
-                NonZeroUsize::try_from(shape.max_block_frames)
-                    .map_err(|_| PlayError::Internal("session output block exceeds usize".into()))
-            })
-            .transpose()?;
+        let (preload_chunks, audio_buffer_chunks) = match warp.render_quantum_frames() {
+            Some(quantum) => {
+                let shape = stream_shape.ok_or(SessionError::NoContext)?;
+                let (preload, ring) =
+                    playback_buffers(shape, quantum, self.player.core.response_budget_frames)?;
+                (preload, Some(ring))
+            }
+            None => (config.preload_chunks, config.audio_buffer_chunks),
+        };
         let resampler = match config.decoder.resampler().cloned() {
             Some(settings) => Some(settings),
             None => stream_shape
@@ -68,9 +99,8 @@ where
             worker: Some(self.player.core.worker.clone()),
             consumer_wake_mode: Some(self.player.core.engine.consumer_wake_mode()),
             block_on_underrun: self.player.core.block_on_underrun,
-            output_buffer_frames,
-            response_budget_frames: output_buffer_frames
-                .map(|_| self.player.core.response_budget_frames),
+            preload_chunks,
+            audio_buffer_chunks,
             host_sample_rate,
             decoder,
             warp,
@@ -112,10 +142,11 @@ mod tests {
     use kithara_audio::ConsumerWakeMode;
     use kithara_platform::sync::Arc;
     use kithara_test_utils::kithara;
+    use kithara_warp::WarpConfig;
 
     use super::*;
     use crate::{
-        PlayError, PlayWorker, PlayWorkerConfig, PlaybackResamplerBackend, StreamShape,
+        PlayError, PlayWorker, PlayWorkerConfig, PlaybackResamplerBackend,
         player::PlayerConfig,
         resource::ResourceSrc,
         session::{Cmd, Reply, SessionDispatcher, testing},
@@ -144,6 +175,31 @@ mod tests {
 
     fn worker() -> PlayWorker<TestPools> {
         PlayWorker::new(PlayWorkerConfig::builder(pools()).build())
+    }
+
+    fn player_with_geometry(
+        quantum: usize,
+        output_buffer: u32,
+        response_budget: usize,
+    ) -> PlayerImpl<TestPools> {
+        let shape = StreamShape::new(
+            NonZeroU32::new(output_buffer).expect("fixture output block is non-zero"),
+            testing::TEST_SAMPLE_RATE,
+        );
+        let warp = WarpConfig::builder()
+            .render_quantum_frames(NonZeroUsize::new(quantum).expect("fixture quantum is non-zero"))
+            .build();
+        PlayerImpl::new(
+            PlayerConfig::builder()
+                .sample_rate(testing::TEST_SAMPLE_RATE)
+                .worker(worker())
+                .session(testing::test_session_with_shape(Some(shape)))
+                .warp(warp)
+                .response_budget_frames(
+                    NonZeroUsize::new(response_budget).expect("fixture budget is non-zero"),
+                )
+                .build(),
+        )
     }
 
     #[kithara::test]
@@ -257,5 +313,53 @@ mod tests {
                 .chunk_size,
             256
         );
+    }
+
+    #[kithara::test]
+    #[case::industry_budget(32, 128, 441, 4, 5)]
+    #[case::large_continuity_buffer(64, 512, 639, 8, 9)]
+    fn prepare_config_derives_playback_buffering(
+        #[case] quantum: usize,
+        #[case] output_buffer: u32,
+        #[case] response_budget: usize,
+        #[case] expected_preload: usize,
+        #[case] expected_ring: usize,
+    ) {
+        let player = player_with_geometry(quantum, output_buffer, response_budget);
+
+        let prepared = player
+            .prepare_config(resource_config("https://example.com/song.mp3"))
+            .expect("fixture geometry fits the response budget");
+
+        assert_eq!(prepared.preload_chunks.get(), expected_preload);
+        assert_eq!(
+            prepared.audio_buffer_chunks.map(NonZeroUsize::get),
+            Some(expected_ring)
+        );
+    }
+
+    #[kithara::test]
+    #[case::one_frame_over_budget(64, 128, 254, 255)]
+    #[case::large_buffer_over_industry_budget(64, 512, 441, 639)]
+    fn prepare_config_rejects_buffering_over_budget(
+        #[case] quantum: usize,
+        #[case] output_buffer: u32,
+        #[case] response_budget: usize,
+        #[case] required_frames: usize,
+    ) {
+        let player = player_with_geometry(quantum, output_buffer, response_budget);
+
+        assert!(matches!(
+            player.prepare_config(resource_config("https://example.com/song.mp3")),
+            Err(PlayError::Session(SessionError::ResponseBudgetExceeded {
+                max_block_frames,
+                render_quantum_frames,
+                required_frames: actual_required_frames,
+                budget_frames,
+            })) if max_block_frames == output_buffer
+                && render_quantum_frames == quantum
+                && actual_required_frames == required_frames
+                && budget_frames == response_budget
+        ));
     }
 }

--- a/crates/kithara-play/src/player/flow/transport.rs
+++ b/crates/kithara-play/src/player/flow/transport.rs
@@ -94,7 +94,6 @@ where
             warn!(%error, "failed to allocate track playback buffers");
             false
         });
-        let _ = self.send_to_slot(PlayerCmd::SetPlaybackRate(rate));
         let _ = self.send_to_slot(PlayerCmd::SetPaused(false));
 
         self.enter_playing();

--- a/crates/kithara-play/src/resource/config.rs
+++ b/crates/kithara-play/src/resource/config.rs
@@ -5,7 +5,6 @@ use kithara_abr::AbrMode;
 use kithara_assets::AssetStore;
 use kithara_audio::{AudioDecoderConfig, ConsumerWakeMode};
 use kithara_bufpool::HasPool;
-use kithara_decode::DecodeError;
 use kithara_events::EventBus;
 use kithara_hls::{KeyOptions, SizeProbeMethod};
 use kithara_net::Headers;
@@ -76,12 +75,6 @@ where
     /// Resident Warp resources and live temporal controls.
     #[builder(default = WarpConfig::builder().build())]
     pub(crate) warp: WarpConfig,
-    /// Session-owned output block used to resolve Player ring geometry.
-    #[builder(skip)]
-    pub(crate) output_buffer_frames: Option<NonZeroUsize>,
-    /// Player-owned response budget paired with `output_buffer_frames`.
-    #[builder(skip)]
-    pub(crate) response_budget_frames: Option<NonZeroUsize>,
     /// Explicit playback worker. Player preparation fills this field; direct
     /// Resource callers must configure it themselves.
     pub(crate) worker: Option<PlayWorker<S>>,
@@ -131,68 +124,12 @@ where
             host_sample_rate: self.host_sample_rate,
             look_ahead_bytes: self.look_ahead_bytes,
             warp: self.warp.clone(),
-            output_buffer_frames: self.output_buffer_frames,
-            response_budget_frames: self.response_budget_frames,
             worker: self.worker.clone(),
             consumer_wake_mode: self.consumer_wake_mode,
             block_on_underrun: self.block_on_underrun,
             size_probe_method: self.size_probe_method,
             preferred_peak_bitrate: self.preferred_peak_bitrate,
         }
-    }
-}
-
-impl<S, B> ResourceConfig<S, B>
-where
-    B: Default,
-    S: HasPool<u8> + Send + Sync + 'static,
-{
-    pub(crate) fn resolve_output_geometry(&mut self) -> Result<(), DecodeError> {
-        let (Some(output_buffer_frames), Some(response_budget_frames)) =
-            (self.output_buffer_frames, self.response_budget_frames)
-        else {
-            if self.output_buffer_frames.is_some() || self.response_budget_frames.is_some() {
-                return Err(DecodeError::InvalidData {
-                    detail: "incomplete playback response contract",
-                });
-            }
-            return Ok(());
-        };
-        let quantum = self
-            .warp
-            .render_quantum_frames()
-            .ok_or(DecodeError::InvalidData {
-                detail: "playback response contract requires a Warp render quantum",
-            })?
-            .get();
-        let preload_chunks = output_buffer_frames.get().div_ceil(quantum);
-        let ring_chunks = preload_chunks
-            .checked_add(1)
-            .ok_or(DecodeError::InvalidData {
-                detail: "playback output geometry overflow",
-            })?;
-        let stale_frames = ring_chunks
-            .checked_add(1)
-            .and_then(|chunks| chunks.checked_mul(quantum))
-            .and_then(|frames| frames.checked_sub(1))
-            .ok_or(DecodeError::InvalidData {
-                detail: "playback output geometry overflow",
-            })?;
-        if stale_frames > response_budget_frames.get() {
-            return Err(DecodeError::InvalidData {
-                detail: "playback output buffer exceeds the configured response budget",
-            });
-        }
-        self.preload_chunks =
-            NonZeroUsize::new(preload_chunks).ok_or(DecodeError::InvalidData {
-                detail: "playback preload geometry is empty",
-            })?;
-        self.audio_buffer_chunks = Some(NonZeroUsize::new(ring_chunks).ok_or(
-            DecodeError::InvalidData {
-                detail: "playback output geometry is empty",
-            },
-        )?);
-        Ok(())
     }
 }
 
@@ -434,66 +371,6 @@ mod tests {
 
         assert_eq!(config.preload_chunks.get(), DEFAULT_PRELOAD_CHUNKS.get());
         assert_eq!(config.audio_buffer_chunks, None);
-        assert_eq!(config.output_buffer_frames, None);
-        assert_eq!(config.response_budget_frames, None);
-    }
-
-    fn frame_contract_config(
-        quantum: usize,
-        output_buffer: usize,
-        response_budget: usize,
-    ) -> ResourceConfig<TestPools> {
-        let warp = WarpConfig::builder()
-            .render_quantum_frames(NonZeroUsize::new(quantum).expect("fixture quantum is non-zero"))
-            .build();
-        let mut config = ResourceConfig::for_src(valid_src("https://example.com/song.mp3"))
-            .store(store())
-            .warp(warp)
-            .build();
-        config.output_buffer_frames =
-            Some(NonZeroUsize::new(output_buffer).expect("fixture output block is non-zero"));
-        config.response_budget_frames =
-            Some(NonZeroUsize::new(response_budget).expect("fixture budget is non-zero"));
-        config
-    }
-
-    #[kithara::test]
-    #[case::industry_budget(32, 128, 441, 4, 5)]
-    #[case::large_continuity_buffer(64, 512, 639, 8, 9)]
-    fn frame_contract_resolves_preload_and_ring_depth(
-        #[case] quantum: usize,
-        #[case] output_buffer: usize,
-        #[case] response_budget: usize,
-        #[case] expected_preload: usize,
-        #[case] expected_ring: usize,
-    ) {
-        let mut config = frame_contract_config(quantum, output_buffer, response_budget);
-
-        config.resolve_output_geometry().expect("valid geometry");
-
-        assert_eq!(config.preload_chunks.get(), expected_preload);
-        assert_eq!(
-            config.audio_buffer_chunks.map(NonZeroUsize::get),
-            Some(expected_ring)
-        );
-    }
-
-    #[kithara::test]
-    #[case::one_frame_over_budget(64, 128, 254)]
-    #[case::large_buffer_over_industry_budget(64, 512, 441)]
-    fn frame_contract_rejects_geometry_over_budget(
-        #[case] quantum: usize,
-        #[case] output_buffer: usize,
-        #[case] response_budget: usize,
-    ) {
-        let mut config = frame_contract_config(quantum, output_buffer, response_budget);
-
-        assert!(matches!(
-            config.resolve_output_geometry(),
-            Err(DecodeError::InvalidData {
-                detail: "playback output buffer exceeds the configured response budget"
-            })
-        ));
     }
 
     #[kithara::test]

--- a/crates/kithara-play/src/resource/config.rs
+++ b/crates/kithara-play/src/resource/config.rs
@@ -5,6 +5,7 @@ use kithara_abr::AbrMode;
 use kithara_assets::AssetStore;
 use kithara_audio::{AudioDecoderConfig, ConsumerWakeMode};
 use kithara_bufpool::HasPool;
+use kithara_decode::DecodeError;
 use kithara_events::EventBus;
 use kithara_hls::{KeyOptions, SizeProbeMethod};
 use kithara_net::Headers;
@@ -75,6 +76,12 @@ where
     /// Resident Warp resources and live temporal controls.
     #[builder(default = WarpConfig::builder().build())]
     pub(crate) warp: WarpConfig,
+    /// Session-owned output block used to resolve Player ring geometry.
+    #[builder(skip)]
+    pub(crate) output_buffer_frames: Option<NonZeroUsize>,
+    /// Player-owned response budget paired with `output_buffer_frames`.
+    #[builder(skip)]
+    pub(crate) response_budget_frames: Option<NonZeroUsize>,
     /// Explicit playback worker. Player preparation fills this field; direct
     /// Resource callers must configure it themselves.
     pub(crate) worker: Option<PlayWorker<S>>,
@@ -124,12 +131,68 @@ where
             host_sample_rate: self.host_sample_rate,
             look_ahead_bytes: self.look_ahead_bytes,
             warp: self.warp.clone(),
+            output_buffer_frames: self.output_buffer_frames,
+            response_budget_frames: self.response_budget_frames,
             worker: self.worker.clone(),
             consumer_wake_mode: self.consumer_wake_mode,
             block_on_underrun: self.block_on_underrun,
             size_probe_method: self.size_probe_method,
             preferred_peak_bitrate: self.preferred_peak_bitrate,
         }
+    }
+}
+
+impl<S, B> ResourceConfig<S, B>
+where
+    B: Default,
+    S: HasPool<u8> + Send + Sync + 'static,
+{
+    pub(crate) fn resolve_output_geometry(&mut self) -> Result<(), DecodeError> {
+        let (Some(output_buffer_frames), Some(response_budget_frames)) =
+            (self.output_buffer_frames, self.response_budget_frames)
+        else {
+            if self.output_buffer_frames.is_some() || self.response_budget_frames.is_some() {
+                return Err(DecodeError::InvalidData {
+                    detail: "incomplete playback response contract",
+                });
+            }
+            return Ok(());
+        };
+        let quantum = self
+            .warp
+            .render_quantum_frames()
+            .ok_or(DecodeError::InvalidData {
+                detail: "playback response contract requires a Warp render quantum",
+            })?
+            .get();
+        let preload_chunks = output_buffer_frames.get().div_ceil(quantum);
+        let ring_chunks = preload_chunks
+            .checked_add(1)
+            .ok_or(DecodeError::InvalidData {
+                detail: "playback output geometry overflow",
+            })?;
+        let stale_frames = ring_chunks
+            .checked_add(1)
+            .and_then(|chunks| chunks.checked_mul(quantum))
+            .and_then(|frames| frames.checked_sub(1))
+            .ok_or(DecodeError::InvalidData {
+                detail: "playback output geometry overflow",
+            })?;
+        if stale_frames > response_budget_frames.get() {
+            return Err(DecodeError::InvalidData {
+                detail: "playback output buffer exceeds the configured response budget",
+            });
+        }
+        self.preload_chunks =
+            NonZeroUsize::new(preload_chunks).ok_or(DecodeError::InvalidData {
+                detail: "playback preload geometry is empty",
+            })?;
+        self.audio_buffer_chunks = Some(NonZeroUsize::new(ring_chunks).ok_or(
+            DecodeError::InvalidData {
+                detail: "playback output geometry is empty",
+            },
+        )?);
+        Ok(())
     }
 }
 
@@ -363,6 +426,74 @@ mod tests {
         assert_eq!(config.hint.as_deref(), Some("mp3"));
         assert_eq!(config.discriminator.as_deref(), Some("test"));
         assert_eq!(config.preload_chunks.get(), 5);
+    }
+
+    #[kithara::test]
+    fn direct_config_preserves_platform_buffer_defaults() {
+        let config = test_config("https://example.com/song.mp3").expect("valid config");
+
+        assert_eq!(config.preload_chunks.get(), DEFAULT_PRELOAD_CHUNKS.get());
+        assert_eq!(config.audio_buffer_chunks, None);
+        assert_eq!(config.output_buffer_frames, None);
+        assert_eq!(config.response_budget_frames, None);
+    }
+
+    fn frame_contract_config(
+        quantum: usize,
+        output_buffer: usize,
+        response_budget: usize,
+    ) -> ResourceConfig<TestPools> {
+        let warp = WarpConfig::builder()
+            .render_quantum_frames(NonZeroUsize::new(quantum).expect("fixture quantum is non-zero"))
+            .build();
+        let mut config = ResourceConfig::for_src(valid_src("https://example.com/song.mp3"))
+            .store(store())
+            .warp(warp)
+            .build();
+        config.output_buffer_frames =
+            Some(NonZeroUsize::new(output_buffer).expect("fixture output block is non-zero"));
+        config.response_budget_frames =
+            Some(NonZeroUsize::new(response_budget).expect("fixture budget is non-zero"));
+        config
+    }
+
+    #[kithara::test]
+    #[case::industry_budget(32, 128, 441, 4, 5)]
+    #[case::large_continuity_buffer(64, 512, 639, 8, 9)]
+    fn frame_contract_resolves_preload_and_ring_depth(
+        #[case] quantum: usize,
+        #[case] output_buffer: usize,
+        #[case] response_budget: usize,
+        #[case] expected_preload: usize,
+        #[case] expected_ring: usize,
+    ) {
+        let mut config = frame_contract_config(quantum, output_buffer, response_budget);
+
+        config.resolve_output_geometry().expect("valid geometry");
+
+        assert_eq!(config.preload_chunks.get(), expected_preload);
+        assert_eq!(
+            config.audio_buffer_chunks.map(NonZeroUsize::get),
+            Some(expected_ring)
+        );
+    }
+
+    #[kithara::test]
+    #[case::one_frame_over_budget(64, 128, 254)]
+    #[case::large_buffer_over_industry_budget(64, 512, 441)]
+    fn frame_contract_rejects_geometry_over_budget(
+        #[case] quantum: usize,
+        #[case] output_buffer: usize,
+        #[case] response_budget: usize,
+    ) {
+        let mut config = frame_contract_config(quantum, output_buffer, response_budget);
+
+        assert!(matches!(
+            config.resolve_output_geometry(),
+            Err(DecodeError::InvalidData {
+                detail: "playback output buffer exceeds the configured response budget"
+            })
+        ));
     }
 
     #[kithara::test]

--- a/crates/kithara-play/src/resource/reader.rs
+++ b/crates/kithara-play/src/resource/reader.rs
@@ -169,7 +169,7 @@ impl Resource {
     }
 
     async fn open<S, B>(
-        mut config: ResourceConfig<S, B>,
+        config: ResourceConfig<S, B>,
         observer: Option<Box<dyn AudioObserver>>,
     ) -> DecodeResult<Self>
     where
@@ -181,7 +181,6 @@ impl Resource {
         let worker = config.worker.clone().ok_or(DecodeError::InvalidData {
             detail: "ResourceConfig requires an explicit PlayWorker",
         })?;
-        config.resolve_output_geometry()?;
         let warp = config.warp.clone();
         let engine_load = config.engine_load.clone();
         // Capture the per-track cancel before `build_*_config` consumes `config`

--- a/crates/kithara-play/src/resource/reader.rs
+++ b/crates/kithara-play/src/resource/reader.rs
@@ -98,13 +98,6 @@ impl PlaybackRate {
             Self::Fixed
         }
     }
-
-    fn apply(&self, requested: f32) -> f32 {
-        if let Self::Warp(controls) = self {
-            controls.set_speed(requested);
-        }
-        self.into()
-    }
 }
 
 impl From<&PlaybackRate> for f32 {
@@ -284,10 +277,6 @@ impl Resource {
 
     pub(crate) fn render_reader(&self) -> Option<RenderReader> {
         self.render_publisher.as_ref().map(RenderPublisher::reader)
-    }
-
-    pub(crate) fn apply_playback_rate(&self, rate: f32) -> f32 {
-        self.playback_rate.apply(rate)
     }
 
     pub(crate) fn playback_rate(&self) -> f32 {
@@ -633,18 +622,17 @@ mod tests {
     #[kithara::test(native, flash(false))]
     fn playback_rate_reports_only_a_real_warp_control() {
         let fixed = Resource::from_reader(EofReader::default(), None);
-        assert_eq!(fixed.apply_playback_rate(1.5), 1.0);
+        assert_eq!(fixed.playback_rate(), 1.0);
 
         let controls = StretchControls::new(1.0);
         let warped = Resource::from_reader(EofReader::default(), None)
             .with_playback_rate(PlaybackRate::for_warp(Arc::clone(&controls)));
         if supports_playback_rate() {
-            assert_eq!(warped.apply_playback_rate(1.5), 1.5);
+            controls.set_speed(1.5);
             assert!((controls.speed() - 1.5).abs() < f32::EPSILON);
             controls.set_speed(1.25);
             assert_eq!(warped.playback_rate(), 1.25);
         } else {
-            assert_eq!(warped.apply_playback_rate(1.5), 1.0);
             assert!((controls.speed() - 1.0).abs() < f32::EPSILON);
             controls.set_speed(1.25);
             assert_eq!(warped.playback_rate(), 1.0);

--- a/crates/kithara-play/src/resource/reader.rs
+++ b/crates/kithara-play/src/resource/reader.rs
@@ -98,6 +98,13 @@ impl PlaybackRate {
             Self::Fixed
         }
     }
+
+    fn apply(&self, requested: f32) -> f32 {
+        if let Self::Warp(controls) = self {
+            controls.set_speed(requested);
+        }
+        self.into()
+    }
 }
 
 impl From<&PlaybackRate> for f32 {
@@ -282,6 +289,10 @@ impl Resource {
 
     pub(crate) fn playback_rate(&self) -> f32 {
         (&self.playback_rate).into()
+    }
+
+    pub(crate) fn apply_playback_rate(&self, rate: f32) -> f32 {
+        self.playback_rate.apply(rate)
     }
 
     pub(crate) fn set_service_class(&self, class: ServiceClass) {
@@ -623,17 +634,19 @@ mod tests {
     #[kithara::test(native, flash(false))]
     fn playback_rate_reports_only_a_real_warp_control() {
         let fixed = Resource::from_reader(EofReader::default(), None);
+        assert_eq!(fixed.apply_playback_rate(1.5), 1.0);
         assert_eq!(fixed.playback_rate(), 1.0);
 
         let controls = StretchControls::new(1.0);
         let warped = Resource::from_reader(EofReader::default(), None)
             .with_playback_rate(PlaybackRate::for_warp(Arc::clone(&controls)));
         if supports_playback_rate() {
-            controls.set_speed(1.5);
+            assert_eq!(warped.apply_playback_rate(1.5), 1.5);
             assert!((controls.speed() - 1.5).abs() < f32::EPSILON);
             controls.set_speed(1.25);
             assert_eq!(warped.playback_rate(), 1.25);
         } else {
+            assert_eq!(warped.apply_playback_rate(1.5), 1.0);
             assert!((controls.speed() - 1.0).abs() < f32::EPSILON);
             controls.set_speed(1.25);
             assert_eq!(warped.playback_rate(), 1.0);

--- a/crates/kithara-play/src/resource/reader.rs
+++ b/crates/kithara-play/src/resource/reader.rs
@@ -162,7 +162,7 @@ impl Resource {
     }
 
     async fn open<S, B>(
-        config: ResourceConfig<S, B>,
+        mut config: ResourceConfig<S, B>,
         observer: Option<Box<dyn AudioObserver>>,
     ) -> DecodeResult<Self>
     where
@@ -174,6 +174,7 @@ impl Resource {
         let worker = config.worker.clone().ok_or(DecodeError::InvalidData {
             detail: "ResourceConfig requires an explicit PlayWorker",
         })?;
+        config.resolve_output_geometry()?;
         let warp = config.warp.clone();
         let engine_load = config.engine_load.clone();
         // Capture the per-track cancel before `build_*_config` consumes `config`

--- a/crates/kithara-play/src/rt/command.rs
+++ b/crates/kithara-play/src/rt/command.rs
@@ -20,12 +20,6 @@ impl PlayerNodeProcessor {
         }
     }
 
-    fn apply_playback_rate(&mut self, rate: f32) {
-        for (_, track) in self.tracks.iter_mut() {
-            track.set_playback_rate(rate);
-        }
-    }
-
     fn apply_prefetch_duration(&mut self, duration: f32) {
         self.prefetch_duration = duration.max(0.0);
         for (_, track) in self.tracks.iter_mut() {
@@ -110,9 +104,6 @@ impl PlayerNodeProcessor {
                 }
                 PlayerCmd::SetPrefetchDuration(duration) => {
                     self.apply_prefetch_duration(duration);
-                }
-                PlayerCmd::SetPlaybackRate(rate) => {
-                    self.apply_playback_rate(rate);
                 }
             }
         }

--- a/crates/kithara-play/src/rt/track/core.rs
+++ b/crates/kithara-play/src/rt/track/core.rs
@@ -215,9 +215,6 @@ impl PlayerTrack {
             /// Effective media seconds consumed per output second.
             #[must_use]
             pub(crate) fn playback_rate(&self) -> f32;
-            /// Apply a playback-rate target to this track's resource.
-            #[call(apply_playback_rate)]
-            pub fn set_playback_rate(&mut self, rate: f32);
             /// Propagate the host sample rate to the owned resource.
             pub fn set_host_sample_rate(&self, sample_rate: NonZeroU32);
         }

--- a/crates/kithara-play/src/rt/track/core.rs
+++ b/crates/kithara-play/src/rt/track/core.rs
@@ -215,6 +215,9 @@ impl PlayerTrack {
             /// Effective media seconds consumed per output second.
             #[must_use]
             pub(crate) fn playback_rate(&self) -> f32;
+            /// Apply a playback-rate target directly to this track's Warp controls.
+            #[call(apply_playback_rate)]
+            pub fn set_playback_rate(&mut self, rate: f32);
             /// Propagate the host sample rate to the owned resource.
             pub fn set_host_sample_rate(&self, sample_rate: NonZeroU32);
         }

--- a/crates/kithara-play/src/rt/track/feeder.rs
+++ b/crates/kithara-play/src/rt/track/feeder.rs
@@ -142,6 +142,10 @@ impl PlayerResource {
         self.resource.get().decoded_frontier().as_secs_f64()
     }
 
+    pub(crate) fn apply_playback_rate(&self, rate: f32) -> f32 {
+        self.resource.get().apply_playback_rate(rate)
+    }
+
     fn fill_scratch(&mut self, target_frames: usize, metrics: &RtMetrics) -> bool {
         let mut eof_reached = self.eof_seen;
 

--- a/crates/kithara-play/src/rt/track/feeder.rs
+++ b/crates/kithara-play/src/rt/track/feeder.rs
@@ -128,10 +128,6 @@ impl PlayerResource {
         })
     }
 
-    pub(crate) fn apply_playback_rate(&self, rate: f32) -> f32 {
-        self.resource.get().apply_playback_rate(rate)
-    }
-
     /// Cached span in seconds: how much of the source is on disk and needs no
     /// further network.
     #[must_use]

--- a/crates/kithara-play/src/rt/track/feeder.rs
+++ b/crates/kithara-play/src/rt/track/feeder.rs
@@ -146,7 +146,8 @@ impl PlayerResource {
         let mut eof_reached = self.eof_seen;
 
         while target_frames > self.write_len && !eof_reached {
-            let avail = self.channel_buffers[0].len() - self.write_pos;
+            let needed = target_frames - self.write_len;
+            let avail = (self.channel_buffers[0].len() - self.write_pos).min(needed);
             if avail == 0 {
                 break;
             }

--- a/crates/kithara-play/src/rt/track/feeder.rs
+++ b/crates/kithara-play/src/rt/track/feeder.rs
@@ -209,20 +209,6 @@ impl PlayerResource {
             .min(self.channel_buffers[0].len())
     }
 
-    #[kithara::probe(
-        render_revision = source.render_revision(),
-        session_epoch = u64::from(context.session_epoch()),
-        output_start = i64::from(context.output_frames().start)
-            .saturating_add(i64::try_from(output.start).unwrap_or(i64::MAX)),
-        output_end = i64::from(context.output_frames().start)
-            .saturating_add(i64::try_from(output.end).unwrap_or(i64::MAX)),
-        source_start = source.start(),
-        source_end = source.end()
-    )]
-    fn pcm_consumed(&mut self, context: &RenderContext, output: Range<usize>, source: SourceSpan) {
-        self.last_source_end = Some(SourceEnd::new(source.end(), source.sample_rate()));
-    }
-
     fn consume_source(&mut self, mut frames: usize, context: Option<&RenderContext>) {
         let mut output_start = 0usize;
         while frames > 0 {
@@ -233,7 +219,18 @@ impl PlayerResource {
             let output_end = output_start.saturating_add(consumed);
             match (context, span.take(consumed)) {
                 (Some(context), Some(source)) => {
-                    self.pcm_consumed(context, output_start..output_end, source);
+                    kithara::probe_event!(
+                        pcm_consumed,
+                        render_revision = source.render_revision(),
+                        session_epoch = u64::from(context.session_epoch()),
+                        output_start = i64::from(context.output_frames().start)
+                            .saturating_add(i64::try_from(output_start).unwrap_or(i64::MAX)),
+                        output_end = i64::from(context.output_frames().start)
+                            .saturating_add(i64::try_from(output_end).unwrap_or(i64::MAX)),
+                        source_start = source.start(),
+                        source_end = source.end()
+                    );
+                    self.last_source_end = Some(SourceEnd::new(source.end(), source.sample_rate()));
                 }
                 (_, source) => {
                     self.last_source_end =

--- a/crates/kithara-play/src/session/protocol.rs
+++ b/crates/kithara-play/src/session/protocol.rs
@@ -1,4 +1,6 @@
 mod wire {
+    use std::num::NonZeroUsize;
+
     use kithara_bufpool::PoolRegion;
     use kithara_events::EventBus;
     use kithara_warp::{BeatGridId, BeatGridIdAllocationError, SyncError};
@@ -51,6 +53,17 @@ mod wire {
         TransportFrameExhausted,
         #[error("session transport revision is exhausted")]
         TransportRevisionExhausted,
+        #[error(
+            "session output requires {required_frames} response frames for block {max_block_frames} and quantum {render_quantum_frames}, exceeding budget {budget_frames}"
+        )]
+        ResponseBudgetExceeded {
+            max_block_frames: u32,
+            render_quantum_frames: usize,
+            required_frames: usize,
+            budget_frames: usize,
+        },
+        #[error("session output response geometry overflowed")]
+        ResponseGeometryOverflow,
         #[error(transparent)]
         Sync(#[from] SyncError),
         #[error(transparent)]
@@ -73,6 +86,8 @@ mod wire {
         StartPlayer {
             master_volume: f32,
             player_id: PlayerId,
+            render_quantum_frames: Option<NonZeroUsize>,
+            response_budget_frames: NonZeroUsize,
             sample_rate: u32,
         },
         StopPlayer {
@@ -201,7 +216,7 @@ mod wire {
 }
 
 mod handle {
-    use std::num::NonZeroU32;
+    use std::num::{NonZeroU32, NonZeroUsize};
 
     use kithara_audio::ConsumerWakeMode;
     use kithara_bufpool::PoolRegion;
@@ -465,11 +480,15 @@ mod handle {
             &self,
             player_id: PlayerId,
             master_volume: f32,
+            render_quantum_frames: Option<NonZeroUsize>,
+            response_budget_frames: NonZeroUsize,
         ) -> Result<(), PlayError> {
             let sample_rate = self.requested_sample_rate()?.get();
             self.exec_ok(Cmd::StartPlayer {
                 master_volume,
                 player_id,
+                render_quantum_frames,
+                response_budget_frames,
                 sample_rate,
             })
             .map(|_| ())
@@ -496,7 +515,7 @@ pub use wire::{AllocatedSlot, Cmd, PlayerId, PlayerLevel, Reply, SessionError, S
 #[cfg(test)]
 mod tests {
     use std::{
-        num::NonZeroU32,
+        num::{NonZeroU32, NonZeroUsize},
         sync::atomic::{AtomicU32, Ordering},
     };
 
@@ -608,7 +627,14 @@ mod tests {
         assert_eq!(capture.0.load(Ordering::Relaxed), sample_rate().get());
 
         capture.0.store(0, Ordering::Relaxed);
-        handle.start_player(player_id, 1.0).expect("start player");
+        handle
+            .start_player(
+                player_id,
+                1.0,
+                None,
+                NonZeroUsize::new(448).expect("fixture response budget is non-zero"),
+            )
+            .expect("start player");
         assert_eq!(capture.0.load(Ordering::Relaxed), sample_rate().get());
     }
 }

--- a/crates/kithara-play/src/worker/core.rs
+++ b/crates/kithara-play/src/worker/core.rs
@@ -84,6 +84,10 @@ impl<S> PlayWorker<S> {
     pub fn pools(&self) -> &PoolRegion<S> {
         &self.0.pools
     }
+
+    pub(crate) fn wake(&self) {
+        self.0.dispatcher.wake_handle().wake();
+    }
 }
 
 impl<S> Clone for PlayWorker<S> {

--- a/crates/kithara-play/src/worker/source.rs
+++ b/crates/kithara-play/src/worker/source.rs
@@ -579,6 +579,7 @@ where
         match self.source.step_track() {
             TrackStep::Produced(Fetch::Data { data, epoch, .. }) => {
                 if data.spec() == self.spec
+                    && self.prepared_frames.is_none()
                     && self
                         .warp
                         .prepare_quantum(data.meta, data.frames())

--- a/crates/kithara-play/src/worker/source.rs
+++ b/crates/kithara-play/src/worker/source.rs
@@ -1062,7 +1062,11 @@ mod tests {
             flush_deferred(&mut source);
         }
 
-        assert_eq!(output_frames, input_frames);
+        assert!(output_frames.iter().all(|frames| *frames <= quantum_frames));
+        assert_eq!(
+            output_frames.iter().sum::<usize>(),
+            input_frames.iter().copied().sum::<usize>()
+        );
         assert_eq!(output_samples, expected_samples);
     }
 
@@ -1253,30 +1257,18 @@ mod tests {
         let pools = pools();
         let first_active_end = u64::from(ACTIVE_FRAMES);
         let first_unity_end = first_active_end.saturating_add(u64::from(UNITY_FRAMES));
-        let second_active_end = first_unity_end.saturating_add(u64::from(ACTIVE_FRAMES));
-        let second_unity_end = second_active_end.saturating_add(u64::from(UNITY_FRAMES));
-        let sentinel_end = second_unity_end.saturating_add(u64::from(SENTINEL_FRAMES));
+        let sentinel_end = first_unity_end.saturating_add(u64::from(SENTINEL_FRAMES));
 
         let first_active = chunk_with_frames(&pools, spec, 0, ACTIVE_FRAMES, 0.25);
         let first_unity = chunk_with_frames(&pools, spec, first_active_end, UNITY_FRAMES, 0.5);
-        let first_unity_ptr = first_unity.samples.as_ptr();
-        let first_unity_samples = first_unity.samples.to_vec();
-        let second_active = chunk_with_frames(&pools, spec, first_unity_end, ACTIVE_FRAMES, -0.25);
-        let second_unity = chunk_with_frames(&pools, spec, second_active_end, UNITY_FRAMES, -0.5);
-        let sentinel = chunk_with_frames(&pools, spec, second_unity_end, SENTINEL_FRAMES, 0.75);
+        let sentinel = chunk_with_frames(&pools, spec, first_unity_end, SENTINEL_FRAMES, 0.75);
         let sentinel_ptr = sentinel.samples.as_ptr();
         let sentinel_samples = sentinel.samples.to_vec();
 
         let head = Arc::new(AtomicU64::new(0));
         let seek = Arc::new(SeekState::new());
         let raw = RawSource {
-            chunks: VecDeque::from([
-                first_active,
-                first_unity,
-                second_active,
-                second_unity,
-                sentinel,
-            ]),
+            chunks: VecDeque::from([first_active, first_unity, sentinel]),
             head: Arc::clone(&head),
             seek: Arc::clone(&seek),
         };
@@ -1329,73 +1321,12 @@ mod tests {
         assert_eq!(head.load(Ordering::Acquire), first_unity_end);
         assert!(source.warp.transition_pending());
 
-        let mut drain_steps = 0;
-        let emitted_unity = loop {
-            flush_deferred(&mut source);
-            let held_head = head.load(Ordering::Acquire);
-            let step = source.step_track();
-            assert_eq!(
-                head.load(Ordering::Acquire),
-                held_head,
-                "live Warp drain must not pull the next source chunk"
-            );
-            drain_steps += 1;
-            assert!(drain_steps < 64, "live Warp drain must converge");
-            if source.warp.transition_pending() {
-                assert!(matches!(
-                    step,
-                    TrackStep::Produced(_) | TrackStep::StateChanged
-                ));
-                continue;
-            }
-            let TrackStep::Produced(Fetch::Data { data, .. }) = step else {
-                panic!("the completed tail must release queued unity samples");
-            };
-            break data;
-        };
-        assert!(drain_steps > 0);
-        assert_eq!(emitted_unity.samples.as_ptr(), first_unity_ptr);
-        assert_eq!(&emitted_unity.samples[..], &first_unity_samples);
-
-        controls.set_speed(0.5);
-        flush_deferred(&mut source);
-        let second_active = source.step_track();
-        assert!(matches!(
-            &second_active,
-            TrackStep::Produced(_) | TrackStep::StateChanged
-        ));
-        assert_eq!(head.load(Ordering::Acquire), second_active_end);
-        flush_deferred(&mut source);
-        if matches!(&second_active, TrackStep::StateChanged) {
-            let TrackStep::Produced(_) = source.step_track() else {
-                panic!("the second active quantum must render");
-            };
-        }
-
-        controls.set_speed(1.0);
-        flush_deferred(&mut source);
-        let second_transition = source.step_track();
-        assert!(matches!(
-            &second_transition,
-            TrackStep::Produced(_) | TrackStep::StateChanged
-        ));
-        assert_eq!(head.load(Ordering::Acquire), second_unity_end);
-        flush_deferred(&mut source);
-        if matches!(&second_transition, TrackStep::StateChanged) {
-            let TrackStep::Produced(_) = source.step_track() else {
-                panic!("the second transition must emit its first tail quantum");
-            };
-        }
-        assert_eq!(head.load(Ordering::Acquire), second_unity_end);
-        assert!(source.warp.transition_pending());
-        flush_deferred(&mut source);
-
         assert_eq!(
             seek.begin(kithara_platform::time::Duration::from_secs(1)),
             1
         );
         assert!(matches!(source.step_track(), TrackStep::StateChanged));
-        assert_eq!(head.load(Ordering::Acquire), second_unity_end);
+        assert_eq!(head.load(Ordering::Acquire), first_unity_end);
         assert!(!source.warp.transition_pending());
 
         flush_deferred(&mut source);

--- a/crates/kithara-queue/src/loader.rs
+++ b/crates/kithara-queue/src/loader.rs
@@ -171,7 +171,7 @@ where
                 LoadClass::Interactive => &this.interactive_lane,
                 LoadClass::Prefetch => &this.prefetch_lane,
             };
-            admission_started(id);
+            kithara::probe_event!(admission_started, track_id = id.as_u64());
             let permit = tokio::select! {
                 biased;
                 _ = Self::wait_and_cancel_track(&cancel, &track_cancel) => {
@@ -257,9 +257,6 @@ where
         std::future::pending().await
     }
 }
-
-#[kithara::probe(track_id = id.as_u64())]
-fn admission_started(id: TrackId) {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/kithara-queue/src/queue/selection/apply.rs
+++ b/crates/kithara-queue/src/queue/selection/apply.rs
@@ -36,9 +36,12 @@ where
                     return;
                 }
             };
+            #[cfg(not(target_arch = "wasm32"))]
             drop(task::spawn_blocking(move || {
                 queue.apply_loaded(id, resource);
             }));
+            #[cfg(target_arch = "wasm32")]
+            queue.apply_loaded(id, resource);
         }));
     }
 

--- a/crates/kithara-signal/CONTEXT.md
+++ b/crates/kithara-signal/CONTEXT.md
@@ -21,8 +21,10 @@ features.
 Decoder, playback, Warp, and analyzer crates consume these values without
 creating aliases or duplicate decoded-signal types.
 
-`segment_index` and `variant_index` are opaque provenance values supplied by a
-decoder; this crate does not interpret them or own protocol policy.
+`segment_index`, `variant_index`, and `render_revision` are opaque provenance
+values supplied by producers; this crate stores but does not interpret them or
+own decoder, protocol, or Warp policy. Keeping the revision with the samples
+preserves causality through buffered signal processing.
 
 ## Stable Value Shapes
 

--- a/crates/kithara-stream/src/dl/batch.rs
+++ b/crates/kithara-stream/src/dl/batch.rs
@@ -76,88 +76,17 @@ impl NetObserver for RequestObserver {
     }
 }
 
-/// Transition a fetch from queued → in-flight. Increments the
-/// `inflight` counter (the fact subscribers and the watchdog actually
-/// observe) and notifies bus listeners with the realised
-/// queue-residence time.
-#[kithara::probe(request_id, wait_in_queue)]
-fn start_request(
-    bus: Option<&EventBus>,
-    inflight: &std::sync::atomic::AtomicUsize,
-    request_id: RequestId,
-    wait_in_queue: Duration,
-) {
-    inflight.fetch_add(1, Ordering::Relaxed);
-    if let Some(b) = bus {
-        b.publish(DownloaderEvent::RequestStarted {
-            request_id,
-            wait_in_queue,
-        });
-    }
-}
-
-/// Record a fetch as successfully finished. Feeds the realised
-/// bandwidth into ABR (the fact downstream throttling cares about) and
-/// notifies subscribers.
-#[kithara::probe(request_id, bytes_transferred, duration)]
-fn finish_request(
-    bus: Option<&EventBus>,
-    abr: &Arc<AbrController>,
-    peer_id: AbrPeerId,
-    request_id: RequestId,
-    bytes_transferred: u64,
-    duration: Duration,
-) {
-    if bytes_transferred > 0 {
-        abr.record_bandwidth(
-            peer_id,
-            bytes_transferred,
-            duration,
-            BandwidthSource::Network,
-        );
-    }
-    if let Some(b) = bus {
-        b.publish(DownloaderEvent::RequestCompleted {
-            request_id,
-            bytes_transferred,
-            duration,
-            bandwidth_bps: bandwidth_bps(bytes_transferred, duration),
-        });
-    }
-}
-
-/// Abort a fetch and propagate the cancel reason. `was_in_flight`
-/// distinguishes a mid-flight kill (a fetch task was already running)
-/// from a before-start kill the [`deliver_cancelled_with_event`] path
-/// performs on entries that never spawned.
-#[kithara::probe(request_id, reason, bytes_transferred, was_in_flight)]
-fn abort_request(
+fn publish_cancelled(
     bus: Option<&EventBus>,
     request_id: RequestId,
     reason: CancelReason,
     bytes_transferred: u64,
-    was_in_flight: bool,
 ) {
     if let Some(bus) = bus {
         bus.publish(DownloaderEvent::RequestCancelled {
             request_id,
             reason,
             bytes_transferred,
-        });
-    }
-    let _ = was_in_flight;
-}
-
-/// Mark a fetch as failed (network or protocol error). Tags the
-/// failure as retryable or terminal so callers can decide whether to
-/// re-queue.
-#[kithara::probe(request_id, retryable)]
-fn fail_request(bus: Option<&EventBus>, request_id: RequestId, err: &NetError, retryable: bool) {
-    if let Some(bus) = bus {
-        bus.publish(DownloaderEvent::RequestFailed {
-            request_id,
-            retryable,
-            error: err.clone(),
         });
     }
 }
@@ -251,7 +180,14 @@ fn spawn_fetch(inner: &DownloaderInner, internal: InternalCmd, peer_cancel: Canc
     let cancel = internal.cancel.clone();
     let epoch_cancel = cmd.cancel.clone();
 
-    start_request(bus.as_ref(), &inflight, request_id, wait_in_queue);
+    kithara::probe_event!(start_request, request_id, wait_in_queue);
+    inflight.fetch_add(1, Ordering::Relaxed);
+    if let Some(bus) = bus.as_ref() {
+        bus.publish(DownloaderEvent::RequestStarted {
+            request_id,
+            wait_in_queue,
+        });
+    }
 
     task::spawn(async move {
         let slow_bus = bus.clone();
@@ -512,7 +448,23 @@ async fn deliver(request_id: RequestId, ctx: DeliveryContext<'_>) {
                 let elapsed = fetch_elapsed(started);
                 match write_result {
                     Ok(total) => {
-                        finish_request(bus.as_ref(), &abr, peer_id, request_id, total, elapsed);
+                        kithara::probe_event!(
+                            finish_request,
+                            request_id,
+                            bytes_transferred = total,
+                            duration = elapsed
+                        );
+                        if total > 0 {
+                            abr.record_bandwidth(peer_id, total, elapsed, BandwidthSource::Network);
+                        }
+                        if let Some(bus) = bus.as_ref() {
+                            bus.publish(DownloaderEvent::RequestCompleted {
+                                request_id,
+                                bytes_transferred: total,
+                                duration: elapsed,
+                                bandwidth_bps: bandwidth_bps(total, elapsed),
+                            });
+                        }
                         if let Some(cb) = on_complete_cb {
                             cb(total, Some(&headers), None);
                         }
@@ -564,10 +516,24 @@ fn publish_failure_or_cancel(
 ) {
     if matches!(err, NetError::Cancelled) {
         let reason = classify_cancel(peer_cancel, epoch_cancel, downloader_cancel);
-        abort_request(bus, request_id, reason, bytes_transferred, true);
+        kithara::probe_event!(
+            abort_request,
+            request_id,
+            reason,
+            bytes_transferred,
+            was_in_flight = true
+        );
+        publish_cancelled(bus, request_id, reason, bytes_transferred);
     } else {
         let retryable = err.retryability() == Retryability::Transient;
-        fail_request(bus, request_id, err, retryable);
+        kithara::probe_event!(fail_request, request_id, retryable);
+        if let Some(bus) = bus {
+            bus.publish(DownloaderEvent::RequestFailed {
+                request_id,
+                retryable,
+                error: err.clone(),
+            });
+        }
     }
 }
 
@@ -584,7 +550,14 @@ pub(super) fn deliver_cancelled_with_event(internal: InternalCmd, peer_cancel: &
     let epoch_cancel = internal.cmd.cancel.clone();
     let placeholder_inner = CancelToken::never();
     let reason = classify_cancel(peer_cancel, epoch_cancel.as_ref(), &placeholder_inner);
-    abort_request(bus.as_ref(), request_id, reason, 0, false);
+    kithara::probe_event!(
+        abort_request,
+        request_id,
+        reason,
+        bytes_transferred = 0_u64,
+        was_in_flight = false
+    );
+    publish_cancelled(bus.as_ref(), request_id, reason, 0);
     deliver_cancelled(internal.response, internal.cmd);
 }
 

--- a/crates/kithara-stream/src/playhead.rs
+++ b/crates/kithara-stream/src/playhead.rs
@@ -115,15 +115,6 @@ impl PlayheadState {
         self.position_ns
             .store(ns.min(self.cap()), Ordering::Release);
     }
-
-    /// Capped playhead write that also fires the `committed_ns` USDT probe.
-    /// The probe lives here because the produce path advances the playhead
-    /// directly through this `PlayheadWrite` handle. The FLAC
-    /// `swallow_detector` consumes this probe (`tests/src/swallow_detector.rs`).
-    #[kithara::probe(committed_ns = pos.end_position_ns)]
-    fn write_playhead(&self, pos: &ChunkPosition) {
-        self.write_ns_capped(pos.end_position_ns);
-    }
 }
 
 impl Default for PlayheadState {
@@ -158,7 +149,8 @@ impl PlayheadRead for PlayheadState {
 
 impl PlayheadWrite for PlayheadState {
     fn advance(&self, pos: &ChunkPosition) {
-        self.write_playhead(pos);
+        kithara::probe_event!(write_playhead, committed_ns = pos.end_position_ns);
+        self.write_ns_capped(pos.end_position_ns);
     }
 
     fn advance_partial(&self, position: Duration) {

--- a/crates/kithara-stretch/src/backends/signalsmith.rs
+++ b/crates/kithara-stretch/src/backends/signalsmith.rs
@@ -189,6 +189,7 @@ impl ElasticEngine for SignalsmithElastic {
         prime_input
             .ensure_len(prime_samples.max(native_tail_samples))
             .map_err(|_| ElasticError::PoolCapacity)?;
+        prime_input.shrink_to_fit();
         Ok(Self {
             inner,
             capabilities,

--- a/crates/kithara-stretch/src/elastic/rate.rs
+++ b/crates/kithara-stretch/src/elastic/rate.rs
@@ -38,6 +38,27 @@ impl ElasticRateEnvelope {
             && source_frames_per_output <= self.max_source_frames_per_output.next_up()
     }
 
+    /// Largest request whose exact ratio rounds to `source_frames_per_output`.
+    #[must_use]
+    pub fn largest_request_at(
+        self,
+        source_frames_per_output: f64,
+        max_source_frames: usize,
+        max_output_frames: usize,
+    ) -> Option<ElasticRequest> {
+        if !self.contains_rate(source_frames_per_output) {
+            return None;
+        }
+        let minimum = binary_midpoint(
+            source_frames_per_output.next_down(),
+            source_frames_per_output,
+        )?;
+        let maximum =
+            binary_midpoint(source_frames_per_output, source_frames_per_output.next_up())?;
+        largest_request_between(minimum, maximum, max_source_frames, max_output_frames)
+            .filter(|request| self.contains(*request))
+    }
+
     pub(crate) fn has_representable_request(
         self,
         max_source_frames: usize,
@@ -167,7 +188,7 @@ impl TryFrom<RangeInclusive<f64>> for ElasticRateEnvelope {
 mod tests {
     use kithara_test_utils::kithara;
 
-    use super::{ElasticError, ElasticRateEnvelope};
+    use super::{ElasticError, ElasticRateEnvelope, ElasticRequest};
 
     fn envelope() -> ElasticRateEnvelope {
         ElasticRateEnvelope::try_from(2.0 / 3.0..=4.0 / 3.0)
@@ -203,5 +224,22 @@ mod tests {
                 Err(ElasticError::InvalidRateEnvelope { .. })
             ));
         }
+    }
+
+    #[kithara::test]
+    fn largest_request_preserves_exact_rates_inside_frame_limits() {
+        let envelope = ElasticRateEnvelope::try_from(0.05..=4.0)
+            .expect("invariant: practical rate envelope is valid");
+
+        assert_eq!(
+            envelope.largest_request_at(0.05, 8192, 64),
+            ElasticRequest::new(3, 60).ok()
+        );
+        assert_eq!(
+            envelope.largest_request_at(4.0, 8192, 64),
+            ElasticRequest::new(256, 64).ok()
+        );
+        assert_eq!(envelope.largest_request_at(0.05, 8192, 19), None);
+        assert_eq!(envelope.largest_request_at(0.049, 8192, 64), None);
     }
 }

--- a/crates/kithara-test-macros/CONTEXT.md
+++ b/crates/kithara-test-macros/CONTEXT.md
@@ -99,8 +99,8 @@ guard, so probes stay active but `RTSan`-transparent under `--cfg rtsan`.
   `caller_line`, `seq`, `thread_id`, `thread_seq`, `install_id`). Use for very-frequent production functions whose
   parameters are not `IntoProbeArg` (e.g. `Future::poll_next(&self, cx: &mut Context)`).
 - `#[kithara::probe(field1, field2, …)]` — parameter idents recorded as wire args; each must match a real parameter name.
-- `#[kithara::probe(name = expr, …)]` — records a computed value under wire-name `name`. `expr` is evaluated inside the
-  function body at probe-firing time (so it can read `self`, parameters, locals) and must implement `IntoProbeArg`. A
+- `#[kithara::probe(name = expr, …)]` — records a computed value under wire-name `name`. `expr` is evaluated at function
+  entry (so it can read `self` and parameters, but not later locals) and must implement `IntoProbeArg`. A
   computed name may not collide with a plain ident in the same attribute; `caller` and `probe_return` are reserved.
 - Plain and computed entries share one ceiling: **6 wire args total**, the USDT provider arity limit. Over it, fold fields
   into a `#[derive(kithara::Probe)]` struct or split the function.
@@ -108,3 +108,7 @@ guard, so probes stay active but `RTSan`-transparent under `--cfg rtsan`.
   costs roughly a millisecond per firing; do NOT use on `poll_next`-style hot probes.
 - `#[kithara::probe(probe_return)]` — records the return value through `Probe::record_probe`, emits no entry event, and is
   the only form that drops `#[track_caller]`.
+
+Use `kithara::probe_event!(name, field, wire_name = expression)` when the observed
+values exist only inside a real product operation. Do not extract a one-call or
+one-assignment function just to attach `#[kithara::probe]`.

--- a/crates/kithara-test-macros/src/lib.rs
+++ b/crates/kithara-test-macros/src/lib.rs
@@ -4,7 +4,8 @@
 //! (Rust requires them in the crate root) and delegates logic to per-macro modules:
 //! - [`test`] — `#[kithara::test]` (sync/async/native/wasm with case+fixture).
 //! - [`fixture`] — `#[kithara::fixture]` (rstest-fixture replacement).
-//! - [`probe`] — `#[kithara::probe]` + `#[derive(kithara::Probe)]`
+//! - [`probe`] — `#[kithara::probe]`, `kithara::probe_event!`, and
+//!   `#[derive(kithara::Probe)]`
 //!   (USDT + tracing instrumentation; auto-gated
 //!   `cfg(any(test, feature = "probe"))`, with the emit wrapped in a
 //!   `kithara_test_utils::rtsan::permit` guard so probes stay active but
@@ -125,6 +126,13 @@ pub fn facade_allow_block(attr: TokenStream, item: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn probe(attr: TokenStream, item: TokenStream) -> TokenStream {
     probe::expand_attr(attr, item)
+}
+
+/// `kithara::probe_event!(name, field, wire_name = expression)` — emit a probe
+/// from inside the product operation that owns the observed transition.
+#[proc_macro]
+pub fn probe_event(input: TokenStream) -> TokenStream {
+    probe::expand_event_entry(input)
 }
 
 /// `#[kithara::mock]` — workspace replacement for `#[unimock(...)]`.

--- a/crates/kithara-test-macros/src/probe/entry.rs
+++ b/crates/kithara-test-macros/src/probe/entry.rs
@@ -4,9 +4,16 @@ use syn::{DeriveInput, Error, ItemFn, parse_macro_input};
 
 use super::{
     derive::{expand_derive, expand_derive_into_probe_arg},
-    expand::expand,
-    parse::parse_filter,
+    expand::{expand, expand_event},
+    parse::{ProbeEvent, parse_filter},
 };
+
+pub(crate) fn expand_event_entry(input: TokenStream) -> TokenStream {
+    let event = parse_macro_input!(input as ProbeEvent);
+    expand_event(event)
+        .unwrap_or_else(Error::into_compile_error)
+        .into()
+}
 
 /// Entry-point for `#[kithara::probe]` — forwarded from `lib.rs`.
 pub(crate) fn expand_attr(attr: TokenStream, item: TokenStream) -> TokenStream {

--- a/crates/kithara-test-macros/src/probe/expand.rs
+++ b/crates/kithara-test-macros/src/probe/expand.rs
@@ -1,8 +1,18 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
-use syn::{Error, Ident, ItemFn, Pat, PatIdent};
+use syn::{Error, Expr, Ident, ItemFn, Pat, PatIdent};
 
-use super::parse::ProbeFilter;
+use super::parse::{ProbeEvent, ProbeFilter};
+
+struct WireFields {
+    arg_bindings: Vec<TokenStream2>,
+    computed_bindings: Vec<TokenStream2>,
+    arg_consumes: Vec<TokenStream2>,
+    computed_consumes: Vec<TokenStream2>,
+    fire_fn: Ident,
+    slots: Vec<Ident>,
+    tracing_fields: Vec<TokenStream2>,
+}
 
 /// Collect every named parameter ident from a function signature.
 /// Rejects patterns (`(a, b): _`, ref/mut bindings) — the probe
@@ -50,6 +60,91 @@ fn resolve_arg_idents(
     Ok(names)
 }
 
+fn wire_fields(
+    args: &[Ident],
+    computed: &[(Ident, Expr)],
+    owner: &Ident,
+) -> syn::Result<WireFields> {
+    if let Some((name, _)) = computed
+        .iter()
+        .find(|(name, _)| args.iter().any(|arg| arg == name))
+    {
+        return Err(Error::new_spanned(
+            name,
+            format!("probe wire-name `{name}` is specified more than once"),
+        ));
+    }
+    let total = args.len() + computed.len();
+    if total > 6 {
+        return Err(Error::new_spanned(
+            owner,
+            "probe supports at most 6 wire arguments (USDT provider arity ceiling)",
+        ));
+    }
+
+    let arg_slots: Vec<Ident> = (0..args.len())
+        .map(|index| format_ident!("__probe_arg_{index}"))
+        .collect();
+    let computed_slots: Vec<Ident> = (0..computed.len())
+        .map(|index| format_ident!("__probe_computed_{index}"))
+        .collect();
+    let arg_bindings = args
+        .iter()
+        .zip(&arg_slots)
+        .map(|(arg, slot)| {
+            quote! {
+                #[cfg(any(test, feature = "probe"))]
+                let #slot: u64 =
+                    ::kithara_test_utils::probe::IntoProbeArg::into_probe_arg(#arg);
+            }
+        })
+        .collect();
+    let computed_bindings = computed
+        .iter()
+        .zip(&computed_slots)
+        .map(|((_, expression), slot)| {
+            quote! {
+                #[cfg(any(test, feature = "probe"))]
+                let #slot: u64 =
+                    ::kithara_test_utils::probe::IntoProbeArg::into_probe_arg(#expression);
+            }
+        })
+        .collect();
+    let arg_consumes = args.iter().map(|arg| quote! { let _ = &#arg; }).collect();
+    let computed_consumes = computed
+        .iter()
+        .map(|(_, expression)| {
+            quote! {
+                if false {
+                    let _ = #expression;
+                }
+            }
+        })
+        .collect();
+    let slots = arg_slots.iter().chain(&computed_slots).cloned().collect();
+    let tracing_fields = args
+        .iter()
+        .zip(&arg_slots)
+        .map(|(name, slot)| quote! { #name = #slot })
+        .chain(
+            computed
+                .iter()
+                .zip(&computed_slots)
+                .map(|((name, _), slot)| quote! { #name = #slot }),
+        )
+        .collect();
+
+    Ok(WireFields {
+        arg_bindings,
+        computed_bindings,
+        arg_consumes,
+        computed_consumes,
+        fire_fn: format_ident!("fire_{total}"),
+        slots,
+        tracing_fields,
+    })
+}
+
 pub(crate) fn expand(input: &ItemFn, filter: ProbeFilter) -> syn::Result<TokenStream2> {
     let fn_name = input.sig.ident.clone();
     let fn_name_str = fn_name.to_string();
@@ -67,96 +162,8 @@ pub(crate) fn expand(input: &ItemFn, filter: ProbeFilter) -> syn::Result<TokenSt
     let all_args = collect_fn_param_idents(input)?;
     let arg_idents = resolve_arg_idents(filter.args, &all_args)?;
     let computed = filter.computed;
-
-    for (name, _) in &computed {
-        if arg_idents.iter().any(|a| a == name) {
-            return Err(Error::new_spanned(
-                name,
-                format!(
-                    "#[kithara::probe(...)] computed wire-name `{name}` \
-                     collides with a parameter passed in the same probe \
-                     attribute; pick a different name"
-                ),
-            ));
-        }
-    }
-
-    let total_wire = arg_idents.len() + computed.len();
-    if total_wire > 6 {
-        return Err(Error::new_spanned(
-            &input.sig.ident,
-            "#[kithara::probe] supports at most 6 wire arguments \
-             (USDT provider arity ceiling) — counting both plain \
-             parameters and `name = expr` computed values. Pass fewer \
-             fields, fold them into a single struct via \
-             `#[derive(Probe)]`, or split the function so each probe \
-             site stays under the limit.",
-        ));
-    }
     let probe_return = filter.probe_return;
-
-    let arg_slot_idents: Vec<Ident> = (0..arg_idents.len())
-        .map(|i| format_ident!("__probe_arg_{}", i))
-        .collect();
-    let computed_slot_idents: Vec<Ident> = (0..computed.len())
-        .map(|i| format_ident!("__probe_computed_{}", i))
-        .collect();
-
-    let arg_bindings: Vec<TokenStream2> = arg_idents
-        .iter()
-        .zip(arg_slot_idents.iter())
-        .map(|(arg, slot)| {
-            quote! {
-                #[cfg(any(test, feature = "probe"))]
-                let #slot: u64 = ::kithara_test_utils::probe::IntoProbeArg::into_probe_arg(#arg);
-            }
-        })
-        .collect();
-
-    let computed_bindings: Vec<TokenStream2> = computed
-        .iter()
-        .zip(computed_slot_idents.iter())
-        .map(|((_, expr), slot)| {
-            quote! {
-                #[cfg(any(test, feature = "probe"))]
-                let #slot: u64 = ::kithara_test_utils::probe::IntoProbeArg::into_probe_arg(#expr);
-            }
-        })
-        .collect();
-
-    let arg_consume: Vec<TokenStream2> =
-        arg_idents.iter().map(|a| quote! { let _ = &#a; }).collect();
-
-    let computed_consume: Vec<TokenStream2> = computed
-        .iter()
-        .map(|(_, expr)| {
-            quote! {
-                if false {
-                    let _ = #expr;
-                }
-            }
-        })
-        .collect();
-
-    let fire_fn = format_ident!("fire_{}", total_wire);
-
-    let mut probe_slot_idents: Vec<Ident> = Vec::with_capacity(total_wire);
-    probe_slot_idents.extend(arg_slot_idents.iter().cloned());
-    probe_slot_idents.extend(computed_slot_idents.iter().cloned());
-
-    let mut tracing_fields: Vec<TokenStream2> = Vec::with_capacity(total_wire);
-    tracing_fields.extend(
-        arg_idents
-            .iter()
-            .zip(arg_slot_idents.iter())
-            .map(|(name, slot)| quote! { #name = #slot }),
-    );
-    tracing_fields.extend(
-        computed
-            .iter()
-            .zip(computed_slot_idents.iter())
-            .map(|((name, _), slot)| quote! { #name = #slot }),
-    );
+    let fields = wire_fields(&arg_idents, &computed, &input.sig.ident)?;
 
     let attrs = &input.attrs;
     let vis = &input.vis;
@@ -194,11 +201,18 @@ pub(crate) fn expand(input: &ItemFn, filter: ProbeFilter) -> syn::Result<TokenSt
         probe_return,
         &fn_name_str,
         &target,
-        &fire_fn,
-        &probe_slot_idents,
-        &tracing_fields,
+        &fields.fire_fn,
+        &fields.slots,
+        &fields.tracing_fields,
         &capture_caller_fn,
     );
+    let WireFields {
+        arg_bindings,
+        computed_bindings,
+        arg_consumes,
+        computed_consumes,
+        ..
+    } = fields;
 
     let track_caller_attr = if probe_return {
         quote! {}
@@ -210,14 +224,51 @@ pub(crate) fn expand(input: &ItemFn, filter: ProbeFilter) -> syn::Result<TokenSt
         #(#attrs)*
         #track_caller_attr
         #vis #sig {
-            #(#arg_consume)*
-            #(#computed_consume)*
+            #(#arg_consumes)*
+            #(#computed_consumes)*
             #(#arg_bindings)*
             #(#computed_bindings)*
             #emit_entry_event
             #body
         }
     })
+}
+
+pub(crate) fn expand_event(event: ProbeEvent) -> syn::Result<TokenStream2> {
+    let ProbeEvent {
+        name,
+        args,
+        computed,
+    } = event;
+    let crate_name = std::env::var("CARGO_PKG_NAME")
+        .map_err(|_| Error::new_spanned(&name, "probe requires CARGO_PKG_NAME"))?
+        .replace('-', "_");
+    let probe_name = name.to_string();
+    let fields = wire_fields(&args, &computed, &name)?;
+    let capture_caller_fn = quote! { let __probe_caller_fn = ""; };
+    let emit = build_emit_entry_event(
+        false,
+        &probe_name,
+        &format!("{crate_name}_probe"),
+        &fields.fire_fn,
+        &fields.slots,
+        &fields.tracing_fields,
+        &capture_caller_fn,
+    );
+    let WireFields {
+        arg_bindings,
+        computed_bindings,
+        arg_consumes,
+        computed_consumes,
+        ..
+    } = fields;
+    Ok(quote! {{
+        #(#arg_consumes)*
+        #(#computed_consumes)*
+        #(#arg_bindings)*
+        #(#computed_bindings)*
+        #emit
+    }})
 }
 
 fn build_emit_entry_event(

--- a/crates/kithara-test-macros/src/probe/mod.rs
+++ b/crates/kithara-test-macros/src/probe/mod.rs
@@ -3,4 +3,6 @@ mod entry;
 mod expand;
 mod parse;
 
-pub(crate) use entry::{expand_attr, expand_derive_entry, expand_derive_into_probe_arg_entry};
+pub(crate) use entry::{
+    expand_attr, expand_derive_entry, expand_derive_into_probe_arg_entry, expand_event_entry,
+};

--- a/crates/kithara-test-macros/src/probe/parse.rs
+++ b/crates/kithara-test-macros/src/probe/parse.rs
@@ -5,6 +5,35 @@ use syn::{
     punctuated::Punctuated,
 };
 
+pub(super) struct ProbeEvent {
+    pub name: Ident,
+    pub args: Vec<Ident>,
+    pub computed: Vec<(Ident, Expr)>,
+}
+
+impl Parse for ProbeEvent {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let name = input.parse()?;
+        let filter = if input.is_empty() {
+            ProbeFilter::default()
+        } else {
+            input.parse::<Token![,]>()?;
+            parse_entries(input)?
+        };
+        if filter.caller || filter.probe_return {
+            return Err(Error::new_spanned(
+                name,
+                "kithara::probe_event! does not accept attribute-only flags",
+            ));
+        }
+        Ok(Self {
+            name,
+            args: filter.args.unwrap_or_default(),
+            computed: filter.computed,
+        })
+    }
+}
+
 /// Parsed `#[kithara::probe(...)]` arguments: parameter idents, computed
 /// `name = expr` values, and the `caller` / `probe_return` flags. See the
 /// crate `CONTEXT.md` "`#[kithara::probe(...)]` arguments" for the syntax.
@@ -48,6 +77,14 @@ pub(crate) fn parse_filter(attr: TokenStream2) -> syn::Result<ProbeFilter> {
     }
     let parser = Punctuated::<ProbeArg, Token![,]>::parse_terminated;
     let parsed = parser.parse2(attr)?;
+    filter_entries(parsed)
+}
+
+fn parse_entries(input: ParseStream) -> syn::Result<ProbeFilter> {
+    filter_entries(Punctuated::<ProbeArg, Token![,]>::parse_terminated(input)?)
+}
+
+fn filter_entries(parsed: Punctuated<ProbeArg, Token![,]>) -> syn::Result<ProbeFilter> {
     let mut filter = ProbeFilter::default();
     let mut args: Vec<Ident> = Vec::new();
     for entry in parsed {

--- a/crates/kithara-test-utils/src/lib.rs
+++ b/crates/kithara-test-utils/src/lib.rs
@@ -25,7 +25,7 @@ pub mod test;
 pub mod kithara {
     pub use kithara_test_macros::{
         Probe, allow_block, asset, fixture, flash, hang_watchdog, measure, measure_block, mock,
-        no_block, probe, rtsan_allow_blocking, rtsan_forbid_blocking, test,
+        no_block, probe, probe_event, rtsan_allow_blocking, rtsan_forbid_blocking, test,
     };
 }
 

--- a/crates/kithara-test-utils/src/probe/real/wire.rs
+++ b/crates/kithara-test-utils/src/probe/real/wire.rs
@@ -323,7 +323,7 @@ pub fn bump_install_id() -> u64 {
 /// nightly-only) but implements `Hash` over that inner value directly, so
 /// we hash the `ThreadId` itself — no `format!`/`String` allocation. That
 /// matters because this runs on the real-time render path (e.g.
-/// `PlayheadState::write_playhead`); allocating here would abort under
+/// `PlayheadWrite::advance`); allocating here would abort under
 /// `-Zsanitizer=realtime`. Equal `ThreadId` values hash to the same `u64`,
 /// distinct values almost certainly do not — the only consumer is "group
 /// probe events by thread" and a hash collision would fold two threads

--- a/crates/kithara-warp/CONTEXT.md
+++ b/crates/kithara-warp/CONTEXT.md
@@ -45,12 +45,14 @@ contracts for the later actuator integration.
 ## Configuration
 
 `WarpConfig` is built with `bon`, uses `fieldwork` for read access, and carries
-the shared `StretchControls` owned by the resident identity `Warp<S>` and
-consumed by its native renderer. The identity renderer deliberately ignores
-temporal intent while preserving the same stage contract. Every renderer
-receives the caller's configured `PoolRegion<S>`; it never creates a pool region. Source
-ownership, cancellation, and worker resources remain in their canonical
-configs and are not duplicated here.
+the shared `StretchControls` owned by the resident identity `Warp<S>`. On
+native targets it also carries backend preparation, source-block, smoothing,
+and optional render-quantum settings expressed in frames. The identity
+renderer deliberately ignores temporal intent while preserving the same stage
+contract. Every renderer receives the caller's configured `PoolRegion<S>`; it
+never creates a pool region. Source ownership, cancellation, worker resources,
+and response budgets remain in their canonical configs and are not duplicated
+here.
 
 Fixed-ratio sample-rate conversion remains owned by `kithara-decode`; it is not
 a substitute Warp backend because resampling changes pitch. Targets without an

--- a/crates/kithara-warp/Cargo.toml
+++ b/crates/kithara-warp/Cargo.toml
@@ -14,8 +14,8 @@ default = []
 perf = ["kithara-stretch?/perf"]
 probe = ["dep:kithara-test-utils"]
 render = ["dep:kithara-bufpool"]
-stretch-signalsmith = ["dep:kithara-stretch", "kithara-stretch/stretch-signalsmith", "render"]
-stretch-bungee = ["dep:kithara-stretch", "kithara-stretch/stretch-bungee", "render"]
+stretch-signalsmith = ["dep:firewheel-core", "dep:kithara-stretch", "kithara-stretch/stretch-signalsmith", "render"]
+stretch-bungee = ["dep:firewheel-core", "dep:kithara-stretch", "kithara-stretch/stretch-bungee", "render"]
 
 [dependencies]
 kithara-bufpool = { workspace = true, optional = true }
@@ -29,6 +29,7 @@ bon = { workspace = true }
 delegate = { workspace = true }
 derive_more = { workspace = true }
 fieldwork = { workspace = true }
+firewheel-core = { workspace = true, optional = true }
 num-traits = { workspace = true }
 portable-atomic = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/kithara-warp/src/warp/config.rs
+++ b/crates/kithara-warp/src/warp/config.rs
@@ -2,8 +2,18 @@ use std::num::NonZeroUsize;
 
 use bon::Builder;
 use kithara_platform::sync::Arc;
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    any(feature = "stretch-signalsmith", feature = "stretch-bungee")
+))]
+use kithara_stretch::ElasticBackendConfig;
 
 use crate::StretchControls;
+
+const DEFAULT_SOURCE_BLOCK_FRAMES: NonZeroUsize = match NonZeroUsize::new(8192) {
+    Some(frames) => frames,
+    None => unreachable!(),
+};
 
 /// Fixed resources used to construct one resident [`super::Warp`].
 #[derive(Clone, Debug, Builder, fieldwork::Fieldwork)]
@@ -15,6 +25,22 @@ pub struct WarpConfig {
     #[builder(default = StretchControls::new(1.0))]
     #[field(get, deref = false)]
     stretch: Arc<StretchControls>,
+    /// Preparation parameters for the compiled elastic backends.
+    #[cfg(all(
+        not(target_arch = "wasm32"),
+        any(feature = "stretch-signalsmith", feature = "stretch-bungee")
+    ))]
+    #[builder(default)]
+    #[field(get, copy)]
+    backends: ElasticBackendConfig,
+    /// Maximum source frames admitted to one elastic render operation.
+    #[builder(default = DEFAULT_SOURCE_BLOCK_FRAMES)]
+    #[field(get, copy)]
+    source_block_frames: NonZeroUsize,
+    /// Output-frame window used to smooth live rate changes.
+    #[builder(default = NonZeroUsize::MIN)]
+    #[field(get, copy)]
+    rate_smooth_frames: NonZeroUsize,
     /// Optional output-frame cap between samples of live temporal controls.
     /// Without a cap, Warp consumes the complete source span accepted by its backend.
     #[field(get, copy)]

--- a/crates/kithara-warp/src/warp/render/identity.rs
+++ b/crates/kithara-warp/src/warp/render/identity.rs
@@ -21,23 +21,6 @@ impl<S> WarpRenderer<S>
 where
     S: HasPool<f32>,
 {
-    #[kithara::probe(
-        session_epoch = u64::from(committed.context().session_epoch()),
-        transport_revision = committed.context().transport_revision().map_or(0, u64::from),
-        output_start,
-        output_end = i64::from(committed.frontier().output()),
-        source_start,
-        source_end = committed.frontier().source()
-    )]
-    fn render_committed(
-        &mut self,
-        committed: RenderSnapshot,
-        source_start: u64,
-        output_start: i64,
-    ) {
-        self.committed = Some(committed);
-    }
-
     pub(crate) fn new(
         _config: &WarpConfig,
         context: RenderReader,
@@ -127,7 +110,19 @@ where
             if let Some(committed) =
                 snapshot.advance(self.committed.as_ref(), source, chunk.frames())
             {
-                self.render_committed(committed, source_start, output_start);
+                kithara::probe_event!(
+                    render_committed,
+                    session_epoch = u64::from(committed.context().session_epoch()),
+                    transport_revision = committed
+                        .context()
+                        .transport_revision()
+                        .map_or(0, u64::from),
+                    output_start,
+                    output_end = i64::from(committed.frontier().output()),
+                    source_start,
+                    source_end = committed.frontier().source()
+                );
+                self.committed = Some(committed);
             }
         }
         Some(chunk)

--- a/crates/kithara-warp/src/warp/render/mod.rs
+++ b/crates/kithara-warp/src/warp/render/mod.rs
@@ -18,6 +18,11 @@ mod renderer;
     not(target_arch = "wasm32"),
     any(feature = "stretch-signalsmith", feature = "stretch-bungee")
 ))]
+mod renderer_activation;
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    any(feature = "stretch-signalsmith", feature = "stretch-bungee")
+))]
 mod renderer_lifecycle;
 #[cfg(all(
     not(target_arch = "wasm32"),

--- a/crates/kithara-warp/src/warp/render/renderer.rs
+++ b/crates/kithara-warp/src/warp/render/renderer.rs
@@ -387,7 +387,19 @@ where
         else {
             return;
         };
-        self.render_committed(committed, source_start, output_start);
+        kithara::probe_event!(
+            render_committed,
+            session_epoch = u64::from(committed.context().session_epoch()),
+            transport_revision = committed
+                .context()
+                .transport_revision()
+                .map_or(0, u64::from),
+            output_start,
+            output_end = i64::from(committed.frontier().output()),
+            source_start,
+            source_end = committed.frontier().source()
+        );
+        self.committed = Some(committed);
     }
 
     pub(super) fn commit_rate_render(
@@ -409,50 +421,15 @@ where
         else {
             return;
         };
-        self.rate_applied(
-            committed,
+        kithara::probe_event!(
+            rate_applied,
             request_revision,
-            applied_rate.to_bits(),
+            applied_rate_bits = applied_rate.to_bits(),
+            session_epoch = u64::from(committed.context().session_epoch()),
             session_frame,
             source_start,
-            source_end,
+            source_end
         );
-    }
-
-    #[kithara::probe(
-        session_epoch = u64::from(committed.context().session_epoch()),
-        transport_revision = committed.context().transport_revision().map_or(0, u64::from),
-        output_start,
-        output_end = i64::from(committed.frontier().output()),
-        source_start,
-        source_end = committed.frontier().source()
-    )]
-    fn render_committed(
-        &mut self,
-        committed: RenderSnapshot,
-        source_start: u64,
-        output_start: i64,
-    ) {
-        self.committed = Some(committed);
-    }
-
-    #[kithara::probe(
-        request_revision,
-        applied_rate_bits,
-        session_epoch = u64::from(committed.context().session_epoch()),
-        session_frame,
-        source_start,
-        source_end
-    )]
-    fn rate_applied(
-        &mut self,
-        committed: RenderSnapshot,
-        request_revision: u64,
-        applied_rate_bits: u32,
-        session_frame: i64,
-        source_start: u64,
-        source_end: u64,
-    ) {
         self.committed = Some(committed);
     }
 

--- a/crates/kithara-warp/src/warp/render/renderer.rs
+++ b/crates/kithara-warp/src/warp/render/renderer.rs
@@ -3,7 +3,7 @@ use std::num::{NonZeroU32, NonZeroUsize};
 use kithara_bufpool::{HasPool, PoolRegion, SampleBuffer};
 use kithara_platform::{sync::Arc, time::Duration};
 use kithara_signal::{AudioChunkInfo, AudioSpec, FrameCount};
-use kithara_stretch::{ElasticEngine, ElasticError, StretchKind};
+use kithara_stretch::{ElasticBackendConfig, ElasticEngine, ElasticError, StretchKind};
 use kithara_test_macros as kithara;
 use tracing::warn;
 
@@ -28,6 +28,7 @@ pub struct WarpRenderer<S> {
     pub(super) context: RenderReader,
     pub(super) committed: Option<RenderSnapshot>,
     pub(super) controls: Arc<StretchControls>,
+    pub(super) backends: ElasticBackendConfig,
     pub(super) engine: Option<Box<dyn ElasticEngine>>,
     /// Engine displaced by a checked render failure. The scheduler shell
     /// drops it from `prepare`, outside `produce_tick_rt`.
@@ -43,6 +44,8 @@ pub struct WarpRenderer<S> {
     pub(super) region: Option<ActiveRegion>,
     pub(super) pools: PoolRegion<S>,
     pub(super) spec: AudioSpec,
+    /// Maximum source frames admitted to one elastic render operation.
+    pub(super) source_block_frames: NonZeroUsize,
     /// Maximum output frames between samples of live temporal controls.
     pub(super) render_quantum_frames: Option<NonZeroUsize>,
     /// Source span and live speed selected by the scheduler for the next render.
@@ -87,7 +90,6 @@ where
     S: HasPool<f32>,
 {
     pub(super) const MAX_OUTPUT_FRAMES: usize = 163_840;
-    pub(super) const MAX_SOURCE_FRAMES: usize = 8192;
     pub(super) const OUTPUT_ROUNDING_MARGIN: f64 = 0.5;
     /// Re-apply pitch to the backend only when it moves this much.
     pub(super) const RATIO_EPS: f64 = 1e-4;
@@ -102,16 +104,26 @@ where
         let controls = Arc::clone(config.stretch());
         let current_kind = controls.backend();
         let plan = controls.region_plan();
-        let target = Self::prepare_target(current_kind, spec, &pools, None, None);
+        let target = Self::prepare_target(
+            current_kind,
+            config.backends(),
+            config.source_block_frames(),
+            spec,
+            &pools,
+            None,
+            None,
+        );
         Self {
             context,
             committed: None,
+            backends: config.backends(),
             engine: target.engine,
             retired_engine: None,
             current_kind,
             controls,
             pools,
             spec,
+            source_block_frames: config.source_block_frames(),
             render_quantum_frames: config.render_quantum_frames(),
             prepared_quantum: None,
             applied_pitch: f64::NAN,

--- a/crates/kithara-warp/src/warp/render/renderer.rs
+++ b/crates/kithara-warp/src/warp/render/renderer.rs
@@ -2,11 +2,13 @@ use std::num::{NonZeroU32, NonZeroUsize};
 
 use kithara_bufpool::{HasPool, PoolRegion, SampleBuffer};
 use kithara_platform::{sync::Arc, time::Duration};
-use kithara_signal::{AudioChunkInfo, AudioSpec, FrameCount};
-use kithara_stretch::{ElasticBackendConfig, ElasticEngine, ElasticError, StretchKind};
+use kithara_signal::{AudioChunkInfo, AudioSpec};
+use kithara_stretch::{
+    ElasticBackendConfig, ElasticEngine, ElasticError, ElasticRequest, StretchKind,
+};
 use kithara_test_macros as kithara;
-use tracing::warn;
 
+use super::renderer_target::PreparedTarget;
 use crate::{
     ActiveRegion, RegionPlan, RenderReader, RenderSnapshot, StretchControls, WarpConfig,
     temporal::RateTarget,
@@ -17,8 +19,24 @@ mod tests;
 
 #[derive(Clone, Copy)]
 pub(super) struct PreparedQuantum {
+    pub(super) active_frames: usize,
+    pub(super) activation: Option<PreparedActivation>,
     pub(super) frames: usize,
     pub(super) rate: RateTarget,
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct PreparedActivation {
+    pub(super) history_frames: usize,
+    pub(super) warm: ElasticRequest,
+}
+
+impl PreparedActivation {
+    pub(super) fn prefix_frames(self) -> Result<usize, ElasticError> {
+        self.history_frames
+            .checked_add(self.warm.source_frames())
+            .ok_or(ElasticError::SampleCountOverflow)
+    }
 }
 
 /// Source-timeline exact-span time-stretch driven by shared live controls.
@@ -55,6 +73,8 @@ pub struct WarpRenderer<S> {
     /// Interleaved output scratch prepared by the scheduler shell. A produced
     /// chunk takes this buffer; the consumed input becomes its replacement.
     pub(super) scratch: Option<SampleBuffer>,
+    /// Latency-sized pooled output discarded while priming an inactive engine.
+    pub(super) activation_scratch: Option<SampleBuffer>,
     /// Consumed input retained until the scheduler shell can resize or recycle
     /// it outside the checked render core.
     pub(super) deferred_scratch: Option<SampleBuffer>,
@@ -70,6 +90,8 @@ pub struct WarpRenderer<S> {
     pub(super) pending_source: Option<SampleBuffer>,
     /// Earliest metadata represented by `pending_source`.
     pub(super) pending_meta: Option<AudioChunkInfo>,
+    /// Oldest sample in the rolling unity history stored in `pending_source`.
+    pub(super) passthrough_history_head: Option<usize>,
     /// Unity chunk retained while the active backend drains its tail.
     /// Its samples occupy `pending_source` without a copy.
     pub(super) pending_unity_meta: Option<AudioChunkInfo>,
@@ -77,6 +99,8 @@ pub struct WarpRenderer<S> {
     pub(super) rendered_source_end: Option<(u64, NonZeroU32)>,
     /// Source frames admitted since the last renderer reset.
     pub(super) source_frames_admitted: u64,
+    /// Warm source consumed while priming but not yet represented by output.
+    pub(super) primed_source_debt: u64,
     /// Reset requested by seek or a return to unity passthrough. The scheduler
     /// shell performs it outside the checked render core.
     pub(super) reset_pending: bool,
@@ -110,9 +134,9 @@ where
             config.source_block_frames(),
             spec,
             &pools,
-            None,
-            None,
+            PreparedTarget::default(),
         );
+        let passthrough_history_head = target.engine.is_some().then_some(0);
         Self {
             context,
             committed: None,
@@ -131,54 +155,21 @@ where
             output_remainder: 0.0,
             pending_source: target.pending_source,
             pending_meta: None,
+            passthrough_history_head,
             pending_unity_meta: None,
             rendered_source_end: None,
             source_frames_admitted: 0,
+            primed_source_debt: 0,
             reset_pending: false,
             rebuild_pending: false,
             last_input_meta: None,
             output_start_meta: None,
             scratch: target.scratch,
+            activation_scratch: target.activation_scratch,
             deferred_scratch: None,
             plan,
             region: None,
         }
-    }
-
-    /// Select the next source span that fits the configured output quantum.
-    pub fn prepare_quantum(
-        &mut self,
-        meta: AudioChunkInfo,
-        remaining: usize,
-    ) -> Option<FrameCount> {
-        self.sync_plan();
-        let rate = self.controls.rate_target();
-        match self.source_frames_for_quantum(meta, remaining, rate.speed()) {
-            Ok(frames) => {
-                self.prepared_quantum = Some(PreparedQuantum { frames, rate });
-                Some(FrameCount::new(frames))
-            }
-            Err(error) => {
-                self.prepared_quantum = None;
-                warn!(%error, "time-stretch source quantum sizing failed");
-                None
-            }
-        }
-    }
-
-    /// Shrink a prepared source span at true EOF without sampling controls again.
-    pub fn prepare_terminal_quantum(
-        &mut self,
-        _meta: AudioChunkInfo,
-        frames: usize,
-    ) -> Option<FrameCount> {
-        let mut prepared = self.prepared_quantum.take()?;
-        if frames == 0 || frames > prepared.frames {
-            return None;
-        }
-        prepared.frames = frames;
-        self.prepared_quantum = Some(prepared);
-        Some(FrameCount::new(frames))
     }
 
     /// Whether this target has elastic DSP and needs worker staging.
@@ -206,6 +197,7 @@ where
             source.clear();
         }
         self.pending_meta = None;
+        self.passthrough_history_head = None;
         self.pending_unity_meta = None;
     }
 
@@ -219,6 +211,9 @@ where
         if let Some(scratch) = self.scratch.as_mut() {
             scratch.clear();
         }
+        if let Some(scratch) = self.activation_scratch.as_mut() {
+            scratch.clear();
+        }
         self.clear_pending_source();
         self.last_input_meta = None;
         self.output_start_meta = None;
@@ -227,6 +222,7 @@ where
         self.prepared_quantum = None;
         self.rendered_source_end = None;
         self.source_frames_admitted = 0;
+        self.primed_source_debt = 0;
         self.active = false;
         self.region = None;
     }
@@ -274,7 +270,7 @@ where
     }
 
     pub(super) fn pending_frames(&self, channels: usize) -> usize {
-        if self.transition_pending() {
+        if self.transition_pending() || self.passthrough_history_head.is_some() {
             return 0;
         }
         self.pending_source
@@ -312,7 +308,9 @@ where
         let backend_held = u64::try_from(latency)
             .unwrap_or(u64::MAX)
             .min(backend_admitted);
-        pending.saturating_add(backend_held)
+        pending
+            .saturating_add(backend_held)
+            .saturating_add(self.primed_source_debt)
     }
 
     pub(super) fn record_rendered_source_end(

--- a/crates/kithara-warp/src/warp/render/renderer.rs
+++ b/crates/kithara-warp/src/warp/render/renderer.rs
@@ -1,5 +1,6 @@
 use std::num::{NonZeroU32, NonZeroUsize};
 
+use firewheel_core::param::smoother::{SmoothedParam, SmootherConfig};
 use kithara_bufpool::{HasPool, PoolRegion, SampleBuffer};
 use kithara_platform::{sync::Arc, time::Duration};
 use kithara_signal::{AudioChunkInfo, AudioSpec};
@@ -7,6 +8,8 @@ use kithara_stretch::{
     ElasticBackendConfig, ElasticEngine, ElasticError, ElasticRequest, StretchKind,
 };
 use kithara_test_macros as kithara;
+use num_traits::cast::AsPrimitive;
+use tracing::warn;
 
 use super::renderer_target::PreparedTarget;
 use crate::{
@@ -23,6 +26,7 @@ pub(super) struct PreparedQuantum {
     pub(super) activation: Option<PreparedActivation>,
     pub(super) frames: usize,
     pub(super) rate: RateTarget,
+    pub(super) speed: f32,
 }
 
 #[derive(Clone, Copy)]
@@ -68,6 +72,8 @@ pub struct WarpRenderer<S> {
     pub(super) render_quantum_frames: Option<NonZeroUsize>,
     /// Source span and live speed selected by the scheduler for the next render.
     pub(super) prepared_quantum: Option<PreparedQuantum>,
+    /// Renderer-owned applied speed. Shared controls contain only the target.
+    pub(super) applied_speed: Option<SmoothedParam>,
     /// Engine kind currently prepared by the scheduler shell.
     pub(super) current_kind: StretchKind,
     /// Interleaved output scratch prepared by the scheduler shell. A produced
@@ -128,6 +134,9 @@ where
         let controls = Arc::clone(config.stretch());
         let current_kind = controls.backend();
         let plan = controls.region_plan();
+        let speed = controls.speed();
+        let smooth_frames: f32 = config.rate_smooth_frames().get().as_();
+        let sample_rate: f32 = spec.sample_rate.get().as_();
         let target = Self::prepare_target(
             current_kind,
             config.backends(),
@@ -150,6 +159,16 @@ where
             source_block_frames: config.source_block_frames(),
             render_quantum_frames: config.render_quantum_frames(),
             prepared_quantum: None,
+            applied_speed: (config.rate_smooth_frames().get() > 1).then(|| {
+                SmoothedParam::new(
+                    speed,
+                    SmootherConfig {
+                        smooth_seconds: smooth_frames / sample_rate,
+                        ..SmootherConfig::default()
+                    },
+                    spec.sample_rate,
+                )
+            }),
             applied_pitch: f64::NAN,
             active: false,
             output_remainder: 0.0,
@@ -225,6 +244,14 @@ where
         self.primed_source_debt = 0;
         self.active = false;
         self.region = None;
+    }
+
+    pub(super) fn snap_speed(&mut self) {
+        if let Some(applied) = self.applied_speed.as_mut() {
+            applied.set_value(self.controls.speed());
+            applied.reset_to_target();
+        }
+        self.prepared_quantum = None;
     }
 
     pub(super) fn defer_scratch(&mut self, replacement: Option<SampleBuffer>) {
@@ -369,7 +396,11 @@ where
         output_frames: usize,
         request_revision: u64,
         applied_rate: f32,
+        target_rate: f32,
     ) {
+        if let Err(error) = self.advance_speed(target_rate, output_frames) {
+            warn!(%error, "time-stretch speed smoothing failed");
+        }
         let Some(snapshot) = snapshot else {
             return;
         };

--- a/crates/kithara-warp/src/warp/render/renderer/tests/playback.rs
+++ b/crates/kithara-warp/src/warp/render/renderer/tests/playback.rs
@@ -261,15 +261,15 @@ fn rendered_source_frontier_excludes_backend_lookahead(#[case] backend: StretchK
 #[cfg_attr(feature = "stretch-bungee", case::bungee(StretchKind::Bungee))]
 fn rendered_source_frontier_reaches_end_only_on_completed_drain(#[case] backend: StretchKind) {
     const SOURCE_START: u64 = 10_000;
-    const SOURCE_FRAMES: usize = WarpRenderer::MAX_SOURCE_FRAMES;
 
     let mut renderer = keylocked(backend, StretchControls::MIN_SPEED);
+    let source_frames = renderer.source_block_frames.get();
     let pools = renderer.pools.clone();
-    let source = sine(SOURCE_FRAMES);
+    let source = sine(source_frames);
     let mut input = chunk(&pools, &source);
     input.meta.frame_offset = SOURCE_START;
     let admitted = SOURCE_START
-        .checked_add(u64::try_from(SOURCE_FRAMES).expect("source frame count fits u64"))
+        .checked_add(u64::try_from(source_frames).expect("source frame count fits u64"))
         .expect("source frontier fits u64");
     let source_latency = renderer
         .engine
@@ -279,7 +279,7 @@ fn rendered_source_frontier_reaches_end_only_on_completed_drain(#[case] backend:
         .latency()
         .source_frames();
     let held =
-        u64::try_from(source_latency.min(SOURCE_FRAMES)).expect("backend source latency fits u64");
+        u64::try_from(source_latency.min(source_frames)).expect("backend source latency fits u64");
 
     render_serviced(&mut renderer, input).expect("minimum-speed render emits samples");
     assert_eq!(

--- a/crates/kithara-warp/src/warp/render/renderer/tests/playback.rs
+++ b/crates/kithara-warp/src/warp/render/renderer/tests/playback.rs
@@ -61,6 +61,78 @@ fn source_span_is_planned_from_the_output_quantum(
 }
 
 #[kithara::test]
+#[cfg_attr(
+    feature = "stretch-signalsmith",
+    case::signalsmith(StretchKind::Signalsmith)
+)]
+#[cfg_attr(feature = "stretch-bungee", case::bungee(StretchKind::Bungee))]
+fn live_activation_primes_from_passthrough_history(#[case] backend: StretchKind) {
+    let controls = StretchControls::new(1.0);
+    controls.set_backend(backend);
+    let config = WarpConfig::builder()
+        .stretch(Arc::clone(&controls))
+        .render_quantum_frames(NonZeroUsize::new(32).expect("test quantum is non-zero"))
+        .build();
+    let mut renderer = Warp::new((), &config).renderer(spec(), pools());
+    renderer.prepare(spec());
+    let latency = renderer
+        .engine
+        .as_ref()
+        .expect("compiled backend is available")
+        .capabilities()
+        .latency();
+    let cue = latency.source_frames();
+    assert!(cue > 0, "activation needs backend history");
+
+    let pools = renderer.pools.clone();
+    let source = sine(cue);
+    let unity = render_serviced(&mut renderer, chunk(&pools, &source))
+        .expect("unity history remains byte-exact");
+    assert_eq!(&unity.samples[..], &source);
+
+    let revision = controls.set_speed(2.0);
+    let mut meta = AudioChunkInfo {
+        frame_offset: u64::try_from(cue).expect("cue fits u64"),
+        spec: spec(),
+        timestamp: spec()
+            .duration_for(u64::try_from(cue).expect("cue fits u64"))
+            .expect("cue timestamp fits"),
+        ..AudioChunkInfo::default()
+    };
+    let input_frames = renderer
+        .prepare_quantum(meta, 128)
+        .expect("activation quantum is plannable")
+        .get();
+    assert!(
+        input_frames > 128,
+        "activation includes lookahead and warmup"
+    );
+    let active = sine(input_frames);
+    meta.frames = u32::try_from(input_frames).expect("input frames fit u32");
+    meta.end_timestamp = meta
+        .timestamp
+        .checked_add(
+            spec()
+                .duration_for(u64::try_from(input_frames).expect("input frames fit u64"))
+                .expect("input duration fits"),
+        )
+        .expect("input end timestamp fits");
+
+    let mut input = chunk(&pools, &active);
+    input.meta = meta;
+    let output = renderer
+        .render_quantum(input)
+        .expect("primed activation emits immediately");
+
+    assert_eq!(
+        output.meta.frame_offset,
+        u64::try_from(cue).expect("cue fits u64")
+    );
+    assert_eq!(output.meta.render_revision, revision);
+    assert!(output.frames() > 0);
+}
+
+#[kithara::test]
 fn rendered_quantum_keeps_the_rate_revision_selected_during_planning() {
     let controls = StretchControls::new(1.0);
     let expected_revision = controls.set_speed(1.0);

--- a/crates/kithara-warp/src/warp/render/renderer/tests/playback.rs
+++ b/crates/kithara-warp/src/warp/render/renderer/tests/playback.rs
@@ -21,7 +21,7 @@ use crate::{Warp, WarpConfig, test_pools::pools};
 )]
 #[cfg_attr(
     feature = "stretch-signalsmith",
-    case::signalsmith_unity(StretchKind::Signalsmith, 1.0, 128)
+    case::signalsmith_unity(StretchKind::Signalsmith, 1.0, 32)
 )]
 #[cfg_attr(
     feature = "stretch-signalsmith",
@@ -33,7 +33,7 @@ use crate::{Warp, WarpConfig, test_pools::pools};
 )]
 #[cfg_attr(
     feature = "stretch-bungee",
-    case::bungee_unity(StretchKind::Bungee, 1.0, 128)
+    case::bungee_unity(StretchKind::Bungee, 1.0, 32)
 )]
 #[cfg_attr(
     feature = "stretch-bungee",

--- a/crates/kithara-warp/src/warp/render/renderer/tests/timeline.rs
+++ b/crates/kithara-warp/src/warp/render/renderer/tests/timeline.rs
@@ -210,7 +210,7 @@ fn rendered_source_frontier_excludes_pending_source(#[case] backend: StretchKind
         .capabilities()
         .latency()
         .source_frames();
-    assert!(source_latency <= WarpRenderer::MAX_SOURCE_FRAMES);
+    assert!(source_latency <= fx.source_block_frames.get());
     controls.set_region_plan(Some(Arc::new(
         RegionPlan::new(vec![GridSegment::new(
             u64::try_from(source_latency).expect("source latency fits u64") + 1,

--- a/crates/kithara-warp/src/warp/render/renderer_activation.rs
+++ b/crates/kithara-warp/src/warp/render/renderer_activation.rs
@@ -9,35 +9,6 @@ use tracing::warn;
 
 use super::renderer::{PreparedActivation, PreparedQuantum, WarpRenderer};
 
-struct PrimeBuffers<'a> {
-    history: &'a [f32],
-    lookahead: &'a [f32],
-    source: &'a [f32],
-    discarded_output: &'a mut [f32],
-}
-
-#[kithara::probe(
-    request_revision,
-    target_rate_bits,
-    source_frames = request.source_frames(),
-    output_frames = request.output_frames()
-)]
-fn prime_activation(
-    engine: &mut dyn kithara_stretch::ElasticEngine,
-    request_revision: u64,
-    target_rate_bits: u32,
-    request: ElasticRequest,
-    buffers: PrimeBuffers<'_>,
-) -> Result<(), ElasticError> {
-    engine.prime(
-        request,
-        buffers.history,
-        buffers.lookahead,
-        buffers.source,
-        buffers.discarded_output,
-    )
-}
-
 impl<S> WarpRenderer<S>
 where
     S: HasPool<f32>,
@@ -365,21 +336,17 @@ where
         scratch
             .ensure_len(discard_samples)
             .map_err(|_| ElasticError::PoolCapacity)?;
-        prime_activation(
-            self.engine
-                .as_mut()
-                .ok_or(ElasticError::EnginePreparation("engine is unavailable"))?
-                .as_mut(),
-            prepared.rate.revision(),
-            prepared.rate.speed().to_bits(),
-            activation.warm,
-            PrimeBuffers {
-                history,
-                lookahead,
-                source: warm,
-                discarded_output: scratch,
-            },
-        )?;
+        kithara::probe_event!(
+            prime_activation,
+            request_revision = prepared.rate.revision(),
+            target_rate_bits = prepared.rate.speed().to_bits(),
+            source_frames = activation.warm.source_frames(),
+            output_frames = activation.warm.output_frames()
+        );
+        self.engine
+            .as_mut()
+            .ok_or(ElasticError::EnginePreparation("engine is unavailable"))?
+            .prime(activation.warm, history, lookahead, warm, scratch)?;
         scratch.clear();
 
         self.clear_pending_source();

--- a/crates/kithara-warp/src/warp/render/renderer_activation.rs
+++ b/crates/kithara-warp/src/warp/render/renderer_activation.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroUsize;
+
 use kithara_bufpool::HasPool;
 use kithara_signal::{AudioChunk, AudioChunkInfo, FrameCount};
 use kithara_stretch::{ElasticError, ElasticRequest};
@@ -48,9 +50,17 @@ where
     ) -> Option<FrameCount> {
         self.sync_plan();
         let rate = self.controls.rate_target();
+        let preview_frames = self
+            .render_quantum_frames
+            .map_or(remaining, NonZeroUsize::get)
+            .max(1);
         let result = self
-            .prepared_activation(rate.speed())
-            .and_then(|activation| {
+            .preview_speed(rate.speed(), preview_frames)
+            .and_then(|speed| {
+                self.prepared_activation(speed)
+                    .map(|activation| (speed, activation))
+            })
+            .and_then(|(speed, activation)| {
                 let prefix = activation.map_or(Ok(0), PreparedActivation::prefix_frames)?;
                 let frame_offset = meta
                     .frame_offset
@@ -61,7 +71,7 @@ where
                 let active_frames = self.source_frames_for_quantum(
                     Self::meta_at_frame(meta, frame_offset),
                     remaining,
-                    rate.speed(),
+                    speed,
                 )?;
                 let frames = prefix
                     .checked_add(active_frames)
@@ -71,6 +81,7 @@ where
                     activation,
                     frames,
                     rate,
+                    speed,
                 })
             });
         match result {

--- a/crates/kithara-warp/src/warp/render/renderer_activation.rs
+++ b/crates/kithara-warp/src/warp/render/renderer_activation.rs
@@ -1,0 +1,398 @@
+use kithara_bufpool::HasPool;
+use kithara_signal::{AudioChunk, AudioChunkInfo, FrameCount};
+use kithara_stretch::{ElasticError, ElasticRequest};
+use kithara_test_macros as kithara;
+use num_traits::ToPrimitive;
+use tracing::warn;
+
+use super::renderer::{PreparedActivation, PreparedQuantum, WarpRenderer};
+
+struct PrimeBuffers<'a> {
+    history: &'a [f32],
+    lookahead: &'a [f32],
+    source: &'a [f32],
+    discarded_output: &'a mut [f32],
+}
+
+#[kithara::probe(
+    request_revision,
+    target_rate_bits,
+    source_frames = request.source_frames(),
+    output_frames = request.output_frames()
+)]
+fn prime_activation(
+    engine: &mut dyn kithara_stretch::ElasticEngine,
+    request_revision: u64,
+    target_rate_bits: u32,
+    request: ElasticRequest,
+    buffers: PrimeBuffers<'_>,
+) -> Result<(), ElasticError> {
+    engine.prime(
+        request,
+        buffers.history,
+        buffers.lookahead,
+        buffers.source,
+        buffers.discarded_output,
+    )
+}
+
+impl<S> WarpRenderer<S>
+where
+    S: HasPool<f32>,
+{
+    /// Select the next source span that fits the configured output quantum.
+    pub fn prepare_quantum(
+        &mut self,
+        meta: AudioChunkInfo,
+        remaining: usize,
+    ) -> Option<FrameCount> {
+        self.sync_plan();
+        let rate = self.controls.rate_target();
+        let result = self
+            .prepared_activation(rate.speed())
+            .and_then(|activation| {
+                let prefix = activation.map_or(Ok(0), PreparedActivation::prefix_frames)?;
+                let frame_offset = meta
+                    .frame_offset
+                    .checked_add(
+                        u64::try_from(prefix).map_err(|_| ElasticError::SampleCountOverflow)?,
+                    )
+                    .ok_or(ElasticError::SampleCountOverflow)?;
+                let active_frames = self.source_frames_for_quantum(
+                    Self::meta_at_frame(meta, frame_offset),
+                    remaining,
+                    rate.speed(),
+                )?;
+                let frames = prefix
+                    .checked_add(active_frames)
+                    .ok_or(ElasticError::SampleCountOverflow)?;
+                Ok(PreparedQuantum {
+                    active_frames,
+                    activation,
+                    frames,
+                    rate,
+                })
+            });
+        match result {
+            Ok(prepared) => {
+                self.prepared_quantum = Some(prepared);
+                Some(FrameCount::new(prepared.frames))
+            }
+            Err(error) => {
+                self.prepared_quantum = None;
+                warn!(%error, "time-stretch source quantum sizing failed");
+                None
+            }
+        }
+    }
+
+    /// Shrink a prepared source span at true EOF without sampling controls again.
+    pub fn prepare_terminal_quantum(
+        &mut self,
+        _meta: AudioChunkInfo,
+        frames: usize,
+    ) -> Option<FrameCount> {
+        let mut prepared = self.prepared_quantum.take()?;
+        if frames == 0 || frames > prepared.frames {
+            return None;
+        }
+        prepared.frames = frames;
+        if let Some(activation) = prepared.activation {
+            let prefix = activation.prefix_frames().ok()?;
+            if frames > prefix {
+                prepared.active_frames = frames - prefix;
+            } else {
+                prepared.active_frames = frames;
+                prepared.activation = None;
+            }
+        } else {
+            prepared.active_frames = frames;
+        }
+        self.prepared_quantum = Some(prepared);
+        Some(FrameCount::new(frames))
+    }
+
+    pub(super) fn reset_passthrough_history(&mut self) -> Result<(), ElasticError> {
+        let channels = usize::from(self.spec.channels.max(1));
+        let history_samples = self
+            .engine
+            .as_ref()
+            .ok_or(ElasticError::EnginePreparation("engine is unavailable"))?
+            .capabilities()
+            .latency()
+            .source_frames()
+            .checked_mul(channels)
+            .ok_or(ElasticError::SampleCountOverflow)?;
+        let history = self
+            .pending_source
+            .as_mut()
+            .ok_or(ElasticError::PoolCapacity)?;
+        history
+            .ensure_len(history_samples)
+            .map_err(|_| ElasticError::PoolCapacity)?;
+        history.fill(0.0);
+        self.passthrough_history_head = Some(0);
+        Ok(())
+    }
+
+    fn write_passthrough_history(history: &mut [f32], head: usize, source: &[f32]) -> usize {
+        debug_assert!(!history.is_empty());
+        debug_assert!(source.len() < history.len());
+        let first = source.len().min(history.len() - head);
+        history[head..head + first].copy_from_slice(&source[..first]);
+        let rest = source.len() - first;
+        history[..rest].copy_from_slice(&source[first..]);
+        (head + source.len()) % history.len()
+    }
+
+    pub(super) fn retain_passthrough_history(
+        &mut self,
+        meta: AudioChunkInfo,
+        source: &[f32],
+    ) -> Result<(), ElasticError> {
+        let Some(engine) = self.engine.as_ref() else {
+            self.clear_pending_source();
+            return Ok(());
+        };
+        let channels = usize::from(self.spec.channels.max(1));
+        let history_frames = engine.capabilities().latency().source_frames();
+        let history_samples = history_frames
+            .checked_mul(channels)
+            .ok_or(ElasticError::SampleCountOverflow)?;
+        let continuous = self.rendered_source_end.is_none_or(|(frame, sample_rate)| {
+            frame == meta.frame_offset && sample_rate == meta.spec.sample_rate
+        });
+        if !continuous {
+            self.clear_pending_source();
+        }
+        if history_samples == 0 {
+            self.passthrough_history_head = Some(0);
+            return Ok(());
+        }
+        let history = self
+            .pending_source
+            .as_mut()
+            .ok_or(ElasticError::PoolCapacity)?;
+        if history_samples > history.capacity() {
+            return Err(ElasticError::SourceFrameLimit {
+                frames: history_frames,
+                limit: history.capacity() / channels,
+            });
+        }
+        if source.len() >= history_samples {
+            history
+                .ensure_len(history_samples)
+                .map_err(|_| ElasticError::PoolCapacity)?;
+            history.copy_from_slice(&source[source.len() - history_samples..]);
+            self.passthrough_history_head = Some(0);
+            return Ok(());
+        }
+
+        let current = history.len();
+        if current < history_samples {
+            let appended = source.len().min(history_samples - current);
+            history
+                .try_extend_from_slice(&source[..appended])
+                .map_err(|_| ElasticError::PoolCapacity)?;
+            if appended == source.len() {
+                self.passthrough_history_head = Some(0);
+                return Ok(());
+            }
+            let rest = &source[appended..];
+            self.passthrough_history_head = Some(Self::write_passthrough_history(history, 0, rest));
+            return Ok(());
+        }
+
+        let head = self.passthrough_history_head.unwrap_or(0);
+        self.passthrough_history_head =
+            Some(Self::write_passthrough_history(history, head, source));
+        Ok(())
+    }
+
+    fn activation_latency_frames(&self) -> Option<(usize, usize)> {
+        if self.active || self.scratch.is_none() || self.rendered_source_end.is_none() {
+            return None;
+        }
+        let latency = self.engine.as_ref()?.capabilities().latency();
+        let history_frames = latency.source_frames();
+        let output_frames = latency.output_frames();
+        let channels = usize::from(self.spec.channels.max(1));
+        let history_samples = history_frames.checked_mul(channels)?;
+        if history_frames == 0
+            || output_frames == 0
+            || self.passthrough_history_head.is_none()
+            || self.pending_source.as_deref()?.len() != history_samples
+        {
+            return None;
+        }
+        Some((history_frames, output_frames))
+    }
+
+    pub(super) fn prepared_activation(
+        &self,
+        speed: f32,
+    ) -> Result<Option<PreparedActivation>, ElasticError> {
+        if self.unity_passthrough(speed) {
+            return Ok(None);
+        }
+        let Some((history_frames, output_frames)) = self.activation_latency_frames() else {
+            return Ok(None);
+        };
+        let source_frames = output_frames
+            .to_f64()
+            .map(|frames| (frames * f64::from(speed)).round())
+            .and_then(|frames| frames.to_usize())
+            .ok_or(ElasticError::SampleCountOverflow)?;
+        Ok(Some(PreparedActivation {
+            history_frames,
+            warm: ElasticRequest::new(source_frames, output_frames)?,
+        }))
+    }
+
+    pub(super) fn activate_prepared_quantum(
+        &mut self,
+        chunk: &mut AudioChunk,
+        prepared: PreparedQuantum,
+    ) -> Result<(), ElasticError> {
+        let Some(activation) = prepared.activation else {
+            if self.passthrough_history_head.is_some() {
+                self.clear_pending_source();
+            }
+            return Ok(());
+        };
+        let prefix_frames = activation.prefix_frames()?;
+        let (cue, sample_rate) =
+            self.rendered_source_end
+                .ok_or(ElasticError::EnginePreparation(
+                    "Warp renderer has no presented source frontier",
+                ))?;
+        if chunk.meta.frame_offset != cue || chunk.meta.spec.sample_rate != sample_rate {
+            return Err(ElasticError::DiscontinuousSource {
+                expected: cue.to_f64().ok_or(ElasticError::SampleCountOverflow)?,
+                actual: chunk
+                    .meta
+                    .frame_offset
+                    .to_f64()
+                    .ok_or(ElasticError::SampleCountOverflow)?,
+            });
+        }
+        if chunk.frames() != prepared.frames {
+            return Err(ElasticError::SourceFrameLimit {
+                frames: chunk.frames(),
+                limit: prepared.frames,
+            });
+        }
+
+        let channels = usize::from(self.spec.channels.max(1));
+        let history_samples = activation
+            .history_frames
+            .checked_mul(channels)
+            .ok_or(ElasticError::SampleCountOverflow)?;
+        let warm_samples = activation
+            .warm
+            .source_frames()
+            .checked_mul(channels)
+            .ok_or(ElasticError::SampleCountOverflow)?;
+        let prefix_samples = prefix_frames
+            .checked_mul(channels)
+            .ok_or(ElasticError::SampleCountOverflow)?;
+        let active_samples = prepared
+            .active_frames
+            .checked_mul(channels)
+            .ok_or(ElasticError::SampleCountOverflow)?;
+        let active_end = prefix_samples
+            .checked_add(active_samples)
+            .ok_or(ElasticError::SampleCountOverflow)?;
+        let discard_samples = activation
+            .warm
+            .output_frames()
+            .checked_mul(channels)
+            .ok_or(ElasticError::SampleCountOverflow)?;
+        let pitch = if self.controls.keylock() {
+            1.0
+        } else {
+            f64::from(prepared.rate.speed())
+        };
+        self.apply_pitch(pitch)?;
+
+        let head = self
+            .passthrough_history_head
+            .ok_or(ElasticError::EnginePreparation(
+                "Warp renderer history is unavailable",
+            ))?;
+        let history = self
+            .pending_source
+            .as_mut()
+            .ok_or(ElasticError::PoolCapacity)?;
+        if history.len() != history_samples {
+            return Err(ElasticError::HistorySampleCount {
+                actual: history.len(),
+                expected: history_samples,
+            });
+        }
+        history.rotate_left(head);
+
+        let lookahead = chunk.samples.get(..history_samples).ok_or_else(|| {
+            ElasticError::LookaheadSampleCount {
+                actual: chunk.samples.len().min(history_samples),
+                expected: history_samples,
+            }
+        })?;
+        let warm = chunk
+            .samples
+            .get(history_samples..prefix_samples)
+            .ok_or_else(|| ElasticError::SourceSampleCount {
+                actual: chunk.samples.len().saturating_sub(history_samples),
+                expected: warm_samples,
+            })?;
+        let scratch = self
+            .activation_scratch
+            .as_mut()
+            .ok_or(ElasticError::EnginePreparation(
+                "activation scratch is unavailable",
+            ))?;
+        scratch
+            .ensure_len(discard_samples)
+            .map_err(|_| ElasticError::PoolCapacity)?;
+        prime_activation(
+            self.engine
+                .as_mut()
+                .ok_or(ElasticError::EnginePreparation("engine is unavailable"))?
+                .as_mut(),
+            prepared.rate.revision(),
+            prepared.rate.speed().to_bits(),
+            activation.warm,
+            PrimeBuffers {
+                history,
+                lookahead,
+                source: warm,
+                discarded_output: scratch,
+            },
+        )?;
+        scratch.clear();
+
+        self.clear_pending_source();
+        chunk.samples.copy_within(prefix_samples..active_end, 0);
+        chunk.samples.truncate(active_samples);
+        let original = chunk.meta;
+        chunk.meta = Self::meta_at_frame(
+            original,
+            original
+                .frame_offset
+                .checked_add(
+                    u64::try_from(prefix_frames).map_err(|_| ElasticError::SampleCountOverflow)?,
+                )
+                .ok_or(ElasticError::SampleCountOverflow)?,
+        );
+        chunk.meta.frames =
+            u32::try_from(prepared.active_frames).map_err(|_| ElasticError::SampleCountOverflow)?;
+        chunk.meta.end_timestamp = original.end_timestamp;
+        self.output_start_meta = Some(original);
+        self.source_frames_admitted =
+            u64::try_from(prefix_frames).map_err(|_| ElasticError::SampleCountOverflow)?;
+        self.primed_source_debt = u64::try_from(activation.warm.source_frames())
+            .map_err(|_| ElasticError::SampleCountOverflow)?;
+        self.active = true;
+        Ok(())
+    }
+}

--- a/crates/kithara-warp/src/warp/render/renderer_lifecycle.rs
+++ b/crates/kithara-warp/src/warp/render/renderer_lifecycle.rs
@@ -59,6 +59,7 @@ where
         self.applied_pitch = f64::NAN;
         self.output_remainder = 0.0;
         self.source_frames_admitted = 0;
+        self.primed_source_debt = 0;
         self.active = false;
         self.region = None;
     }
@@ -74,6 +75,7 @@ where
         self.applied_pitch = f64::NAN;
         self.output_remainder = 0.0;
         self.source_frames_admitted = 0;
+        self.primed_source_debt = 0;
         self.reset_pending = false;
         self.active = false;
         self.region = None;
@@ -360,8 +362,15 @@ where
         let snapshot = self.context.load();
         self.prepared_quantum = None;
         let rate = self.controls.rate_target();
+        let speed = match self.preview_speed(rate.speed(), chunk.frames().max(1)) {
+            Ok(speed) => speed,
+            Err(error) => {
+                warn!(%error, "time-stretch speed smoothing failed");
+                return None;
+            }
+        };
         chunk.meta.render_revision = rate.revision();
-        self.render_at(chunk, rate.speed(), snapshot, None)
+        self.render_at(chunk, speed, snapshot, None, rate.speed())
     }
 
     /// Render the source span selected by [`Self::prepare_quantum`].
@@ -372,7 +381,13 @@ where
         }
         let snapshot = self.context.load();
         chunk.meta.render_revision = prepared.rate.revision();
-        self.render_at(chunk, prepared.rate.speed(), snapshot, Some(prepared))
+        self.render_at(
+            chunk,
+            prepared.speed,
+            snapshot,
+            Some(prepared),
+            prepared.rate.speed(),
+        )
     }
 
     fn render_at(
@@ -381,6 +396,7 @@ where
         speed: f32,
         snapshot: Option<crate::RenderSnapshot>,
         prepared: Option<PreparedQuantum>,
+        target_speed: f32,
     ) -> Option<AudioChunk> {
         if chunk.spec() != self.spec {
             warn!(
@@ -420,6 +436,7 @@ where
                 output.frames(),
                 output.meta.render_revision,
                 speed,
+                target_speed,
             );
         }
         output
@@ -430,5 +447,6 @@ where
         self.reset_pending = true;
         self.clear_render_state();
         self.committed = None;
+        self.snap_speed();
     }
 }

--- a/crates/kithara-warp/src/warp/render/renderer_lifecycle.rs
+++ b/crates/kithara-warp/src/warp/render/renderer_lifecycle.rs
@@ -6,7 +6,7 @@ use kithara_stretch::ElasticError;
 use num_traits::ToPrimitive;
 use tracing::warn;
 
-use super::renderer::WarpRenderer;
+use super::renderer::{PreparedQuantum, WarpRenderer};
 
 impl<S> WarpRenderer<S>
 where
@@ -209,6 +209,10 @@ where
     fn process_unity(&mut self, chunk: AudioChunk) -> Option<AudioChunk> {
         let channels = usize::from(self.spec.channels.max(1));
         if !self.active && self.pending_frames(channels) == 0 {
+            if let Err(error) = self.retain_passthrough_history(chunk.meta, &chunk.samples) {
+                warn!(%error, "time-stretch passthrough history retention failed");
+                self.clear_pending_source();
+            }
             self.record_rendered_source_end(chunk.meta, 0);
             return Some(chunk);
         }
@@ -274,7 +278,6 @@ where
 
         let AudioChunk { meta, samples } = chunk;
         self.last_input_meta = Some(meta);
-        self.output_start_meta = None;
         if let Some(scratch) = self.scratch.as_mut() {
             scratch.clear();
         }
@@ -358,7 +361,7 @@ where
         self.prepared_quantum = None;
         let rate = self.controls.rate_target();
         chunk.meta.render_revision = rate.revision();
-        self.render_at(chunk, rate.speed(), snapshot)
+        self.render_at(chunk, rate.speed(), snapshot, None)
     }
 
     /// Render the source span selected by [`Self::prepare_quantum`].
@@ -369,7 +372,7 @@ where
         }
         let snapshot = self.context.load();
         chunk.meta.render_revision = prepared.rate.revision();
-        self.render_at(chunk, prepared.rate.speed(), snapshot)
+        self.render_at(chunk, prepared.rate.speed(), snapshot, Some(prepared))
     }
 
     fn render_at(
@@ -377,6 +380,7 @@ where
         chunk: AudioChunk,
         speed: f32,
         snapshot: Option<crate::RenderSnapshot>,
+        prepared: Option<PreparedQuantum>,
     ) -> Option<AudioChunk> {
         if chunk.spec() != self.spec {
             warn!(
@@ -396,6 +400,18 @@ where
         let output = if self.unity_passthrough(speed) {
             self.process_unity(chunk)
         } else {
+            let mut chunk = chunk;
+            if let Some(prepared) = prepared {
+                if let Err(error) = self.activate_prepared_quantum(&mut chunk, prepared) {
+                    warn!(%error, "time-stretch activation failed; dropping chunk");
+                    self.retire_engine();
+                    self.clear_render_state();
+                    self.defer_scratch(Some(chunk.samples));
+                    return None;
+                }
+            } else if self.passthrough_history_head.is_some() {
+                self.clear_pending_source();
+            }
             self.process_active(chunk, speed)
         };
         if let Some(output) = output.as_ref() {

--- a/crates/kithara-warp/src/warp/render/renderer_lifecycle.rs
+++ b/crates/kithara-warp/src/warp/render/renderer_lifecycle.rs
@@ -281,10 +281,10 @@ where
 
         let channels = usize::from(self.spec.channels.max(1));
         let frames = samples.len() / channels;
-        if frames > Self::MAX_SOURCE_FRAMES {
+        if frames > self.source_block_frames.get() {
             let error = ElasticError::SourceFrameLimit {
                 frames,
-                limit: Self::MAX_SOURCE_FRAMES,
+                limit: self.source_block_frames.get(),
             };
             warn!(%error, "time-stretch rendering failed; dropping chunk");
             self.defer_scratch(Some(samples));

--- a/crates/kithara-warp/src/warp/render/renderer_render.rs
+++ b/crates/kithara-warp/src/warp/render/renderer_render.rs
@@ -1,7 +1,7 @@
 use firewheel_core::param::smoother::SmoothedParam;
 use kithara_bufpool::HasPool;
 use kithara_signal::{AudioChunkInfo, FrameCount, SampleCount};
-use kithara_stretch::{ElasticError, ElasticRequest};
+use kithara_stretch::{ElasticCapabilities, ElasticError, ElasticRequest};
 use num_traits::ToPrimitive;
 
 use super::renderer::WarpRenderer;
@@ -106,8 +106,7 @@ where
             || capabilities.max_output_frames(),
             |frames| capabilities.max_output_frames().min(frames.get()),
         );
-        let source_limit =
-            Self::source_block_limit(stretch, capabilities.max_source_frames(), output_limit)?;
+        let source_limit = Self::source_block_limit(stretch, capabilities, output_limit)?;
         let pending_frames = self.pending_frames(channels);
         let available =
             source_limit
@@ -124,13 +123,26 @@ where
 
     pub(super) fn source_block_limit(
         stretch: f64,
-        max_source_frames: usize,
-        max_output_frames: usize,
+        capabilities: ElasticCapabilities,
+        output_limit: usize,
     ) -> Result<usize, ElasticError> {
         if !stretch.is_finite() || stretch <= 0.0 {
             return Err(ElasticError::InvalidRate(stretch));
         }
-        let output_limit = max_output_frames
+        let envelope = capabilities.rate_envelope();
+        let rate = stretch.recip();
+        let boundary = [
+            envelope.min_source_frames_per_output(),
+            envelope.max_source_frames_per_output(),
+        ]
+        .into_iter()
+        .find(|boundary| boundary.to_f32() == rate.to_f32());
+        if let Some(request) = boundary.and_then(|boundary| {
+            envelope.largest_request_at(boundary, capabilities.max_source_frames(), output_limit)
+        }) {
+            return Ok(request.source_frames());
+        }
+        let output_limit = output_limit
             .to_f64()
             .ok_or(ElasticError::SampleCountOverflow)?;
         let output_budget = (output_limit - Self::OUTPUT_ROUNDING_MARGIN).max(1.0);
@@ -138,7 +150,7 @@ where
             .floor()
             .to_usize()
             .ok_or(ElasticError::SampleCountOverflow)?;
-        let source_limit = source_limit.min(max_source_frames);
+        let source_limit = source_limit.min(capabilities.max_source_frames());
         if source_limit == 0 {
             return Err(ElasticError::InvalidRate(1.0 / stretch));
         }
@@ -225,6 +237,41 @@ where
         Ok((output_frames, exact - emitted))
     }
 
+    fn fit_output_to_envelope(
+        source_frames: usize,
+        output_frames: usize,
+        remainder: f64,
+        capabilities: ElasticCapabilities,
+    ) -> Result<(usize, f64), ElasticError> {
+        let source_frames_f = source_frames
+            .to_f64()
+            .ok_or(ElasticError::SampleCountOverflow)?;
+        let envelope = capabilities.rate_envelope();
+        let minimum_output = (source_frames_f / envelope.max_source_frames_per_output())
+            .ceil()
+            .to_usize()
+            .ok_or(ElasticError::SampleCountOverflow)?;
+        let maximum_output = (source_frames_f / envelope.min_source_frames_per_output())
+            .floor()
+            .to_usize()
+            .ok_or(ElasticError::SampleCountOverflow)?
+            .min(capabilities.max_output_frames());
+        if minimum_output == 0 || minimum_output > maximum_output {
+            return Err(ElasticError::InvalidRate(source_frames_f));
+        }
+        let bounded = output_frames.clamp(minimum_output, maximum_output);
+        let displaced = output_frames
+            .to_f64()
+            .and_then(|output| bounded.to_f64().map(|bounded| output - bounded))
+            .ok_or(ElasticError::SampleCountOverflow)?;
+        Ok((bounded, remainder + displaced))
+    }
+}
+
+impl<S> WarpRenderer<S>
+where
+    S: HasPool<f32>,
+{
     pub(super) fn render_terminal_pending(&mut self, channels: usize) -> Result<(), ElasticError> {
         let source_frames = self.pending_frames(channels);
         if source_frames == 0 {
@@ -322,11 +369,8 @@ where
                 .as_ref()
                 .map(|engine| engine.capabilities())
                 .ok_or(ElasticError::EnginePreparation("engine is unavailable"))?;
-            let source_limit = Self::source_block_limit(
-                stretch,
-                capabilities.max_source_frames(),
-                capabilities.max_output_frames(),
-            )?;
+            let source_limit =
+                Self::source_block_limit(stretch, capabilities, capabilities.max_output_frames())?;
             let remaining = usize::try_from(span).unwrap_or(frames - consumed);
             let pending_frames = self.pending_frames(channels);
             let available =
@@ -361,6 +405,12 @@ where
             let source_frames = pending_frames
                 .checked_add(sub)
                 .ok_or(ElasticError::SampleCountOverflow)?;
+            let (output_frames, next_remainder) = Self::fit_output_to_envelope(
+                source_frames,
+                output_frames,
+                next_remainder,
+                capabilities,
+            )?;
             let output_frames = FrameCount::new(output_frames);
             let request = ElasticRequest::new(source_frames, output_frames.get())?;
             let output_samples = output_frames

--- a/crates/kithara-warp/src/warp/render/renderer_render.rs
+++ b/crates/kithara-warp/src/warp/render/renderer_render.rs
@@ -23,7 +23,9 @@ where
             && self.pending_frames(usize::from(self.spec.channels.max(1))) == 0
             && self.unity_passthrough(speed)
         {
-            return Ok(remaining);
+            return Ok(self
+                .render_quantum_frames
+                .map_or(remaining, |frames| remaining.min(frames.get())));
         }
 
         let channels = usize::from(self.spec.channels.max(1));

--- a/crates/kithara-warp/src/warp/render/renderer_render.rs
+++ b/crates/kithara-warp/src/warp/render/renderer_render.rs
@@ -1,9 +1,64 @@
+use firewheel_core::param::smoother::SmoothedParam;
 use kithara_bufpool::HasPool;
 use kithara_signal::{AudioChunkInfo, FrameCount, SampleCount};
 use kithara_stretch::{ElasticError, ElasticRequest};
 use num_traits::ToPrimitive;
 
 use super::renderer::WarpRenderer;
+
+impl<S> WarpRenderer<S>
+where
+    S: HasPool<f32>,
+{
+    pub(super) fn preview_speed(
+        &self,
+        target: f32,
+        output_frames: usize,
+    ) -> Result<f32, ElasticError> {
+        let Some(applied) = self.applied_speed else {
+            return Ok(target);
+        };
+        let (speed, _) = Self::smoothed_speed(applied, target, output_frames)?;
+        Ok(speed)
+    }
+
+    pub(super) fn advance_speed(
+        &mut self,
+        target: f32,
+        output_frames: usize,
+    ) -> Result<(), ElasticError> {
+        let Some(applied) = self.applied_speed else {
+            return Ok(());
+        };
+        let (_, next) = Self::smoothed_speed(applied, target, output_frames)?;
+        self.applied_speed = Some(next);
+        Ok(())
+    }
+
+    fn smoothed_speed(
+        mut applied: SmoothedParam,
+        target: f32,
+        output_frames: usize,
+    ) -> Result<(f32, SmoothedParam), ElasticError> {
+        if output_frames == 0 {
+            return Err(ElasticError::EmptyOutput);
+        }
+        applied.set_value(target);
+        let mut total = 0.0_f64;
+        for _ in 0..output_frames {
+            total += f64::from(applied.next_smoothed());
+        }
+        applied.settle();
+        let frames = output_frames
+            .to_f64()
+            .ok_or(ElasticError::SampleCountOverflow)?;
+        let speed = (total / frames)
+            .to_f32()
+            .filter(|speed| speed.is_finite() && *speed > 0.0)
+            .ok_or(ElasticError::InvalidRate(total / frames))?;
+        Ok((speed, applied))
+    }
+}
 
 impl<S> WarpRenderer<S>
 where

--- a/crates/kithara-warp/src/warp/render/renderer_render.rs
+++ b/crates/kithara-warp/src/warp/render/renderer_render.rs
@@ -320,7 +320,7 @@ where
             if pending_frames > 0 {
                 self.append_pending_source(part, meta, frame)?;
             }
-            if start == 0 {
+            if start == 0 && self.output_start_meta.is_none() {
                 self.output_start_meta = if pending_frames > 0 {
                     self.pending_meta
                 } else {

--- a/crates/kithara-warp/src/warp/render/renderer_target.rs
+++ b/crates/kithara-warp/src/warp/render/renderer_target.rs
@@ -11,6 +11,7 @@ use super::renderer::WarpRenderer;
 
 #[derive(Default)]
 pub(super) struct PreparedTarget {
+    pub(super) activation_scratch: Option<SampleBuffer>,
     pub(super) engine: Option<Box<dyn ElasticEngine>>,
     pub(super) pending_source: Option<SampleBuffer>,
     pub(super) scratch: Option<SampleBuffer>,
@@ -26,9 +27,15 @@ where
         source_block_frames: NonZeroUsize,
         spec: AudioSpec,
         pools: &PoolRegion<S>,
-        reusable_pending: Option<SampleBuffer>,
-        reusable_scratch: Option<SampleBuffer>,
+        reusable: PreparedTarget,
     ) -> PreparedTarget {
+        let PreparedTarget {
+            activation_scratch: reusable_activation_scratch,
+            engine: reusable_engine,
+            pending_source: reusable_pending,
+            scratch: reusable_scratch,
+        } = reusable;
+        drop(reusable_engine);
         let result = Self::config_for(kind, backends, source_block_frames, spec, pools)
             .and_then(build_engine)
             .and_then(|engine| {
@@ -36,6 +43,7 @@ where
                 let pending_samples = SampleCount::new(
                     source_block_frames
                         .get()
+                        .max(engine.capabilities().latency().source_frames())
                         .checked_mul(channels)
                         .ok_or(ElasticError::SampleCountOverflow)?,
                 );
@@ -43,17 +51,37 @@ where
                 pending
                     .ensure_len(pending_samples.get())
                     .map_err(|_| ElasticError::PoolCapacity)?;
-                pending.clear();
+                let history_samples = engine
+                    .capabilities()
+                    .latency()
+                    .source_frames()
+                    .checked_mul(channels)
+                    .ok_or(ElasticError::SampleCountOverflow)?;
+                pending.truncate(history_samples);
+                pending.fill(0.0);
                 let scratch_samples = Self::scratch_samples(engine.as_ref(), spec)?;
                 let mut scratch = reusable_scratch.unwrap_or_else(|| pools.get::<f32>());
                 scratch
                     .ensure_len(scratch_samples.get())
                     .map_err(|_| ElasticError::PoolCapacity)?;
                 scratch.clear();
-                Ok((engine, pending, scratch))
+                let activation_samples = engine
+                    .capabilities()
+                    .latency()
+                    .output_frames()
+                    .checked_mul(channels)
+                    .ok_or(ElasticError::SampleCountOverflow)?;
+                let mut activation_scratch =
+                    reusable_activation_scratch.unwrap_or_else(|| pools.get::<f32>());
+                activation_scratch
+                    .ensure_len(activation_samples)
+                    .map_err(|_| ElasticError::PoolCapacity)?;
+                activation_scratch.clear();
+                Ok((engine, pending, scratch, activation_scratch))
             });
         match result {
-            Ok((engine, pending, scratch)) => PreparedTarget {
+            Ok((engine, pending, scratch, activation_scratch)) => PreparedTarget {
+                activation_scratch: Some(activation_scratch),
                 engine: Some(engine),
                 pending_source: Some(pending),
                 scratch: Some(scratch),
@@ -147,20 +175,23 @@ where
             self.rebuild_pending = false;
             drop(self.deferred_scratch.take());
             self.clear_render_state();
-            let reusable_pending = self.pending_source.take();
-            let reusable_scratch = self.scratch.take();
-            drop(self.engine.take());
             let target = Self::prepare_target(
                 kind,
                 self.backends,
                 self.source_block_frames,
                 spec,
                 &self.pools,
-                reusable_pending,
-                reusable_scratch,
+                PreparedTarget {
+                    activation_scratch: self.activation_scratch.take(),
+                    engine: self.engine.take(),
+                    pending_source: self.pending_source.take(),
+                    scratch: self.scratch.take(),
+                },
             );
+            self.activation_scratch = target.activation_scratch;
             self.engine = target.engine;
             self.pending_source = target.pending_source;
+            self.passthrough_history_head = self.engine.is_some().then_some(0);
             self.scratch = target.scratch;
             self.current_kind = kind;
             self.spec = spec;
@@ -180,6 +211,11 @@ where
             warn!(%error, "time-stretch deferred reset failed");
             self.engine = None;
             self.rebuild_pending = true;
+            return;
+        }
+        if let Err(error) = self.reset_passthrough_history() {
+            warn!(%error, "time-stretch history preparation failed");
+            self.clear_pending_source();
         }
     }
 }

--- a/crates/kithara-warp/src/warp/render/renderer_target.rs
+++ b/crates/kithara-warp/src/warp/render/renderer_target.rs
@@ -162,6 +162,12 @@ where
         }
         self.sync_plan();
 
+        if spec.sample_rate != self.spec.sample_rate
+            && let Some(applied) = self.applied_speed.as_mut()
+        {
+            applied.update_sample_rate(spec.sample_rate);
+        }
+
         let kind = self.controls.backend();
         let channels = usize::from(self.spec.channels.max(1));
         let entering_unity = spec == self.spec

--- a/crates/kithara-warp/src/warp/render/renderer_target.rs
+++ b/crates/kithara-warp/src/warp/render/renderer_target.rs
@@ -1,6 +1,10 @@
+use std::num::NonZeroUsize;
+
 use kithara_bufpool::{HasPool, PoolRegion, SampleBuffer};
 use kithara_signal::{AudioSpec, SampleCount};
-use kithara_stretch::{ElasticConfig, ElasticEngine, ElasticError, StretchKind, build_engine};
+use kithara_stretch::{
+    ElasticBackendConfig, ElasticConfig, ElasticEngine, ElasticError, StretchKind, build_engine,
+};
 use tracing::warn;
 
 use super::renderer::WarpRenderer;
@@ -18,17 +22,20 @@ where
 {
     pub(super) fn prepare_target(
         kind: StretchKind,
+        backends: ElasticBackendConfig,
+        source_block_frames: NonZeroUsize,
         spec: AudioSpec,
         pools: &PoolRegion<S>,
         reusable_pending: Option<SampleBuffer>,
         reusable_scratch: Option<SampleBuffer>,
     ) -> PreparedTarget {
-        let result = Self::config_for(kind, spec, pools)
+        let result = Self::config_for(kind, backends, source_block_frames, spec, pools)
             .and_then(build_engine)
             .and_then(|engine| {
                 let channels = usize::from(spec.channels.max(1));
                 let pending_samples = SampleCount::new(
-                    Self::MAX_SOURCE_FRAMES
+                    source_block_frames
+                        .get()
                         .checked_mul(channels)
                         .ok_or(ElasticError::SampleCountOverflow)?,
                 );
@@ -60,15 +67,18 @@ where
 
     fn config_for(
         backend: StretchKind,
+        backends: ElasticBackendConfig,
+        source_block_frames: NonZeroUsize,
         spec: AudioSpec,
         pools: &PoolRegion<S>,
     ) -> Result<ElasticConfig<S>, ElasticError> {
         ElasticConfig::builder()
             .backend(backend)
+            .backends(backends)
             .sample_rate(spec.sample_rate.get())
             .channels(usize::from(spec.channels.max(1)))
             .pools(pools.clone())
-            .max_source_frames(Self::MAX_SOURCE_FRAMES)
+            .max_source_frames(source_block_frames.get())
             .max_output_frames(Self::MAX_OUTPUT_FRAMES)
             .build()
     }
@@ -140,8 +150,15 @@ where
             let reusable_pending = self.pending_source.take();
             let reusable_scratch = self.scratch.take();
             drop(self.engine.take());
-            let target =
-                Self::prepare_target(kind, spec, &self.pools, reusable_pending, reusable_scratch);
+            let target = Self::prepare_target(
+                kind,
+                self.backends,
+                self.source_block_frames,
+                spec,
+                &self.pools,
+                reusable_pending,
+                reusable_scratch,
+            );
             self.engine = target.engine;
             self.pending_source = target.pending_source;
             self.scratch = target.scratch;

--- a/tests/src/offline/harness.rs
+++ b/tests/src/offline/harness.rs
@@ -1,4 +1,4 @@
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, NonZeroUsize};
 
 use kithara::{
     decode::GaplessMode,
@@ -40,6 +40,7 @@ pub struct OfflinePlayerOptions {
     block_on_underrun: bool,
     warp: Option<WarpConfig>,
     output_block_frames: Option<NonZeroU32>,
+    response_budget_frames: Option<NonZeroUsize>,
 }
 
 impl OfflinePlayerHarness {
@@ -66,6 +67,7 @@ impl OfflinePlayerHarness {
             .worker(worker.clone())
             .maybe_eq_layout(options.eq_layout)
             .maybe_warp(options.warp)
+            .maybe_response_budget_frames(options.response_budget_frames)
             .build();
 
         let player = PlayerImpl::new(player_config);

--- a/tests/src/offline/harness.rs
+++ b/tests/src/offline/harness.rs
@@ -39,6 +39,7 @@ pub struct OfflinePlayerOptions {
     #[builder(default)]
     block_on_underrun: bool,
     warp: Option<WarpConfig>,
+    output_block_frames: Option<NonZeroU32>,
 }
 
 impl OfflinePlayerHarness {
@@ -46,7 +47,10 @@ impl OfflinePlayerHarness {
         let pools = pools();
         let sample_rate =
             NonZeroU32::new(sample_rate).expect("offline player sample rate must be non-zero");
-        let session = HostConfig::offline(pools).sample_rate(sample_rate).build();
+        let session = HostConfig::offline(pools)
+            .sample_rate(sample_rate)
+            .maybe_max_block_frames(options.output_block_frames)
+            .build();
         Self::new(options, session)
     }
 

--- a/tests/src/ring/session.rs
+++ b/tests/src/ring/session.rs
@@ -1,4 +1,7 @@
-use std::{any::Any, num::NonZeroU32};
+use std::{
+    any::Any,
+    num::{NonZeroU32, NonZeroUsize},
+};
 
 use firewheel::FirewheelCtx;
 use kithara::{
@@ -389,6 +392,9 @@ fn bootstrap(
     match state.exec(Cmd::StartPlayer {
         master_volume: 1.0,
         player_id,
+        render_quantum_frames: None,
+        response_budget_frames: NonZeroUsize::new(448)
+            .expect("fixture response budget is non-zero"),
         sample_rate: session_rate.get(),
     }) {
         Reply::Ok => {}

--- a/tests/src/swallow_detector.rs
+++ b/tests/src/swallow_detector.rs
@@ -37,7 +37,8 @@ pub fn assert_committed_reached(recorder: &Recorder, min_secs: f64) {
 /// `max_step_secs` in a single commit — the FLAC "swallow" signature, where
 /// the source timeline's `committed_position` leaps ahead by ~one segment
 /// with no seek. Reads the `committed_ns` field off the `write_playhead`
-/// USDT probe (the only surface that exposes the jump; the player's
+/// USDT probe emitted by `PlayheadWrite::advance` (the only surface that
+/// exposes the jump; the player's
 /// served-frame position does not). Panics listing the offending jumps.
 pub fn assert_no_committed_swallow(recorder: &Recorder, max_step_secs: f64) {
     let commits = committed_positions(recorder);

--- a/tests/tests/kithara_play/engine_tests.rs
+++ b/tests/tests/kithara_play/engine_tests.rs
@@ -1,4 +1,4 @@
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, NonZeroUsize};
 
 use kithara::{
     self,
@@ -32,6 +32,10 @@ fn slot_id(value: u64) -> SlotId {
     SlotId::new(value)
 }
 
+fn response_budget() -> NonZeroUsize {
+    NonZeroUsize::new(448).expect("fixture response budget is non-zero")
+}
+
 fn make_engine() -> EngineImpl<TestPools> {
     EngineImpl::new(
         EngineConfig::builder()
@@ -39,6 +43,7 @@ fn make_engine() -> EngineImpl<TestPools> {
             .grid_id(BeatGridId::allocate().expect("fixture grid id"))
             .session(Arc::new(FixtureSession))
             .pools(pools())
+            .response_budget_frames(response_budget())
             .build(),
         EventBus::default(),
     )
@@ -88,6 +93,7 @@ fn engine_config_builder() {
         .channels(1)
         .eq_layout(kithara::play::effects::eq::generate_log_spaced_bands(5))
         .pools(pools())
+        .response_budget_frames(response_budget())
         .build();
     let engine = EngineImpl::new(config, EventBus::default());
     assert_eq!(engine.max_slots(), 8);
@@ -143,6 +149,7 @@ fn engine_master_sample_rate_returns_config_when_stopped() {
         .session(Arc::new(FixtureSession))
         .sample_rate(NonZeroU32::new(48_000).expect("fixture sample rate is non-zero"))
         .pools(pools())
+        .response_budget_frames(response_budget())
         .build();
     let engine = EngineImpl::new(config, EventBus::default());
     assert_eq!(engine.master_sample_rate(), 48000);

--- a/tests/tests/kithara_play/mod.rs
+++ b/tests/tests/kithara_play/mod.rs
@@ -22,6 +22,7 @@ mod player_queue_api_regressions;
 mod player_resource_internal;
 mod player_track_internal;
 mod quality_switch_continuity;
+mod rate_response;
 mod red_crossfade_hls_to_mp3_blocks_render;
 mod resource_internal;
 mod resource_regressions;

--- a/tests/tests/kithara_play/player_processor_internal.rs
+++ b/tests/tests/kithara_play/player_processor_internal.rs
@@ -140,16 +140,6 @@ fn processor_seek_without_tracks_does_not_panic() {
 }
 
 #[kithara::test]
-fn processor_set_playback_rate_without_tracks_does_not_panic() {
-    let (mut processor, mut control) = make_processor();
-    control
-        .cmd_tx
-        .try_push(PlayerCmd::SetPlaybackRate(2.0))
-        .ok();
-    processor.drain_commands();
-}
-
-#[kithara::test]
 fn processor_set_paused_updates_playback() {
     let (mut processor, mut control) = make_processor();
 

--- a/tests/tests/kithara_play/player_resource_internal.rs
+++ b/tests/tests/kithara_play/player_resource_internal.rs
@@ -322,21 +322,28 @@ async fn read_returns_constant_samples_full() {
 
 #[kithara::test]
 fn full_read_refills_before_the_next_callback_drains_scratch() {
+    const CALLBACK_FRAMES: usize = 512;
+
     let emitted = Arc::new(AtomicU64::new(0));
     let reader = ChunkReader::new(Arc::clone(&emitted));
     let resource = Resource::from_reader(reader, None);
     let mut player = PlayerResource::new(resource, Arc::from("chunked"), &pools())
         .expect("player resource fits the test pool budget");
-    let mut left = vec![0.0f32; 512];
-    let mut right = vec![0.0f32; 512];
+    let mut left = vec![0.0f32; CALLBACK_FRAMES];
+    let mut right = vec![0.0f32; CALLBACK_FRAMES];
     let mut output: Vec<&mut [f32]> = vec![&mut left, &mut right];
 
-    let result = player.read(&mut output, 0..512, &RtMetrics::default());
+    let result = player.read(&mut output, 0..CALLBACK_FRAMES, &RtMetrics::default());
 
-    assert_eq!(result, BlockReadOutcome::Full { frames: 512 });
+    assert_eq!(
+        result,
+        BlockReadOutcome::Full {
+            frames: CALLBACK_FRAMES
+        }
+    );
     assert_eq!(
         emitted.load(Ordering::Relaxed),
-        2 * ChunkReader::CHUNK_FRAMES as u64,
+        (2 * CALLBACK_FRAMES) as u64,
         "a successful callback must refill while one callback is still buffered",
     );
 }

--- a/tests/tests/kithara_play/rate_response.rs
+++ b/tests/tests/kithara_play/rate_response.rs
@@ -1,0 +1,424 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::num::{NonZeroU32, NonZeroUsize};
+
+use kithara::{
+    host::HostOwned,
+    platform::time::{self, Duration},
+    play::{Resource, ResourceConfig, ResourceSrc},
+    queue::{Queue, QueueConfig, Transition, test_utils::QueueProbe},
+    stretch::ElasticBackendConfig,
+    warp::{StretchControls, StretchKind, WarpConfig},
+};
+use kithara_integration_tests::{
+    TestTempDir, disk_asset_store, kithara,
+    offline::{OfflinePlayerHarness, OfflinePlayerOptions},
+    temp_dir,
+};
+use kithara_test_fixtures::{assets::signal_mp3_sine880_30s, signal::goertzel_magnitude};
+use kithara_test_utils::probe::capture::{self as probe_capture, ProbeEvent, Recorder};
+
+use crate::bufpool_ext::TestPools;
+
+const SAMPLE_RATE: u32 = 44_100;
+const CHANNELS: u16 = 2;
+const TARGET_WINDOW_FRAMES: usize = 128;
+const TONES_HZ: [f64; 4] = [440.0, 880.0, 1_760.0, 3_520.0];
+const TONE_DOMINANCE_RATIO: f64 = 4.0;
+const MIN_SIGNAL_RMS: f64 = 0.003;
+const WARMUP_BLOCK_BUDGET: usize = 200;
+
+const MINIMUM: ResponseCase = ResponseCase::new(128, 4_096, 16, 1, 441, 1.0, 1, 2.0, 2, 0);
+const PRODUCT: ResponseCase = ResponseCase::new(128, 8_192, 32, 12, 441, 2.0, 2, 0.5, 0, 0);
+const EXTREME: ResponseCase = ResponseCase::new(512, 16_384, 64, 64, 441, 0.5, 0, 4.0, 3, 64);
+
+#[derive(Clone, Copy, Debug)]
+struct ResponseCase {
+    callback_frames: usize,
+    source_block_frames: usize,
+    render_quantum_frames: usize,
+    smooth_frames: usize,
+    response_budget_frames: usize,
+    initial_rate: f32,
+    initial_tone: usize,
+    target_rate: f32,
+    target_tone: usize,
+    burst: usize,
+}
+
+impl ResponseCase {
+    const fn new(
+        callback_frames: usize,
+        source_block_frames: usize,
+        render_quantum_frames: usize,
+        smooth_frames: usize,
+        response_budget_frames: usize,
+        initial_rate: f32,
+        initial_tone: usize,
+        target_rate: f32,
+        target_tone: usize,
+        burst: usize,
+    ) -> Self {
+        Self {
+            callback_frames,
+            source_block_frames,
+            render_quantum_frames,
+            smooth_frames,
+            response_budget_frames,
+            initial_rate,
+            initial_tone,
+            target_rate,
+            target_tone,
+            burst,
+        }
+    }
+
+    fn observation_frames(self) -> usize {
+        self.response_budget_frames
+            .saturating_add(self.source_block_frames.saturating_mul(2))
+            .saturating_add(TARGET_WINDOW_FRAMES)
+            .saturating_add(self.callback_frames.saturating_mul(2))
+    }
+}
+
+fn frame_period(frames: usize) -> Duration {
+    Duration::from_secs_f64(
+        f64::from(u32::try_from(frames).expect("callback frame count fits u32"))
+            / f64::from(SAMPLE_RATE),
+    )
+}
+
+fn signal_rms(samples: &[f32]) -> f64 {
+    let mut energy = 0.0;
+    let mut frames = 0_u32;
+    for frame in samples.chunks_exact(usize::from(CHANNELS)) {
+        energy = f64::from(frame[0]).mul_add(f64::from(frame[0]), energy);
+        frames += 1;
+    }
+    if frames == 0 {
+        return 0.0;
+    }
+    (energy / f64::from(frames)).sqrt()
+}
+
+fn tone_is_dominant(samples: &[f32], target: usize) -> bool {
+    let mut channel = [0.0; TARGET_WINDOW_FRAMES];
+    let mut frames = 0;
+    for (sample, frame) in channel
+        .iter_mut()
+        .zip(samples.chunks_exact(usize::from(CHANNELS)))
+    {
+        *sample = frame[0];
+        frames += 1;
+    }
+    let magnitudes = TONES_HZ.map(|tone| goertzel_magnitude(&channel[..frames], tone, SAMPLE_RATE));
+    signal_rms(samples) >= MIN_SIGNAL_RMS
+        && magnitudes.iter().enumerate().all(|(index, magnitude)| {
+            index == target || magnitudes[target] > magnitude * TONE_DOMINANCE_RATIO
+        })
+}
+
+fn first_target_onset(samples: &[f32], command_frame: usize, target: usize) -> Option<usize> {
+    let channels = usize::from(CHANNELS);
+    let frames = samples.len() / channels;
+    (command_frame + TARGET_WINDOW_FRAMES..=frames).find_map(|end| {
+        let start = end - TARGET_WINDOW_FRAMES;
+        tone_is_dominant(&samples[start * channels..end * channels], target)
+            .then_some(start - command_frame)
+    })
+}
+
+async fn capture_frames(
+    harness: &OfflinePlayerHarness,
+    frames: usize,
+    callback_frames: usize,
+) -> Vec<f32> {
+    let mut samples = Vec::with_capacity(frames * usize::from(CHANNELS));
+    while samples.len() / usize::from(CHANNELS) < frames {
+        let remaining = frames - samples.len() / usize::from(CHANNELS);
+        let block_frames = remaining.min(callback_frames);
+        samples.extend(harness.render(block_frames));
+        let _ = harness.tick_and_drain();
+        time::sleep(frame_period(block_frames)).await;
+    }
+    samples
+}
+
+async fn capture_command_boundary(
+    harness: &OfflinePlayerHarness,
+    recorder: &Recorder,
+    target: usize,
+    callback_frames: usize,
+) -> Vec<f32> {
+    let mut publish_seq = latest_probe_seq(&recorder.snapshot(), "publish");
+    for _ in 0..WARMUP_BLOCK_BUDGET {
+        let block = capture_frames(harness, callback_frames, callback_frames).await;
+        let after = recorder.snapshot();
+        let current_publish_seq = latest_probe_seq(&after, "publish");
+        let published = current_publish_seq > publish_seq;
+        publish_seq = current_publish_seq;
+        if published && tone_is_dominant(&block, target) {
+            return block;
+        }
+    }
+    panic!("precondition: no callback presented the initial tone at a transport boundary");
+}
+
+fn latest_probe_seq(events: &[ProbeEvent], name: &str) -> Option<u64> {
+    events
+        .iter()
+        .filter(|event| event.probe_name() == Some(name))
+        .filter_map(ProbeEvent::seq)
+        .max()
+}
+
+async fn playing_queue(
+    temp_dir: &TestTempDir,
+    backend: StretchKind,
+    backends: ElasticBackendConfig,
+    case: ResponseCase,
+) -> (OfflinePlayerHarness, HostOwned<Queue<TestPools>>) {
+    let stretch = StretchControls::new(1.0);
+    stretch.set_backend(backend);
+    let warp = WarpConfig::builder()
+        .stretch(stretch)
+        .backends(backends)
+        .source_block_frames(
+            NonZeroUsize::new(case.source_block_frames).expect("case source block is non-zero"),
+        )
+        .rate_smooth_frames(
+            NonZeroUsize::new(case.smooth_frames).expect("case smoothing is non-zero"),
+        )
+        .render_quantum_frames(
+            NonZeroUsize::new(case.render_quantum_frames).expect("case quantum is non-zero"),
+        )
+        .build();
+    let harness = OfflinePlayerHarness::with_sample_rate(
+        OfflinePlayerOptions::builder()
+            .crossfade_duration(0.0)
+            .warp(warp)
+            .output_block_frames(
+                NonZeroU32::new(
+                    u32::try_from(case.callback_frames).expect("case callback fits u32"),
+                )
+                .expect("case callback is non-zero"),
+            )
+            .build(),
+        SAMPLE_RATE,
+    );
+    let path = signal_mp3_sine880_30s()
+        .path()
+        .expect("generated sine fixture is stored on disk");
+    let config: ResourceConfig<TestPools> = ResourceConfig::for_src(
+        ResourceSrc::parse(path.to_str().expect("utf-8 fixture path"))
+            .expect("fixture path is a valid resource source"),
+    )
+    .store(disk_asset_store(
+        temp_dir.path().join("rate-response-store"),
+    ))
+    .build();
+    let config = harness
+        .player()
+        .prepare_config(config)
+        .expect("offline player remains open");
+    let resource = Resource::new(config).await.expect("open sine fixture");
+    let queue = Queue::new(
+        QueueConfig::builder()
+            .player(harness.take_player())
+            .should_autoplay(false)
+            .build(),
+    );
+    let queue = harness.insert(queue);
+    queue.set_default_rate(case.initial_rate);
+    let id = queue.insert_loaded_for_test(resource);
+    queue
+        .select(id, Transition::None)
+        .expect("select live-rate fixture");
+    (harness, queue)
+}
+
+fn revision_probe<'a>(
+    events: &'a [ProbeEvent],
+    name: &str,
+    field: &str,
+    revision: u64,
+) -> Option<&'a ProbeEvent> {
+    events
+        .iter()
+        .filter(|event| event.probe_name() == Some(name))
+        .filter(|event| event.u64(field) == Some(revision))
+        .min_by_key(|event| event.seq().unwrap_or(u64::MAX))
+}
+
+fn assert_response(
+    backend: StretchKind,
+    case: ResponseCase,
+    command_frame: usize,
+    samples: &[f32],
+    events: &[ProbeEvent],
+) {
+    let requested = events
+        .iter()
+        .filter(|event| event.probe_name() == Some("rate_requested"))
+        .max_by_key(|event| event.seq().unwrap_or(0))
+        .unwrap_or_else(|| {
+            let publish = events
+                .iter()
+                .filter(|event| event.probe_name() == Some("publish"))
+                .count();
+            let consumed = events
+                .iter()
+                .filter(|event| event.probe_name() == Some("pcm_consumed"))
+                .count();
+            let applied = events
+                .iter()
+                .filter(|event| event.probe_name() == Some("rate_applied"))
+                .count();
+            panic!(
+                "{backend} emitted no rate_requested probe; publish={publish}, rate_applied={applied}, pcm_consumed={consumed}"
+            )
+        });
+    let revision = requested
+        .u64("request_revision")
+        .unwrap_or_else(|| panic!("{backend} request probe has no revision"));
+    assert_eq!(
+        requested.u64("target_rate_bits"),
+        Some(u64::from(case.target_rate.to_bits())),
+        "{backend} correlated the wrong final rate request"
+    );
+    let request_frame = requested
+        .u64("session_frame")
+        .and_then(|frame| i64::try_from(frame).ok())
+        .unwrap_or_else(|| panic!("{backend} request probe has no session frame"));
+    let budget = i64::try_from(case.response_budget_frames).expect("case budget fits i64");
+    let observed_frames = samples
+        .len()
+        .checked_div(usize::from(CHANNELS))
+        .and_then(|frames| frames.checked_sub(command_frame))
+        .expect("captured output includes the command boundary");
+    let applied = revision_probe(events, "rate_applied", "request_revision", revision)
+        .unwrap_or_else(|| {
+            panic!(
+                "{backend} did not apply revision {revision} within {observed_frames} rendered output frames; response budget is {budget}"
+            )
+        });
+    let consumed = revision_probe(events, "pcm_consumed", "render_revision", revision)
+        .unwrap_or_else(|| panic!("{backend} presented no PCM for {revision}"));
+    let applied_frame = applied
+        .u64("session_frame")
+        .and_then(|frame| i64::try_from(frame).ok())
+        .unwrap_or_else(|| panic!("{backend} apply probe has no session frame"));
+    let consumed_frame = consumed
+        .u64("output_start")
+        .and_then(|frame| i64::try_from(frame).ok())
+        .unwrap_or_else(|| panic!("{backend} PCM probe has no output start"));
+    let applied_response = applied_frame
+        .checked_sub(request_frame)
+        .unwrap_or_else(|| panic!("{backend} applied revision before its request"));
+    let presented_response = consumed_frame
+        .checked_sub(request_frame)
+        .unwrap_or_else(|| panic!("{backend} presented revision before its request"));
+    assert!(
+        applied_response <= budget,
+        "{backend} applied revision {revision} after {applied_response} frames; budget is {budget}"
+    );
+    assert!(
+        presented_response <= budget,
+        "{backend} presented revision {revision} after {presented_response} frames; budget is {budget}"
+    );
+    let onset = first_target_onset(samples, command_frame, case.target_tone)
+        .unwrap_or_else(|| panic!("{backend} never produced the target tone"));
+    assert!(
+        onset <= case.response_budget_frames,
+        "{backend} target tone began after {onset} frames; budget is {}",
+        case.response_budget_frames
+    );
+}
+
+async fn run_case(
+    temp_dir: &TestTempDir,
+    backend: StretchKind,
+    backends: ElasticBackendConfig,
+    case: ResponseCase,
+) {
+    let (harness, queue) = playing_queue(temp_dir, backend, backends, case).await;
+    let recorder = probe_capture::install();
+    let mut samples =
+        capture_command_boundary(&harness, &recorder, case.initial_tone, case.callback_frames)
+            .await;
+    let command_frame = samples.len() / usize::from(CHANNELS);
+    assert!(
+        queue.is_playing(),
+        "{backend} command boundary is not playing"
+    );
+    let ready = recorder.snapshot();
+    let published_end = ready
+        .iter()
+        .filter(|event| event.probe_name() == Some("publish"))
+        .max_by_key(|event| event.seq().unwrap_or(0))
+        .and_then(|event| event.u64("output_end"));
+    let consumed_end = ready
+        .iter()
+        .filter(|event| event.probe_name() == Some("pcm_consumed"))
+        .max_by_key(|event| event.seq().unwrap_or(0))
+        .and_then(|event| event.u64("output_end"));
+    let published_end = published_end
+        .unwrap_or_else(|| panic!("{backend} command boundary has no published transport"));
+    let consumed_end = consumed_end
+        .unwrap_or_else(|| panic!("{backend} command boundary has no presented transport"));
+    assert!(
+        consumed_end <= published_end,
+        "{backend} presented transport {consumed_end} is ahead of published transport {published_end}"
+    );
+    for command in 0..case.burst {
+        queue.set_rate(if command.is_multiple_of(2) { 4.0 } else { 0.5 });
+    }
+    queue.set_rate(case.target_rate);
+    samples.extend(capture_frames(&harness, case.observation_frames(), case.callback_frames).await);
+    let events = recorder.snapshot();
+
+    let precommand_start = command_frame.saturating_sub(TARGET_WINDOW_FRAMES);
+    let precommand =
+        &samples[precommand_start * usize::from(CHANNELS)..command_frame * usize::from(CHANNELS)];
+    assert!(
+        tone_is_dominant(precommand, case.initial_tone),
+        "{backend} was not playing the initial tone before set_rate"
+    );
+    assert!(
+        !tone_is_dominant(precommand, case.target_tone),
+        "{backend} already contained the target tone before set_rate"
+    );
+    assert_response(backend, case, command_frame, &samples, &events);
+}
+
+#[kithara::test(
+    tokio,
+    multi_thread,
+    serial,
+    flash(false),
+    timeout(Duration::from_secs(60)),
+    hang_timeout_secs(5)
+)]
+#[case::signalsmith_minimum(StretchKind::Signalsmith, ElasticBackendConfig::default(), MINIMUM)]
+#[case::signalsmith_product(StretchKind::Signalsmith, ElasticBackendConfig::default(), PRODUCT)]
+#[case::signalsmith_extreme(StretchKind::Signalsmith, ElasticBackendConfig::default(), EXTREME)]
+#[cfg_attr(
+    not(all(target_os = "windows", target_env = "msvc")),
+    case::bungee_minimum(StretchKind::Bungee, ElasticBackendConfig::default(), MINIMUM)
+)]
+#[cfg_attr(
+    not(all(target_os = "windows", target_env = "msvc")),
+    case::bungee_product(StretchKind::Bungee, ElasticBackendConfig::default(), PRODUCT)
+)]
+#[cfg_attr(
+    not(all(target_os = "windows", target_env = "msvc")),
+    case::bungee_extreme(StretchKind::Bungee, ElasticBackendConfig::default(), EXTREME)
+)]
+async fn live_rate_change_reaches_presented_pcm_within_response_budget(
+    temp_dir: TestTempDir,
+    #[case] backend: StretchKind,
+    #[case] backends: ElasticBackendConfig,
+    #[case] case: ResponseCase,
+) {
+    run_case(&temp_dir, backend, backends, case).await;
+}

--- a/tests/tests/kithara_play/rate_response.rs
+++ b/tests/tests/kithara_play/rate_response.rs
@@ -328,9 +328,11 @@ fn assert_response(
     );
     let onset = first_target_onset(samples, command_frame, case.target_tone)
         .unwrap_or_else(|| panic!("{backend} never produced the target tone"));
+    let primed = revision_probe(events, "prime_activation", "request_revision", revision)
+        .map(|event| (event.u64("source_frames"), event.u64("output_frames")));
     assert!(
         onset <= case.response_budget_frames,
-        "{backend} target tone began after {onset} frames; budget is {}",
+        "{backend} target tone began after {onset} frames; budget is {}; primed={primed:?}",
         case.response_budget_frames
     );
 }

--- a/tests/tests/kithara_play/rate_response.rs
+++ b/tests/tests/kithara_play/rate_response.rs
@@ -416,7 +416,8 @@ fn assert_response(
     );
     assert!(
         presented_response <= budget,
-        "{backend} presented revision {revision} after {presented_response} frames; budget is {budget}"
+        "{backend} presented revision {revision} after {presented_response} frames; applied after {applied_response} frames; apply-to-presentation delay is {} frames; budget is {budget}",
+        presented_response - applied_response
     );
     if case.smooth_frames > 1 {
         let low = case.initial_rate.min(case.target_rate);

--- a/tests/tests/kithara_play/rate_response.rs
+++ b/tests/tests/kithara_play/rate_response.rs
@@ -168,6 +168,7 @@ async fn capture_command_boundary(
     callback_frames: usize,
 ) -> Vec<f32> {
     let mut publish_seq = latest_probe_seq(&recorder.snapshot(), "publish");
+    let mut last_block = Vec::new();
     for _ in 0..WARMUP_BLOCK_BUDGET {
         let block = capture_frames(harness, callback_frames, callback_frames).await;
         let after = recorder.snapshot();
@@ -177,8 +178,29 @@ async fn capture_command_boundary(
         if published && tone_is_dominant(&block, target) {
             return block;
         }
+        last_block = block;
     }
-    panic!("precondition: no callback presented the initial tone at a transport boundary");
+    let events = recorder.snapshot();
+    let publish = events
+        .iter()
+        .filter(|event| event.probe_name() == Some("publish"))
+        .count();
+    let rendered = events
+        .iter()
+        .filter(|event| event.probe_name() == Some("render_committed"))
+        .count();
+    let consumed = events
+        .iter()
+        .filter(|event| event.probe_name() == Some("pcm_consumed"))
+        .count();
+    let applied = events
+        .iter()
+        .filter(|event| event.probe_name() == Some("rate_applied"))
+        .count();
+    panic!(
+        "precondition: no callback presented the initial tone at a transport boundary; publish={publish}, rendered={rendered}, rate_applied={applied}, pcm_consumed={consumed}, last_rms={}",
+        signal_rms(&last_block)
+    );
 }
 
 fn latest_probe_seq(events: &[ProbeEvent], name: &str) -> Option<u64> {

--- a/tests/tests/kithara_play/rate_response.rs
+++ b/tests/tests/kithara_play/rate_response.rs
@@ -7,7 +7,7 @@ use kithara::{
     platform::time::{self, Duration},
     play::{Resource, ResourceConfig, ResourceSrc},
     queue::{Queue, QueueConfig, Transition, test_utils::QueueProbe},
-    stretch::ElasticBackendConfig,
+    stretch::{BungeeConfig, ElasticBackendConfig, SignalsmithConfig},
     warp::{StretchControls, StretchKind, WarpConfig},
 };
 use kithara_integration_tests::{
@@ -27,6 +27,22 @@ const TONES_HZ: [f64; 4] = [440.0, 880.0, 1_760.0, 3_520.0];
 const TONE_DOMINANCE_RATIO: f64 = 4.0;
 const MIN_SIGNAL_RMS: f64 = 0.003;
 const WARMUP_BLOCK_BUDGET: usize = 200;
+
+fn response_backends() -> ElasticBackendConfig {
+    ElasticBackendConfig::builder()
+        .signalsmith(
+            SignalsmithConfig::builder()
+                .block_frames(NonZeroUsize::new(224).expect("case block is non-zero"))
+                .interval_frames(NonZeroUsize::new(32).expect("case interval is non-zero"))
+                .build(),
+        )
+        .bungee(
+            BungeeConfig::builder()
+                .log2_synthesis_hop_adjust(-4)
+                .build(),
+        )
+        .build()
+}
 
 const MINIMUM: ResponseCase = ResponseCase::new(128, 4_096, 16, 1, 441, 1.0, 1, 2.0, 2, 0);
 const PRODUCT: ResponseCase = ResponseCase::new(128, 8_192, 32, 12, 441, 2.0, 2, 0.5, 0, 0);
@@ -298,8 +314,57 @@ fn assert_response(
         .expect("captured output includes the command boundary");
     let applied = revision_probe(events, "rate_applied", "request_revision", revision)
         .unwrap_or_else(|| {
+            let applied: Vec<_> = events
+                .iter()
+                .filter(|event| event.probe_name() == Some("rate_applied"))
+                .map(|event| {
+                    (
+                        event.u64("request_revision"),
+                        event.u64("session_frame"),
+                        event
+                            .u64("applied_rate_bits")
+                            .and_then(|bits| u32::try_from(bits).ok())
+                            .map(f32::from_bits),
+                        event.u64("source_start"),
+                        event.u64("source_end"),
+                    )
+                })
+                .collect();
+            let presented: Vec<_> = events
+                .iter()
+                .filter(|event| event.probe_name() == Some("pcm_consumed"))
+                .filter_map(|event| {
+                    event
+                        .u64("render_revision")
+                        .zip(event.u64("output_start"))
+                        .zip(event.u64("output_end"))
+                })
+                .collect();
+            let rendered: Vec<_> = events
+                .iter()
+                .filter(|event| event.probe_name() == Some("render_committed"))
+                .filter_map(|event| {
+                    event
+                        .u64("source_start")
+                        .zip(event.u64("source_end"))
+                        .zip(event.u64("output_start"))
+                        .zip(event.u64("output_end"))
+                })
+                .collect();
+            let published: Vec<_> = events
+                .iter()
+                .filter(|event| event.probe_name() == Some("publish"))
+                .filter_map(|event| {
+                    event
+                        .u64("source")
+                        .zip(event.u64("presentation_frame"))
+                        .zip(event.u64("output_start"))
+                        .zip(event.u64("output_end"))
+                })
+                .collect();
+            let target_onset = first_target_onset(samples, command_frame, case.target_tone);
             panic!(
-                "{backend} did not apply revision {revision} within {observed_frames} rendered output frames; response budget is {budget}"
+                "{backend} did not apply revision {revision} within {observed_frames} rendered output frames; response budget is {budget}; target_onset={target_onset:?}; applied={applied:?}; presented={presented:?}; rendered={rendered:?}; published={published:?}"
             )
         });
     let consumed = revision_probe(events, "pcm_consumed", "render_revision", revision)
@@ -308,6 +373,11 @@ fn assert_response(
         .u64("session_frame")
         .and_then(|frame| i64::try_from(frame).ok())
         .unwrap_or_else(|| panic!("{backend} apply probe has no session frame"));
+    let applied_rate = applied
+        .u64("applied_rate_bits")
+        .and_then(|bits| u32::try_from(bits).ok())
+        .map(f32::from_bits)
+        .unwrap_or_else(|| panic!("{backend} apply probe has no rate"));
     let consumed_frame = consumed
         .u64("output_start")
         .and_then(|frame| i64::try_from(frame).ok())
@@ -326,6 +396,17 @@ fn assert_response(
         presented_response <= budget,
         "{backend} presented revision {revision} after {presented_response} frames; budget is {budget}"
     );
+    if case.smooth_frames > 1 {
+        let low = case.initial_rate.min(case.target_rate);
+        let high = case.initial_rate.max(case.target_rate);
+        assert!(
+            applied_rate > low && applied_rate < high,
+            "{backend} jumped from {} directly to {} instead of smoothing over {} output frames",
+            case.initial_rate,
+            applied_rate,
+            case.smooth_frames
+        );
+    }
     let onset = first_target_onset(samples, command_frame, case.target_tone)
         .unwrap_or_else(|| panic!("{backend} never produced the target tone"));
     let primed = revision_probe(events, "prime_activation", "request_revision", revision)
@@ -401,20 +482,20 @@ async fn run_case(
     timeout(Duration::from_secs(60)),
     hang_timeout_secs(5)
 )]
-#[case::signalsmith_minimum(StretchKind::Signalsmith, ElasticBackendConfig::default(), MINIMUM)]
-#[case::signalsmith_product(StretchKind::Signalsmith, ElasticBackendConfig::default(), PRODUCT)]
-#[case::signalsmith_extreme(StretchKind::Signalsmith, ElasticBackendConfig::default(), EXTREME)]
+#[case::signalsmith_minimum(StretchKind::Signalsmith, response_backends(), MINIMUM)]
+#[case::signalsmith_product(StretchKind::Signalsmith, response_backends(), PRODUCT)]
+#[case::signalsmith_extreme(StretchKind::Signalsmith, response_backends(), EXTREME)]
 #[cfg_attr(
     not(all(target_os = "windows", target_env = "msvc")),
-    case::bungee_minimum(StretchKind::Bungee, ElasticBackendConfig::default(), MINIMUM)
+    case::bungee_minimum(StretchKind::Bungee, response_backends(), MINIMUM)
 )]
 #[cfg_attr(
     not(all(target_os = "windows", target_env = "msvc")),
-    case::bungee_product(StretchKind::Bungee, ElasticBackendConfig::default(), PRODUCT)
+    case::bungee_product(StretchKind::Bungee, response_backends(), PRODUCT)
 )]
 #[cfg_attr(
     not(all(target_os = "windows", target_env = "msvc")),
-    case::bungee_extreme(StretchKind::Bungee, ElasticBackendConfig::default(), EXTREME)
+    case::bungee_extreme(StretchKind::Bungee, response_backends(), EXTREME)
 )]
 async fn live_rate_change_reaches_presented_pcm_within_response_budget(
     temp_dir: TestTempDir,

--- a/tests/tests/kithara_play/rate_response.rs
+++ b/tests/tests/kithara_play/rate_response.rs
@@ -47,7 +47,7 @@ fn response_backends() -> ElasticBackendConfig {
 
 const MINIMUM: ResponseCase = ResponseCase::new(128, 4_096, 16, 1, 441, 1.0, 1, 2.0, 2, 0);
 const PRODUCT: ResponseCase = ResponseCase::new(128, 8_192, 32, 12, 441, 2.0, 2, 0.5, 0, 0);
-const EXTREME: ResponseCase = ResponseCase::new(512, 16_384, 64, 64, 441, 0.5, 0, 4.0, 3, 64);
+const EXTREME: ResponseCase = ResponseCase::new(128, 16_384, 64, 64, 441, 0.5, 0, 4.0, 3, 64);
 
 #[derive(Clone, Copy, Debug)]
 struct ResponseCase {
@@ -241,6 +241,10 @@ async fn playing_queue(
                     u32::try_from(case.callback_frames).expect("case callback fits u32"),
                 )
                 .expect("case callback is non-zero"),
+            )
+            .response_budget_frames(
+                NonZeroUsize::new(case.response_budget_frames)
+                    .expect("case response budget is non-zero"),
             )
             .build(),
         SAMPLE_RATE,
@@ -436,7 +440,7 @@ fn assert_response(
         .map(|event| (event.u64("source_frames"), event.u64("output_frames")));
     assert!(
         onset <= case.response_budget_frames,
-        "{backend} target tone began after {onset} frames; budget is {}; primed={primed:?}",
+        "{backend} target tone began after {onset} frames; applied after {applied_response}; presented after {presented_response}; budget is {}; primed={primed:?}",
         case.response_budget_frames
     );
 }

--- a/tests/tests/kithara_play/rate_response.rs
+++ b/tests/tests/kithara_play/rate_response.rs
@@ -5,8 +5,8 @@ use std::num::{NonZeroU32, NonZeroUsize};
 use kithara::{
     host::HostOwned,
     platform::time::{self, Duration},
-    play::{Resource, ResourceConfig, ResourceSrc},
-    queue::{Queue, QueueConfig, Transition, test_utils::QueueProbe},
+    play::{ResourceConfig, ResourceSrc},
+    queue::{Queue, QueueConfig, Transition},
     stretch::{BungeeConfig, ElasticBackendConfig, SignalsmithConfig},
     warp::{StretchControls, StretchKind, WarpConfig},
 };
@@ -14,6 +14,7 @@ use kithara_integration_tests::{
     TestTempDir, disk_asset_store, kithara,
     offline::{OfflinePlayerHarness, OfflinePlayerOptions},
     temp_dir,
+    waits::wait_for_loader_done_event,
 };
 use kithara_test_fixtures::{assets::signal_mp3_sine880_30s, signal::goertzel_magnitude};
 use kithara_test_utils::probe::capture::{self as probe_capture, ProbeEvent, Recorder};
@@ -222,6 +223,14 @@ async fn playing_queue(
             .build(),
         SAMPLE_RATE,
     );
+    let queue = Queue::new(
+        QueueConfig::builder()
+            .player(harness.take_player())
+            .should_autoplay(false)
+            .build(),
+    );
+    let queue = harness.insert(queue);
+    queue.set_default_rate(case.initial_rate);
     let path = signal_mp3_sine880_30s()
         .path()
         .expect("generated sine fixture is stored on disk");
@@ -233,20 +242,11 @@ async fn playing_queue(
         temp_dir.path().join("rate-response-store"),
     ))
     .build();
-    let config = harness
-        .player()
-        .prepare_config(config)
-        .expect("offline player remains open");
-    let resource = Resource::new(config).await.expect("open sine fixture");
-    let queue = Queue::new(
-        QueueConfig::builder()
-            .player(harness.take_player())
-            .should_autoplay(false)
-            .build(),
-    );
-    let queue = harness.insert(queue);
-    queue.set_default_rate(case.initial_rate);
-    let id = queue.insert_loaded_for_test(resource);
+    let mut events = queue.subscribe();
+    let id = queue.append(config).expect("append sine fixture");
+    wait_for_loader_done_event(&mut events, &queue, id, Duration::from_secs(30))
+        .await
+        .expect("load sine fixture through resident queue");
     queue
         .select(id, Transition::None)
         .expect("select live-rate fixture");

--- a/tests/tests/kithara_play/rate_response.rs
+++ b/tests/tests/kithara_play/rate_response.rs
@@ -47,7 +47,7 @@ fn response_backends() -> ElasticBackendConfig {
 
 const MINIMUM: ResponseCase = ResponseCase::new(128, 4_096, 16, 1, 441, 1.0, 1, 2.0, 2, 0);
 const PRODUCT: ResponseCase = ResponseCase::new(128, 8_192, 32, 12, 441, 2.0, 2, 0.5, 0, 0);
-const EXTREME: ResponseCase = ResponseCase::new(128, 16_384, 64, 64, 441, 0.5, 0, 4.0, 3, 64);
+const EXTREME: ResponseCase = ResponseCase::new(64, 16_384, 32, 64, 441, 0.5, 0, 4.0, 3, 64);
 
 #[derive(Clone, Copy, Debug)]
 struct ResponseCase {
@@ -168,17 +168,24 @@ async fn capture_command_boundary(
     callback_frames: usize,
 ) -> Vec<f32> {
     let mut publish_seq = latest_probe_seq(&recorder.snapshot(), "publish");
-    let mut last_block = Vec::new();
+    let mut samples = Vec::new();
     for _ in 0..WARMUP_BLOCK_BUDGET {
         let block = capture_frames(harness, callback_frames, callback_frames).await;
+        samples.extend_from_slice(&block);
         let after = recorder.snapshot();
         let current_publish_seq = latest_probe_seq(&after, "publish");
         let published = current_publish_seq > publish_seq;
         publish_seq = current_publish_seq;
-        if published && tone_is_dominant(&block, target) {
-            return block;
+        let frames = samples.len() / usize::from(CHANNELS);
+        if published
+            && frames >= TARGET_WINDOW_FRAMES
+            && tone_is_dominant(
+                &samples[(frames - TARGET_WINDOW_FRAMES) * usize::from(CHANNELS)..],
+                target,
+            )
+        {
+            return samples;
         }
-        last_block = block;
     }
     let events = recorder.snapshot();
     let publish = events
@@ -199,7 +206,7 @@ async fn capture_command_boundary(
         .count();
     panic!(
         "precondition: no callback presented the initial tone at a transport boundary; publish={publish}, rendered={rendered}, rate_applied={applied}, pcm_consumed={consumed}, last_rms={}",
-        signal_rms(&last_block)
+        signal_rms(&samples)
     );
 }
 

--- a/tests/tests/kithara_play/ring_admission.rs
+++ b/tests/tests/kithara_play/ring_admission.rs
@@ -1,6 +1,6 @@
 #![cfg(not(target_arch = "wasm32"))]
 
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, NonZeroUsize};
 
 use firewheel::{
     channel_config::{ChannelConfig, ChannelCount},
@@ -74,6 +74,9 @@ fn register_started_player(session: &ManualRingSession) -> PlayerId {
             .exec(Cmd::StartPlayer {
                 master_volume: 1.0,
                 player_id,
+                render_quantum_frames: None,
+                response_budget_frames: NonZeroUsize::new(448)
+                    .expect("fixture response budget is non-zero"),
                 sample_rate: SAMPLE_RATE,
             })
             .expect("start player command"),

--- a/tests/tests/kithara_queue/flac_swallow_fixture.rs
+++ b/tests/tests/kithara_queue/flac_swallow_fixture.rs
@@ -46,7 +46,8 @@ const BLOCKS_PER_WINDOW: usize = 8;
 const PLAY_SECS: f64 = 18.0;
 const MIN_DELAYED_PLAYHEAD_SECS: f64 = 14.0;
 /// The committed playhead advances ~one decoded chunk (~0.1 s) per
-/// `write_playhead`. A single forward step beyond this is the production
+/// `write_playhead` event from `PlayheadWrite::advance`. A single forward step
+/// beyond this is the production
 /// swallow — the playhead leaping forward by ~one segment with no seek.
 const MAX_COMMITTED_STEP_SECS: f64 = 0.5;
 
@@ -112,8 +113,8 @@ async fn play_realtime(player: &mut OfflinePlayer, windows: u64, window_secs: f6
 ///
 /// The bug: the source timeline's `committed_position` jumps forward by ~one
 /// segment with no seek when a slow FLAC segment isn't ready by the real-time
-/// deadline. Detector: the `committed_ns` USDT probe on
-/// `PlayheadState::write_playhead` — fail if the committed playhead ever jumps
+/// deadline. Detector: the `committed_ns` `write_playhead` USDT probe emitted by
+/// `PlayheadWrite::advance` — fail if the committed playhead ever jumps
 /// forward by more than [`MAX_COMMITTED_STEP_SECS`] in a single commit.
 #[kithara::test(tokio, multi_thread, timeout(Duration::from_secs(120)))]
 #[case::symphonia(DecoderBackend::Symphonia)]

--- a/tests/tests/kithara_queue/zvuk_prod_flac_swallow.rs
+++ b/tests/tests/kithara_queue/zvuk_prod_flac_swallow.rs
@@ -33,7 +33,8 @@ const BLOCKS_PER_WINDOW: usize = 8;
 /// in production (app.log 2026-05-27).
 const PLAY_SECS: f64 = 90.0;
 /// The committed playhead advances ~one decoded chunk (~0.1 s) per
-/// `write_playhead`. A single forward step beyond this is the production
+/// `write_playhead` event from `PlayheadWrite::advance`. A single forward step
+/// beyond this is the production
 /// swallow — the playhead leaping forward by seconds with no seek (app.log
 /// showed +10.4 s in one step).
 const MAX_COMMITTED_STEP_SECS: f64 = 1.5;
@@ -48,9 +49,9 @@ const MAX_COMMITTED_STEP_SECS: f64 = 1.5;
 /// `committed_position` runs ahead of decoded content with no seek (app.log
 /// 2026-05-27: committed +10.4 s in one step, ~50 s ahead of decoded).
 ///
-/// Detector: the `committed_ns` USDT probe on `PlayheadState::write_playhead`
-/// fires on every playhead commit. We capture the firing sequence and fail if
-/// the committed playhead ever jumps forward by more than
+/// Detector: the `committed_ns` `write_playhead` USDT probe emitted by
+/// `PlayheadWrite::advance` fires on every playhead commit. We capture the
+/// firing sequence and fail if the committed playhead ever jumps forward by more than
 /// [`MAX_COMMITTED_STEP_SECS`] in a single commit. The player's served-frame
 /// position does **not** expose this jump — only the source playhead does.
 ///


### PR DESCRIPTION
## Summary
PR #232 completes the rebuilt live-rate response path on top of the merged foundation slices. Queue rate requests are latest-wins, reach Warp without accumulating a command backlog, are smoothed at the Warp application boundary, and are correlated with the PCM that is actually presented. The acceptance matrix keeps the production default at 448 frames while proving a case-supplied 441-frame response budget for both stretch backends.

## Behavior / scope
- contract or behavior: live rate changes are presented within the configured response budget; burst updates retain the latest target; route changes, seek, EOF, Queue playback, and unity passthrough preserve their existing contracts
- affected area: Host output geometry, Player resource/ring buffering, Warp activation and smoothing, source-span presentation, and end-to-end rate-response probes
- production defaults: `PlayerConfig` keeps the 448-frame response budget; the 441-frame limit and 64/128-frame callback geometries are supplied only by parameterized tests
- preserved API: `set_playback_rate` remains available on the Player track contract

## Validation
- exact head `905b7189b3647ab5e2c3346a992d35049d2ebe7e` against base `568f9f615abc607c7d8a87adc1f815f9b01994b4`
- exact-head GitHub non-UI CI: all required lanes passed, including real/simulated-clock tests, lint, MSRV, dependency checks, architecture, memory/performance, wasm/Chromium, and RTSan — https://github.com/gerasim13/kithara/actions/runs/34040392861
- exact-head focused stress: 100/100 iterations passed across the rate-response, non-unity route-change, early-close seek, and repeated HLS seek cases — https://github.com/gerasim13/kithara/actions/runs/34047416193
- exact-head GitLab quarantine pipeline: passed — https://gitlab.zvq.me/disrupt/kithara/-/pipelines/2139146
- `git diff --check 568f9f615abc607c7d8a87adc1f815f9b01994b4...HEAD`: passed
- interactive desktop smoke: completed twice during PR validation; not rerun in this final readiness check
- request-only UI workflow: not run because this PR does not change UI behavior

## Surface impact
- Public API: preserved: existing playback-rate control remains available; rate publication carries a revision for request/application correlation
- Platform/runtime: changed: native Player/Queue/Warp/stretch paths and the wasm identity-Warp path share the reconciled control flow
- Perf-sensitive paths: changed: Warp rendering, stretch activation, pooled staging, worker delivery, and PCM presentation

## Risks / follow-ups
- full multi-deck musical synchronization remains separate from this bounded live-rate response change
