### PR TITLE
test(sync): restore full synchronization oracle matrix

### DIFF
--- a/crates/kithara-test-fixtures/src/defs/encoded.rs
+++ b/crates/kithara-test-fixtures/src/defs/encoded.rs
@@ -1,7 +1,10 @@
 use kithara_encode::{BytesEncodeRequest, BytesEncodeTarget, EncoderFactory};
 use kithara_test_macros as kithara;
 
-use crate::signal::{Pcm, Wave};
+use crate::{
+    defs::wav::{RhythmControl, rhythm_pcm},
+    signal::{Pcm, Wave},
+};
 
 struct Consts;
 
@@ -27,6 +30,35 @@ fn sine_mp3(total_frames: usize, peak: i16) -> Vec<u8> {
             hz: Consts::TONE_HZ,
             peak,
         },
+    );
+    EncoderFactory::encode_bytes(BytesEncodeRequest {
+        pcm: &pcm,
+        target: BytesEncodeTarget::Mp3,
+        bit_rate: None,
+    })
+    .unwrap_or_else(|error| panic!("kithara-test-fixtures: MP3 encode failed: {error}"))
+    .bytes
+}
+
+/// Frame-addressable 120 BPM pulse tracks for encoded-file tests.
+#[kithara::asset(ext = "mp3", content_type = "audio/mpeg")]
+#[case::deck_a_120bpm_48k(48_000, 2, 576_000, 120.0, 220.0)]
+#[case::deck_b_120bpm_48k(48_000, 2, 576_000, 120.0, 880.0)]
+fn rhythm_mp3(
+    sample_rate: u32,
+    channels: u16,
+    total_frames: usize,
+    bpm: f64,
+    carrier_hz: f64,
+) -> Vec<u8> {
+    let pcm = rhythm_pcm(
+        sample_rate,
+        channels,
+        total_frames,
+        bpm,
+        carrier_hz,
+        0,
+        RhythmControl::Aligned,
     );
     EncoderFactory::encode_bytes(BytesEncodeRequest {
         pcm: &pcm,

--- a/crates/kithara-test-fixtures/src/defs/packaged.rs
+++ b/crates/kithara-test-fixtures/src/defs/packaged.rs
@@ -1,10 +1,13 @@
+use std::sync::OnceLock;
+
 use kithara_bufpool::{BytePool, SamplePool};
 use kithara_encode::{EncoderFactory, PackagedEncodeRequest};
 use kithara_stream::{AudioCodec, ContainerFormat, MediaInfo};
 use kithara_test_macros as kithara;
 
 use crate::{
-    fmp4::{GaplessEncoding, mux_audio_track},
+    defs::wav::{RhythmControl, rhythm_pcm},
+    fmp4::{Fmp4Package, GaplessEncoding, mux_audio_track},
     signal::{Pcm, Wave},
 };
 
@@ -16,6 +19,71 @@ impl Consts {
     const CHANNELS: u16 = 2;
     const ONE_SECOND_FRAMES: usize = 44_100;
     const SAMPLE_RATE: u32 = 44_100;
+    const RHYTHM_BIT_RATE: u64 = 512_000;
+    const RHYTHM_FRAMES: usize = 576_000;
+    const RHYTHM_SAMPLE_RATE: u32 = 48_000;
+}
+
+static RHYTHM_FMP4: [OnceLock<Fmp4Package>; 2] = [OnceLock::new(), OnceLock::new()];
+
+fn rhythm_fmp4(index: usize, carrier_hz: f64) -> &'static Fmp4Package {
+    RHYTHM_FMP4[index].get_or_init(|| {
+        let codec = AudioCodec::Flac;
+        let frame_samples = EncoderFactory::frame_samples(codec).unwrap_or_else(|error| {
+            panic!("kithara-test-fixtures: FLAC frame size failed: {error}")
+        });
+        let packets = Consts::RHYTHM_FRAMES.div_ceil(frame_samples);
+        let pcm = rhythm_pcm(
+            Consts::RHYTHM_SAMPLE_RATE,
+            Consts::CHANNELS,
+            packets * frame_samples,
+            120.0,
+            carrier_hz,
+            0,
+            RhythmControl::Aligned,
+        );
+        let media_info = MediaInfo::builder()
+            .codec(codec)
+            .container(ContainerFormat::Fmp4)
+            .sample_rate(Consts::RHYTHM_SAMPLE_RATE)
+            .channels(Consts::CHANNELS)
+            .build();
+        let track = EncoderFactory::encode_packaged(
+            PackagedEncodeRequest::for_pools(BytePool::default(), SamplePool::default())
+                .pcm(&pcm)
+                .media_info(media_info)
+                .timescale(Consts::RHYTHM_SAMPLE_RATE)
+                .bit_rate(Consts::RHYTHM_BIT_RATE)
+                .packets_per_segment(packets)
+                .encoder_delay(0)
+                .trailing_delay(0)
+                .build(),
+        )
+        .unwrap_or_else(|error| {
+            panic!("kithara-test-fixtures: rhythmic FLAC encode failed: {error}")
+        });
+        mux_audio_track(&track, GaplessEncoding::None).unwrap_or_else(|error| {
+            panic!("kithara-test-fixtures: rhythmic fMP4 mux failed: {error}")
+        })
+    })
+}
+
+#[kithara::asset(ext = "mp4", content_type = "audio/mp4")]
+#[case::deck_a_120bpm_48k(0, 220.0)]
+#[case::deck_b_120bpm_48k(1, 880.0)]
+fn rhythm_fmp4_init(index: usize, carrier_hz: f64) -> Vec<u8> {
+    rhythm_fmp4(index, carrier_hz).init_segment.clone()
+}
+
+#[kithara::asset(ext = "m4s", content_type = "audio/mp4")]
+#[case::deck_a_120bpm_48k(0, 220.0)]
+#[case::deck_b_120bpm_48k(1, 880.0)]
+fn rhythm_fmp4_media(index: usize, carrier_hz: f64) -> Vec<u8> {
+    rhythm_fmp4(index, carrier_hz)
+        .media_segments
+        .first()
+        .cloned()
+        .expect("rhythmic fMP4 has one media segment")
 }
 
 /// A saw packaged as a single-segment fMP4 body, the shape a browser hands to

--- a/crates/kithara-test-fixtures/src/defs/wav.rs
+++ b/crates/kithara-test-fixtures/src/defs/wav.rs
@@ -1,7 +1,7 @@
 use kithara_test_macros as kithara;
 use num_traits::cast;
 
-use crate::signal::{Wave, wav, wav_from_fn};
+use crate::signal::{Pcm, Wave, header, wav, wav_from_fn};
 
 struct Consts;
 
@@ -25,7 +25,7 @@ impl Consts {
 }
 
 #[derive(Clone, Copy)]
-enum RhythmControl {
+pub(super) enum RhythmControl {
     Aligned,
     BarPhaseBeats(usize),
     MissingBeat(usize),
@@ -110,6 +110,32 @@ fn rhythm_wav(
     phase_frame: usize,
     control: RhythmControl,
 ) -> Vec<u8> {
+    let mut bytes = header(
+        sample_rate,
+        channels,
+        Some(total_frames * usize::from(channels) * size_of::<i16>()),
+    );
+    bytes.extend(Vec::<u8>::from(rhythm_pcm(
+        sample_rate,
+        channels,
+        total_frames,
+        bpm,
+        carrier_hz,
+        phase_frame,
+        control,
+    )));
+    bytes
+}
+
+pub(super) fn rhythm_pcm(
+    sample_rate: u32,
+    channels: u16,
+    total_frames: usize,
+    bpm: f64,
+    carrier_hz: f64,
+    phase_frame: usize,
+    control: RhythmControl,
+) -> Pcm {
     let beat_frames: usize =
         cast((f64::from(sample_rate) * Consts::SECONDS_PER_MINUTE / bpm).round())
             .expect("invariant: a fixture beat period fits usize");
@@ -123,7 +149,7 @@ fn rhythm_wav(
         RhythmControl::MissingBeat(missing) => (0, Some(missing)),
     };
 
-    wav_from_fn(sample_rate, channels, total_frames, |frame| {
+    Pcm::from_fn(sample_rate, channels, total_frames, |frame| {
         let Some(since_first) = frame.checked_sub(first_beat) else {
             return 0;
         };

--- a/crates/kithara-test-fixtures/src/defs/wav.rs
+++ b/crates/kithara-test-fixtures/src/defs/wav.rs
@@ -1,4 +1,5 @@
 use kithara_test_macros as kithara;
+use num_traits::cast;
 
 use crate::signal::{Wave, wav, wav_from_fn};
 
@@ -50,4 +51,54 @@ fn marked_sine_wav(total_frames: usize, peak: i16, marker_peak: i16) -> Vec<u8> 
             .sample(frame, Consts::SAMPLE_RATE)
         },
     )
+}
+
+/// Four-beat pulse track with an exact frame-addressable beat marker.
+#[kithara::asset(ext = "wav", content_type = "audio/wav")]
+#[case::deck_a_120bpm_48k(48_000, 2, 576_000, 120.0, 220.0, 0)]
+#[case::deck_b_120bpm_48k(48_000, 2, 576_000, 120.0, 880.0, 0)]
+#[case::deck_c_120bpm_48k(48_000, 2, 576_000, 120.0, 1_760.0, 0)]
+#[case::deck_d_120bpm_48k(48_000, 2, 576_000, 120.0, 3_520.0, 0)]
+#[case::deck_b_one_frame_late_120bpm_48k(48_000, 2, 576_000, 120.0, 880.0, 1)]
+fn rhythm_wav(
+    sample_rate: u32,
+    channels: u16,
+    total_frames: usize,
+    bpm: f64,
+    carrier_hz: f64,
+    phase_frame: usize,
+) -> Vec<u8> {
+    let beat_frames: usize = cast((f64::from(sample_rate) * 60.0 / bpm).round())
+        .expect("invariant: a fixture beat period fits usize");
+    let first_beat = beat_frames + phase_frame;
+    let pulse_frames =
+        usize::try_from(sample_rate).expect("invariant: a sample rate fits usize") / 25;
+
+    wav_from_fn(sample_rate, channels, total_frames, |frame| {
+        let Some(since_first) = frame.checked_sub(first_beat) else {
+            return 0;
+        };
+        let beat = since_first / beat_frames;
+        let within_beat = since_first % beat_frames;
+        if within_beat == 0 {
+            return if beat.is_multiple_of(4) {
+                28_000
+            } else {
+                22_000
+            };
+        }
+        if within_beat >= pulse_frames {
+            return 0;
+        }
+
+        Wave::Sine {
+            hz: carrier_hz,
+            peak: if beat.is_multiple_of(4) {
+                14_000
+            } else {
+                10_000
+            },
+        }
+        .sample(within_beat, sample_rate)
+    })
 }

--- a/crates/kithara-test-fixtures/src/defs/wav.rs
+++ b/crates/kithara-test-fixtures/src/defs/wav.rs
@@ -6,14 +6,29 @@ use crate::signal::{Wave, wav, wav_from_fn};
 struct Consts;
 
 impl Consts {
+    const BEAT_MARKER_PEAK: i16 = 22_000;
+    const BEAT_TONE_PEAK: i16 = 10_000;
+    const BEATS_PER_BAR: usize = 4;
     const CHANNELS: u16 = 2;
+    const DOWNBEAT_MARKER_PEAK: i16 = 28_000;
+    const DOWNBEAT_TONE_PEAK: i16 = 14_000;
     const MARKER_FRAMES: usize = 2_205;
     const MARKER_PEAK: i16 = 2_000;
     const MARKER_STARTS: [usize; 2] = [17_640, 35_280];
+    const MILLIS_PER_SECOND: usize = 1_000;
+    const PULSE_DURATION_MS: usize = 40;
     const SAMPLE_RATE: u32 = 44_100;
+    const SECONDS_PER_MINUTE: f64 = 60.0;
     const SOURCE_FRAMES: usize = 264_600;
     const TONE_HZ: f64 = 440.0;
     const TONE_PEAK: i16 = 16_000;
+}
+
+#[derive(Clone, Copy)]
+enum RhythmControl {
+    Aligned,
+    BarPhaseBeats(usize),
+    MissingBeat(usize),
 }
 
 /// Plain 440 Hz tone.
@@ -55,11 +70,37 @@ fn marked_sine_wav(total_frames: usize, peak: i16, marker_peak: i16) -> Vec<u8> 
 
 /// Four-beat pulse track with an exact frame-addressable beat marker.
 #[kithara::asset(ext = "wav", content_type = "audio/wav")]
-#[case::deck_a_120bpm_48k(48_000, 2, 576_000, 120.0, 220.0, 0)]
-#[case::deck_b_120bpm_48k(48_000, 2, 576_000, 120.0, 880.0, 0)]
-#[case::deck_c_120bpm_48k(48_000, 2, 576_000, 120.0, 1_760.0, 0)]
-#[case::deck_d_120bpm_48k(48_000, 2, 576_000, 120.0, 3_520.0, 0)]
-#[case::deck_b_one_frame_late_120bpm_48k(48_000, 2, 576_000, 120.0, 880.0, 1)]
+#[case::deck_a_120bpm_48k(48_000, 2, 576_000, 120.0, 220.0, 0, RhythmControl::Aligned)]
+#[case::deck_b_120bpm_48k(48_000, 2, 576_000, 120.0, 880.0, 0, RhythmControl::Aligned)]
+#[case::deck_c_120bpm_48k(48_000, 2, 576_000, 120.0, 1_760.0, 0, RhythmControl::Aligned)]
+#[case::deck_d_120bpm_48k(48_000, 2, 576_000, 120.0, 3_520.0, 0, RhythmControl::Aligned)]
+#[case::deck_b_one_frame_late_120bpm_48k(
+    48_000,
+    2,
+    576_000,
+    120.0,
+    880.0,
+    1,
+    RhythmControl::Aligned
+)]
+#[case::deck_b_one_beat_bar_late_120bpm_48k(
+    48_000,
+    2,
+    576_000,
+    120.0,
+    880.0,
+    0,
+    RhythmControl::BarPhaseBeats(1)
+)]
+#[case::deck_b_missing_beat_120bpm_48k(
+    48_000,
+    2,
+    576_000,
+    120.0,
+    880.0,
+    0,
+    RhythmControl::MissingBeat(5)
+)]
 fn rhythm_wav(
     sample_rate: u32,
     channels: u16,
@@ -67,12 +108,20 @@ fn rhythm_wav(
     bpm: f64,
     carrier_hz: f64,
     phase_frame: usize,
+    control: RhythmControl,
 ) -> Vec<u8> {
-    let beat_frames: usize = cast((f64::from(sample_rate) * 60.0 / bpm).round())
-        .expect("invariant: a fixture beat period fits usize");
+    let beat_frames: usize =
+        cast((f64::from(sample_rate) * Consts::SECONDS_PER_MINUTE / bpm).round())
+            .expect("invariant: a fixture beat period fits usize");
     let first_beat = beat_frames + phase_frame;
-    let pulse_frames =
-        usize::try_from(sample_rate).expect("invariant: a sample rate fits usize") / 25;
+    let pulse_frames = usize::try_from(sample_rate).expect("invariant: a sample rate fits usize")
+        * Consts::PULSE_DURATION_MS
+        / Consts::MILLIS_PER_SECOND;
+    let (bar_phase, missing_beat) = match control {
+        RhythmControl::Aligned => (0, None),
+        RhythmControl::BarPhaseBeats(phase) => (phase, None),
+        RhythmControl::MissingBeat(missing) => (0, Some(missing)),
+    };
 
     wav_from_fn(sample_rate, channels, total_frames, |frame| {
         let Some(since_first) = frame.checked_sub(first_beat) else {
@@ -80,11 +129,15 @@ fn rhythm_wav(
         };
         let beat = since_first / beat_frames;
         let within_beat = since_first % beat_frames;
+        if missing_beat == Some(beat) {
+            return 0;
+        }
+        let downbeat = beat % Consts::BEATS_PER_BAR == bar_phase;
         if within_beat == 0 {
-            return if beat.is_multiple_of(4) {
-                28_000
+            return if downbeat {
+                Consts::DOWNBEAT_MARKER_PEAK
             } else {
-                22_000
+                Consts::BEAT_MARKER_PEAK
             };
         }
         if within_beat >= pulse_frames {
@@ -93,10 +146,10 @@ fn rhythm_wav(
 
         Wave::Sine {
             hz: carrier_hz,
-            peak: if beat.is_multiple_of(4) {
-                14_000
+            peak: if downbeat {
+                Consts::DOWNBEAT_TONE_PEAK
             } else {
-                10_000
+                Consts::BEAT_TONE_PEAK
             },
         }
         .sample(within_beat, sample_rate)

--- a/tests/src/cochlea.rs
+++ b/tests/src/cochlea.rs
@@ -5,6 +5,9 @@ use num_traits::cast;
 use serde::Serialize;
 
 const BEAT_MARKER_THRESHOLD: f32 = 0.6;
+const BEATS_PER_BAR: usize = 4;
+const DOWNBEAT_MARKER_THRESHOLD: f32 = 0.8;
+const SECONDS_PER_MINUTE: f64 = 60.0;
 const TEMPO_TOLERANCE_BPM: f64 = 0.5;
 const WINDOW_MS: f64 = 5.0;
 
@@ -124,10 +127,12 @@ pub fn synchronization_failures(
 
     let mut failures = Vec::new();
     let channel_count = usize::from(channels);
-    let beat_period: usize = cast((f64::from(sample_rate) * 60.0 / target_bpm).round())
-        .unwrap_or(1)
-        .max(1);
+    let beat_period: usize =
+        cast((f64::from(sample_rate) * SECONDS_PER_MINUTE / target_bpm).round())
+            .unwrap_or(1)
+            .max(1);
     let mut phases = Vec::with_capacity(tracks.len());
+    let mut bar_offsets = Vec::with_capacity(tracks.len());
     for (index, &samples) in tracks.iter().enumerate() {
         assert!(
             samples.len().is_multiple_of(channel_count),
@@ -156,11 +161,34 @@ pub fn synchronization_failures(
             ));
         }
 
-        let Some(first) = first_beat_marker(samples, channel_count) else {
+        let (markers, downbeats) = rhythm_markers(samples, channel_count);
+        let Some(&first) = markers.first() else {
             failures.push(format!("{label}: track {index} has no exact beat markers"));
             continue;
         };
+        let marker_period = markers
+            .windows(2)
+            .map(|pair| pair[1] - pair[0])
+            .min()
+            .unwrap_or(beat_period);
+        if let Some(pair) = markers
+            .windows(2)
+            .find(|pair| pair[1] - pair[0] == marker_period.saturating_mul(2))
+        {
+            failures.push(format!(
+                "{label}: track {index} is missing a rhythmic event before frame {}",
+                pair[1],
+            ));
+        }
         phases.push(first % beat_period);
+
+        let Some(&first_downbeat) = downbeats.first() else {
+            failures.push(format!(
+                "{label}: track {index} has no exact downbeat markers"
+            ));
+            continue;
+        };
+        bar_offsets.push((first_downbeat - first) / marker_period % BEATS_PER_BAR);
     }
 
     if phases.len() == tracks.len() {
@@ -172,15 +200,31 @@ pub fn synchronization_failures(
             ));
         }
     }
+    if bar_offsets.len() == tracks.len() {
+        let spread = circular_spread(&mut bar_offsets, BEATS_PER_BAR);
+        if spread > 0 {
+            let suffix = if spread == 1 { "" } else { "s" };
+            failures.push(format!(
+                "{label}: bar phase spread is {spread} beat{suffix}",
+            ));
+        }
+    }
     failures
 }
 
-fn first_beat_marker(samples: &[f32], channels: usize) -> Option<usize> {
-    samples.chunks_exact(channels).position(|values| {
-        values
-            .iter()
-            .any(|sample| sample.abs() >= BEAT_MARKER_THRESHOLD)
-    })
+fn rhythm_markers(samples: &[f32], channels: usize) -> (Vec<usize>, Vec<usize>) {
+    let mut beats = Vec::new();
+    let mut downbeats = Vec::new();
+    for (frame, values) in samples.chunks_exact(channels).enumerate() {
+        let peak = values.iter().map(|sample| sample.abs()).fold(0.0, f32::max);
+        if peak >= BEAT_MARKER_THRESHOLD {
+            beats.push(frame);
+        }
+        if peak >= DOWNBEAT_MARKER_THRESHOLD {
+            downbeats.push(frame);
+        }
+    }
+    (beats, downbeats)
 }
 
 fn circular_spread(phases: &mut [usize], period: usize) -> usize {

--- a/tests/src/cochlea.rs
+++ b/tests/src/cochlea.rs
@@ -1,6 +1,11 @@
-use cochlea_features::{Audio, ProbeOpts, SegmentOpts, probe, segment_timeline};
+use cochlea_features::{
+    Audio, ProbeOpts, SegmentOpts, TempoOpts, estimate_tempo, probe, segment_timeline,
+};
+use num_traits::cast;
 use serde::Serialize;
 
+const BEAT_MARKER_THRESHOLD: f32 = 0.6;
+const TEMPO_TOLERANCE_BPM: f64 = 0.5;
 const WINDOW_MS: f64 = 5.0;
 
 /// Select a percentile from test-oracle samples after sorting them in place.
@@ -95,6 +100,98 @@ pub fn time_stretch_failures(
     control: &CochleaReport,
 ) -> Vec<String> {
     cochlea_failures(label, candidate, control, false)
+}
+
+/// Validate tempo and exact beat phase across deterministic rhythmic stems.
+#[must_use]
+pub fn synchronization_failures(
+    label: &str,
+    tracks: &[&[f32]],
+    channels: u16,
+    sample_rate: u32,
+    target_bpm: f64,
+) -> Vec<String> {
+    assert!(channels > 0, "synchronization oracle needs a channel");
+    assert!(
+        sample_rate > 0,
+        "synchronization oracle needs a sample rate"
+    );
+    assert!(
+        target_bpm.is_finite() && target_bpm > 0.0,
+        "synchronization oracle needs a positive finite BPM"
+    );
+    assert!(!tracks.is_empty(), "synchronization oracle needs a track");
+
+    let mut failures = Vec::new();
+    let channel_count = usize::from(channels);
+    let beat_period: usize = cast((f64::from(sample_rate) * 60.0 / target_bpm).round())
+        .unwrap_or(1)
+        .max(1);
+    let mut phases = Vec::with_capacity(tracks.len());
+    for (index, &samples) in tracks.iter().enumerate() {
+        assert!(
+            samples.len().is_multiple_of(channel_count),
+            "track {index} must contain complete frames"
+        );
+
+        let tempo = estimate_tempo(
+            &Audio {
+                samples: samples.to_vec(),
+                channels,
+                sample_rate,
+            },
+            &TempoOpts::default(),
+        );
+        match tempo.bpm {
+            Some(actual) if (actual - target_bpm).abs() <= TEMPO_TOLERANCE_BPM => {}
+            Some(actual) => failures.push(format!(
+                "{label}: track {index} tempo is {actual:.3} BPM, expected {target_bpm:.3} +/- {TEMPO_TOLERANCE_BPM:.3}",
+            )),
+            None => failures.push(format!("{label}: track {index} has no detected tempo")),
+        }
+        if !tempo.clear_rhythm {
+            failures.push(format!(
+                "{label}: track {index} has no clear rhythm: confidence={:.6}",
+                tempo.confidence,
+            ));
+        }
+
+        let Some(first) = first_beat_marker(samples, channel_count) else {
+            failures.push(format!("{label}: track {index} has no exact beat markers"));
+            continue;
+        };
+        phases.push(first % beat_period);
+    }
+
+    if phases.len() == tracks.len() {
+        let spread = circular_spread(&mut phases, beat_period);
+        if spread > 0 {
+            let suffix = if spread == 1 { "" } else { "s" };
+            failures.push(format!(
+                "{label}: beat phase spread is {spread} frame{suffix}",
+            ));
+        }
+    }
+    failures
+}
+
+fn first_beat_marker(samples: &[f32], channels: usize) -> Option<usize> {
+    samples.chunks_exact(channels).position(|values| {
+        values
+            .iter()
+            .any(|sample| sample.abs() >= BEAT_MARKER_THRESHOLD)
+    })
+}
+
+fn circular_spread(phases: &mut [usize], period: usize) -> usize {
+    phases.sort_unstable();
+    let inner_gap = phases
+        .windows(2)
+        .map(|pair| pair[1] - pair[0])
+        .max()
+        .unwrap_or(0);
+    let wrap_gap = period - phases[phases.len() - 1] + phases[0];
+    period - inner_gap.max(wrap_gap)
 }
 
 fn cochlea_failures(

--- a/tests/src/offline/session.rs
+++ b/tests/src/offline/session.rs
@@ -75,14 +75,20 @@ impl OfflineSession {
     /// thread never calls [`render`](Self::render).
     #[must_use]
     pub fn new() -> Self {
-        Self::spawn(true)
+        Self::spawn(true, OFFLINE_BLOCK_FRAMES)
     }
 
     /// Manual mode: the worker only dispatches commands; the audio
     /// graph advances only when [`render`](Self::render) is called.
     #[must_use]
     pub fn new_manual() -> Self {
-        Self::spawn(false)
+        Self::new_manual_with_block_frames(OFFLINE_BLOCK_FRAMES)
+    }
+
+    /// Manual mode with the audio callback size used by the scenario.
+    #[must_use]
+    pub fn new_manual_with_block_frames(block_frames: usize) -> Self {
+        Self::spawn(false, block_frames)
     }
 
     /// Convenience: `Arc<dyn SessionDispatcher>` over a fresh
@@ -104,10 +110,12 @@ impl OfflineSession {
         Arc::new(Self::new_manual())
     }
 
-    fn spawn(auto_render: bool) -> Self {
+    fn spawn(auto_render: bool, block_frames: usize) -> Self {
+        let block_frames = u32::try_from(block_frames).expect("offline block size fits u32");
+        assert!(block_frames > 0, "offline block size must be non-zero");
         let (cmd_tx, cmd_rx) = mpsc::channel::<OfflineMsg>();
         let handle = spawn_named("kithara-engine-offline-instance", move || {
-            offline_session_thread(&cmd_rx, auto_render);
+            offline_session_thread(&cmd_rx, auto_render, block_frames);
         });
         Self {
             cmd_tx: Mutex::new(cmd_tx),
@@ -207,18 +215,29 @@ impl SessionDispatcher for OfflineSession {
 fn start_stream_offline(
     ctx: &mut firewheel::FirewheelCtx<OfflineBackend>,
     sample_rate: u32,
+    block_frames: u32,
 ) -> Result<(), String> {
     let config = OfflineConfig {
+        block_frames,
         sample_rate,
-        block_frames: u32::try_from(OFFLINE_BLOCK_FRAMES).unwrap_or(u32::MAX),
     };
     ctx.start_stream(config).map_err(|err| err.to_string())
 }
 
-fn offline_session_thread(cmd_rx: &mpsc::Receiver<OfflineMsg>, auto_render: bool) {
-    let mut state = GraphSession::<OfflineBackend>::new(start_stream_offline);
+fn offline_session_thread(
+    cmd_rx: &mpsc::Receiver<OfflineMsg>,
+    auto_render: bool,
+    block_frames: u32,
+) {
+    let mut state = GraphSession::<OfflineBackend>::new(move |ctx, sample_rate| {
+        start_stream_offline(ctx, sample_rate, block_frames)
+    });
     if auto_render {
-        run_auto(&mut state, cmd_rx);
+        run_auto(
+            &mut state,
+            cmd_rx,
+            usize::try_from(block_frames).expect("offline block size fits usize"),
+        );
     } else {
         run_manual(&mut state, cmd_rx);
     }
@@ -240,7 +259,11 @@ fn run_manual(state: &mut GraphSession<OfflineBackend>, cmd_rx: &mpsc::Receiver<
     }
 }
 
-fn run_auto(state: &mut GraphSession<OfflineBackend>, cmd_rx: &mpsc::Receiver<OfflineMsg>) {
+fn run_auto(
+    state: &mut GraphSession<OfflineBackend>,
+    cmd_rx: &mpsc::Receiver<OfflineMsg>,
+    block_frames: usize,
+) {
     loop {
         // Block on the next command, but no longer than one render budget: a
         // command (or `Shutdown`) wakes us at once through the engine-aware
@@ -259,7 +282,7 @@ fn run_auto(state: &mut GraphSession<OfflineBackend>, cmd_rx: &mpsc::Receiver<Of
             }
             Ok(OfflineMsg::Shutdown) | Err(mpsc::RecvTimeoutError::Disconnected) => return,
             Err(mpsc::RecvTimeoutError::Timeout) => {
-                let _ = render_block(state, OFFLINE_BLOCK_FRAMES);
+                let _ = render_block(state, block_frames);
             }
         }
     }

--- a/tests/tests/kithara_play/mod.rs
+++ b/tests/tests/kithara_play/mod.rs
@@ -34,3 +34,4 @@ mod seamless_queue_advance;
 mod session_transport;
 #[cfg(not(target_arch = "wasm32"))]
 mod sync_oracle;
+mod sync_product_matrix;

--- a/tests/tests/kithara_play/mod.rs
+++ b/tests/tests/kithara_play/mod.rs
@@ -35,3 +35,4 @@ mod session_transport;
 #[cfg(not(target_arch = "wasm32"))]
 mod sync_oracle;
 mod sync_product_matrix;
+mod sync_runtime_oracles;

--- a/tests/tests/kithara_play/mod.rs
+++ b/tests/tests/kithara_play/mod.rs
@@ -32,3 +32,5 @@ mod rt_metrics;
 mod seamless_queue_advance;
 #[cfg(not(target_arch = "wasm32"))]
 mod session_transport;
+#[cfg(not(target_arch = "wasm32"))]
+mod sync_oracle;

--- a/tests/tests/kithara_play/mod.rs
+++ b/tests/tests/kithara_play/mod.rs
@@ -32,6 +32,7 @@ mod rt_metrics;
 mod seamless_queue_advance;
 #[cfg(not(target_arch = "wasm32"))]
 mod session_transport;
+mod sync_listening;
 #[cfg(not(target_arch = "wasm32"))]
 mod sync_oracle;
 mod sync_product_matrix;

--- a/tests/tests/kithara_play/sync_listening.rs
+++ b/tests/tests/kithara_play/sync_listening.rs
@@ -1,0 +1,107 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+use kithara::platform::time::Duration;
+use kithara_integration_tests::{audio_artifact::write_audio_artifact, kithara};
+
+use super::sync_product_matrix::{
+    BLOCK_FRAMES, CHANNELS, ProductHarness, Provider, SEQUENTIAL_SYNC, SyncCase,
+};
+
+const CAPTURE_FRAMES: usize = 48_000 * 6;
+const RIDE_STEPS: usize = 32;
+
+async fn capture_solo(audible_deck: usize) -> (Vec<f32>, Vec<String>) {
+    let mut harness = ProductHarness::new(SEQUENTIAL_SYNC, Provider::Synthetic, audible_deck).await;
+    let pcm = harness
+        .capture_frames(SEQUENTIAL_SYNC, CAPTURE_FRAMES, BLOCK_FRAMES)
+        .await;
+    (pcm, harness.failures)
+}
+
+async fn capture_mix(provider: Provider, target_bpm: Option<f64>) -> (Vec<f32>, Vec<String>) {
+    let case = SEQUENTIAL_SYNC;
+    let mut harness = ProductHarness::new(case, provider, 0).await;
+    for deck in &harness.decks {
+        deck.set_muted(false);
+        deck.set_volume(0.5);
+    }
+    harness.request_sync(case).await;
+
+    let pcm = if let Some(target_bpm) = target_bpm {
+        capture_ride(&mut harness, case, target_bpm).await
+    } else {
+        harness
+            .capture_frames(case, CAPTURE_FRAMES, BLOCK_FRAMES)
+            .await
+    };
+    (pcm, harness.failures)
+}
+
+async fn capture_ride(harness: &mut ProductHarness, case: SyncCase, target_bpm: f64) -> Vec<f32> {
+    let mut pcm = Vec::with_capacity(CAPTURE_FRAMES * usize::from(CHANNELS));
+    let mut rendered = 0;
+    for step in 1..=RIDE_STEPS {
+        let progress = step as f64 / RIDE_STEPS as f64;
+        harness.set_tempo(case, (target_bpm - 120.0).mul_add(progress, 120.0), false);
+        let deadline = CAPTURE_FRAMES * step / RIDE_STEPS;
+        pcm.extend(
+            harness
+                .capture_frames(case, deadline - rendered, BLOCK_FRAMES)
+                .await,
+        );
+        rendered = deadline;
+    }
+    pcm
+}
+
+#[kithara::test(
+    native,
+    tokio,
+    multi_thread,
+    serial,
+    flash(false),
+    timeout(Duration::from_secs(300))
+)]
+#[ignore = "writes opt-in listening WAVs; ignored-red until Warp alignment is implemented"]
+async fn record_pr150_sync_listening_wavs() {
+    let (deck_a, mut failures) = capture_solo(0).await;
+    let (deck_b, deck_b_failures) = capture_solo(1).await;
+    let (fixed_mix, fixed_failures) = capture_mix(Provider::Synthetic, None).await;
+    let (ridden_mix, ridden_failures) = capture_mix(Provider::Synthetic, Some(127.0)).await;
+    let (sweep_mix, sweep_failures) = capture_mix(Provider::Sweep, Some(145.0)).await;
+    failures.extend(deck_b_failures);
+    failures.extend(fixed_failures);
+    failures.extend(ridden_failures);
+    failures.extend(sweep_failures);
+
+    let manifest = serde_json::json!({
+        "case": "pr150-sync-listening",
+        "sample_rate": SEQUENTIAL_SYNC.sample_rate,
+        "channels": CHANNELS,
+        "capture_frames": CAPTURE_FRAMES,
+        "failures": failures,
+    });
+    let written = write_audio_artifact(
+        "pr150-sync-listening",
+        SEQUENTIAL_SYNC.sample_rate,
+        CHANNELS,
+        &[
+            ("01-deck-a-120bpm", &deck_a),
+            ("02-deck-b-120bpm", &deck_b),
+            ("03-mix-on-120bpm-grid", &fixed_mix),
+            ("04-mix-riding-120-to-127", &ridden_mix),
+            ("05-sweep-mix-riding-120-to-145", &sweep_mix),
+        ],
+        &manifest,
+    )
+    .expect("write PR150 listening WAVs");
+    assert!(
+        written.is_some(),
+        "KITHARA_AUDIO_ARTIFACT_DIR must be set for the listening recorder"
+    );
+    assert!(
+        failures.is_empty(),
+        "PR150 listening capture failed:\n{}",
+        failures.join("\n"),
+    );
+}

--- a/tests/tests/kithara_play/sync_oracle.rs
+++ b/tests/tests/kithara_play/sync_oracle.rs
@@ -3,6 +3,7 @@ use kithara_test_fixtures::{
     asset::Asset,
     assets::{
         rhythm_wav_deck_a_120bpm_48k, rhythm_wav_deck_b_120bpm_48k,
+        rhythm_wav_deck_b_missing_beat_120bpm_48k, rhythm_wav_deck_b_one_beat_bar_late_120bpm_48k,
         rhythm_wav_deck_b_one_frame_late_120bpm_48k, rhythm_wav_deck_c_120bpm_48k,
         rhythm_wav_deck_d_120bpm_48k,
     },
@@ -65,5 +66,59 @@ fn static_rhythmic_oracle_accepts_aligned_stems_and_rejects_one_frame_phase_erro
         failures.as_slice(),
         ["one-frame-late static stem: beat phase spread is 1 frame"],
         "the negative control must fail only because of its exact one-frame phase error",
+    );
+}
+
+#[kithara::test(native, flash(false))]
+fn static_rhythmic_oracle_rejects_one_missing_event_for_that_reason() {
+    let deck_a = samples(rhythm_wav_deck_a_120bpm_48k());
+    let missing = samples(rhythm_wav_deck_b_missing_beat_120bpm_48k());
+    let failures = synchronization_failures(
+        "missing static beat",
+        &[deck_a.as_slice(), missing.as_slice()],
+        CHANNELS,
+        SAMPLE_RATE,
+        TARGET_BPM,
+    );
+
+    assert_eq!(
+        failures.as_slice(),
+        ["missing static beat: track 1 is missing a rhythmic event before frame 168000"],
+    );
+}
+
+#[kithara::test(native, flash(false))]
+fn static_rhythmic_oracle_rejects_wrong_target_tempo_for_that_reason() {
+    let deck = samples(rhythm_wav_deck_a_120bpm_48k());
+    let failures = synchronization_failures(
+        "wrong target tempo",
+        &[deck.as_slice()],
+        CHANNELS,
+        SAMPLE_RATE,
+        127.0,
+    );
+
+    assert_eq!(failures.len(), 1, "unexpected failures: {failures:?}");
+    assert!(
+        failures[0].contains("tempo is") && failures[0].contains("expected 127.000"),
+        "the control must fail only on its 120 BPM signal against 127 BPM target: {failures:?}",
+    );
+}
+
+#[kithara::test(native, flash(false))]
+fn static_rhythmic_oracle_rejects_one_beat_bar_phase_error_for_that_reason() {
+    let deck_a = samples(rhythm_wav_deck_a_120bpm_48k());
+    let shifted = samples(rhythm_wav_deck_b_one_beat_bar_late_120bpm_48k());
+    let failures = synchronization_failures(
+        "one-beat-late static bar",
+        &[deck_a.as_slice(), shifted.as_slice()],
+        CHANNELS,
+        SAMPLE_RATE,
+        TARGET_BPM,
+    );
+
+    assert_eq!(
+        failures.as_slice(),
+        ["one-beat-late static bar: bar phase spread is 1 beat"],
     );
 }

--- a/tests/tests/kithara_play/sync_oracle.rs
+++ b/tests/tests/kithara_play/sync_oracle.rs
@@ -1,0 +1,69 @@
+use kithara_integration_tests::{cochlea::synchronization_failures, kithara};
+use kithara_test_fixtures::{
+    asset::Asset,
+    assets::{
+        rhythm_wav_deck_a_120bpm_48k, rhythm_wav_deck_b_120bpm_48k,
+        rhythm_wav_deck_b_one_frame_late_120bpm_48k, rhythm_wav_deck_c_120bpm_48k,
+        rhythm_wav_deck_d_120bpm_48k,
+    },
+};
+
+const CHANNELS: u16 = 2;
+const SAMPLE_RATE: u32 = 48_000;
+const TARGET_BPM: f64 = 120.0;
+
+fn samples(asset: Asset) -> Vec<f32> {
+    let bytes = asset.bytes();
+    let header = kithara_test_fixtures::signal::header(SAMPLE_RATE, CHANNELS, Some(0));
+    bytes[header.len()..]
+        .chunks_exact(size_of::<i16>())
+        .map(|sample| f32::from(i16::from_le_bytes([sample[0], sample[1]])) / f32::from(i16::MAX))
+        .collect()
+}
+
+#[kithara::test(native, flash(false))]
+fn static_rhythmic_oracle_accepts_aligned_stems_and_rejects_one_frame_phase_error() {
+    let deck_a = samples(rhythm_wav_deck_a_120bpm_48k());
+    let deck_b = samples(rhythm_wav_deck_b_120bpm_48k());
+    let deck_c = samples(rhythm_wav_deck_c_120bpm_48k());
+    let deck_d = samples(rhythm_wav_deck_d_120bpm_48k());
+    let aligned = [
+        deck_a.as_slice(),
+        deck_b.as_slice(),
+        deck_c.as_slice(),
+        deck_d.as_slice(),
+    ];
+
+    assert!(
+        synchronization_failures(
+            "aligned static stems",
+            &aligned,
+            CHANNELS,
+            SAMPLE_RATE,
+            TARGET_BPM,
+        )
+        .is_empty(),
+        "known-aligned build-time stems must pass the synchronization oracle",
+    );
+
+    let shifted = samples(rhythm_wav_deck_b_one_frame_late_120bpm_48k());
+    let one_frame_late = [
+        deck_a.as_slice(),
+        shifted.as_slice(),
+        deck_c.as_slice(),
+        deck_d.as_slice(),
+    ];
+    let failures = synchronization_failures(
+        "one-frame-late static stem",
+        &one_frame_late,
+        CHANNELS,
+        SAMPLE_RATE,
+        TARGET_BPM,
+    );
+
+    assert_eq!(
+        failures.as_slice(),
+        ["one-frame-late static stem: beat phase spread is 1 frame"],
+        "the negative control must fail only because of its exact one-frame phase error",
+    );
+}

--- a/tests/tests/kithara_play/sync_product_matrix.rs
+++ b/tests/tests/kithara_play/sync_product_matrix.rs
@@ -1,0 +1,717 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::{env, num::NonZeroU32, path::Path};
+
+use kithara::{
+    bufpool::{BytePool, SamplePool},
+    events::TrackStatus,
+    hls::AbrMode,
+    platform::{
+        sync::Arc,
+        time::{self, Duration, Instant},
+    },
+    play::{
+        Cmd, PlayWorker, PlayWorkerConfig, PlayerConfig, PlayerImpl, Reply, ResourceConfig,
+        SessionDispatcher, Tempo, player::Player,
+    },
+    queue::{Queue, QueueConfig, TrackSource, Transition},
+    warp::{
+        AlignmentSource, BeatGrid, LoadGeneration, PresentationFrontier, SessionFrame, SyncGroup,
+        SyncIntent, SyncOperation,
+    },
+};
+use kithara_integration_tests::{
+    HlsFixtureBuilder, TestServerHelper, cochlea::synchronization_failures, kithara,
+    memory_asset_store, offline::OfflineSession,
+};
+use kithara_test_fixtures::{
+    asset::Asset,
+    assets::{
+        rhythm_fmp4_init_deck_a_120bpm_48k, rhythm_fmp4_media_deck_a_120bpm_48k,
+        rhythm_mp3_deck_a_120bpm_48k, rhythm_mp3_deck_b_120bpm_48k, rhythm_wav_deck_a_120bpm_48k,
+        rhythm_wav_deck_b_120bpm_48k, rhythm_wav_deck_c_120bpm_48k, rhythm_wav_deck_d_120bpm_48k,
+    },
+};
+
+const BLOCK_FRAMES: usize = 512;
+const CHANNELS: u16 = 2;
+const LOAD_TIMEOUT: Duration = Duration::from_secs(30);
+const START_BPM: f64 = 120.0;
+
+#[derive(Clone, Copy, Debug)]
+enum Operation {
+    Play,
+    Seek,
+    Sync,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum OperationOrder {
+    PlaySyncSeek,
+    PlaySeekSync,
+    SeekPlaySync,
+    SeekSyncPlay,
+    SyncPlaySeek,
+    SyncSeekPlay,
+    SequentialSync,
+}
+
+impl OperationOrder {
+    const fn operations(self) -> &'static [Operation] {
+        match self {
+            Self::PlaySyncSeek | Self::SequentialSync => {
+                &[Operation::Play, Operation::Sync, Operation::Seek]
+            }
+            Self::PlaySeekSync => &[Operation::Play, Operation::Seek, Operation::Sync],
+            Self::SeekPlaySync => &[Operation::Seek, Operation::Play, Operation::Sync],
+            Self::SeekSyncPlay => &[Operation::Seek, Operation::Sync, Operation::Play],
+            Self::SyncPlaySeek => &[Operation::Sync, Operation::Play, Operation::Seek],
+            Self::SyncSeekPlay => &[Operation::Sync, Operation::Seek, Operation::Play],
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum TempoRide {
+    Down,
+    Triangle,
+    Up,
+}
+
+impl TempoRide {
+    const fn points(self) -> &'static [f64] {
+        match self {
+            Self::Down => &[116.0, 112.0, 108.0],
+            Self::Triangle => &[116.0, 112.0, 116.0, 120.0],
+            Self::Up => &[122.0, 125.0, 127.0],
+        }
+    }
+
+    const fn final_bpm(self) -> f64 {
+        match self {
+            Self::Down => 108.0,
+            Self::Triangle => 120.0,
+            Self::Up => 127.0,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct SyncCase {
+    id: &'static str,
+    decks: usize,
+    sample_rate: u32,
+    order: OperationOrder,
+    paused: bool,
+    ride: TempoRide,
+    updates_hz: u32,
+}
+
+impl SyncCase {
+    const fn running(
+        id: &'static str,
+        decks: usize,
+        sample_rate: u32,
+        order: OperationOrder,
+    ) -> Self {
+        Self {
+            id,
+            decks,
+            sample_rate,
+            order,
+            paused: false,
+            ride: TempoRide::Triangle,
+            updates_hz: 60,
+        }
+    }
+
+    const fn paused(mut self) -> Self {
+        self.paused = true;
+        self
+    }
+
+    const fn ride(mut self, ride: TempoRide, updates_hz: u32) -> Self {
+        self.ride = ride;
+        self.updates_hz = updates_hz;
+        self
+    }
+}
+
+const PLAY_SYNC_SEEK: SyncCase =
+    SyncCase::running("play-sync-seek", 2, 48_000, OperationOrder::PlaySyncSeek);
+const PLAY_SEEK_SYNC: SyncCase =
+    SyncCase::running("play-seek-sync", 2, 44_100, OperationOrder::PlaySeekSync)
+        .ride(TempoRide::Up, 30);
+const SEEK_PLAY_SYNC: SyncCase =
+    SyncCase::running("seek-play-sync", 2, 48_000, OperationOrder::SeekPlaySync)
+        .ride(TempoRide::Down, 60);
+const SEEK_SYNC_PLAY: SyncCase =
+    SyncCase::running("seek-sync-play", 2, 44_100, OperationOrder::SeekSyncPlay)
+        .ride(TempoRide::Triangle, 30);
+const SYNC_PLAY_SEEK: SyncCase =
+    SyncCase::running("sync-play-seek", 2, 48_000, OperationOrder::SyncPlaySeek)
+        .ride(TempoRide::Up, 60);
+const SYNC_SEEK_PLAY: SyncCase =
+    SyncCase::running("sync-seek-play", 2, 44_100, OperationOrder::SyncSeekPlay)
+        .ride(TempoRide::Down, 120);
+const SEQUENTIAL_SYNC: SyncCase =
+    SyncCase::running("sequential-sync", 2, 48_000, OperationOrder::SequentialSync);
+const PAUSED_SYNC: SyncCase = SyncCase::running(
+    "paused-sync-then-play",
+    2,
+    48_000,
+    OperationOrder::SyncPlaySeek,
+)
+.paused();
+const FOUR_DECK_SYNC: SyncCase = SyncCase::running(
+    "four-deck-sequential-sync",
+    4,
+    48_000,
+    OperationOrder::SequentialSync,
+);
+const TEMPO_UP_120: SyncCase =
+    SyncCase::running("tempo-up-120hz", 2, 48_000, OperationOrder::PlaySyncSeek)
+        .ride(TempoRide::Up, 120);
+const TEMPO_DOWN_30: SyncCase =
+    SyncCase::running("tempo-down-30hz", 2, 44_100, OperationOrder::PlaySyncSeek)
+        .ride(TempoRide::Down, 30);
+
+#[derive(Clone, Copy, Debug)]
+enum Provider {
+    Synthetic,
+    HlsSame,
+    Library,
+    Mp3Same,
+    Mp3Distinct,
+    HlsMp3,
+}
+
+struct ProductHarness {
+    decks: Vec<Queue>,
+    failures: Vec<String>,
+    output_frames: u64,
+    session: Arc<OfflineSession>,
+}
+
+impl ProductHarness {
+    async fn new(case: SyncCase, provider: Provider, audible_deck: usize) -> Self {
+        let server = TestServerHelper::new().await;
+        let sources = sources(provider, case.decks, &server).await;
+        let session = Arc::new(OfflineSession::new_manual());
+        let dispatcher: Arc<dyn SessionDispatcher> = session.clone();
+        let worker = PlayWorker::new(
+            PlayWorkerConfig::for_pools(BytePool::default(), SamplePool::default()).build(),
+        );
+        let sample_rate = NonZeroU32::new(case.sample_rate).expect("fixture sample rate");
+        let mut decks = Vec::with_capacity(sources.len());
+        let mut ids = Vec::with_capacity(sources.len());
+        for (index, source) in sources.into_iter().enumerate() {
+            let player = PlayerImpl::new(
+                PlayerConfig::builder()
+                    .worker(worker.clone())
+                    .sample_rate(sample_rate)
+                    .session(dispatcher.clone())
+                    .crossfade_duration(0.0)
+                    .build(),
+            );
+            let queue = Queue::new(QueueConfig::builder().player(player).build());
+            queue.set_muted(index != audible_deck);
+            let config = ResourceConfig::for_src(
+                ResourceConfig::parse_src(&source)
+                    .unwrap_or_else(|error| panic!("{}: parse source {source}: {error}", case.id)),
+            )
+            .store(memory_asset_store())
+            .initial_abr_mode(AbrMode::manual(0))
+            .discriminator(format!("{}-{provider:?}-{index}", case.id))
+            .build();
+            let id = queue
+                .append(TrackSource::Config(Box::new(config)))
+                .unwrap_or_else(|error| panic!("{}: append deck {index}: {error}", case.id));
+            decks.push(queue);
+            ids.push(id);
+        }
+        let mut harness = Self {
+            decks,
+            failures: Vec::new(),
+            output_frames: 0,
+            session,
+        };
+        harness.wait_loaded(case, &ids).await;
+        for (index, (deck, id)) in harness.decks.iter().zip(ids).enumerate() {
+            deck.select(id, Transition::None)
+                .unwrap_or_else(|error| panic!("{}: select deck {index}: {error}", case.id));
+        }
+        harness.set_tempo(case, START_BPM, true);
+        let _ = harness.render(case, BLOCK_FRAMES).await;
+        if !case.paused {
+            harness.start_staggered(case).await;
+        }
+        harness
+    }
+
+    async fn wait_loaded(&mut self, case: SyncCase, ids: &[kithara::events::TrackId]) {
+        let deadline = Instant::now() + LOAD_TIMEOUT;
+        loop {
+            self.tick_all(case);
+            let mut loaded = true;
+            for (index, (deck, id)) in self.decks.iter().zip(ids).enumerate() {
+                match deck.track(*id).map(|track| track.status) {
+                    Some(TrackStatus::Loaded) => {}
+                    Some(TrackStatus::Failed(error)) => {
+                        panic!("{}: deck {index} failed to load: {error}", case.id)
+                    }
+                    Some(_) | None => loaded = false,
+                }
+            }
+            if loaded {
+                return;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "{}: deck load timed out",
+                case.id
+            );
+            time::sleep(Duration::from_millis(5)).await;
+        }
+    }
+
+    fn tick_all(&self, case: SyncCase) {
+        for (index, deck) in self.decks.iter().enumerate() {
+            deck.tick()
+                .unwrap_or_else(|error| panic!("{}: tick deck {index}: {error}", case.id));
+        }
+    }
+
+    async fn render(&mut self, case: SyncCase, frames: usize) -> Vec<f32> {
+        self.tick_all(case);
+        let pcm = self.session.render(frames);
+        self.output_frames = self
+            .output_frames
+            .saturating_add(u64::try_from(frames).expect("render frame count fits u64"));
+        time::sleep(Duration::from_millis(1)).await;
+        pcm
+    }
+
+    async fn settle(&mut self, case: SyncCase, blocks: usize) {
+        for _ in 0..blocks {
+            let _ = self.render(case, BLOCK_FRAMES).await;
+        }
+    }
+
+    fn play_all(&self) {
+        for deck in &self.decks {
+            deck.play();
+        }
+    }
+
+    async fn start_staggered(&mut self, case: SyncCase) {
+        let stagger_frames =
+            (f64::from(case.sample_rate) * 3.0 / 8.0 * 60.0 / START_BPM).round() as usize;
+        for index in 0..self.decks.len() {
+            self.decks[index].play();
+            if index + 1 < self.decks.len() {
+                let _ = self.render(case, stagger_frames).await;
+            }
+        }
+        self.settle(case, 2).await;
+    }
+
+    async fn seek_staggered(&mut self, case: SyncCase) {
+        let stagger_seconds = 3.0 / 8.0 * 60.0 / START_BPM;
+        for (index, deck) in self.decks.iter().enumerate() {
+            deck.seek(5.25 + index as f64 * stagger_seconds)
+                .unwrap_or_else(|error| panic!("{}: seek deck {index}: {error}", case.id));
+        }
+        self.settle(case, 96).await;
+    }
+
+    fn set_tempo(&mut self, case: SyncCase, bpm: f64, required: bool) {
+        let tempo = Tempo::new(bpm).expect("fixture tempo");
+        match self.session.exec(Cmd::SetSessionTempo { tempo }) {
+            Ok(Reply::Ok) => {}
+            Ok(Reply::Err(error)) if !required => self
+                .failures
+                .push(format!("tempo request {bpm:.6} BPM was rejected: {error}")),
+            Ok(Reply::Err(error)) => panic!("{}: set initial tempo: {error}", case.id),
+            Ok(_) if !required => self.failures.push(format!(
+                "tempo request {bpm:.6} BPM returned an unexpected reply"
+            )),
+            Ok(_) => panic!("{}: initial tempo returned an unexpected reply", case.id),
+            Err(error) if !required => self.failures.push(format!(
+                "tempo request {bpm:.6} BPM could not reach Host: {error}"
+            )),
+            Err(error) => panic!("{}: initial tempo could not reach Host: {error}", case.id),
+        }
+    }
+
+    fn transport_revision(&self, case: SyncCase) -> kithara::warp::TransportRevision {
+        match self.session.exec(Cmd::QuerySessionTransport) {
+            Ok(Reply::SessionTransport(snapshot)) => snapshot.revision(),
+            Ok(Reply::Err(error)) => panic!("{}: query Host transport: {error}", case.id),
+            Ok(_) => panic!("{}: Host transport returned an unexpected reply", case.id),
+            Err(error) => panic!("{}: query Host transport: {error}", case.id),
+        }
+    }
+
+    async fn request_sync(&mut self, case: SyncCase) {
+        let transport = self.transport_revision(case);
+        for index in 0..self.decks.len() {
+            {
+                let deck = &mut self.decks[index];
+                let position = Player::playback_view(deck).position.unwrap_or(0.0);
+                let source = if Player::playback_view(deck).playing {
+                    AlignmentSource::Audible(
+                        PresentationFrontier::builder()
+                            .source((position * f64::from(case.sample_rate)).max(0.0) as u64)
+                            .output(SessionFrame::new(
+                                i64::try_from(self.output_frames).unwrap_or(i64::MAX),
+                            ))
+                            .build(),
+                    )
+                } else {
+                    AlignmentSource::Prepared
+                };
+                let _ = deck
+                    .transact(SyncOperation::Sync {
+                        target: deck.id(),
+                        load: LoadGeneration::first(),
+                        transport,
+                        source,
+                        activation: SessionFrame::new(
+                            i64::try_from(self.output_frames).unwrap_or(i64::MAX),
+                        ),
+                        intent: SyncIntent::Enable,
+                    })
+                    .unwrap_or_else(|rejected| {
+                        panic!("{}: sync deck {index}: {rejected}", case.id)
+                    });
+            }
+            if matches!(case.order, OperationOrder::SequentialSync) {
+                let _ = self.render(case, BLOCK_FRAMES).await;
+            }
+        }
+    }
+
+    async fn run_operations(&mut self, case: SyncCase) {
+        for operation in case.order.operations() {
+            match operation {
+                Operation::Play => {
+                    self.play_all();
+                    self.settle(case, 2).await;
+                }
+                Operation::Seek => self.seek_staggered(case).await,
+                Operation::Sync => self.request_sync(case).await,
+            }
+        }
+    }
+
+    async fn ride_tempo(&mut self, case: SyncCase) {
+        let steps_per_leg = (case.updates_hz / 2).max(1);
+        let mut start = START_BPM;
+        let mut rendered = 0_u64;
+        let mut update = 0_u64;
+        for &target in case.ride.points() {
+            for step in 1..=steps_per_leg {
+                let fraction = f64::from(step) / f64::from(steps_per_leg);
+                let bpm = start + (target - start) * fraction;
+                self.set_tempo(case, bpm, false);
+                update += 1;
+                let deadline = update * u64::from(case.sample_rate) / u64::from(case.updates_hz);
+                let frames = deadline.saturating_sub(rendered);
+                rendered = deadline;
+                if frames > 0 {
+                    let frames = usize::try_from(frames).expect("tempo interval fits usize");
+                    let _ = self.render(case, frames).await;
+                }
+            }
+            start = target;
+        }
+        self.settle(case, 4).await;
+    }
+
+    async fn capture(&mut self, case: SyncCase) -> Vec<f32> {
+        self.play_all();
+        self.settle(case, 4).await;
+        let capture_frames =
+            (f64::from(case.sample_rate) * 60.0 / case.ride.final_bpm() * 6.0).round() as usize;
+        let mut pcm = Vec::with_capacity(capture_frames * usize::from(CHANNELS));
+        while pcm.len() < capture_frames * usize::from(CHANNELS) {
+            let remaining_frames =
+                (capture_frames * usize::from(CHANNELS) - pcm.len()) / usize::from(CHANNELS);
+            let frames = remaining_frames.min(BLOCK_FRAMES);
+            let block = self.render(case, frames).await;
+            assert!(
+                !block.is_empty(),
+                "{}: product capture stopped making PCM progress",
+                case.id,
+            );
+            pcm.extend(block);
+        }
+        pcm
+    }
+}
+
+async fn sources(provider: Provider, decks: usize, server: &TestServerHelper) -> Vec<String> {
+    match provider {
+        Provider::Synthetic => cycle_paths(
+            &[
+                rhythm_wav_deck_a_120bpm_48k(),
+                rhythm_wav_deck_b_120bpm_48k(),
+                rhythm_wav_deck_c_120bpm_48k(),
+                rhythm_wav_deck_d_120bpm_48k(),
+            ],
+            decks,
+        ),
+        Provider::Library => cycle_paths_from_strings(&library_paths(), decks),
+        Provider::Mp3Same => cycle_paths(&[rhythm_mp3_deck_a_120bpm_48k()], decks),
+        Provider::Mp3Distinct => cycle_paths(
+            &[
+                rhythm_mp3_deck_a_120bpm_48k(),
+                rhythm_mp3_deck_b_120bpm_48k(),
+            ],
+            decks,
+        ),
+        Provider::HlsSame => {
+            let url = hls(
+                server,
+                rhythm_fmp4_init_deck_a_120bpm_48k(),
+                rhythm_fmp4_media_deck_a_120bpm_48k(),
+            )
+            .await;
+            vec![url; decks]
+        }
+        Provider::HlsMp3 => {
+            let hls = hls(
+                server,
+                rhythm_fmp4_init_deck_a_120bpm_48k(),
+                rhythm_fmp4_media_deck_a_120bpm_48k(),
+            )
+            .await;
+            let mp3 = asset_path(rhythm_mp3_deck_b_120bpm_48k());
+            (0..decks)
+                .map(|index| {
+                    if index.is_multiple_of(2) {
+                        hls.clone()
+                    } else {
+                        mp3.clone()
+                    }
+                })
+                .collect()
+        }
+    }
+}
+
+fn cycle_paths(assets: &[Asset], count: usize) -> Vec<String> {
+    assets
+        .iter()
+        .cycle()
+        .take(count)
+        .map(|asset| {
+            asset
+                .path()
+                .expect("native product fixture is materialized on disk")
+                .to_str()
+                .expect("fixture path is UTF-8")
+                .to_owned()
+        })
+        .collect()
+}
+
+fn cycle_paths_from_strings(paths: &[String], count: usize) -> Vec<String> {
+    paths.iter().cycle().take(count).cloned().collect()
+}
+
+fn library_paths() -> [String; 2] {
+    let root = env::var_os("KITHARA_SYNC_LIBRARY").unwrap_or_else(|| {
+        panic!("BLOCKED_FIXTURE: KITHARA_SYNC_LIBRARY must name the opt-in music library root")
+    });
+    let root = Path::new(&root);
+    let track = |name: &str| {
+        let relative = env::var_os(name).unwrap_or_else(|| {
+            panic!("BLOCKED_FIXTURE: {name} must name a track under KITHARA_SYNC_LIBRARY")
+        });
+        let path = root.join(relative);
+        assert!(
+            path.is_file(),
+            "BLOCKED_FIXTURE: {name} does not resolve to a file under KITHARA_SYNC_LIBRARY: {}",
+            path.display(),
+        );
+        path.to_string_lossy().into_owned()
+    };
+    [
+        track("KITHARA_SYNC_LIBRARY_TRACK_A"),
+        track("KITHARA_SYNC_LIBRARY_TRACK_B"),
+    ]
+}
+
+fn asset_path(asset: Asset) -> String {
+    asset
+        .path()
+        .expect("native product fixture is materialized on disk")
+        .to_str()
+        .expect("fixture path is UTF-8")
+        .to_owned()
+}
+
+async fn hls(server: &TestServerHelper, init: Asset, media: Asset) -> String {
+    server
+        .create_hls(
+            HlsFixtureBuilder::new()
+                .variant_count(1)
+                .segments_per_variant(1)
+                .segment_duration_secs(12.0)
+                .segment_size(media.bytes().len())
+                .codecs("fLaC".to_owned())
+                .init_data_per_variant(vec![Arc::new(init.bytes().to_vec())])
+                .custom_data(Arc::new(media.bytes().to_vec())),
+        )
+        .await
+        .expect("register build-time rhythmic fMP4 as HLS")
+        .master_url()
+        .to_string()
+}
+
+async fn run(case: SyncCase, provider: Provider) {
+    let expected_samples = (f64::from(case.sample_rate) * 60.0 / case.ride.final_bpm() * 6.0)
+        .round() as usize
+        * usize::from(CHANNELS);
+    let mut tracks = Vec::with_capacity(case.decks);
+    let mut request_failures = Vec::new();
+    for audible_deck in 0..case.decks {
+        let mut harness = ProductHarness::new(case, provider, audible_deck).await;
+        harness.run_operations(case).await;
+        harness.ride_tempo(case).await;
+        let pcm = harness.capture(case).await;
+        assert_eq!(
+            pcm.len(),
+            expected_samples,
+            "{} {provider:?}: deck {audible_deck} capture must contain six complete beats",
+            case.id,
+        );
+        tracks.push(pcm);
+        request_failures.extend(harness.failures);
+    }
+    let track_slices = tracks.iter().map(Vec::as_slice).collect::<Vec<_>>();
+    let mut failures = synchronization_failures(
+        &format!("{} {provider:?}", case.id),
+        &track_slices,
+        CHANNELS,
+        case.sample_rate,
+        case.ride.final_bpm(),
+    );
+    failures.extend(request_failures);
+    assert!(
+        failures.is_empty(),
+        "ignored-red product synchronization assertion failed for {} {provider:?}:\n{}",
+        case.id,
+        failures.join("\n"),
+    );
+}
+
+#[kithara::test(
+    native,
+    tokio,
+    multi_thread,
+    serial,
+    flash(false),
+    timeout(Duration::from_secs(900))
+)]
+#[ignore = "ignored-red: product Warp alignment is not implemented"]
+#[case::play_sync_seek(PLAY_SYNC_SEEK)]
+#[case::play_seek_sync(PLAY_SEEK_SYNC)]
+#[case::seek_play_sync(SEEK_PLAY_SYNC)]
+#[case::seek_sync_play(SEEK_SYNC_PLAY)]
+#[case::sync_play_seek(SYNC_PLAY_SEEK)]
+#[case::sync_seek_play(SYNC_SEEK_PLAY)]
+#[case::sequential_sync(SEQUENTIAL_SYNC)]
+#[case::paused_sync_then_play(PAUSED_SYNC)]
+#[case::four_deck_sequential_sync(FOUR_DECK_SYNC)]
+#[case::tempo_up_120hz(TEMPO_UP_120)]
+#[case::tempo_down_30hz(TEMPO_DOWN_30)]
+async fn synthetic_product_rows_reach_the_pcm_oracle(#[case] case: SyncCase) {
+    run(case, Provider::Synthetic).await;
+}
+
+#[kithara::test(
+    native,
+    tokio,
+    multi_thread,
+    serial,
+    flash(false),
+    timeout(Duration::from_secs(900))
+)]
+#[ignore = "ignored-red: product Warp alignment is not implemented"]
+#[case::hls_same_play_sync_seek(Provider::HlsSame, PLAY_SYNC_SEEK)]
+#[case::hls_same_play_seek_sync(Provider::HlsSame, PLAY_SEEK_SYNC)]
+#[case::hls_same_seek_play_sync(Provider::HlsSame, SEEK_PLAY_SYNC)]
+#[case::hls_same_seek_sync_play(Provider::HlsSame, SEEK_SYNC_PLAY)]
+#[case::hls_same_sync_play_seek(Provider::HlsSame, SYNC_PLAY_SEEK)]
+#[case::hls_same_sync_seek_play(Provider::HlsSame, SYNC_SEEK_PLAY)]
+#[case::hls_same_sequential_sync(Provider::HlsSame, SEQUENTIAL_SYNC)]
+#[case::hls_same_paused_sync_then_play(Provider::HlsSame, PAUSED_SYNC)]
+#[case::hls_same_four_deck_sequential_sync(Provider::HlsSame, FOUR_DECK_SYNC)]
+#[case::hls_same_tempo_up_120hz(Provider::HlsSame, TEMPO_UP_120)]
+#[case::hls_same_tempo_down_30hz(Provider::HlsSame, TEMPO_DOWN_30)]
+#[case::mp3_same_play_sync_seek(Provider::Mp3Same, PLAY_SYNC_SEEK)]
+#[case::mp3_same_play_seek_sync(Provider::Mp3Same, PLAY_SEEK_SYNC)]
+#[case::mp3_same_seek_play_sync(Provider::Mp3Same, SEEK_PLAY_SYNC)]
+#[case::mp3_same_seek_sync_play(Provider::Mp3Same, SEEK_SYNC_PLAY)]
+#[case::mp3_same_sync_play_seek(Provider::Mp3Same, SYNC_PLAY_SEEK)]
+#[case::mp3_same_sync_seek_play(Provider::Mp3Same, SYNC_SEEK_PLAY)]
+#[case::mp3_same_sequential_sync(Provider::Mp3Same, SEQUENTIAL_SYNC)]
+#[case::mp3_same_paused_sync_then_play(Provider::Mp3Same, PAUSED_SYNC)]
+#[case::mp3_same_four_deck_sequential_sync(Provider::Mp3Same, FOUR_DECK_SYNC)]
+#[case::mp3_same_tempo_up_120hz(Provider::Mp3Same, TEMPO_UP_120)]
+#[case::mp3_same_tempo_down_30hz(Provider::Mp3Same, TEMPO_DOWN_30)]
+#[case::mp3_distinct_play_sync_seek(Provider::Mp3Distinct, PLAY_SYNC_SEEK)]
+#[case::mp3_distinct_play_seek_sync(Provider::Mp3Distinct, PLAY_SEEK_SYNC)]
+#[case::mp3_distinct_seek_play_sync(Provider::Mp3Distinct, SEEK_PLAY_SYNC)]
+#[case::mp3_distinct_seek_sync_play(Provider::Mp3Distinct, SEEK_SYNC_PLAY)]
+#[case::mp3_distinct_sync_play_seek(Provider::Mp3Distinct, SYNC_PLAY_SEEK)]
+#[case::mp3_distinct_sync_seek_play(Provider::Mp3Distinct, SYNC_SEEK_PLAY)]
+#[case::mp3_distinct_sequential_sync(Provider::Mp3Distinct, SEQUENTIAL_SYNC)]
+#[case::mp3_distinct_paused_sync_then_play(Provider::Mp3Distinct, PAUSED_SYNC)]
+#[case::mp3_distinct_four_deck_sequential_sync(Provider::Mp3Distinct, FOUR_DECK_SYNC)]
+#[case::mp3_distinct_tempo_up_120hz(Provider::Mp3Distinct, TEMPO_UP_120)]
+#[case::mp3_distinct_tempo_down_30hz(Provider::Mp3Distinct, TEMPO_DOWN_30)]
+#[case::hls_mp3_play_sync_seek(Provider::HlsMp3, PLAY_SYNC_SEEK)]
+#[case::hls_mp3_play_seek_sync(Provider::HlsMp3, PLAY_SEEK_SYNC)]
+#[case::hls_mp3_seek_play_sync(Provider::HlsMp3, SEEK_PLAY_SYNC)]
+#[case::hls_mp3_seek_sync_play(Provider::HlsMp3, SEEK_SYNC_PLAY)]
+#[case::hls_mp3_sync_play_seek(Provider::HlsMp3, SYNC_PLAY_SEEK)]
+#[case::hls_mp3_sync_seek_play(Provider::HlsMp3, SYNC_SEEK_PLAY)]
+#[case::hls_mp3_sequential_sync(Provider::HlsMp3, SEQUENTIAL_SYNC)]
+#[case::hls_mp3_paused_sync_then_play(Provider::HlsMp3, PAUSED_SYNC)]
+#[case::hls_mp3_four_deck_sequential_sync(Provider::HlsMp3, FOUR_DECK_SYNC)]
+#[case::hls_mp3_tempo_up_120hz(Provider::HlsMp3, TEMPO_UP_120)]
+#[case::hls_mp3_tempo_down_30hz(Provider::HlsMp3, TEMPO_DOWN_30)]
+async fn real_media_product_rows_reach_the_pcm_oracle(
+    #[case] provider: Provider,
+    #[case] case: SyncCase,
+) {
+    run(case, provider).await;
+}
+
+#[kithara::test(
+    native,
+    tokio,
+    multi_thread,
+    serial,
+    flash(false),
+    timeout(Duration::from_secs(1_800))
+)]
+#[ignore = "ignored-red: requires KITHARA_SYNC_LIBRARY and product Warp alignment"]
+#[case::play_sync_seek(PLAY_SYNC_SEEK)]
+#[case::play_seek_sync(PLAY_SEEK_SYNC)]
+#[case::seek_play_sync(SEEK_PLAY_SYNC)]
+#[case::seek_sync_play(SEEK_SYNC_PLAY)]
+#[case::sync_play_seek(SYNC_PLAY_SEEK)]
+#[case::sync_seek_play(SYNC_SEEK_PLAY)]
+#[case::sequential_sync(SEQUENTIAL_SYNC)]
+#[case::paused_sync_then_play(PAUSED_SYNC)]
+#[case::four_deck_sequential_sync(FOUR_DECK_SYNC)]
+#[case::tempo_up_120hz(TEMPO_UP_120)]
+#[case::tempo_down_30hz(TEMPO_DOWN_30)]
+async fn opt_in_library_product_rows_reach_the_pcm_oracle(#[case] case: SyncCase) {
+    run(case, Provider::Library).await;
+}

--- a/tests/tests/kithara_play/sync_product_matrix.rs
+++ b/tests/tests/kithara_play/sync_product_matrix.rs
@@ -16,8 +16,8 @@ use kithara::{
     },
     queue::{Queue, QueueConfig, TrackSource, Transition},
     warp::{
-        AlignmentSource, BeatGrid, LoadGeneration, PresentationFrontier, SessionFrame, SyncGroup,
-        SyncIntent, SyncOperation,
+        AlignmentSource, BeatGrid, LoadGeneration, PresentationFrontier, SessionFrame,
+        SyncAdmission, SyncGroup, SyncIntent, SyncOperation,
     },
 };
 use kithara_integration_tests::{
@@ -30,11 +30,12 @@ use kithara_test_fixtures::{
         rhythm_fmp4_init_deck_a_120bpm_48k, rhythm_fmp4_media_deck_a_120bpm_48k,
         rhythm_mp3_deck_a_120bpm_48k, rhythm_mp3_deck_b_120bpm_48k, rhythm_wav_deck_a_120bpm_48k,
         rhythm_wav_deck_b_120bpm_48k, rhythm_wav_deck_c_120bpm_48k, rhythm_wav_deck_d_120bpm_48k,
+        signal_mp3_sweep_up_60s,
     },
 };
 
-const BLOCK_FRAMES: usize = 512;
-const CHANNELS: u16 = 2;
+pub(super) const BLOCK_FRAMES: usize = 512;
+pub(super) const CHANNELS: u16 = 2;
 const LOAD_TIMEOUT: Duration = Duration::from_secs(30);
 const START_BPM: f64 = 120.0;
 
@@ -97,10 +98,10 @@ impl TempoRide {
 }
 
 #[derive(Clone, Copy, Debug)]
-struct SyncCase {
+pub(super) struct SyncCase {
     id: &'static str,
     decks: usize,
-    sample_rate: u32,
+    pub(super) sample_rate: u32,
     order: OperationOrder,
     paused: bool,
     ride: TempoRide,
@@ -134,6 +135,10 @@ impl SyncCase {
         self.ride = ride;
         self.updates_hz = updates_hz;
         self
+    }
+
+    pub(super) const fn final_bpm(self) -> f64 {
+        self.ride.final_bpm()
     }
 }
 
@@ -175,29 +180,67 @@ const TEMPO_UP_120: SyncCase =
 const TEMPO_DOWN_30: SyncCase =
     SyncCase::running("tempo-down-30hz", 2, 44_100, OperationOrder::PlaySyncSeek)
         .ride(TempoRide::Down, 30);
+pub(super) const ONE_DECK: SyncCase =
+    SyncCase::running("one-deck-runtime", 1, 48_000, OperationOrder::PlaySyncSeek);
+pub(super) const SHARED_DEADLINE: SyncCase = SyncCase::running(
+    "shared-worker-deadline",
+    4,
+    48_000,
+    OperationOrder::PlaySyncSeek,
+)
+.ride(TempoRide::Up, 120);
+pub(super) const SHARED_DEADLINE_CONTROL: SyncCase = SyncCase::running(
+    "shared-worker-control",
+    1,
+    48_000,
+    OperationOrder::PlaySyncSeek,
+)
+.ride(TempoRide::Up, 120);
 
 #[derive(Clone, Copy, Debug)]
-enum Provider {
+pub(super) enum Provider {
     Synthetic,
     HlsSame,
     Library,
     Mp3Same,
     Mp3Distinct,
     HlsMp3,
+    Sweep,
 }
 
-struct ProductHarness {
-    decks: Vec<Queue>,
-    failures: Vec<String>,
+pub(super) struct ProductHarness {
+    pub(super) decks: Vec<Queue>,
+    pub(super) failures: Vec<String>,
+    block_frames: usize,
     output_frames: u64,
+    paced: bool,
     session: Arc<OfflineSession>,
 }
 
 impl ProductHarness {
-    async fn new(case: SyncCase, provider: Provider, audible_deck: usize) -> Self {
+    pub(super) async fn new(case: SyncCase, provider: Provider, audible_deck: usize) -> Self {
+        Self::build(case, provider, audible_deck, BLOCK_FRAMES, false).await
+    }
+
+    pub(super) async fn new_for_block(
+        case: SyncCase,
+        provider: Provider,
+        audible_deck: usize,
+        block_frames: usize,
+    ) -> Self {
+        Self::build(case, provider, audible_deck, block_frames, true).await
+    }
+
+    async fn build(
+        case: SyncCase,
+        provider: Provider,
+        audible_deck: usize,
+        block_frames: usize,
+        paced: bool,
+    ) -> Self {
         let server = TestServerHelper::new().await;
         let sources = sources(provider, case.decks, &server).await;
-        let session = Arc::new(OfflineSession::new_manual());
+        let session = Arc::new(OfflineSession::new_manual_with_block_frames(block_frames));
         let dispatcher: Arc<dyn SessionDispatcher> = session.clone();
         let worker = PlayWorker::new(
             PlayWorkerConfig::for_pools(BytePool::default(), SamplePool::default()).build(),
@@ -233,7 +276,9 @@ impl ProductHarness {
         let mut harness = Self {
             decks,
             failures: Vec::new(),
+            block_frames,
             output_frames: 0,
+            paced,
             session,
         };
         harness.wait_loaded(case, &ids).await;
@@ -242,7 +287,7 @@ impl ProductHarness {
                 .unwrap_or_else(|error| panic!("{}: select deck {index}: {error}", case.id));
         }
         harness.set_tempo(case, START_BPM, true);
-        let _ = harness.render(case, BLOCK_FRAMES).await;
+        let _ = harness.render(case, harness.block_frames).await;
         if !case.paused {
             harness.start_staggered(case).await;
         }
@@ -282,19 +327,27 @@ impl ProductHarness {
         }
     }
 
-    async fn render(&mut self, case: SyncCase, frames: usize) -> Vec<f32> {
+    pub(super) async fn render(&mut self, case: SyncCase, frames: usize) -> Vec<f32> {
+        let started = Instant::now();
         self.tick_all(case);
         let pcm = self.session.render(frames);
+        self.tick_all(case);
         self.output_frames = self
             .output_frames
             .saturating_add(u64::try_from(frames).expect("render frame count fits u64"));
-        time::sleep(Duration::from_millis(1)).await;
+        let delay = if self.paced {
+            Duration::from_secs_f64(frames as f64 / f64::from(case.sample_rate))
+                .saturating_sub(started.elapsed())
+        } else {
+            Duration::from_millis(1)
+        };
+        time::sleep(delay).await;
         pcm
     }
 
-    async fn settle(&mut self, case: SyncCase, blocks: usize) {
+    pub(super) async fn settle(&mut self, case: SyncCase, blocks: usize) {
         for _ in 0..blocks {
-            let _ = self.render(case, BLOCK_FRAMES).await;
+            let _ = self.render(case, self.block_frames).await;
         }
     }
 
@@ -325,22 +378,31 @@ impl ProductHarness {
         self.settle(case, 96).await;
     }
 
-    fn set_tempo(&mut self, case: SyncCase, bpm: f64, required: bool) {
+    pub(super) fn set_tempo(&mut self, case: SyncCase, bpm: f64, required: bool) {
         let tempo = Tempo::new(bpm).expect("fixture tempo");
         match self.session.exec(Cmd::SetSessionTempo { tempo }) {
             Ok(Reply::Ok) => {}
             Ok(Reply::Err(error)) if !required => self
-                .failures
-                .push(format!("tempo request {bpm:.6} BPM was rejected: {error}")),
+                .record_tempo_failure(format!("tempo request {bpm:.6} BPM was rejected: {error}")),
             Ok(Reply::Err(error)) => panic!("{}: set initial tempo: {error}", case.id),
-            Ok(_) if !required => self.failures.push(format!(
+            Ok(_) if !required => self.record_tempo_failure(format!(
                 "tempo request {bpm:.6} BPM returned an unexpected reply"
             )),
             Ok(_) => panic!("{}: initial tempo returned an unexpected reply", case.id),
-            Err(error) if !required => self.failures.push(format!(
+            Err(error) if !required => self.record_tempo_failure(format!(
                 "tempo request {bpm:.6} BPM could not reach Host: {error}"
             )),
             Err(error) => panic!("{}: initial tempo could not reach Host: {error}", case.id),
+        }
+    }
+
+    fn record_tempo_failure(&mut self, failure: String) {
+        if !self
+            .failures
+            .iter()
+            .any(|failure| failure.starts_with("tempo request"))
+        {
+            self.failures.push(failure);
         }
     }
 
@@ -353,7 +415,11 @@ impl ProductHarness {
         }
     }
 
-    async fn request_sync(&mut self, case: SyncCase) {
+    pub(super) async fn request_sync(&mut self, case: SyncCase) {
+        self.request_sync_intent(case, SyncIntent::Enable).await;
+    }
+
+    pub(super) async fn request_sync_intent(&mut self, case: SyncCase, intent: SyncIntent) {
         let transport = self.transport_revision(case);
         for index in 0..self.decks.len() {
             {
@@ -371,7 +437,7 @@ impl ProductHarness {
                 } else {
                     AlignmentSource::Prepared
                 };
-                let _ = deck
+                let admission = deck
                     .transact(SyncOperation::Sync {
                         target: deck.id(),
                         load: LoadGeneration::first(),
@@ -380,19 +446,24 @@ impl ProductHarness {
                         activation: SessionFrame::new(
                             i64::try_from(self.output_frames).unwrap_or(i64::MAX),
                         ),
-                        intent: SyncIntent::Enable,
+                        intent,
                     })
                     .unwrap_or_else(|rejected| {
                         panic!("{}: sync deck {index}: {rejected}", case.id)
                     });
+                if let SyncAdmission::Unavailable { capability, .. } = admission {
+                    self.failures.push(format!(
+                        "sync deck {index} admitted unavailable capability {capability:?}"
+                    ));
+                }
             }
             if matches!(case.order, OperationOrder::SequentialSync) {
-                let _ = self.render(case, BLOCK_FRAMES).await;
+                let _ = self.render(case, self.block_frames).await;
             }
         }
     }
 
-    async fn run_operations(&mut self, case: SyncCase) {
+    pub(super) async fn run_operations(&mut self, case: SyncCase) {
         for operation in case.order.operations() {
             match operation {
                 Operation::Play => {
@@ -405,7 +476,7 @@ impl ProductHarness {
         }
     }
 
-    async fn ride_tempo(&mut self, case: SyncCase) {
+    pub(super) async fn ride_tempo(&mut self, case: SyncCase) {
         let steps_per_leg = (case.updates_hz / 2).max(1);
         let mut start = START_BPM;
         let mut rendered = 0_u64;
@@ -434,11 +505,21 @@ impl ProductHarness {
         self.settle(case, 4).await;
         let capture_frames =
             (f64::from(case.sample_rate) * 60.0 / case.ride.final_bpm() * 6.0).round() as usize;
+        self.capture_frames(case, capture_frames, self.block_frames)
+            .await
+    }
+
+    pub(super) async fn capture_frames(
+        &mut self,
+        case: SyncCase,
+        capture_frames: usize,
+        block_frames: usize,
+    ) -> Vec<f32> {
         let mut pcm = Vec::with_capacity(capture_frames * usize::from(CHANNELS));
         while pcm.len() < capture_frames * usize::from(CHANNELS) {
             let remaining_frames =
                 (capture_frames * usize::from(CHANNELS) - pcm.len()) / usize::from(CHANNELS);
-            let frames = remaining_frames.min(BLOCK_FRAMES);
+            let frames = remaining_frames.min(block_frames);
             let block = self.render(case, frames).await;
             assert!(
                 !block.is_empty(),
@@ -446,6 +527,30 @@ impl ProductHarness {
                 case.id,
             );
             pcm.extend(block);
+        }
+        pcm
+    }
+
+    pub(super) async fn capture_paced(
+        &mut self,
+        case: SyncCase,
+        capture_frames: usize,
+    ) -> Vec<f32> {
+        let mut pcm = Vec::with_capacity(capture_frames * usize::from(CHANNELS));
+        while pcm.len() < capture_frames * usize::from(CHANNELS) {
+            let remaining =
+                (capture_frames * usize::from(CHANNELS) - pcm.len()) / usize::from(CHANNELS);
+            let frames = remaining.min(self.block_frames);
+            let started = Instant::now();
+            let block = self.render(case, frames).await;
+            assert!(
+                !block.is_empty(),
+                "{}: paced capture stopped making PCM progress",
+                case.id,
+            );
+            pcm.extend(block);
+            let period = Duration::from_secs_f64(frames as f64 / f64::from(case.sample_rate));
+            time::sleep(period.saturating_sub(started.elapsed())).await;
         }
         pcm
     }
@@ -464,6 +569,7 @@ async fn sources(provider: Provider, decks: usize, server: &TestServerHelper) ->
         ),
         Provider::Library => cycle_paths_from_strings(&library_paths(), decks),
         Provider::Mp3Same => cycle_paths(&[rhythm_mp3_deck_a_120bpm_48k()], decks),
+        Provider::Sweep => cycle_paths(&[signal_mp3_sweep_up_60s()], decks),
         Provider::Mp3Distinct => cycle_paths(
             &[
                 rhythm_mp3_deck_a_120bpm_48k(),

--- a/tests/tests/kithara_play/sync_product_matrix.rs
+++ b/tests/tests/kithara_play/sync_product_matrix.rs
@@ -720,7 +720,7 @@ async fn run(case: SyncCase, provider: Provider) {
     multi_thread,
     serial,
     flash(false),
-    timeout(Duration::from_secs(900))
+    timeout(Duration::from_secs(600))
 )]
 #[ignore = "ignored-red: product Warp alignment is not implemented"]
 #[case::play_sync_seek(PLAY_SYNC_SEEK)]
@@ -744,7 +744,7 @@ async fn synthetic_product_rows_reach_the_pcm_oracle(#[case] case: SyncCase) {
     multi_thread,
     serial,
     flash(false),
-    timeout(Duration::from_secs(900))
+    timeout(Duration::from_secs(600))
 )]
 #[ignore = "ignored-red: product Warp alignment is not implemented"]
 #[case::hls_same_play_sync_seek(Provider::HlsSame, PLAY_SYNC_SEEK)]
@@ -804,7 +804,7 @@ async fn real_media_product_rows_reach_the_pcm_oracle(
     multi_thread,
     serial,
     flash(false),
-    timeout(Duration::from_secs(1_800))
+    timeout(Duration::from_secs(600))
 )]
 #[ignore = "ignored-red: requires KITHARA_SYNC_LIBRARY and product Warp alignment"]
 #[case::play_sync_seek(PLAY_SYNC_SEEK)]

--- a/tests/tests/kithara_play/sync_product_matrix.rs
+++ b/tests/tests/kithara_play/sync_product_matrix.rs
@@ -159,7 +159,7 @@ const SYNC_PLAY_SEEK: SyncCase =
 const SYNC_SEEK_PLAY: SyncCase =
     SyncCase::running("sync-seek-play", 2, 44_100, OperationOrder::SyncSeekPlay)
         .ride(TempoRide::Down, 120);
-const SEQUENTIAL_SYNC: SyncCase =
+pub(super) const SEQUENTIAL_SYNC: SyncCase =
     SyncCase::running("sequential-sync", 2, 48_000, OperationOrder::SequentialSync);
 const PAUSED_SYNC: SyncCase = SyncCase::running(
     "paused-sync-then-play",

--- a/tests/tests/kithara_play/sync_runtime_oracles.rs
+++ b/tests/tests/kithara_play/sync_runtime_oracles.rs
@@ -1,0 +1,457 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+use kithara::{platform::time::Duration, warp::SyncIntent};
+use kithara_integration_tests::{
+    cochlea::{
+        CochleaReport, continuity_failures, synchronization_failures, time_stretch_failures,
+    },
+    kithara,
+};
+
+use super::sync_product_matrix::{
+    BLOCK_FRAMES, CHANNELS, ONE_DECK, ProductHarness, Provider, SHARED_DEADLINE,
+    SHARED_DEADLINE_CONTROL, SyncCase,
+};
+
+const TWENTY_MS_FRAMES: usize = 960;
+
+struct CommandRun {
+    command_index: usize,
+    failures: Vec<String>,
+    samples: Vec<f32>,
+}
+
+struct AlignedRun {
+    candidate: Vec<f32>,
+    command_index: usize,
+    control: Vec<f32>,
+}
+
+async fn tempo_retarget_run(block_frames: usize, warm_blocks: usize, retarget: bool) -> CommandRun {
+    let mut harness =
+        ProductHarness::new_for_block(ONE_DECK, Provider::Sweep, 0, block_frames).await;
+    harness.request_sync(ONE_DECK).await;
+    let warm_frames = warm_blocks * BLOCK_FRAMES;
+    for _ in 0..warm_frames.div_ceil(block_frames) {
+        let _ = harness.render(ONE_DECK, block_frames).await;
+    }
+    let mut samples = harness
+        .capture_frames(ONE_DECK, ONE_DECK.sample_rate as usize, block_frames)
+        .await;
+    let command_index = samples.len() / usize::from(CHANNELS);
+    if retarget {
+        harness.set_tempo(ONE_DECK, 132.0, false);
+    }
+    samples.extend(
+        harness
+            .capture_frames(ONE_DECK, ONE_DECK.sample_rate as usize * 2, block_frames)
+            .await,
+    );
+    CommandRun {
+        command_index,
+        failures: harness.failures,
+        samples,
+    }
+}
+
+async fn running_sync_run(block_frames: usize, issue_sync: bool) -> CommandRun {
+    let mut harness =
+        ProductHarness::new_for_block(ONE_DECK, Provider::Synthetic, 0, block_frames).await;
+    let pre_frames = ONE_DECK.sample_rate as usize;
+    let settled_frames = BLOCK_FRAMES * 96;
+    let command_at_seconds = 8.0;
+    let seek_seconds =
+        command_at_seconds - (settled_frames + pre_frames) as f64 / f64::from(ONE_DECK.sample_rate);
+    harness.decks[0]
+        .seek(seek_seconds)
+        .unwrap_or_else(|error| panic!("running SYNC fixture seek failed: {error}"));
+    harness
+        .settle(ONE_DECK, settled_frames.div_ceil(block_frames))
+        .await;
+    let mut samples = harness
+        .capture_frames(ONE_DECK, pre_frames, block_frames)
+        .await;
+    let command_index = samples.len() / usize::from(CHANNELS);
+    if issue_sync {
+        harness.request_sync(ONE_DECK).await;
+    }
+    samples.extend(
+        harness
+            .capture_frames(ONE_DECK, pre_frames * 2, block_frames)
+            .await,
+    );
+    CommandRun {
+        command_index,
+        failures: harness.failures,
+        samples,
+    }
+}
+
+fn frame_deltas<'a>(candidate: &'a [f32], control: &'a [f32]) -> impl Iterator<Item = f32> + 'a {
+    candidate
+        .chunks_exact(usize::from(CHANNELS))
+        .zip(control.chunks_exact(usize::from(CHANNELS)))
+        .map(|(candidate, control)| {
+            candidate
+                .iter()
+                .zip(control)
+                .map(|(candidate, control)| (candidate - control).abs())
+                .fold(0.0_f32, f32::max)
+        })
+}
+
+fn align_runs(candidate: &CommandRun, control: &CommandRun) -> AlignedRun {
+    const ALIGNMENT_FRAMES: usize = 4_096;
+    const SAMPLE_STRIDE: usize = 8;
+
+    let prefix = ALIGNMENT_FRAMES
+        .min(candidate.command_index)
+        .min(control.command_index);
+    assert!(prefix > 0, "alignment needs pre-command PCM");
+    let candidate_limit = candidate.command_index - prefix;
+    let mut anchor = (f64::NEG_INFINITY, 0);
+    for start in (0..=candidate_limit).step_by(SAMPLE_STRIDE) {
+        let energy = (0..prefix)
+            .step_by(SAMPLE_STRIDE)
+            .map(|frame| {
+                let sample = candidate.samples[(start + frame) * usize::from(CHANNELS)];
+                let sample = f64::from(sample);
+                sample * sample
+            })
+            .sum::<f64>();
+        if energy >= anchor.0 {
+            anchor = (energy, start);
+        }
+    }
+    let candidate_anchor = anchor.1;
+    let min_lag = -i64::try_from(candidate_anchor).expect("alignment anchor fits i64");
+    let max_lag = i64::try_from(control.command_index - prefix).expect("command index fits i64")
+        - i64::try_from(candidate_anchor).expect("alignment anchor fits i64");
+    let mut best = (f64::INFINITY, i64::MAX, 0_i64);
+    for lag in min_lag..=max_lag {
+        let control_anchor = usize::try_from(
+            i64::try_from(candidate_anchor).expect("alignment anchor fits i64") + lag,
+        )
+        .expect("control alignment anchor fits usize");
+        let squared = (0..prefix)
+            .step_by(SAMPLE_STRIDE)
+            .map(|frame| {
+                let candidate =
+                    candidate.samples[(candidate_anchor + frame) * usize::from(CHANNELS)];
+                let control = control.samples[(control_anchor + frame) * usize::from(CHANNELS)];
+                let delta = f64::from(candidate - control);
+                delta * delta
+            })
+            .sum::<f64>();
+        if squared < best.0 || (squared == best.0 && lag.abs() < best.1) {
+            best = (squared, lag.abs(), lag);
+        }
+    }
+    let lag = best.2;
+    let candidate_start = usize::try_from((-lag).max(0)).expect("alignment lag fits usize");
+    let control_start = usize::try_from(lag.max(0)).expect("alignment lag fits usize");
+    let candidate_frames = candidate.samples.len() / usize::from(CHANNELS) - candidate_start;
+    let control_frames = control.samples.len() / usize::from(CHANNELS) - control_start;
+    let frames = candidate_frames.min(control_frames);
+    AlignedRun {
+        candidate: candidate.samples[candidate_start * usize::from(CHANNELS)
+            ..(candidate_start + frames) * usize::from(CHANNELS)]
+            .to_vec(),
+        command_index: candidate.command_index - candidate_start,
+        control: control.samples[control_start * usize::from(CHANNELS)
+            ..(control_start + frames) * usize::from(CHANNELS)]
+            .to_vec(),
+    }
+}
+
+fn first_sustained_delta(
+    candidate: &[f32],
+    control: &[f32],
+    range: std::ops::Range<usize>,
+) -> Option<usize> {
+    const DELTA_THRESHOLD: f32 = 0.002;
+    const SUSTAINED_FRAMES: usize = 32;
+
+    let mut run = 0;
+    for (frame, delta) in frame_deltas(candidate, control).enumerate() {
+        if !range.contains(&frame) {
+            continue;
+        }
+        if delta > DELTA_THRESHOLD {
+            run += 1;
+            if run == SUSTAINED_FRAMES {
+                return Some(frame + 1 - SUSTAINED_FRAMES);
+            }
+        } else {
+            run = 0;
+        }
+    }
+    None
+}
+
+fn append_run_failures(label: &str, run: &CommandRun, failures: &mut Vec<String>) {
+    failures.extend(
+        run.failures
+            .iter()
+            .map(|failure| format!("{label}: {failure}")),
+    );
+}
+
+#[kithara::test(
+    native,
+    tokio,
+    multi_thread,
+    serial,
+    flash(false),
+    timeout(Duration::from_secs(300))
+)]
+#[ignore = "ignored-red: bound Warp tempo retarget is not implemented"]
+async fn bound_tempo_retarget_reaches_pcm_within_twenty_ms() {
+    for (phase, warm_blocks) in [("early", 47), ("middle", 94), ("late", 140)] {
+        for block_frames in [128, 256, 512] {
+            let control = tempo_retarget_run(block_frames, warm_blocks, false).await;
+            let candidate = tempo_retarget_run(block_frames, warm_blocks, true).await;
+            let aligned = align_runs(&candidate, &control);
+            let control_report = CochleaReport::measure(&aligned.control, CHANNELS, 48_000);
+            let candidate_report = CochleaReport::measure(&aligned.candidate, CHANNELS, 48_000);
+            let mut failures =
+                time_stretch_failures("bound tempo retarget", &candidate_report, &control_report);
+            append_run_failures("control", &control, &mut failures);
+            append_run_failures("candidate", &candidate, &mut failures);
+            if let Some(frame) = first_sustained_delta(
+                &aligned.candidate,
+                &aligned.control,
+                0..aligned.command_index,
+            ) {
+                failures.push(format!(
+                    "candidate diverged before retarget at frame {frame}"
+                ));
+            }
+            let transition = first_sustained_delta(
+                &aligned.candidate,
+                &aligned.control,
+                aligned.command_index..aligned.candidate.len() / usize::from(CHANNELS),
+            );
+            let latency_budget = TWENTY_MS_FRAMES.min(block_frames * 2);
+            match transition.map(|frame| frame - aligned.command_index) {
+                Some(frames) if frames <= latency_budget => {}
+                Some(frames) => failures.push(format!(
+                    "retarget changed PCM after {frames} frames; budget is {latency_budget}"
+                )),
+                None => failures.push("retarget produced no sustained PCM change".to_owned()),
+            }
+            assert!(
+                failures.is_empty(),
+                "{block_frames}-frame {phase} retarget failed:\n{}",
+                failures.join("\n"),
+            );
+        }
+    }
+}
+
+#[kithara::test(
+    native,
+    tokio,
+    multi_thread,
+    serial,
+    flash(false),
+    timeout(Duration::from_secs(300))
+)]
+#[ignore = "ignored-red: running Warp alignment is not implemented"]
+async fn running_sync_command_changes_audible_pcm_within_one_block() {
+    for block_frames in [128, 256, 512] {
+        let control = running_sync_run(block_frames, false).await;
+        let candidate = running_sync_run(block_frames, true).await;
+        let aligned = align_runs(&candidate, &control);
+        let control_report = CochleaReport::measure(&aligned.control, CHANNELS, 48_000);
+        let candidate_report = CochleaReport::measure(&aligned.candidate, CHANNELS, 48_000);
+        let mut failures = continuity_failures("running SYNC", &candidate_report, &control_report);
+        append_run_failures("control", &control, &mut failures);
+        append_run_failures("candidate", &candidate, &mut failures);
+        if let Some(frame) = first_sustained_delta(
+            &aligned.candidate,
+            &aligned.control,
+            0..aligned.command_index,
+        ) {
+            failures.push(format!("candidate diverged before SYNC at frame {frame}"));
+        }
+        let transition = first_sustained_delta(
+            &aligned.candidate,
+            &aligned.control,
+            aligned.command_index..aligned.candidate.len() / usize::from(CHANNELS),
+        );
+        match transition.map(|frame| frame - aligned.command_index) {
+            Some(frames) if frames <= block_frames => {}
+            Some(frames) => failures.push(format!(
+                "running SYNC changed PCM after {frames} frames; budget is {block_frames}"
+            )),
+            None => failures.push("running SYNC produced no sustained PCM change".to_owned()),
+        }
+        assert!(
+            failures.is_empty(),
+            "running SYNC {block_frames}-frame contract failed:\n{}",
+            failures.join("\n"),
+        );
+    }
+}
+
+async fn capture_intent_sequence(intents: &[SyncIntent]) -> CommandRun {
+    let mut harness = ProductHarness::new(ONE_DECK, Provider::Synthetic, 0).await;
+    harness.decks[0]
+        .seek(5.25)
+        .unwrap_or_else(|error| panic!("latest-target fixture seek failed: {error}"));
+    harness.settle(ONE_DECK, 96).await;
+    for &intent in intents {
+        harness.request_sync_intent(ONE_DECK, intent).await;
+    }
+    let samples = harness
+        .capture_frames(ONE_DECK, ONE_DECK.sample_rate as usize * 3, BLOCK_FRAMES)
+        .await;
+    CommandRun {
+        command_index: 0,
+        failures: harness.failures,
+        samples,
+    }
+}
+
+#[kithara::test(
+    native,
+    tokio,
+    multi_thread,
+    serial,
+    flash(false),
+    timeout(Duration::from_secs(300))
+)]
+#[ignore = "ignored-red: latest Warp target replacement is not implemented"]
+async fn latest_sync_target_wins_in_pcm() {
+    let first = capture_intent_sequence(&[SyncIntent::Enable]).await;
+    let second = capture_intent_sequence(&[SyncIntent::Disable]).await;
+    let latest = capture_intent_sequence(&[SyncIntent::AlignNow]).await;
+    let candidate = capture_intent_sequence(&[
+        SyncIntent::Enable,
+        SyncIntent::Disable,
+        SyncIntent::AlignNow,
+    ])
+    .await;
+    let latest_report = CochleaReport::measure(&latest.samples, CHANNELS, 48_000);
+    let candidate_report = CochleaReport::measure(&candidate.samples, CHANNELS, 48_000);
+    let mut failures = continuity_failures("latest target", &candidate_report, &latest_report);
+    for (label, run) in [
+        ("first", &first),
+        ("second", &second),
+        ("latest", &latest),
+        ("candidate", &candidate),
+    ] {
+        append_run_failures(label, run, &mut failures);
+    }
+    if let Some(frame) = first_sustained_delta(
+        &candidate.samples,
+        &latest.samples,
+        0..candidate.samples.len() / usize::from(CHANNELS),
+    ) {
+        failures.push(format!(
+            "candidate diverged from the latest target at frame {frame}"
+        ));
+    }
+    for (label, stale) in [("first", &first), ("second", &second)] {
+        if first_sustained_delta(
+            &candidate.samples,
+            &stale.samples,
+            0..candidate.samples.len() / usize::from(CHANNELS),
+        )
+        .is_none()
+        {
+            failures.push(format!(
+                "candidate PCM is indistinguishable from stale {label} target"
+            ));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "latest target PCM contract failed:\n{}",
+        failures.join("\n"),
+    );
+}
+
+#[kithara::test(
+    native,
+    tokio,
+    multi_thread,
+    serial,
+    flash(false),
+    timeout(Duration::from_secs(180))
+)]
+#[ignore = "ignored-red: bound Warp render is not implemented"]
+async fn bound_sync_render_is_rtsan_clean() {
+    let control = tempo_retarget_run(BLOCK_FRAMES, 16, false).await;
+    let candidate = tempo_retarget_run(BLOCK_FRAMES, 16, true).await;
+    let aligned = align_runs(&candidate, &control);
+    let control_report = CochleaReport::measure(&aligned.control, CHANNELS, 48_000);
+    let candidate_report = CochleaReport::measure(&aligned.candidate, CHANNELS, 48_000);
+    let mut failures =
+        time_stretch_failures("RTSan bound render", &candidate_report, &control_report);
+    append_run_failures("control", &control, &mut failures);
+    append_run_failures("candidate", &candidate, &mut failures);
+    assert!(
+        failures.is_empty(),
+        "bound RTSan PCM contract failed:\n{}",
+        failures.join("\n"),
+    );
+}
+
+async fn shared_worker_capture(case: SyncCase) -> CommandRun {
+    let mut harness = ProductHarness::new(case, Provider::HlsMp3, 0).await;
+    harness.run_operations(case).await;
+    harness.ride_tempo(case).await;
+    if harness
+        .decks
+        .iter()
+        .any(|deck| !deck.engine_load().is_active())
+    {
+        harness
+            .failures
+            .push("shared worker did not report active decode load".to_owned());
+    }
+    let frames = (f64::from(case.sample_rate) * 60.0 / case.final_bpm() * 6.0).round() as usize;
+    let samples = harness.capture_paced(case, frames).await;
+    CommandRun {
+        command_index: 0,
+        failures: harness.failures,
+        samples,
+    }
+}
+
+#[kithara::test(
+    native,
+    tokio,
+    multi_thread,
+    serial,
+    flash(false),
+    timeout(Duration::from_secs(300))
+)]
+#[ignore = "ignored-red: bound Warp shared-worker path is not implemented"]
+async fn bound_sync_pcm_stays_clean_under_shared_worker_deadline_load() {
+    let control = shared_worker_capture(SHARED_DEADLINE_CONTROL).await;
+    let candidate = shared_worker_capture(SHARED_DEADLINE).await;
+    let control_report = CochleaReport::measure(&control.samples, CHANNELS, 48_000);
+    let candidate_report = CochleaReport::measure(&candidate.samples, CHANNELS, 48_000);
+    let mut failures = time_stretch_failures(
+        "bound shared-worker load",
+        &candidate_report,
+        &control_report,
+    );
+    failures.extend(synchronization_failures(
+        "bound shared-worker load",
+        &[candidate.samples.as_slice()],
+        CHANNELS,
+        48_000,
+        SHARED_DEADLINE.final_bpm(),
+    ));
+    append_run_failures("control", &control, &mut failures);
+    append_run_failures("candidate", &candidate, &mut failures);
+    assert!(
+        failures.is_empty(),
+        "bound shared-worker deadline contract failed:\n{}",
+        failures.join("\n"),
+    );
+}


### PR DESCRIPTION
## Summary
This restores the synchronization scenarios from the closed PR 118/150/187 work without restoring their obsolete fixture platform or parallel runtime architecture. The tests now use cached build-time assets and the current production path (`AssetStore` → `Queue<Player>` → shared `PlayWorker` → `OfflineSession` → final PCM/Cochlea), so they can serve as stable oracles while Warp synchronization is implemented.

Four static controls are active and prove the oracle accepts aligned stems while rejecting an exact one-frame offset, a missing beat, a wrong target tempo, and a one-beat bar-phase error for the intended reason. The product and runtime synchronization rows remain explicitly ignored-red until their required Warp behavior exists.

## Behavior / scope
- contract or behavior: adds 66 product/library synchronization rows, 5 runtime latency/safety/latest-target rows, and one opt-in five-WAV listening recorder; unavailable synchronization capability is an oracle failure rather than an accidental pass
- affected area: build-time test fixtures, shared Cochlea test oracle, native offline test session, and `kithara_play` integration tests

## Validation
- `just fmt check`
- `just check clippy`
- `just lint full`
- `just test run --flash=off -p kithara-integration-tests --test suite_light -E 'test(~static_rhythmic_oracle)'` — 4 passed
- `just test run --flash=off -p kithara-integration-tests --test suite_light --run-ignored=only -E 'test(~sync_runtime_oracles)'` — expected proof run: all 5 failed on unavailable/missing Warp behavior
- `KITHARA_AUDIO_ARTIFACT_DIR=/tmp/kithara-sync-listening.o2dU8r just test run --flash=off -p kithara-integration-tests --test suite_light --run-ignored=only -E 'test(~record_pr150_sync_listening_wavs)'` — wrote five 6-second float-WAV files, then failed on unavailable Alignment as intended
- compiled ignored inventory: 66 product/library rows + 5 runtime rows + 1 listening diagnostic
- exact-head fork CI for `8b5fa3712e7fc1db8fbc1ddce1a673d359f2ac9c`: https://github.com/gerasim13/kithara/actions/runs/33349195765 — success, including required tests, lint, feature powerset, architecture, WASM, memory, and RTSan jobs

## Surface impact
- Public API: none
- Platform/runtime: none; native test infrastructure only
- Perf-sensitive paths: none; product runtime code is unchanged

## Risks / follow-ups
- The 71 synchronization oracle rows intentionally remain ignored-red. Enable them only as the corresponding Warp behavior becomes implemented and the final PCM assertions pass.
- The opt-in library rows require `KITHARA_SYNC_LIBRARY`, `KITHARA_SYNC_LIBRARY_TRACK_A`, and `KITHARA_SYNC_LIBRARY_TRACK_B`.