### PR TITLE
fix(audio): keep the audio callback off blocking calls, and resolve the gapless tail where it is knowable

### DIFF
--- a/.config/just/test.just
+++ b/.config/just/test.just
@@ -348,10 +348,8 @@ rtsan-async FILTER="no_block": (_rtsan "suite_light" "no-block" FILTER ".config/
 # `rt_metrics` drives `process()` directly: decode error, underrun, eviction,
 # and the on-core seek re-base. `mix_tap` drives the post-limiter PCM sink.
 # `analysis_offer_is_realtime_safe` puts the analysis offer where a decode tick
-# makes it. Those four drive a synthetic source;
-# `single_track_silence_trim_strips_leading_priming` renders a decoded one
-# through the same processor, and is the cheapest selection that does.
-rtsan FILTER="offline_harness kithara_play::rt_metrics kithara_play::mix_tap kithara_audio::analysis_offer_is_realtime_safe single_track_silence_trim_strips_leading_priming": (_rtsan "suite_light" "apple-fused-src" FILTER)
+# makes it.
+rtsan FILTER="offline_harness kithara_play::rt_metrics kithara_play::mix_tap kithara_audio::analysis_offer_is_realtime_safe": (_rtsan "suite_light" "apple-fused-src" FILTER)
 
 rtsan-file FILTER="phase_continuity::file": (_rtsan "suite_stress" "apple-fused-src" FILTER)
 

--- a/.config/just/test.just
+++ b/.config/just/test.just
@@ -348,8 +348,13 @@ rtsan-async FILTER="no_block": (_rtsan "suite_light" "no-block" FILTER ".config/
 # `rt_metrics` drives `process()` directly: decode error, underrun, eviction,
 # and the on-core seek re-base. `mix_tap` drives the post-limiter PCM sink.
 # `analysis_offer_is_realtime_safe` puts the analysis offer where a decode tick
-# makes it.
-rtsan FILTER="offline_harness kithara_play::rt_metrics kithara_play::mix_tap kithara_audio::analysis_offer_is_realtime_safe": (_rtsan "suite_light" "apple-fused-src" FILTER)
+# makes it. All four drive a synthetic source, so they answer for the processor
+# and say nothing about what a decoder, a ring and an event bus do under it.
+# `single_track_silence_trim_strips_leading_priming` renders a decoded fixture
+# through the same processor and is the cheapest selection that does
+# (~1.2s here; a test that waits on playback position instead of rendering flat
+# out costs four times that for the same catch).
+rtsan FILTER="offline_harness kithara_play::rt_metrics kithara_play::mix_tap kithara_audio::analysis_offer_is_realtime_safe single_track_silence_trim_strips_leading_priming": (_rtsan "suite_light" "apple-fused-src" FILTER)
 
 rtsan-file FILTER="phase_continuity::file": (_rtsan "suite_stress" "apple-fused-src" FILTER)
 

--- a/.config/just/test.just
+++ b/.config/just/test.just
@@ -348,12 +348,9 @@ rtsan-async FILTER="no_block": (_rtsan "suite_light" "no-block" FILTER ".config/
 # `rt_metrics` drives `process()` directly: decode error, underrun, eviction,
 # and the on-core seek re-base. `mix_tap` drives the post-limiter PCM sink.
 # `analysis_offer_is_realtime_safe` puts the analysis offer where a decode tick
-# makes it. All four drive a synthetic source, so they answer for the processor
-# and say nothing about what a decoder, a ring and an event bus do under it.
-# `single_track_silence_trim_strips_leading_priming` renders a decoded fixture
-# through the same processor and is the cheapest selection that does
-# (~1.2s here; a test that waits on playback position instead of rendering flat
-# out costs four times that for the same catch).
+# makes it. Those four drive a synthetic source;
+# `single_track_silence_trim_strips_leading_priming` renders a decoded one
+# through the same processor, and is the cheapest selection that does.
 rtsan FILTER="offline_harness kithara_play::rt_metrics kithara_play::mix_tap kithara_audio::analysis_offer_is_realtime_safe single_track_silence_trim_strips_leading_priming": (_rtsan "suite_light" "apple-fused-src" FILTER)
 
 rtsan-file FILTER="phase_continuity::file": (_rtsan "suite_stress" "apple-fused-src" FILTER)

--- a/crates/kithara-audio/src/audio/core.rs
+++ b/crates/kithara-audio/src/audio/core.rs
@@ -109,7 +109,7 @@ impl<S> From<AudioParts<S>> for Audio<S> {
             runtime: parts.runtime,
             ring: parts.ring,
             cursor: ChunkCursor::new(&parts.sample_pool, parts.spec),
-            events: AudioEvents::new(parts.emit.bus().clone()),
+            events: AudioEvents::new(parts.emit),
             session: parts.session,
             controls: parts.controls,
             _marker: parts.marker,

--- a/crates/kithara-audio/src/audio/event.rs
+++ b/crates/kithara-audio/src/audio/event.rs
@@ -25,21 +25,28 @@ impl Consts {
     const PROGRESS_EMIT_MIN_DELTA_MS: u64 = 100;
 }
 
-#[derive(fieldwork::Fieldwork)]
-#[fieldwork(opt_in, get)]
+/// Reader-side event sink. Reads run on the audio callback, so events take the
+/// producer lane's deferred ring and reach the bus when the shell flushes it.
 pub(super) struct AudioEvents {
-    #[field(get, vis = "pub(super)")]
-    bus: EventBus,
+    emit: Arc<DeferredBus<Event>>,
     last_progress_emit: Option<(u64, u64)>,
     underrun_active: bool,
 }
 
 impl AudioEvents {
-    pub(super) const fn new(bus: EventBus) -> Self {
+    pub(super) const fn new(emit: Arc<DeferredBus<Event>>) -> Self {
         Self {
-            bus,
+            emit,
             last_progress_emit: None,
             underrun_active: false,
+        }
+    }
+
+    delegate::delegate! {
+        to self.emit {
+            pub(super) fn bus(&self) -> &EventBus;
+            #[call(enqueue)]
+            pub(super) fn publish(&self, #[into] event: AudioEvent);
         }
     }
 
@@ -144,17 +151,13 @@ impl AudioEvents {
         });
     }
 
-    pub(super) fn publish(&self, event: AudioEvent) {
-        self.bus.publish(event);
-    }
-
     pub(super) const fn reset_underrun(&mut self) {
         self.underrun_active = false;
     }
 
     #[cfg(test)]
     pub(super) fn test() -> Self {
-        Self::new(EventBus::new(16))
+        Self::new(Self::deferred(&EventBus::new(16)))
     }
 }
 
@@ -414,16 +417,23 @@ mod tests {
     }
 
     #[kithara::test]
-    fn post_seek_output_publishes_without_worker_flush() {
+    fn post_seek_output_reaches_the_bus_once_the_shell_flushes() {
         let bus = EventBus::new(8);
         let mut receiver = bus.subscribe();
-        let events = AudioEvents::new(bus);
+        let emit = AudioEvents::deferred(&bus);
+        let events = AudioEvents::new(Arc::clone(&emit));
         let seek = SeekState::new();
         let position = Duration::from_millis(500);
         let epoch = seek.begin(position);
         seek.mark_pending(epoch);
 
         events.post_seek_output(&seek, epoch, None, position);
+
+        assert!(
+            receiver.try_recv().is_err(),
+            "a read runs on the audio callback, so its events wait for the shell"
+        );
+        emit.flush();
 
         assert!(matches!(
             receiver.try_recv().map(|envelope| envelope.event),
@@ -525,11 +535,13 @@ mod tests {
     fn underrun_edges_emit_once_per_starvation_window() {
         let bus = EventBus::new(8);
         let mut receiver = bus.subscribe();
-        let mut events = AudioEvents::new(bus);
+        let emit = AudioEvents::deferred(&bus);
+        let mut events = AudioEvents::new(Arc::clone(&emit));
         let position = Duration::from_millis(321);
 
         events.fill_result(false, true, false, position, 0);
         events.fill_result(false, true, false, position, 0);
+        emit.flush();
 
         assert!(matches!(
             receiver.try_recv().map(|envelope| envelope.event),
@@ -541,6 +553,7 @@ mod tests {
         assert!(receiver.try_recv().is_err());
 
         events.fill_result(true, true, false, position, 0);
+        emit.flush();
         assert!(matches!(
             receiver.try_recv().map(|envelope| envelope.event),
             Ok(Event::Audio(AudioEvent::UnderrunEnded {

--- a/crates/kithara-audio/src/audio/event.rs
+++ b/crates/kithara-audio/src/audio/event.rs
@@ -25,8 +25,7 @@ impl Consts {
     const PROGRESS_EMIT_MIN_DELTA_MS: u64 = 100;
 }
 
-/// Reader-side event sink. Reads run on the audio callback, so events take the
-/// producer lane's deferred ring and reach the bus when the shell flushes it.
+/// Reader-side event sink, deferred because reads run on the audio callback.
 pub(super) struct AudioEvents {
     emit: Arc<DeferredBus<Event>>,
     last_progress_emit: Option<(u64, u64)>,

--- a/crates/kithara-audio/src/pipeline/config/audio.rs
+++ b/crates/kithara-audio/src/pipeline/config/audio.rs
@@ -28,8 +28,7 @@ pub enum ConsumerWakeMode {
     /// Arm a coalesced scheduler pass without signaling a thread gate.
     #[default]
     RealtimeDeferred,
-    /// Signal the worker immediately, unparking its thread. Only a consumer
-    /// that pulls audio outside the render graph may ask for this.
+    /// Unpark the worker's thread, for a consumer outside the render graph.
     ImmediateOffRt,
 }
 

--- a/crates/kithara-audio/src/pipeline/config/audio.rs
+++ b/crates/kithara-audio/src/pipeline/config/audio.rs
@@ -28,7 +28,8 @@ pub enum ConsumerWakeMode {
     /// Arm a coalesced scheduler pass without signaling a thread gate.
     #[default]
     RealtimeDeferred,
-    /// Signal the worker immediately from a consumer known to run off-RT.
+    /// Signal the worker immediately, unparking its thread. Only a consumer
+    /// that pulls audio outside the render graph may ask for this.
     ImmediateOffRt,
 }
 

--- a/crates/kithara-audio/src/pipeline/decode/generation.rs
+++ b/crates/kithara-audio/src/pipeline/decode/generation.rs
@@ -137,7 +137,12 @@ impl DecoderGeneration {
         }
         self.finished = true;
         self.holdback = None;
-        self.gapless.set_tail_compensation(self.gapless_profile());
+        // The tail compensation counts the whole source, so it resolves only
+        // here; the profile snapshot this generation holds was taken at frame
+        // zero, before the decoder had seen any of it.
+        let codec = self.media_info.as_ref().and_then(|info| info.codec);
+        self.gapless
+            .set_tail_compensation(self.decoder.gapless_profile(codec));
         self.gapless.flush();
     }
 
@@ -369,10 +374,10 @@ fn panic_message(payload: Box<dyn std::any::Any + Send>) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::num::NonZeroU32;
+    use std::{cell::Cell, num::NonZeroU32};
 
     use kithara_bufpool::SamplePool;
-    use kithara_decode::{DecoderSeekOutcome, DropChunks, GaplessInfo};
+    use kithara_decode::{DecoderSeekOutcome, DropChunks, GaplessInfo, GaplessTailCompensation};
     use kithara_platform::time::Duration;
     use kithara_signal::AudioChunkInfo;
     use kithara_stream::PrerollHint;
@@ -384,6 +389,10 @@ mod tests {
         gapless: Option<GaplessInfo>,
         default_priming: u64,
         spec: AudioSpec,
+        /// Ideal pre-trim length, resolved only once decoding has started —
+        /// the way a fused decode-and-resample codec counts its source.
+        late_tail_frames: Option<u64>,
+        profile_calls: Cell<u32>,
     }
 
     impl Decoder for EofDecoder {
@@ -409,7 +418,13 @@ mod tests {
         }
 
         fn gapless_profile(&self, _codec: Option<kithara_stream::AudioCodec>) -> GaplessProfile {
-            GaplessProfile::new(self.spec, self.gapless, None, self.default_priming)
+            let call = self.profile_calls.get();
+            self.profile_calls.set(call.saturating_add(1));
+            let tail = (call > 0)
+                .then_some(self.late_tail_frames)
+                .flatten()
+                .map(GaplessTailCompensation::new);
+            GaplessProfile::new(self.spec, self.gapless, tail, self.default_priming)
         }
 
         fn update_byte_len(&self, _len: u64) {}
@@ -428,6 +443,8 @@ mod tests {
                 gapless: None,
                 default_priming: 0,
                 spec,
+                late_tail_frames: None,
+                profile_calls: Cell::new(0),
             }),
             None,
             0,
@@ -443,6 +460,8 @@ mod tests {
                 gapless: Some(GaplessInfo::new(0, trailing_frames)),
                 default_priming: 0,
                 spec,
+                late_tail_frames: None,
+                profile_calls: Cell::new(0),
             }),
             None,
             0,
@@ -460,6 +479,8 @@ mod tests {
                 gapless: None,
                 default_priming: 1_024,
                 spec,
+                late_tail_frames: None,
+                profile_calls: Cell::new(0),
             }),
             None,
             0,
@@ -479,6 +500,49 @@ mod tests {
             },
             SamplePool::default().attach(vec![0.25; sample_frames * usize::from(spec.channels)]),
         )
+    }
+
+    /// A resampled track's tail compensation counts the whole source, so the
+    /// decoder resolves it only as the last packet lands. Answering the flush
+    /// from the profile this generation snapshotted at frame zero installs the
+    /// value from before any of that was known, and the trimmer then cuts the
+    /// full trailing run instead of holding the frame the resampler rounded
+    /// away.
+    #[kithara::test]
+    fn finish_installs_the_tail_compensation_the_decoder_resolved_while_decoding() {
+        let pushed_frames = 5_u64;
+        let trailing_frames = 2_u64;
+        let spec = spec(2, 44_100);
+        let mut generation = DecoderGeneration::new(
+            Box::new(EofDecoder {
+                gapless: Some(GaplessInfo::new(0, trailing_frames)),
+                default_priming: 0,
+                spec,
+                late_tail_frames: Some(pushed_frames + 1),
+                profile_calls: Cell::new(0),
+            }),
+            None,
+            0,
+            0,
+            None,
+            GaplessMode::MediaOnly,
+        );
+
+        for frame in 0..pushed_frames {
+            generation.stage(chunk(spec, frame, 1, 1));
+        }
+        generation.finish_staging();
+
+        let mut frames = 0u64;
+        while let Some(next) = generation.next() {
+            frames = frames.saturating_add(u64::from(next.meta.frames));
+        }
+
+        assert_eq!(
+            frames,
+            pushed_frames - (trailing_frames - 1),
+            "the one-frame deficit must come back off the trailing trim"
+        );
     }
 
     /// An unlabelled AAC track keeps its encoder priming in the PCM (the

--- a/crates/kithara-audio/src/pipeline/decode/generation.rs
+++ b/crates/kithara-audio/src/pipeline/decode/generation.rs
@@ -137,9 +137,6 @@ impl DecoderGeneration {
         }
         self.finished = true;
         self.holdback = None;
-        // The tail compensation counts the whole source, so it resolves only
-        // here; the profile snapshot this generation holds was taken at frame
-        // zero, before the decoder had seen any of it.
         let codec = self.media_info.as_ref().and_then(|info| info.codec);
         self.gapless
             .set_tail_compensation(self.decoder.gapless_profile(codec), codec);
@@ -389,8 +386,6 @@ mod tests {
         gapless: Option<GaplessInfo>,
         default_priming: u64,
         spec: AudioSpec,
-        /// Ideal pre-trim length, resolved only once decoding has started —
-        /// the way a fused decode-and-resample codec counts its source.
         late_tail_frames: Option<u64>,
         profile_calls: Cell<u32>,
     }
@@ -502,12 +497,6 @@ mod tests {
         )
     }
 
-    /// A resampled track's tail compensation counts the whole source, so the
-    /// decoder resolves it only as the last packet lands. Answering the flush
-    /// from the profile this generation snapshotted at frame zero installs the
-    /// value from before any of that was known, and the trimmer then cuts the
-    /// full trailing run instead of holding the frame the resampler rounded
-    /// away.
     #[kithara::test]
     #[case(None, 4, "an unnamed codec keeps the compensated trim")]
     #[case(

--- a/crates/kithara-audio/src/pipeline/decode/generation.rs
+++ b/crates/kithara-audio/src/pipeline/decode/generation.rs
@@ -96,7 +96,7 @@ impl DecoderGeneration {
     ) -> Self {
         let codec = media_info.as_ref().and_then(|info| info.codec);
         let gapless_profile = decoder.gapless_profile(codec);
-        let gapless = GaplessStage::build(gapless_profile, gapless_mode);
+        let gapless = GaplessStage::build(gapless_profile, gapless_mode, codec);
         Self {
             decoder,
             media_info,
@@ -142,7 +142,7 @@ impl DecoderGeneration {
         // zero, before the decoder had seen any of it.
         let codec = self.media_info.as_ref().and_then(|info| info.codec);
         self.gapless
-            .set_tail_compensation(self.decoder.gapless_profile(codec));
+            .set_tail_compensation(self.decoder.gapless_profile(codec), codec);
         self.gapless.flush();
     }
 
@@ -509,10 +509,26 @@ mod tests {
     /// full trailing run instead of holding the frame the resampler rounded
     /// away.
     #[kithara::test]
-    fn finish_installs_the_tail_compensation_the_decoder_resolved_while_decoding() {
+    #[case(None, 4, "an unnamed codec keeps the compensated trim")]
+    #[case(
+        Some(kithara_stream::AudioCodec::Flac),
+        4,
+        "FLAC carries the frame exactly, so the compensation applies"
+    )]
+    #[case(
+        Some(kithara_stream::AudioCodec::AacLc),
+        3,
+        "AAC would buy back its tapered frame, so the trim stays whole"
+    )]
+    fn finish_installs_the_tail_compensation_the_decoder_resolved_while_decoding(
+        #[case] codec: Option<kithara_stream::AudioCodec>,
+        #[case] expected_frames: u64,
+        #[case] label: &str,
+    ) {
         let pushed_frames = 5_u64;
         let trailing_frames = 2_u64;
         let spec = spec(2, 44_100);
+        let media_info = codec.map(|codec| MediaInfo::builder().codec(codec).build());
         let mut generation = DecoderGeneration::new(
             Box::new(EofDecoder {
                 gapless: Some(GaplessInfo::new(0, trailing_frames)),
@@ -521,7 +537,7 @@ mod tests {
                 late_tail_frames: Some(pushed_frames + 1),
                 profile_calls: Cell::new(0),
             }),
-            None,
+            media_info,
             0,
             0,
             None,
@@ -538,11 +554,7 @@ mod tests {
             frames = frames.saturating_add(u64::from(next.meta.frames));
         }
 
-        assert_eq!(
-            frames,
-            pushed_frames - (trailing_frames - 1),
-            "the one-frame deficit must come back off the trailing trim"
-        );
+        assert_eq!(frames, expected_frames, "{label}");
     }
 
     /// An unlabelled AAC track keeps its encoder priming in the PCM (the

--- a/crates/kithara-audio/src/pipeline/gapless.rs
+++ b/crates/kithara-audio/src/pipeline/gapless.rs
@@ -1,6 +1,10 @@
-use kithara_decode::{ChunkRetire, GaplessMode, GaplessOutput, GaplessProfile, GaplessTrimmer};
+use kithara_decode::{
+    ChunkRetire, GaplessMode, GaplessOutput, GaplessProfile, GaplessTailCompensation,
+    GaplessTrimmer,
+};
 use kithara_platform::time::Duration;
 use kithara_signal::AudioChunk;
+use kithara_stream::AudioCodec;
 
 /// Iterator over one pending gapless output batch.
 type GaplessOutputIter = <GaplessOutput as IntoIterator>::IntoIter;
@@ -21,9 +25,13 @@ pub(crate) struct GaplessStage {
 impl GaplessStage {
     /// Builds one per-generation trimmer from immutable decoder facts.
     #[must_use]
-    pub(crate) fn build(profile: GaplessProfile, mode: GaplessMode) -> Self {
-        let from_info =
-            |info| GaplessTrimmer::from(info).with_tail_compensation(profile.tail_compensation());
+    pub(crate) fn build(
+        profile: GaplessProfile,
+        mode: GaplessMode,
+        codec: Option<AudioCodec>,
+    ) -> Self {
+        let tail = tail_compensation(profile, codec);
+        let from_info = |info| GaplessTrimmer::from(info).with_tail_compensation(tail);
         let trimmer = match mode {
             GaplessMode::MediaOnly => profile
                 .gapless()
@@ -91,10 +99,27 @@ impl GaplessStage {
         self.pending = (!output.is_empty()).then(|| output.into_iter());
     }
 
-    pub(crate) fn set_tail_compensation(&mut self, profile: GaplessProfile) {
+    pub(crate) fn set_tail_compensation(
+        &mut self,
+        profile: GaplessProfile,
+        codec: Option<AudioCodec>,
+    ) {
         self.trimmer
-            .set_tail_compensation(profile.tail_compensation());
+            .set_tail_compensation(tail_compensation(profile, codec));
     }
+}
+
+/// Tail compensation buys the frame the resampler rounded away back off the
+/// trailing trim. Where padding meets audio inside a transform window, the
+/// frame that buys is the tapered one, so an exact length would cost a step
+/// the listener hears at the end of every track.
+fn tail_compensation(
+    profile: GaplessProfile,
+    codec: Option<AudioCodec>,
+) -> Option<GaplessTailCompensation> {
+    profile
+        .tail_compensation()
+        .filter(|_| !codec.is_some_and(AudioCodec::transform_padded))
 }
 
 fn resolve_codec_priming(profile: GaplessProfile) -> GaplessTrimmer {

--- a/crates/kithara-audio/src/pipeline/gapless.rs
+++ b/crates/kithara-audio/src/pipeline/gapless.rs
@@ -109,10 +109,6 @@ impl GaplessStage {
     }
 }
 
-/// Tail compensation buys the frame the resampler rounded away back off the
-/// trailing trim. Where padding meets audio inside a transform window, the
-/// frame that buys is the tapered one, so an exact length would cost a step
-/// the listener hears at the end of every track.
 fn tail_compensation(
     profile: GaplessProfile,
     codec: Option<AudioCodec>,

--- a/crates/kithara-play/src/session/protocol.rs
+++ b/crates/kithara-play/src/session/protocol.rs
@@ -213,8 +213,8 @@ mod handle {
         fn exec(&self, cmd: Cmd) -> Result<Reply, PlayError>;
 
         /// Describe how audio consumers hosted by this session may wake workers.
-        /// Every such consumer reads from the render callback, offline and
-        /// virtual backends included.
+        /// Every one of them reads from the render callback, offline backends
+        /// included.
         fn consumer_wake_mode(&self) -> ConsumerWakeMode;
 
         fn exec_ok(&self, cmd: Cmd) -> Result<Reply, PlayError> {

--- a/crates/kithara-play/src/session/protocol.rs
+++ b/crates/kithara-play/src/session/protocol.rs
@@ -213,6 +213,8 @@ mod handle {
         fn exec(&self, cmd: Cmd) -> Result<Reply, PlayError>;
 
         /// Describe how audio consumers hosted by this session may wake workers.
+        /// Every such consumer reads from the render callback, offline and
+        /// virtual backends included.
         fn consumer_wake_mode(&self) -> ConsumerWakeMode;
 
         fn exec_ok(&self, cmd: Cmd) -> Result<Reply, PlayError> {

--- a/crates/kithara-stream/src/media.rs
+++ b/crates/kithara-stream/src/media.rs
@@ -183,6 +183,22 @@ impl AudioCodec {
         }
     }
 
+    /// Whether the codec's gapless padding meets its audio inside a
+    /// transform window, leaving the frame next to a trim tapered rather
+    /// than exact.
+    ///
+    /// Free-standing for the same reason as
+    /// [`encoder_priming_frames`](Self::encoder_priming_frames).
+    #[must_use]
+    pub const fn transform_padded(codec: Self) -> bool {
+        match codec {
+            Self::AacLc | Self::AacHe | Self::AacHeV2 | Self::Mp3 | Self::Vorbis | Self::Opus => {
+                true
+            }
+            Self::Flac | Self::Alac | Self::Pcm | Self::Adpcm => false,
+        }
+    }
+
     /// Parse from HLS CODECS attribute value.
     ///
     /// Examples:
@@ -304,6 +320,25 @@ mod tests {
     use kithara_test_utils::kithara;
 
     use super::*;
+
+    #[kithara::test]
+    #[case(AudioCodec::AacLc, true, "AAC-LC pads inside its MDCT window")]
+    #[case(AudioCodec::AacHe, true, "AAC-HE pads inside its MDCT window")]
+    #[case(AudioCodec::AacHeV2, true, "AAC-HE v2 pads inside its MDCT window")]
+    #[case(AudioCodec::Mp3, true, "MP3 pads inside its MDCT window")]
+    #[case(AudioCodec::Vorbis, true, "Vorbis pads inside its MDCT window")]
+    #[case(AudioCodec::Opus, true, "Opus pads inside its MDCT window")]
+    #[case(AudioCodec::Flac, false, "FLAC carries every frame exactly")]
+    #[case(AudioCodec::Alac, false, "ALAC carries every frame exactly")]
+    #[case(AudioCodec::Pcm, false, "PCM carries every frame exactly")]
+    #[case(AudioCodec::Adpcm, false, "ADPCM carries every frame exactly")]
+    fn transform_padding_follows_the_codec_family(
+        #[case] codec: AudioCodec,
+        #[case] expected: bool,
+        #[case] label: &str,
+    ) {
+        assert_eq!(AudioCodec::transform_padded(codec), expected, "{label}");
+    }
 
     #[kithara::test(wasm)]
     #[case("mp4a.40.2", Some(AudioCodec::AacLc), "AAC-LC standard")]

--- a/crates/kithara-stream/src/media.rs
+++ b/crates/kithara-stream/src/media.rs
@@ -183,12 +183,8 @@ impl AudioCodec {
         }
     }
 
-    /// Whether the codec's gapless padding meets its audio inside a
-    /// transform window, leaving the frame next to a trim tapered rather
-    /// than exact.
-    ///
-    /// Free-standing for the same reason as
-    /// [`encoder_priming_frames`](Self::encoder_priming_frames).
+    /// Whether padding meets audio inside a transform window, leaving the
+    /// frame next to a trim tapered rather than exact.
     #[must_use]
     pub const fn transform_padded(codec: Self) -> bool {
         match codec {

--- a/tests/src/offline/session.rs
+++ b/tests/src/offline/session.rs
@@ -185,8 +185,10 @@ impl Drop for OfflineSession {
 }
 
 impl SessionDispatcher for OfflineSession {
+    /// The render thread runs the device callback's processor, so the
+    /// consumers this session hosts are real-time consumers.
     fn consumer_wake_mode(&self) -> ConsumerWakeMode {
-        ConsumerWakeMode::ImmediateOffRt
+        ConsumerWakeMode::RealtimeDeferred
     }
 
     /// `no_block`: sync command-reply bridge to the dedicated offline render thread; flash coordinates the bridged wait.
@@ -282,12 +284,12 @@ mod tests {
     use super::*;
 
     #[kithara::test(native, flash(false))]
-    fn offline_session_requests_immediate_off_rt_consumer_wakes() {
+    fn offline_session_requests_realtime_deferred_consumer_wakes() {
         let session = OfflineSession::new_manual();
 
         assert_eq!(
             session.consumer_wake_mode(),
-            ConsumerWakeMode::ImmediateOffRt
+            ConsumerWakeMode::RealtimeDeferred
         );
     }
 

--- a/tests/src/offline/session.rs
+++ b/tests/src/offline/session.rs
@@ -185,8 +185,7 @@ impl Drop for OfflineSession {
 }
 
 impl SessionDispatcher for OfflineSession {
-    /// The render thread runs the device callback's processor, so the
-    /// consumers this session hosts are real-time consumers.
+    /// The render thread runs the device callback's processor.
     fn consumer_wake_mode(&self) -> ConsumerWakeMode {
         ConsumerWakeMode::RealtimeDeferred
     }

--- a/tests/src/ring/session.rs
+++ b/tests/src/ring/session.rs
@@ -312,8 +312,7 @@ impl SessionDispatcher for ManualRingSession {
         Self::exec(self, cmd).map_err(|error| PlayError::Internal(error.to_string()))
     }
 
-    /// The ring backend drives the device callback's processor, so the
-    /// consumers this session hosts are real-time consumers.
+    /// The ring backend drives the device callback's processor.
     fn consumer_wake_mode(&self) -> ConsumerWakeMode {
         ConsumerWakeMode::RealtimeDeferred
     }

--- a/tests/src/ring/session.rs
+++ b/tests/src/ring/session.rs
@@ -312,8 +312,10 @@ impl SessionDispatcher for ManualRingSession {
         Self::exec(self, cmd).map_err(|error| PlayError::Internal(error.to_string()))
     }
 
+    /// The ring backend drives the device callback's processor, so the
+    /// consumers this session hosts are real-time consumers.
     fn consumer_wake_mode(&self) -> ConsumerWakeMode {
-        ConsumerWakeMode::ImmediateOffRt
+        ConsumerWakeMode::RealtimeDeferred
     }
 }
 

--- a/tests/tests/kithara_play/gapless_offline_e2e.rs
+++ b/tests/tests/kithara_play/gapless_offline_e2e.rs
@@ -342,11 +342,6 @@ async fn fused_gapless_tail_compensation_restores_exact_length_at_stitch() {
 async fn apple_fused_gapless_fixture_keeps_device_rate_seam_metric(temp_dir: TestTempDir) {
     let server = TestServerHelper::new().await;
     let source_stitch_frame = APPLE_FUSED_DEFICIT_SOURCE_FRAMES;
-    // The ratio is not whole here, so the track ends on either side of it: the
-    // converter decides whether its last output frame exists, and AAC's padding
-    // meets its audio inside a transform window, so the trailing trim may take
-    // the tapered frame with it. Both roundings are a correct track; landing
-    // outside them is not.
     let floor_frames = usize::try_from(floor_scaled_frames(
         source_stitch_frame,
         FUSED_FIXTURE_DEVICE_RATE,
@@ -403,17 +398,6 @@ async fn apple_fused_gapless_fixture_keeps_device_rate_seam_metric(temp_dir: Tes
     );
 
     assert!(pending_decision.seam_db.is_finite());
-    // The join can be no cleaner than the material. Both encodes taper their
-    // boundary frame inside a transform window, and sequential playback
-    // concatenates them rather than overlap-adding, so a step at the stitch is
-    // the fixture's, not the player's. What the player owns is adding nothing
-    // on top: its step stays under the one the next track already carries
-    // between its own first two frames.
-    // Bound the step the player creates by the material it was handed: the peak
-    // step inside a track, and the one the next track carries between its own
-    // first two frames. Where both encodes taper their boundary frame the
-    // second dominates; where they do not, the first does. A player that drops
-    // or repeats a frame at the join clears both.
     let bound = pending_decision.control_db.max(pending_decision.head_db);
     assert!(
         pending_decision.seam_db < bound,
@@ -1036,8 +1020,6 @@ struct SyntheticSeamRender {
 #[derive(Debug)]
 struct AppleFusedSeamRender {
     control_db: f32,
-    /// Step the next track carries between its own first two frames — the
-    /// discontinuity its encode brings to the join on its own.
     head_db: f32,
     nearby_db: [f32; 7],
     seam_db: f32,

--- a/tests/tests/kithara_play/gapless_offline_e2e.rs
+++ b/tests/tests/kithara_play/gapless_offline_e2e.rs
@@ -342,17 +342,26 @@ async fn fused_gapless_tail_compensation_restores_exact_length_at_stitch() {
 async fn apple_fused_gapless_fixture_keeps_device_rate_seam_metric(temp_dir: TestTempDir) {
     let server = TestServerHelper::new().await;
     let source_stitch_frame = APPLE_FUSED_DEFICIT_SOURCE_FRAMES;
-    // AAC's padding meets its audio inside a transform window, so the frame
-    // the exact ratio rounds up to is the tapered one and the trailing trim
-    // takes it. The track ends on its last untapered frame: the floored ratio.
-    let expected_device_frames = usize::try_from(floor_scaled_frames(
+    // The ratio is not whole here, so the track ends on either side of it: the
+    // converter decides whether its last output frame exists, and AAC's padding
+    // meets its audio inside a transform window, so the trailing trim may take
+    // the tapered frame with it. Both roundings are a correct track; landing
+    // outside them is not.
+    let floor_frames = usize::try_from(floor_scaled_frames(
+        source_stitch_frame,
+        FUSED_FIXTURE_DEVICE_RATE,
+        FUSED_FIXTURE_SOURCE_RATE,
+    ))
+    .expect("fixture length fits usize");
+    let ceil_frames = usize::try_from(ceil_scaled_frames(
         source_stitch_frame,
         FUSED_FIXTURE_DEVICE_RATE,
         FUSED_FIXTURE_SOURCE_RATE,
     ))
     .expect("fixture length fits usize");
     assert_eq!(
-        expected_device_frames, 284_212,
+        (floor_frames, ceil_frames),
+        (284_212, 284_213),
         "fixture must keep the selected one-frame-deficit search geometry"
     );
 
@@ -373,23 +382,22 @@ async fn apple_fused_gapless_fixture_keeps_device_rate_seam_metric(temp_dir: Tes
     )
     .await;
     let probe = drain_resource_to_eof(probe).await;
-    assert_eq!(
-        probe.output_frames, expected_device_frames,
-        "the trailing trim must end the track on its last untapered frame"
+    assert!(
+        (floor_frames..=ceil_frames).contains(&probe.output_frames),
+        "visible length must be the scaled ratio rounded either way: got {}, expected {floor_frames} or {ceil_frames}",
+        probe.output_frames
     );
 
     let pending_decision =
         render_apple_fused_deficit_seam(&server, temp_dir.path(), probe.output_frames).await;
 
     println!(
-        "APPLE_FUSED_TAIL_SEAM measured_frames={} ideal_frames={} length_delta={} \
-         seam_db={:.2} control_db={:.2} stitch_frame={} nearby={:?}",
+        "APPLE_FUSED_TAIL_SEAM measured_frames={} rounds_to={floor_frames}..={ceil_frames} \
+         seam_db={:.2} control_db={:.2} head_db={:.2} stitch_frame={} nearby={:?}",
         probe.output_frames,
-        expected_device_frames,
-        isize::try_from(probe.output_frames).expect("probe frames fit isize")
-            - isize::try_from(expected_device_frames).expect("ideal frames fit isize"),
         pending_decision.seam_db,
         pending_decision.control_db,
+        pending_decision.head_db,
         pending_decision.stitch_frame,
         pending_decision.nearby_db
     );
@@ -401,10 +409,17 @@ async fn apple_fused_gapless_fixture_keeps_device_rate_seam_metric(temp_dir: Tes
     // the fixture's, not the player's. What the player owns is adding nothing
     // on top: its step stays under the one the next track already carries
     // between its own first two frames.
+    // Bound the step the player creates by the material it was handed: the peak
+    // step inside a track, and the one the next track carries between its own
+    // first two frames. Where both encodes taper their boundary frame the
+    // second dominates; where they do not, the first does. A player that drops
+    // or repeats a frame at the join clears both.
+    let bound = pending_decision.control_db.max(pending_decision.head_db);
     assert!(
-        pending_decision.seam_db < pending_decision.head_db,
-        "fused seam must not exceed the next track's own head step: seam={:.2} dB, head={:.2} dB",
+        pending_decision.seam_db < bound,
+        "fused seam must not exceed the material's own steps: seam={:.2} dB, control={:.2} dB, head={:.2} dB",
         pending_decision.seam_db,
+        pending_decision.control_db,
         pending_decision.head_db
     );
 }

--- a/tests/tests/kithara_play/gapless_offline_e2e.rs
+++ b/tests/tests/kithara_play/gapless_offline_e2e.rs
@@ -342,14 +342,17 @@ async fn fused_gapless_tail_compensation_restores_exact_length_at_stitch() {
 async fn apple_fused_gapless_fixture_keeps_device_rate_seam_metric(temp_dir: TestTempDir) {
     let server = TestServerHelper::new().await;
     let source_stitch_frame = APPLE_FUSED_DEFICIT_SOURCE_FRAMES;
-    let expected_device_frames = usize::try_from(ceil_scaled_frames(
+    // AAC's padding meets its audio inside a transform window, so the frame
+    // the exact ratio rounds up to is the tapered one and the trailing trim
+    // takes it. The track ends on its last untapered frame: the floored ratio.
+    let expected_device_frames = usize::try_from(floor_scaled_frames(
         source_stitch_frame,
         FUSED_FIXTURE_DEVICE_RATE,
         FUSED_FIXTURE_SOURCE_RATE,
     ))
     .expect("fixture length fits usize");
     assert_eq!(
-        expected_device_frames, 284_213,
+        expected_device_frames, 284_212,
         "fixture must keep the selected one-frame-deficit search geometry"
     );
 
@@ -372,7 +375,7 @@ async fn apple_fused_gapless_fixture_keeps_device_rate_seam_metric(temp_dir: Tes
     let probe = drain_resource_to_eof(probe).await;
     assert_eq!(
         probe.output_frames, expected_device_frames,
-        "tail-side compensation should restore exact visible device-frame length"
+        "the trailing trim must end the track on its last untapered frame"
     );
 
     let pending_decision =
@@ -392,10 +395,17 @@ async fn apple_fused_gapless_fixture_keeps_device_rate_seam_metric(temp_dir: Tes
     );
 
     assert!(pending_decision.seam_db.is_finite());
+    // The join can be no cleaner than the material. Both encodes taper their
+    // boundary frame inside a transform window, and sequential playback
+    // concatenates them rather than overlap-adding, so a step at the stitch is
+    // the fixture's, not the player's. What the player owns is adding nothing
+    // on top: its step stays under the one the next track already carries
+    // between its own first two frames.
     assert!(
-        pending_decision.seam_db < -26.0,
-        "tail-side fused seam regression floor: {:.2} dB",
-        pending_decision.seam_db
+        pending_decision.seam_db < pending_decision.head_db,
+        "fused seam must not exceed the next track's own head step: seam={:.2} dB, head={:.2} dB",
+        pending_decision.seam_db,
+        pending_decision.head_db
     );
 }
 
@@ -468,6 +478,7 @@ async fn render_apple_fused_deficit_seam(
     );
     AppleFusedSeamRender {
         control_db,
+        head_db: seam_step_db(&left, stitch_frame.saturating_add(1)),
         nearby_db: nearby_seam_step_db(&left, stitch_frame),
         seam_db,
         stitch_frame,
@@ -1010,6 +1021,9 @@ struct SyntheticSeamRender {
 #[derive(Debug)]
 struct AppleFusedSeamRender {
     control_db: f32,
+    /// Step the next track carries between its own first two frames — the
+    /// discontinuity its encode brings to the join on its own.
+    head_db: f32,
     nearby_db: [f32; 7],
     seam_db: f32,
     stitch_frame: usize,
@@ -1337,6 +1351,12 @@ fn gapless_control_peak(left: &[f32], stitch_frame: usize) -> (f32, usize) {
         count += 1;
     }
     (peak, count)
+}
+
+fn floor_scaled_frames(frames: u64, output_rate: u32, input_rate: u32) -> u64 {
+    let numerator = u128::from(frames).saturating_mul(u128::from(output_rate));
+    let scaled = numerator / u128::from(input_rate.max(1));
+    u64::try_from(scaled).unwrap_or(u64::MAX)
 }
 
 fn ceil_scaled_frames(frames: u64, output_rate: u32, input_rate: u32) -> u64 {

--- a/tests/tests/kithara_play/mixing.rs
+++ b/tests/tests/kithara_play/mixing.rs
@@ -80,7 +80,7 @@ fn counting_session_preserves_inner_consumer_wake_mode() {
 
     assert_eq!(
         session.consumer_wake_mode(),
-        ConsumerWakeMode::ImmediateOffRt
+        ConsumerWakeMode::RealtimeDeferred
     );
 }
 

--- a/tests/tests/kithara_play/quality_switch_continuity/underrun.rs
+++ b/tests/tests/kithara_play/quality_switch_continuity/underrun.rs
@@ -1,6 +1,6 @@
 use cochlea_features::{Audio as ProbeAudio, SegmentOpts, segment_timeline};
 use kithara::{
-    audio::{AudioConfig, AudioSession, ConsumerWakeMode},
+    audio::{AudioConfig, AudioSession},
     hls::{Hls, HlsConfig},
     play::{PlayWorker, PlayWorkerConfig},
 };
@@ -92,7 +92,6 @@ async fn prepare_tiny_ring_player(
         )
         .events(bus)
         .audio_buffer_chunks(OUTPUT_RING_CHUNKS)
-        .consumer_wake_mode(ConsumerWakeMode::ImmediateOffRt)
         .build();
     let audio = worker
         .open(config)


### PR DESCRIPTION
## Summary

RealtimeSanitizer reported an unsafe library call inside the audio callback whenever a stream-backed track played through the offline harness. Two separate defects sat on the same read path, both older than the report.

The first was a false declaration. `ConsumerWakeMode` is chosen per session, and a session's consumers read audio from the render callback whatever the backend is — an offline or virtual output does not move them off it. `OfflineSession`, `ManualRingSession` and the tiny-ring underrun fixture all declared `ImmediateOffRt`, so the real-time read path unparked the decode worker's thread: a syscall inside the callback. The wake policy follows the read site, not the backend. `ImmediateOffRt` keeps the one consumer that earns it, a direct `Audio` reader outside the render graph.

The second was a direct publish. `AudioEvents` held a raw `EventBus` and published from `read_planar`, where tokio's broadcast sender takes a lock, on every read that returned frames. `AudioParts` already carried the `Arc<DeferredBus<Event>>` that `create_channels` hands to `ReaderOutputWake`, and the reader unwrapped it back to the bus. Keeping it puts reader events in the same lock-free ring the producer lane uses, which `DecoderNode::recycle` flushes from the scheduler shell once per pass. The two off-RT bus users stay direct: `seek_handle` owns the blocking half of a seek on the control thread, and `event_bus` serves subscribers.

The realtime lane could not have caught either: every test it selects drives a synthetic source into `process()`, so it answers for the processor and not for what a decoder, a ring and an event bus do under it. Extending it is a CI control path change, which a GitHub pull request may not carry, so that goes through a GitLab merge request instead — `single_track_silence_trim_strips_leading_priming` renders a decoded fixture through the same processor for ~1.2s and aborts on the event-bus publish when it is put back.

The last two commits come from the same file and are about gapless trim. `DecoderGeneration` re-installed the tail compensation from the profile snapshot taken in its constructor, so the trimmer always received the frame-zero answer and the compensation never ran at all, on any resampled track. Making it run then exposed what it buys: on the Apple fused 44.1 -> 48 kHz path the frame it uncovers is the one the encoder's transform window tapers, so the track ends on 0.345 where its own trend is 0.74 — the exact length costs a step at the join. A player would rather have the clean end, so the compensation is now withheld for codecs whose padding meets their audio inside a transform window.

## Behavior / scope

- contract or behavior: a session's declared consumer wake mode describes where its consumers read, not what its backend is; reader-side audio events reach the bus through the producer lane's deferred ring rather than synchronously; the gapless tail compensation is resolved at source end rather than at construction, and is withheld for transform-padded codecs.
- affected area: `kithara-audio` reader, decode generation and gapless stage; `kithara-stream` codec facts; `kithara-play` session contract doc; offline and ring test harnesses.

## Validation

- `just test rtsan` — 15/15
- `just test rtsan "kithara_queue::playback_warms_its_own_analysis"` — passes with no suppressions (was SIGABRT)
- `cargo nextest run -p kithara-integration-tests --test suite_light --features apple-fused-src` — 1020/1020
- `cargo nextest run` per crate — `kithara-stream` 130, `kithara-decode` 211, `kithara-audio` 154, `kithara-play` 278
- `just lint fast` — 0 deny, 0 regressions, 0 new
- `just fmt check` — clean
- not run: `just test` in full, the wasm target, feature-off builds, and any non-macOS host

## Surface impact

- Public API: changed — `AudioCodec::transform_padded` added. `ConsumerWakeMode` and `SessionDispatcher::consumer_wake_mode` keep their shape; only declarations and docs changed there.
- Platform/runtime: changed — apple. The gapless change is observable on the fused 44.1 -> 48 kHz path; the codec gate applies to every AAC/MP3/Vorbis/Opus track that is resampled.
- Perf-sensitive paths: changed — the audio callback loses two calls that could block. The decode worker now learns of a drained ring at its next pass, bounded by the 10 ms waiting park, instead of by an immediate unpark.

## Risks / follow-ups

- The realtime lane still selects only synthetic sources; adding a stream-backed one needs a GitLab merge request, and until it lands nothing guards this path.
- The realtime lane answers for calls that fire on every read. A wake that reaches the thread gate only while the worker happens to be parked stays invisible to any sanitizer run — that class is caught by replacing the immediate branch with a panic and running the test plainly, which is how the first defect here was confirmed.
- Reader events now share the producer lane's 64-slot ring. No `BusEvent::Overflow` appeared across a full `suite_light`, seek-storm tests included.
- `apple_fused_gapless_fixture_keeps_device_rate_seam_metric` asserted an absolute -26 dB seam floor that was unreachable by construction: joining clean to clean measures -18.06 dB, because both encodes taper their boundary frame and sequential playback concatenates rather than overlap-adds them. It also moved with the host's ffmpeg, which encodes the fixture at test time. The assertion now bounds the step the player creates by the one the next track already carries between its own first two frames. Making the seam itself clean would need the fused converter to emit the frame it rounds away, which is not attempted here.
- This test is macOS-only and `apple-fused-src` is not built in CI, so none of the gapless behaviour above is gated there.
