### PR TITLE
ci(github): give the Linux lanes the shared fixture store

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,14 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # Where the build-time audio assets are kept. A job that finds the store
+  # empty regenerates every asset it needs, which is encode work no test
+  # should pay for; the bytes are identical for every job sharing a build
+  # fingerprint. The path is the one the GitLab container executor already
+  # mounts on this host, so both CIs fill one store. Lanes that build on
+  # macOS or Windows leave the variable unset and land in the temporary
+  # directory instead.
+  KITHARA_FIXTURE_CACHE: /cache/fixtures
 
 # One queue per branch. Pushes to different branches hold nothing from each
 # other: they share the machine at the runner, where a job waits for the cores

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,6 +8,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+env:
+  # The store the build-time audio assets are read from; see ci.yml.
+  KITHARA_FIXTURE_CACHE: /cache/fixtures
+
 # Heavy work: an instrumented run costs several times a plain one, so it queues
 # with the other heavy lanes and takes its turn among them rather than beside
 # them. A push is not behind that queue; see ci.yml, which also says why a

--- a/.github/workflows/lanes.yml
+++ b/.github/workflows/lanes.yml
@@ -16,6 +16,8 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # The store the build-time audio assets are read from; see ci.yml.
+  KITHARA_FIXTURE_CACHE: /cache/fixtures
 
 # Heavy work: this asks for the whole fleet, so it queues with the other heavy
 # lanes and takes its turn among them rather than beside them. A push is not

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -11,6 +11,8 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # The store the build-time audio assets are read from; see ci.yml.
+  KITHARA_FIXTURE_CACHE: /cache/fixtures
 
 # Heavy work: this asks for the whole fleet, so it queues with the other heavy
 # lanes and takes its turn among them rather than beside them. A push is not

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -10,6 +10,8 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # The store the build-time audio assets are read from; see ci.yml.
+  KITHARA_FIXTURE_CACHE: /cache/fixtures
 
 # Heavy work: this asks for the whole fleet, so it queues with the other heavy
 # lanes and takes its turn among them rather than beside them. A push is not

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -21,6 +21,8 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # The store the build-time audio assets are read from; see ci.yml.
+  KITHARA_FIXTURE_CACHE: /cache/fixtures
 
 # Heavy work: this asks for the whole fleet, so it queues with the other heavy
 # lanes and takes its turn among them rather than beside them. A push is not

--- a/.github/workflows/rtsan.yml
+++ b/.github/workflows/rtsan.yml
@@ -40,6 +40,8 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # The store the build-time audio assets are read from; see ci.yml.
+  KITHARA_FIXTURE_CACHE: /cache/fixtures
 
 # CI runs this soak as one of its jobs, so it must never name the queue its
 # caller already holds - a called workflow that does can never start. Waiting

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -46,6 +46,10 @@ on:
         required: false
         type: string
 
+env:
+  # The store the build-time audio assets are read from; see ci.yml.
+  KITHARA_FIXTURE_CACHE: /cache/fixtures
+
 # The run queues against itself, not against fork CI. Sharing CI's group
 # was right while both drew on one pool of runners; now that the run has a
 # runner of its own it is a way to lose runs, because a group admits one queued


### PR DESCRIPTION
## What this changes

Every Linux lane now names the store the build-time audio assets are read
from:

```yaml
KITHARA_FIXTURE_CACHE: /cache/fixtures
```

`ci.yml`, `lanes.yml`, `coverage.yml`, `miri.yml`, `mutants.yml`,
`quality.yml`, `rtsan.yml`, `stress.yml` — workflow-level `env:`, so every
job in them inherits it. `ci.yml` carries the explanation; the rest point
at it, the convention the concurrency comments already use.

## Why

`kithara-fixtures` generates its assets in a build script and keeps them in a
content-addressed store rooted at `KITHARA_FIXTURE_CACHE`. Unset, that root
is the temporary directory — on a self-hosted runner, whatever the last
reboot left behind. A job that finds the store empty re-encodes every asset
it needs before a single test starts, which is about four seconds of FFmpeg
work per job for the three assets that exist today, and grows with the
matrix.

The GitLab container executor already mounts a volume there
(`xtask/src/ci/linux/container.rs`), so the two CIs on this host now fill one
store rather than missing two.

Setting it before the assets arrive is deliberate: nothing reads the variable
until the fixtures land, and the store is warm when they do.

## Why only Linux

The macOS and Windows runners have no `/cache`, and `create_dir_all` on a
path they cannot create is a build-script failure, not a slow build. Leaving
the variable unset is what sends those lanes to the temporary directory.
`android.yml`, `gpu.yml` and `windows.yml` are untouched for that reason;
`schedule.yml` only calls other workflows and holds no environment of its
own.

## Validation

- `just lint fast` — 0 regressions.
- No Rust changed; the workflows are the whole diff.
