### PR TITLE
fix(devtools,xtask): a job's build directory stops reading as claimed the moment the job lets it go

### DIFF
--- a/crates/kithara-devtools/src/lease.rs
+++ b/crates/kithara-devtools/src/lease.rs
@@ -1,9 +1,9 @@
 use std::{
-    fs::{self, File, OpenOptions},
+    fs::{self, OpenOptions},
     path::{self, Path},
 };
 
-use fs4::FileExt;
+use crate::lock::FileLock;
 
 /// The file a process locks for as long as it works in a build directory, so a
 /// reclaim running elsewhere can tell "in use" from "left behind".
@@ -18,7 +18,7 @@ pub const FILE: &str = ".kithara-job-lease";
 /// A live claim on a build directory, released when this drops or the process
 /// dies.
 pub struct Lease {
-    _file: File,
+    _lock: FileLock,
 }
 
 /// Claims `directory` until the returned guard drops.
@@ -51,8 +51,8 @@ pub fn hold(directory: &Path) -> Option<Lease> {
         .write(true)
         .open(directory.join(FILE))
         .ok()?;
-    FileExt::try_lock_shared(&file).ok()?;
-    Some(Lease { _file: file })
+    let lock = FileLock::try_shared(file).ok()?;
+    Some(Lease { _lock: lock })
 }
 
 #[cfg(test)]

--- a/crates/kithara-devtools/src/lib.rs
+++ b/crates/kithara-devtools/src/lib.rs
@@ -16,6 +16,7 @@ pub mod junit;
 pub mod lease;
 #[cfg(feature = "lint")]
 pub mod lint;
+pub mod lock;
 pub mod manifest;
 pub mod orphans;
 pub mod perf;

--- a/crates/kithara-devtools/src/lock.rs
+++ b/crates/kithara-devtools/src/lock.rs
@@ -1,0 +1,142 @@
+use std::{fs::File, io};
+
+use fs4::{FileExt, TryLockError};
+
+/// A `flock` held on an open file, released when this drops.
+///
+/// The release is explicit. The lock lives on the open file description, which
+/// every process forked while the descriptor was open holds a duplicate of
+/// until it execs, so closing frees nothing while one of those is alive.
+/// Unlocking acts on the description and is seen by every duplicate at once.
+#[derive(Debug)]
+pub struct FileLock {
+    file: File,
+}
+
+impl FileLock {
+    /// Takes `file`'s shared lock, waiting out an exclusive holder.
+    ///
+    /// # Errors
+    ///
+    /// When the lock cannot be taken.
+    pub fn shared(file: File) -> io::Result<Self> {
+        FileExt::lock_shared(&file)?;
+        Ok(Self { file })
+    }
+
+    /// Takes `file`'s exclusive lock, waiting out every other holder.
+    ///
+    /// # Errors
+    ///
+    /// When the lock cannot be taken.
+    pub fn exclusive(file: File) -> io::Result<Self> {
+        FileExt::lock(&file)?;
+        Ok(Self { file })
+    }
+
+    /// Takes `file`'s shared lock unless an exclusive holder has it.
+    ///
+    /// # Errors
+    ///
+    /// [`TryLockError::WouldBlock`] when a holder has the file.
+    pub fn try_shared(file: File) -> Result<Self, TryLockError> {
+        FileExt::try_lock_shared(&file)?;
+        Ok(Self { file })
+    }
+
+    /// Takes `file`'s exclusive lock unless another holder has it.
+    ///
+    /// # Errors
+    ///
+    /// [`TryLockError::WouldBlock`] when a holder has the file.
+    pub fn try_exclusive(file: File) -> Result<Self, TryLockError> {
+        FileExt::try_lock(&file)?;
+        Ok(Self { file })
+    }
+}
+
+impl Drop for FileLock {
+    fn drop(&mut self) {
+        // Taken on this owned descriptor, so nothing is left to report.
+        let _ = FileExt::unlock(&self.file);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::{File, OpenOptions};
+    #[cfg(unix)]
+    use std::{
+        process::Command,
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+        thread,
+    };
+
+    use fs4::TryLockError;
+    use tempfile::TempDir;
+
+    use super::FileLock;
+
+    fn open(directory: &TempDir) -> File {
+        OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(directory.path().join("lock"))
+            .expect("open the lock file")
+    }
+
+    #[test]
+    fn a_holder_refuses_a_second_exclusive_request() {
+        let directory = TempDir::new().expect("temporary directory");
+        let held = FileLock::try_shared(open(&directory)).expect("take the lock");
+
+        assert!(matches!(
+            FileLock::try_exclusive(open(&directory)),
+            Err(TryLockError::WouldBlock)
+        ));
+        drop(held);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_released_lock_is_free_while_children_are_being_spawned() {
+        let directory = TempDir::new().expect("temporary directory");
+        let stop = Arc::new(AtomicBool::new(false));
+        let spawner = {
+            let stop = Arc::clone(&stop);
+            thread::spawn(move || {
+                while !stop.load(Ordering::Relaxed) {
+                    let mut child = Command::new("/bin/sh")
+                        .args(["-c", "exit 0"])
+                        .spawn()
+                        .expect("spawn a child");
+                    child.wait().expect("reap the child");
+                }
+            })
+        };
+
+        let mut still_held = 0;
+        for _ in 0..2_000 {
+            match FileLock::try_shared(open(&directory)) {
+                Ok(held) => drop(held),
+                Err(_) => still_held += 1,
+            }
+            match FileLock::try_exclusive(open(&directory)) {
+                Ok(held) => drop(held),
+                Err(_) => still_held += 1,
+            }
+        }
+        stop.store(true, Ordering::Relaxed);
+        spawner.join().expect("join the spawner");
+
+        assert_eq!(
+            still_held, 0,
+            "a lock nobody holds must not read as held to the next asker"
+        );
+    }
+}

--- a/xtask/src/ci/bridge/ledger.rs
+++ b/xtask/src/ci/bridge/ledger.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use anyhow::{Context, Result, bail};
-use fs4::FileExt;
+use kithara_devtools::lock::FileLock;
 use serde::{Deserialize, Serialize};
 
 use super::model::VerificationState;
@@ -196,20 +196,17 @@ impl Ledger {
         &self,
         operation: impl FnOnce(&mut LedgerData) -> Result<T>,
     ) -> Result<T> {
-        let lock = OpenOptions::new()
+        let file = OpenOptions::new()
             .create(true)
             .truncate(false)
             .read(true)
             .write(true)
             .open(&self.lock_path)
             .with_context(|| format!("opening ledger lock {}", self.lock_path.display()))?;
-        FileExt::lock(&lock)
+        let _lock = FileLock::exclusive(file)
             .with_context(|| format!("locking ledger {}", self.lock_path.display()))?;
         let mut data = self.read()?;
-        let result = operation(&mut data);
-        FileExt::unlock(&lock)
-            .with_context(|| format!("unlocking ledger {}", self.lock_path.display()))?;
-        result
+        operation(&mut data)
     }
 
     fn read(&self) -> Result<LedgerData> {

--- a/xtask/src/ci/bridge/reconcile.rs
+++ b/xtask/src/ci/bridge/reconcile.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use anyhow::{Context, Result, bail};
-use fs4::FileExt;
+use kithara_devtools::lock::FileLock;
 use tracing::{info, warn};
 
 use super::{
@@ -25,22 +25,22 @@ pub(super) struct Bridge {
 }
 
 struct ReconcileLock {
-    _file: File,
+    _lock: FileLock,
 }
 
 impl ReconcileLock {
     fn acquire(state_dir: &Path) -> Result<Self> {
         let file = open_reconcile_lock(state_dir)?;
-        FileExt::lock(&file)
+        let lock = FileLock::exclusive(file)
             .with_context(|| format!("locking bridge state {}", state_dir.display()))?;
-        Ok(Self { _file: file })
+        Ok(Self { _lock: lock })
     }
 
     #[cfg(test)]
     fn try_acquire(state_dir: &Path) -> Result<Option<Self>> {
         let file = open_reconcile_lock(state_dir)?;
-        match FileExt::try_lock(&file) {
-            Ok(()) => Ok(Some(Self { _file: file })),
+        match FileLock::try_exclusive(file) {
+            Ok(lock) => Ok(Some(Self { _lock: lock })),
             Err(fs4::TryLockError::WouldBlock) => Ok(None),
             Err(fs4::TryLockError::Error(error)) => {
                 Err(error).with_context(|| format!("locking bridge state {}", state_dir.display()))

--- a/xtask/src/ci/build_cache.rs
+++ b/xtask/src/ci/build_cache.rs
@@ -10,8 +10,8 @@ use std::{
 };
 
 use anyhow::{Context, Result, bail};
-use fs4::{FileExt, TryLockError};
-use kithara_devtools::lease;
+use fs4::TryLockError;
+use kithara_devtools::{lease, lock::FileLock};
 use tracing::info;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -24,13 +24,13 @@ pub(crate) struct CacheEntry {
 struct CacheContents {
     entries: Vec<CacheEntry>,
     active: bool,
-    locks: Vec<File>,
+    locks: Vec<FileLock>,
 }
 
 struct DirectoryScan {
     bytes: u64,
     active: bool,
-    locks: Vec<File>,
+    locks: Vec<FileLock>,
 }
 
 pub(crate) fn select_evictions(mut entries: Vec<CacheEntry>, budget_bytes: u64) -> Vec<CacheEntry> {
@@ -91,7 +91,7 @@ pub(crate) fn reclaim_at_least(target_dirs: &[PathBuf], bytes_needed: u64) -> Re
 fn collect(
     target_dirs: &[PathBuf],
     budget_bytes: u64,
-) -> Result<(Vec<CacheEntry>, u64, Vec<File>)> {
+) -> Result<(Vec<CacheEntry>, u64, Vec<FileLock>)> {
     let mut target_dirs = target_dirs.to_vec();
     target_dirs.sort();
     let mut candidates = Vec::new();
@@ -163,7 +163,7 @@ fn candidate_entries(target_dir: &Path) -> Result<CacheContents> {
         entries: Vec::new(),
         // A target a live job leased is active even between compilations,
         // when no `.cargo-lock` is held.
-        active: lease_is_held(target_dir, FileExt::try_lock),
+        active: lease_is_held(target_dir, FileLock::try_exclusive),
         locks: Vec::new(),
     };
     for entry in entries {
@@ -229,14 +229,14 @@ fn scan_directory(path: &Path) -> Result<DirectoryScan> {
     })
 }
 
-fn cargo_lock(path: &Path) -> Result<(bool, Option<File>)> {
-    let lock = OpenOptions::new()
+fn cargo_lock(path: &Path) -> Result<(bool, Option<FileLock>)> {
+    let file = OpenOptions::new()
         .read(true)
         .write(true)
         .open(path)
         .with_context(|| format!("opening Cargo build lock {}", path.display()))?;
-    match FileExt::try_lock(&lock) {
-        Ok(()) => Ok((false, Some(lock))),
+    match FileLock::try_exclusive(file) {
+        Ok(lock) => Ok((false, Some(lock))),
         Err(TryLockError::WouldBlock) => Ok((true, None)),
         Err(TryLockError::Error(error)) => {
             Err(error).with_context(|| format!("checking Cargo build lock {}", path.display()))
@@ -271,13 +271,13 @@ fn allocated_bytes(metadata: &fs::Metadata) -> u64 {
 /// Linux with four observers and no owner, 37694 of 80000 answers were that
 /// invention. Target holders take the lease shared so several coexist, so only
 /// an exclusive request sees them at all.
-fn lease_is_held(directory: &Path, ask: fn(&File) -> Result<(), TryLockError>) -> bool {
+fn lease_is_held(directory: &Path, ask: fn(File) -> Result<FileLock, TryLockError>) -> bool {
     let path = directory.join(lease::FILE);
     let Ok(file) = OpenOptions::new().read(true).write(true).open(&path) else {
         return false;
     };
     // Held by a live job, or unreadable — either way, not ours to remove.
-    ask(&file).is_err()
+    ask(file).is_err()
 }
 
 /// Claims `CARGO_TARGET_DIR` for the life of this process, if one is named.
@@ -368,8 +368,6 @@ mod tests {
         time::{Duration, UNIX_EPOCH},
     };
 
-    use fs4::FileExt;
-
     use super::*;
 
     fn entry(path: &str, size_bytes: u64, age: u64) -> CacheEntry {
@@ -380,13 +378,6 @@ mod tests {
         }
     }
 
-    /// Nobody holds this lease, so every "held" answer is invented. Observers
-    /// must not invent one about each other, which is what asking for the
-    /// owner's own exclusive lock did.
-    ///
-    /// The invention needs `flock` to conflict between two descriptors of one
-    /// process. That is Linux behaviour and what CI runs on; on macOS the same
-    /// pair never conflicts, so this test cannot fail there.
     #[test]
     fn concurrent_observers_do_not_invent_a_checkout_holder() {
         let directory = tempfile::tempdir().unwrap();
@@ -405,7 +396,7 @@ mod tests {
                 let invented = Arc::clone(&invented);
                 thread::spawn(move || {
                     for _ in 0..2_000 {
-                        if lease_is_held(&checkout, FileExt::try_lock_shared) {
+                        if lease_is_held(&checkout, FileLock::try_shared) {
                             invented.fetch_add(1, Ordering::Relaxed);
                         }
                     }
@@ -531,16 +522,17 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let profile = directory.path().join("debug");
         fs::create_dir(&profile).unwrap();
-        let lock = OpenOptions::new()
+        let file = OpenOptions::new()
             .create(true)
             .truncate(false)
             .read(true)
             .write(true)
             .open(profile.join(".cargo-lock"))
             .unwrap();
-        FileExt::lock(&lock).unwrap();
+        let lock = FileLock::exclusive(file).unwrap();
 
         assert!(candidate_entries(directory.path()).unwrap().active);
+        drop(lock);
     }
 
     /// A run that is only executing its built tests holds no
@@ -549,16 +541,17 @@ mod tests {
     #[test]
     fn a_leased_target_defers_eviction() {
         let directory = tempfile::tempdir().unwrap();
-        let lease = OpenOptions::new()
+        let file = OpenOptions::new()
             .create(true)
             .truncate(false)
             .read(true)
             .write(true)
             .open(directory.path().join(lease::FILE))
             .unwrap();
-        FileExt::try_lock_shared(&lease).unwrap();
+        let held = FileLock::try_shared(file).unwrap();
 
         assert!(candidate_entries(directory.path()).unwrap().active);
+        drop(held);
     }
 
     /// A lease file nobody holds is a leftover, not a claim.
@@ -623,14 +616,14 @@ mod tests {
         for name in ["target", "target-flash-off"] {
             checkout_target(&checkout, name, 1);
         }
-        let job = OpenOptions::new()
+        let file = OpenOptions::new()
             .create(true)
             .truncate(false)
             .read(true)
             .write(true)
             .open(checkout.join(lease::FILE))
             .unwrap();
-        FileExt::try_lock(&job).unwrap();
+        let job = FileLock::try_exclusive(file).unwrap();
         let lane = lease::hold(&checkout.join("target")).expect("the lane claims what it builds");
 
         let targets = persistent_target_dirs(root.path()).unwrap();
@@ -654,14 +647,14 @@ mod tests {
         fs::write(checkout.join("Cargo.toml"), b"").unwrap();
         let running = checkout_target(&checkout, "target", 400_000);
         let idle = checkout_target(&checkout, "target-flash-off", 400_000);
-        let job = OpenOptions::new()
+        let file = OpenOptions::new()
             .create(true)
             .truncate(false)
             .read(true)
             .write(true)
             .open(checkout.join(lease::FILE))
             .unwrap();
-        FileExt::try_lock(&job).unwrap();
+        let job = FileLock::try_exclusive(file).unwrap();
         let lane = lease::hold(&running).expect("the lane claims what it builds");
 
         let targets = persistent_target_dirs(root.path()).unwrap();

--- a/xtask/src/ci/environment.rs
+++ b/xtask/src/ci/environment.rs
@@ -2,13 +2,13 @@ use std::{
     collections::BTreeMap,
     env,
     ffi::{OsStr, OsString},
-    fs::{self, File, OpenOptions},
+    fs::{self, OpenOptions},
     path::{Path, PathBuf},
 };
 
 use anyhow::{Context, Result, bail};
-use fs4::{FileExt, TryLockError};
-use kithara_devtools::{Ctx, lease};
+use fs4::TryLockError;
+use kithara_devtools::{Ctx, lease, lock::FileLock};
 use tracing::warn;
 
 use super::{
@@ -20,8 +20,8 @@ pub(crate) const PROVISIONED_LINUX_IMAGE_ENV: &str = "KITHARA_CI_PROVISIONED_LIN
 
 struct SccacheSlot {
     index: usize,
-    /// Keeping the file alive preserves exclusive ownership for the whole job.
-    _lock: File,
+    /// Keeping the lock alive preserves exclusive ownership for the whole job.
+    _lock: FileLock,
 }
 
 impl SccacheSlot {
@@ -35,15 +35,15 @@ impl SccacheSlot {
         })?;
         for index in 0..HOST_JOB_CONCURRENCY {
             let path = lock_root.join(format!("slot-{index}.lock"));
-            let lock = OpenOptions::new()
+            let file = OpenOptions::new()
                 .create(true)
                 .truncate(false)
                 .read(true)
                 .write(true)
                 .open(&path)
                 .with_context(|| format!("opening sccache slot lock {}", path.display()))?;
-            match FileExt::try_lock(&lock) {
-                Ok(()) => return Ok(Self { index, _lock: lock }),
+            match FileLock::try_exclusive(file) {
+                Ok(lock) => return Ok(Self { index, _lock: lock }),
                 Err(TryLockError::WouldBlock) => {}
                 Err(TryLockError::Error(error)) => {
                     return Err(error)
@@ -800,18 +800,18 @@ mod tests {
             let lease = cache_root.join(".kithara-ci-leases/job-29");
             assert!(lease.is_file());
             let lock_path = root.join(".kithara-ci-sccache-slots/slot-0.lock");
-            let contender = OpenOptions::new()
-                .read(true)
-                .write(true)
-                .open(lock_path)
-                .unwrap();
-            assert!(matches!(
-                FileExt::try_lock(&contender),
-                Err(TryLockError::WouldBlock)
-            ));
+            let contend = || {
+                let file = OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .open(&lock_path)
+                    .unwrap();
+                FileLock::try_exclusive(file)
+            };
+            assert!(matches!(contend(), Err(TryLockError::WouldBlock)));
             drop(environment);
             assert!(!lease.exists());
-            FileExt::try_lock(&contender).unwrap();
+            contend().expect("the slot a finished job held must be free");
             return;
         }
 

--- a/xtask/src/ci/verdict.rs
+++ b/xtask/src/ci/verdict.rs
@@ -8,8 +8,10 @@ use std::{
 
 use anyhow::{Context, Result, bail};
 use clap::{Args, Subcommand};
-use fs4::FileExt;
-use kithara_devtools::junit::{CaseTiming, parse_junit};
+use kithara_devtools::{
+    junit::{CaseTiming, parse_junit},
+    lock::FileLock,
+};
 use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 
@@ -103,8 +105,7 @@ impl JournalFile {
     }
 
     fn load(&self) -> Result<Journal> {
-        let lock = self.open_lock()?;
-        FileExt::lock_shared(&lock).with_context(|| {
+        let _lock = FileLock::shared(self.open_lock()?).with_context(|| {
             format!(
                 "locking verdict journal {} for reading",
                 self.path.display()
@@ -114,8 +115,7 @@ impl JournalFile {
     }
 
     fn update<T>(&self, operation: impl FnOnce(&mut Journal) -> Result<T>) -> Result<T> {
-        let lock = self.open_lock()?;
-        FileExt::lock(&lock).with_context(|| {
+        let _lock = FileLock::exclusive(self.open_lock()?).with_context(|| {
             format!("locking verdict journal {} for update", self.path.display())
         })?;
         let mut journal = Journal::load(&self.path)?;
@@ -783,10 +783,9 @@ mod tests {
 
         let contender = JournalFile::new(path.clone()).open_lock().unwrap();
         assert!(matches!(
-            FileExt::try_lock(&contender),
+            FileLock::try_exclusive(contender),
             Err(fs4::TryLockError::WouldBlock)
         ));
-        drop(contender);
 
         let second = thread::spawn(move || {
             second_store

--- a/xtask/src/self_cache/lease.rs
+++ b/xtask/src/self_cache/lease.rs
@@ -5,14 +5,15 @@ use std::{
 };
 
 use anyhow::{Context, Result};
-use fs4::{FileExt, TryLockError};
+use fs4::TryLockError;
+use kithara_devtools::lock::FileLock;
 use tracing::warn;
 
 use super::layout::{self, GENERATION_PREFIX, LEASE_FILE, REFRESH_LOCK};
 
 #[derive(Debug)]
 pub(crate) struct GenerationLease {
-    file: Option<File>,
+    lock: Option<FileLock>,
     cleanup: Option<LeaseCleanup>,
 }
 
@@ -35,29 +36,30 @@ impl GenerationLease {
 
     #[cfg(test)]
     fn acquire(generation: &Path) -> Result<Self> {
-        let file = Self::open(generation)?;
-        FileExt::lock_shared(&file)
-            .with_context(|| format!("lock self-cache generation {}", generation.display()))?;
         Ok(Self {
-            file: Some(file),
+            lock: Some(Self::claim(generation, Self::open(generation)?)?),
             cleanup: None,
         })
     }
 
     fn finish(root: &Path, generation: &Path, file: File) -> Result<Self> {
-        FileExt::lock_shared(&file)
-            .with_context(|| format!("lock self-cache generation {}", generation.display()))?;
+        let lock = Self::claim(generation, file)?;
         let current = layout::load(root, generation)?;
         Ok(Self {
-            file: Some(file),
+            lock: Some(lock),
             cleanup: Some(LeaseCleanup::new(root, current.path)),
         })
+    }
+
+    fn claim(generation: &Path, file: File) -> Result<FileLock> {
+        FileLock::shared(file)
+            .with_context(|| format!("lock self-cache generation {}", generation.display()))
     }
 }
 
 impl Drop for GenerationLease {
     fn drop(&mut self) {
-        drop(self.file.take());
+        drop(self.lock.take());
         if let Some(cleanup) = self.cleanup.take() {
             // Retention is opportunistic — the next lease to fall away retries
             // it — but a failure has to be sayable. Discarded, the cache simply
@@ -103,7 +105,7 @@ impl LeaseCleanup {
 
 #[derive(Debug)]
 pub(super) struct RefreshLock {
-    _file: File,
+    _lock: FileLock,
 }
 
 pub(crate) fn lease_current() -> Result<Option<GenerationLease>> {
@@ -117,14 +119,15 @@ pub(crate) fn lease_current() -> Result<Option<GenerationLease>> {
 
 pub(super) fn refresh(root: &Path) -> Result<RefreshLock> {
     let (file, path) = open_refresh(root)?;
-    FileExt::lock(&file).with_context(|| format!("lock self-cache refresh {}", path.display()))?;
-    Ok(RefreshLock { _file: file })
+    let lock = FileLock::exclusive(file)
+        .with_context(|| format!("lock self-cache refresh {}", path.display()))?;
+    Ok(RefreshLock { _lock: lock })
 }
 
 fn try_refresh(root: &Path) -> Result<Option<RefreshLock>> {
     let (file, path) = open_refresh(root)?;
-    match FileExt::try_lock(&file) {
-        Ok(()) => Ok(Some(RefreshLock { _file: file })),
+    match FileLock::try_exclusive(file) {
+        Ok(lock) => Ok(Some(RefreshLock { _lock: lock })),
         Err(TryLockError::WouldBlock) => Ok(None),
         Err(TryLockError::Error(error)) => {
             Err(error).with_context(|| format!("try lock self-cache refresh {}", path.display()))
@@ -200,8 +203,8 @@ pub(super) fn cleanup(
                     .with_context(|| format!("open self-cache lease {}", lease_path.display()));
             }
         };
-        match FileExt::try_lock(&lease) {
-            Ok(()) => remove_generation(&path)?,
+        match FileLock::try_exclusive(lease) {
+            Ok(_held) => remove_generation(&path)?,
             Err(TryLockError::WouldBlock) => {}
             Err(TryLockError::Error(error)) => {
                 return Err(error).with_context(|| {


### PR DESCRIPTION
## What

A build-directory lease that its owner had already released kept answering "held" to the next process that asked. `flock` lives on the open file description rather than on the descriptor, so every process forked while that descriptor was open holds a duplicate of the description until it execs — and closing the descriptor releases nothing while one of those children is alive. Every lock in the workspace was released that way.

`FileLock` (new, in `kithara-devtools`) takes the file by value and unlocks explicitly on drop. The unlock acts on the description itself and is seen by every duplicate at once. Raw `fs4` lock requests are gone from production code, so the closing form has nowhere left to be written.

## Highlights

- A reclaim no longer keeps an abandoned build cache alive because a sibling process happened to be spawning a child when the lease was dropped.
- A lane that spawns a long-lived child gives its target directory back when it exits, instead of pinning it for the child's lifetime.
- The same release contract now covers the self-cache generation lease, the sccache slot, the verdict journal, the bridge reconcile lock and the bridge ledger — the ledger also lost its unlock on early-return paths.
- `just lint full` stops going red at random: its xtask unit-test step observes the lease protocol in the same process that spawns `sh`, `git` and `launchctl` for its neighbours, so three runs in five failed on a rotating cast of lease assertions.

## Validation

- `cargo test -p xtask --bin xtask` — 20/20 consecutive green (three of five runs failed before); 10/10 green at `--test-threads=32`, where the failure rate was roughly 40%.
- `just lint full` — exit 0, all three summaries at `0 regression(s), 0 new`.
- `just test` — 4086 passed, 0 failed.
- `just fmt check` — exit 0.
- `a_released_lock_is_free_while_children_are_being_spawned` is red-first: without the explicit unlock it fails 5/5 on its own assertion.

The root cause was confirmed at the syscall level before the fix: with four threads spawning children, a released `flock` read as held 1474 times in 160000 probes (13741 without `O_CLOEXEC`); with no spawner, zero; with an explicit `LOCK_UN` before the close, zero.

Not covered: `ci::host::runners::tests::failed_legacy_bootout_removes_a_confirmed_absent_service_plist` was also reported flaky, but never reproduced here (30 runs of that module at `--test-threads=64`, 50 runs of the whole binary) and this change does not touch its path. It may be a separate cause.