### PR TITLE
refactor(tests): generate the HLS and DRM ladders the suites read

### DIFF
--- a/tests/perf/memory_rss.rs
+++ b/tests/perf/memory_rss.rs
@@ -6,10 +6,13 @@
 use hotpath::HotpathGuardBuilder;
 use kithara::{
     assets::{AssetStore, StorageBackend},
-    audio::{AudioConfig, AudioRead},
+    audio::{AudioConfig, AudioRead, DecodeError, ReadOutcome},
     bufpool::Region,
     hls::{Hls, HlsConfig},
-    platform::{time::Duration, tokio::task::spawn_blocking},
+    platform::{
+        time::{Duration, Instant},
+        tokio::task::spawn_blocking,
+    },
     play::{PlayWorker, PlayWorkerConfig},
 };
 use kithara_integration_tests::{TestServerHelper, TestTempDir, auto, temp_dir};
@@ -20,12 +23,91 @@ struct Consts;
 impl Consts {
     const MB: usize = 1024 * 1024;
     const BUDGET_RUNS: usize = 3;
-    const BUDGET_PLAYBACK_SECS: u64 = 10;
-    const BUDGET_SAMPLE_INTERVAL_MS: u64 = 500;
+    const READ_FRAMES: usize = 4096;
+    /// Upper bound on one drain. Nothing paces the reader, so a healthy drain
+    /// ends far below this; it is here so a stalled stream fails the test
+    /// instead of hanging it.
+    const DRAIN_LIMIT: Duration = Duration::from_secs(20);
+    /// Share of a drain that counts as warmup. Measured 2026-08-31: RSS climbs
+    /// from 43.7 MB to 47.0 MB inside the first tenth of the reads and is flat
+    /// for the remaining nine, so a quarter clears the ramp with room to
+    /// spare.
+    const WARMUP_SHARE: usize = 4;
     const RSS_BUDGET_MB: usize = 30;
-    const LEAK_PLAYBACK_SECS: u64 = 15;
-    const LEAK_WARMUP_SECS: u64 = 5;
     const LEAK_TOLERANCE_MB: usize = 5;
+}
+
+/// Why a drain stopped.
+///
+/// Only [`Self::Eof`] leaves a complete measurement behind. The other two
+/// truncate it, and a truncated drain cannot say whether RSS settled.
+#[derive(Debug)]
+enum DrainEnd {
+    Eof,
+    Failed(DecodeError),
+    Deadline,
+}
+
+/// RSS along one read of a stream to its end, and how that read finished.
+struct Drain {
+    samples: Vec<usize>,
+    end: DrainEnd,
+    elapsed: Duration,
+}
+
+impl Drain {
+    /// RSS samples of a drain that reached the end of the stream.
+    ///
+    /// Panics on any other ending. A drain that stops early still produces
+    /// numbers, and those numbers agree with any budget, so scoring one would
+    /// leave the assertions below unable to fail.
+    fn complete_samples(&self) -> &[usize] {
+        assert!(
+            matches!(self.end, DrainEnd::Eof),
+            "drain stopped short of the end of the stream after {:?} and {} reads: {:?}",
+            self.elapsed,
+            self.samples.len(),
+            self.end,
+        );
+        assert!(
+            self.samples.len() >= Consts::WARMUP_SHARE,
+            "drain produced {} reads, too few to tell warmup from the rest",
+            self.samples.len(),
+        );
+        &self.samples
+    }
+}
+
+/// Reads `audio` to the end of the stream, sampling RSS after every read.
+///
+/// The reader is not paced against a clock, so the measurement window is the
+/// drain itself rather than any wall-clock span: the whole track comes out in
+/// a few seconds. That is why the samples are indexed by read below and not by
+/// elapsed time.
+fn drain_sampling_rss<A: AudioRead>(audio: &mut A) -> Drain {
+    let mut buf = vec![0f32; Consts::READ_FRAMES];
+    let mut samples = Vec::new();
+    let start = Instant::now();
+
+    let end = loop {
+        if start.elapsed() >= Consts::DRAIN_LIMIT {
+            break DrainEnd::Deadline;
+        }
+        match audio.read(&mut buf) {
+            Ok(ReadOutcome::Eof { .. }) => break DrainEnd::Eof,
+            Ok(_) => {}
+            Err(error) => break DrainEnd::Failed(error),
+        }
+        if let Some(stats) = memory_stats() {
+            samples.push(stats.physical_mem);
+        }
+    };
+
+    Drain {
+        samples,
+        end,
+        elapsed: start.elapsed(),
+    }
 }
 
 /// Multi-run RSS measurement: peak RSS delta must stay within budget.
@@ -66,45 +148,26 @@ async fn test_hls_playback_rss_within_budget(temp_dir: TestTempDir) {
             PlayWorker::new(PlayWorkerConfig::for_pools(byte_pool, region.sample_pool()).build());
         let mut audio = worker.open(config).await.expect("audio creation");
 
-        let samples = spawn_blocking(move || {
-            let mut buf = vec![0f32; 4096];
-            let mut rss_samples = Vec::new();
-            let start = kithara::platform::time::Instant::now();
-            let mut last_sample = start;
+        let drain = spawn_blocking(move || drain_sampling_rss(&mut audio))
+            .await
+            .expect("spawn_blocking");
 
-            while start.elapsed() < Duration::from_secs(Consts::BUDGET_PLAYBACK_SECS) {
-                let outcome = audio.read(&mut buf);
-                let stop = matches!(
-                    outcome,
-                    Ok(kithara::audio::ReadOutcome::Eof { .. }) | Err(_)
-                );
-                if stop {
-                    break;
-                }
-
-                if last_sample.elapsed() >= Duration::from_millis(Consts::BUDGET_SAMPLE_INTERVAL_MS)
-                {
-                    if let Some(stats) = memory_stats() {
-                        rss_samples.push(stats.physical_mem);
-                    }
-                    last_sample = kithara::platform::time::Instant::now();
-                }
-            }
-            rss_samples
-        })
-        .await
-        .expect("spawn_blocking");
-
-        let peak_rss = samples.iter().copied().max().unwrap_or(baseline_rss);
+        let samples = drain.complete_samples();
+        let peak_rss = samples
+            .iter()
+            .copied()
+            .max()
+            .expect("a complete drain has samples");
         let delta = peak_rss.saturating_sub(baseline_rss);
         run_deltas.push(delta);
 
         info!(
-            "Run {run}: baseline={:.1}MB peak={:.1}MB delta={:.1}MB samples={}",
+            "Run {run}: baseline={:.1}MB peak={:.1}MB delta={:.1}MB reads={} elapsed={:?}",
             baseline_rss as f64 / Consts::MB as f64,
             peak_rss as f64 / Consts::MB as f64,
             delta as f64 / Consts::MB as f64,
             samples.len(),
+            drain.elapsed,
         );
 
         drop(server);
@@ -161,50 +224,28 @@ async fn test_hls_playback_no_rss_leak(temp_dir: TestTempDir) {
         PlayWorker::new(PlayWorkerConfig::for_pools(byte_pool, region.sample_pool()).build());
     let mut audio = worker.open(config).await.expect("audio creation");
 
-    let (warmup_rss, final_rss) = spawn_blocking(move || {
-        let mut buf = vec![0f32; 4096];
-        let start = kithara::platform::time::Instant::now();
-        let mut warmup_rss = None;
-        let mut final_rss = 0usize;
+    let drain = spawn_blocking(move || drain_sampling_rss(&mut audio))
+        .await
+        .expect("spawn_blocking");
 
-        while start.elapsed() < Duration::from_secs(Consts::LEAK_PLAYBACK_SECS) {
-            let outcome = audio.read(&mut buf);
-            let stop = matches!(
-                outcome,
-                Ok(kithara::audio::ReadOutcome::Eof { .. }) | Err(_)
-            );
-            if stop {
-                break;
-            }
-
-            let elapsed = start.elapsed();
-
-            if warmup_rss.is_none()
-                && elapsed >= Duration::from_secs(Consts::LEAK_WARMUP_SECS)
-                && let Some(stats) = memory_stats()
-            {
-                warmup_rss = Some(stats.physical_mem);
-            }
-
-            if let Some(stats) = memory_stats() {
-                final_rss = stats.physical_mem;
-            }
-        }
-
-        let warmup = warmup_rss.unwrap_or(final_rss);
-        (warmup, final_rss)
-    })
-    .await
-    .expect("spawn_blocking");
-
+    let samples = drain.complete_samples();
+    let warmup_reads = samples.len() / Consts::WARMUP_SHARE;
+    let warmup_rss = samples[..warmup_reads]
+        .iter()
+        .copied()
+        .max()
+        .expect("a complete drain has a warmup share");
+    let final_rss = *samples.last().expect("a complete drain has samples");
     let growth = final_rss.saturating_sub(warmup_rss);
 
     info!(
-        "Leak test: warmup={:.1}MB final={:.1}MB growth={:.1}MB tolerance={}MB",
+        "Leak test: warmup={:.1}MB final={:.1}MB growth={:.1}MB tolerance={}MB \
+         reads={} warmup_reads={warmup_reads}",
         warmup_rss as f64 / Consts::MB as f64,
         final_rss as f64 / Consts::MB as f64,
         growth as f64 / Consts::MB as f64,
-        Consts::LEAK_TOLERANCE_MB
+        Consts::LEAK_TOLERANCE_MB,
+        samples.len(),
     );
 
     assert!(

--- a/tests/perf/memory_rss.rs
+++ b/tests/perf/memory_rss.rs
@@ -15,9 +15,12 @@ use kithara::{
     },
     play::{PlayWorker, PlayWorkerConfig},
 };
-use kithara_integration_tests::{TestServerHelper, TestTempDir, auto, temp_dir};
+use kithara_integration_tests::{
+    TestServerHelper, TestTempDir, auto, mixed_codec_ladder, temp_dir,
+};
 use memory_stats::memory_stats;
 use tracing::info;
+use url::Url;
 
 struct Consts;
 impl Consts {
@@ -29,10 +32,21 @@ impl Consts {
     /// instead of hanging it.
     const DRAIN_LIMIT: Duration = Duration::from_secs(20);
     /// Share of a drain that counts as warmup. Measured 2026-08-31: RSS climbs
-    /// from 43.7 MB to 47.0 MB inside the first tenth of the reads and is flat
-    /// for the remaining nine, so a quarter clears the ramp with room to
-    /// spare.
+    /// from 43.7 MB to 47.0 MB and then stays flat, so a quarter of the drain
+    /// clears the ramp as long as the ladder below is long enough.
     const WARMUP_SHARE: usize = 4;
+    /// Reads it took RSS to reach its plateau, measured 2026-08-31: 257, or
+    /// about 12 s of audio. The ramp is a fixed startup cost - pools, decoder,
+    /// first prefetch - and does not grow with the stream, so the warmup share
+    /// has to clear it or warmup gets read off the ramp and every drain looks
+    /// like a leak.
+    const SETTLE_READS: usize = 257;
+    /// The ladder these measurements drain, sized by two facts. A quarter of
+    /// it has to outrun `SETTLE_READS`, and it has to encode cold inside the
+    /// 30 s this test declares alongside three drains - encoding the full
+    /// production ladder cold took 18-23 s when `thread_budget` tried it.
+    const LADDER_SEGMENTS: usize = 25;
+    const LADDER_SEGMENT_SECS: f64 = 4.0;
     const RSS_BUDGET_MB: usize = 30;
     const LEAK_TOLERANCE_MB: usize = 5;
 }
@@ -70,12 +84,34 @@ impl Drain {
             self.end,
         );
         assert!(
-            self.samples.len() >= Consts::WARMUP_SHARE,
-            "drain produced {} reads, too few to tell warmup from the rest",
+            self.samples.len() / Consts::WARMUP_SHARE > Consts::SETTLE_READS,
+            "drain produced {} reads, so its warmup share is {} and RSS needs {} \
+             to settle - warmup would be read off the ramp",
             self.samples.len(),
+            self.samples.len() / Consts::WARMUP_SHARE,
+            Consts::SETTLE_READS,
         );
         &self.samples
     }
+}
+
+/// Serves the production ladder, shortened to `Consts::LADDER_SEGMENTS`, and
+/// hands back its master URL.
+///
+/// The shape is the production one - three AAC-LC variants under a FLAC one -
+/// so `auto` is offered the same codec boundary to cross that it is offered in
+/// production, and a codec switch reallocates decoder state. Only the length is
+/// ours.
+async fn ladder_url(server: &TestServerHelper) -> Url {
+    server
+        .create_hls(
+            mixed_codec_ladder()
+                .segments_per_variant(Consts::LADDER_SEGMENTS)
+                .segment_duration_secs(Consts::LADDER_SEGMENT_SECS),
+        )
+        .await
+        .expect("create the ladder these measurements drain")
+        .master_url()
 }
 
 /// Reads `audio` to the end of the stream, sampling RSS after every read.
@@ -128,7 +164,7 @@ async fn test_hls_playback_rss_within_budget(temp_dir: TestTempDir) {
             .physical_mem;
 
         let server = TestServerHelper::new().await;
-        let url = server.asset("hls/master.m3u8");
+        let url = ladder_url(&server).await;
 
         let region = Region::default();
         let byte_pool = region.byte_pool();
@@ -204,7 +240,7 @@ async fn test_hls_playback_rss_within_budget(temp_dir: TestTempDir) {
 async fn test_hls_playback_no_rss_leak(temp_dir: TestTempDir) {
     let _guard = HotpathGuardBuilder::new("rss_leak").build();
     let server = TestServerHelper::new().await;
-    let url = server.asset("hls/master.m3u8");
+    let url = ladder_url(&server).await;
 
     let region = Region::default();
     let byte_pool = region.byte_pool();

--- a/tests/src/hls_server.rs
+++ b/tests/src/hls_server.rs
@@ -887,6 +887,25 @@ pub fn mixed_codec_ladder_encrypted() -> HlsFixtureBuilder {
     })
 }
 
+/// Serves [`mixed_codec_ladder`], plain or encrypted, and hands back its
+/// master URL.
+///
+/// The two trees this ladder replaces differed only by encryption, so the
+/// suites that read both of them take the axis as a flag rather than as two
+/// separate setup paths.
+pub async fn mixed_codec_ladder_url(server: &TestServerHelper, encrypted: bool) -> Url {
+    let ladder = if encrypted {
+        mixed_codec_ladder_encrypted()
+    } else {
+        mixed_codec_ladder()
+    };
+    server
+        .create_hls(ladder)
+        .await
+        .expect("create the mixed-codec ladder")
+        .master_url()
+}
+
 fn packaged_plain_builder() -> HlsFixtureBuilder {
     HlsFixtureBuilder::new()
         .variant_count(3)

--- a/tests/src/hls_server.rs
+++ b/tests/src/hls_server.rs
@@ -1,4 +1,7 @@
-use kithara::platform::{sync::Arc, time::Duration};
+use kithara::{
+    platform::{sync::Arc, time::Duration},
+    stream::AudioCodec,
+};
 use url::Url;
 
 use crate::{
@@ -851,6 +854,37 @@ fn compat_fixed_encrypted_spec() -> HlsSpec {
         head_reported_segment_size: Some(aes128_plaintext_segment().len()),
         ..HlsSpec::default()
     }
+}
+
+/// Ladder mirroring the production master playlist: three AAC-LC variants
+/// under one FLAC lossless, at the bandwidths the real master advertises,
+/// over 37 × 6 s.
+///
+/// Both halves are load-bearing and neither is optional for the tests that
+/// take this ladder. The FLAC variant is the far side of the codec boundary
+/// an ABR move has to cross; the length is what lets a test seek deep into
+/// the track. `PackagedTestServer` stays the cheaper choice for anything
+/// that needs neither.
+#[must_use]
+pub fn mixed_codec_ladder() -> HlsFixtureBuilder {
+    HlsFixtureBuilder::new()
+        .variant_count(4)
+        .segments_per_variant(37)
+        .segment_duration_secs(6.0)
+        .variant_bandwidths(vec![66_005, 134_107, 269_930, 988_758])
+        .packaged_audio_aac_lc(44_100, 2)
+        .override_variant_codec(3, AudioCodec::Flac)
+}
+
+/// [`mixed_codec_ladder`] with AES-128 segments. The production DRM master
+/// advertises the same four variants at the same bandwidths, so the two
+/// differ only by encryption.
+#[must_use]
+pub fn mixed_codec_ladder_encrypted() -> HlsFixtureBuilder {
+    mixed_codec_ladder().encryption(EncryptionRequest {
+        key_hex: hex::encode(aes128_key_bytes()),
+        iv_hex: Some(hex::encode(aes128_iv())),
+    })
 }
 
 fn packaged_plain_builder() -> HlsFixtureBuilder {

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -86,9 +86,9 @@ pub use fixtures::*;
 pub use hls_server::{
     AbrTestServer, EncryptionConfig, HlsTestServer, HlsTestServerConfig, PackagedTestServer,
     TestServer, abr, compat, master_playlist, mixed_codec_ladder, mixed_codec_ladder_encrypted,
-    packaged, packaged_test_server, test_master_playlist, test_master_playlist_encrypted,
-    test_master_playlist_with_init, test_media_playlist, test_media_playlist_encrypted,
-    test_media_playlist_with_init, test_segment_data, test_server,
+    mixed_codec_ladder_url, packaged, packaged_test_server, test_master_playlist,
+    test_master_playlist_encrypted, test_master_playlist_with_init, test_media_playlist,
+    test_media_playlist_encrypted, test_media_playlist_with_init, test_segment_data, test_server,
 };
 pub use hls_url::{
     HlsSpec, encode_hls_spec, hls_init_path, hls_key_path, hls_master_path, hls_media_path,

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -85,9 +85,10 @@ pub use assets_ext::memory_asset_store;
 pub use fixtures::*;
 pub use hls_server::{
     AbrTestServer, EncryptionConfig, HlsTestServer, HlsTestServerConfig, PackagedTestServer,
-    TestServer, abr, compat, master_playlist, packaged, packaged_test_server, test_master_playlist,
-    test_master_playlist_encrypted, test_master_playlist_with_init, test_media_playlist,
-    test_media_playlist_encrypted, test_media_playlist_with_init, test_segment_data, test_server,
+    TestServer, abr, compat, master_playlist, mixed_codec_ladder, mixed_codec_ladder_encrypted,
+    packaged, packaged_test_server, test_master_playlist, test_master_playlist_encrypted,
+    test_master_playlist_with_init, test_media_playlist, test_media_playlist_encrypted,
+    test_media_playlist_with_init, test_segment_data, test_server,
 };
 pub use hls_url::{
     HlsSpec, encode_hls_spec, hls_init_path, hls_key_path, hls_master_path, hls_media_path,

--- a/tests/tests/integration_regressions/transient_failure_no_permanent_skip.rs
+++ b/tests/tests/integration_regressions/transient_failure_no_permanent_skip.rs
@@ -16,18 +16,24 @@ use kithara::{
     stream::dl::{Downloader, DownloaderConfig},
 };
 use kithara_integration_tests::{
-    Content, Delivery, FixtureBehavior, PrivateTestServer, TestTempDir, kithara,
+    Content, Delivery, FixtureBehavior, HlsFixtureBuilder, PrivateTestServer, TestTempDir, kithara,
     offline::OfflineSession,
     temp_dir,
     waits::{wait_for_event, wait_for_loader_done_event, wait_for_position_event},
 };
 use kithara_test_fixtures::assets::signal_mp3_track_sine440_187s;
 
-/// Bounded look-ahead over the 222 s packaged fixture: the downloader must
-/// still need further segments when the blip lands, otherwise the track is
-/// already fully cached and no fetch can fail. Kept narrow for the same
-/// reason as in the outage trap — a wide window makes the scenario depend on
-/// how much happened to be cached.
+/// The ladder the blip lands on. One variant, since playback pins variant 0
+/// below, and 72 s of it: the downloader must still need further segments
+/// when the network drops, or the track is already fully cached and no fetch
+/// can fail.
+const VARIANT_SEGMENTS: usize = 24;
+const SEGMENT_SECS: f64 = 3.0;
+/// Bounded look-ahead: kept narrow because a wide window makes the scenario
+/// depend on how much happened to be cached. At the encoder's default
+/// 128 kbit/s a segment above runs roughly 48 KiB, so this window holds
+/// about one of them — the ratio the captured tree gave, where a 64 KiB
+/// window sat against ~50 KiB segments.
 const LOOK_AHEAD_BYTES: u64 = 64 * 1024;
 const PLAY_BEFORE_FAILURE_SECS: f64 = 1.0;
 /// How far playback must carry on past the blip. Bounds the "no auto-skip"
@@ -59,7 +65,17 @@ async fn transient_failure_does_not_kill_the_track(temp_dir: TestTempDir) {
     // one with parallel siblings would fail them instead.
     let server = PrivateTestServer::start().await;
     let helper = server.helper();
-    let target_url = helper.asset("hls/master.m3u8");
+    let target = helper
+        .create_hls(
+            HlsFixtureBuilder::new()
+                .variant_count(1)
+                .segments_per_variant(VARIANT_SEGMENTS)
+                .segment_duration_secs(SEGMENT_SECS)
+                .packaged_audio_aac_lc(44_100, 2),
+        )
+        .await
+        .expect("create the ladder the blip lands on");
+    let target_url = target.master_url();
     let fallback_fixture = helper.register_behavior(FixtureBehavior {
         content: Content::StaticBytes {
             bytes: Arc::new(signal_mp3_track_sine440_187s().bytes().to_vec()),

--- a/tests/tests/kithara_hls/abr_mode_switch.rs
+++ b/tests/tests/kithara_hls/abr_mode_switch.rs
@@ -27,6 +27,7 @@ use kithara_integration_tests::{
     TestServerHelper, TestTempDir, auto,
     fixture_protocol::DelayRule,
     hls_server::{HlsTestServer, HlsTestServerConfig},
+    mixed_codec_ladder_url,
     reads::{read_to_eof, read_until_samples},
     waits::{wait_for_event, wait_until},
 };
@@ -1320,9 +1321,9 @@ async fn runtime_manual_switch_via_handle_changes_playing_variant() {
 )]
 async fn runtime_cross_codec_manual_switch_no_hang() {
     let server = TestServerHelper::new().await;
-    let url = server.asset("hls/master.m3u8");
-    // assets/hls/master.m3u8: variants 0..2 are AAC (mp4a.40.2), variant 3
-    // is FLAC (fLaC). Manual(3) forces the cross-codec path.
+    let url = mixed_codec_ladder_url(&server, false).await;
+    // The mixed-codec ladder: variants 0..2 are AAC (mp4a.40.2), variant 3
+    // is FLAC. Manual(3) forces the cross-codec path.
 
     let temp_dir = TestTempDir::new();
     let cancel = CancelToken::never();
@@ -1901,7 +1902,7 @@ async fn auto_does_not_up_switch_on_first_boundary_with_defaults() {
 
     // Long segment duration (6 s in playlist EXTINF) so a full prefetch
     // pushes `buffer_ahead` over the default 10 s `min_buffer_for_up_switch`
-    // gate — same as the real assets/hls/ fixture. Without this the
+    // gate — same as the mixed-codec ladder. Without this the
     // buffer gate alone blocks ABR and the test reports a false GREEN.
     let server = HlsTestServer::new(HlsTestServerConfig {
         variant_count: 3,
@@ -2032,8 +2033,8 @@ async fn auto_does_not_up_switch_on_first_boundary_with_defaults() {
 #[ignore = "current implementation hits a separate same-codec byte_shift mismatch; needs deterministic timing setup to repro the cross→same race"]
 async fn rapid_cross_codec_then_same_codec_switch_no_false_eof() {
     let server = TestServerHelper::new().await;
-    let url = server.asset("hls/master.m3u8");
-    // assets/hls/master.m3u8: variants 0..2 AAC (mp4a.40.2), variant 3
+    let url = mixed_codec_ladder_url(&server, false).await;
+    // The mixed-codec ladder: variants 0..2 AAC (mp4a.40.2), variant 3
     // FLAC. We need Manual(3) (cross-codec) then Manual(1) (same-codec
     // AAC sibling of v=0) before v=3's decoder recreate fires.
 
@@ -2172,10 +2173,11 @@ async fn play_seek_back_then_same_codec_downswitch_no_premature_eof(
     kithara_integration_tests::apple_warmup::warm_if_apple(backend);
 
     let server = TestServerHelper::new().await;
-    let url = server.asset("hls/master.m3u8");
-    // assets/hls/master.m3u8: variants 0..2 AAC (mp4a.40.2), variant 3 FLAC.
-    // The duration of every variant ≈ 220 s. We start on shq (v=2) so we
-    // can downswitch to slq (v=0) for the same-codec scenario.
+    let url = mixed_codec_ladder_url(&server, false).await;
+    // The mixed-codec ladder: variants 0..2 AAC (mp4a.40.2), variant 3 FLAC.
+    // The duration of every variant ≈ 220 s. We start on the top AAC (v=2)
+    // so we can downswitch to the bottom one (v=0) for the same-codec
+    // scenario.
 
     let temp_dir = TestTempDir::new();
     let cancel = CancelToken::never();
@@ -2405,9 +2407,9 @@ async fn seek_backwards_after_manual_switch_to_uncached_variant_does_not_hang(
     kithara_integration_tests::apple_warmup::warm_if_apple(backend);
 
     let server = TestServerHelper::new().await;
-    let url = server.asset("hls/master.m3u8");
-    // assets/hls/master.m3u8: v=0..2 AAC (mp4a.40.2, fmp4), v=3 FLAC
-    // (fLaC, fmp4). Track ≈ 220 s, 37 segments each (~6 s).
+    let url = mixed_codec_ladder_url(&server, false).await;
+    // The mixed-codec ladder: v=0..2 AAC (mp4a.40.2, fmp4), v=3 FLAC
+    // (fmp4). Track ≈ 220 s, 37 segments each (~6 s).
 
     let temp_dir = TestTempDir::new();
     let cancel = CancelToken::never();

--- a/tests/tests/kithara_hls/abr_switch_playback.rs
+++ b/tests/tests/kithara_hls/abr_switch_playback.rs
@@ -23,6 +23,7 @@ use kithara_integration_tests::{
     HlsFixtureBuilder, TestServerHelper, TestTempDir, abr_fast, auto,
     fixture_protocol::{DelayRule, PcmPattern},
     flash_pace::virtual_pace,
+    mixed_codec_ladder_url,
     offline::{OfflinePlayer, resource_from_reader},
     temp_dir,
 };
@@ -139,7 +140,7 @@ async fn read_audio_some(audio: &mut RegisteredAudio<Stream<Hls>>, stage: &str) 
 /// Real fMP4/AAC HLS stream with ABR auto-switch must play without hanging.
 ///
 /// This is the exact scenario from the production crash:
-/// `kithara-app` plays track.mp3 + hls/master.m3u8 + drm/master.m3u8.
+/// `kithara-app` plays one MP3 plus the plain and encrypted HLS masters.
 /// ABR switches variant on HLS track → worker hangs → all tracks die.
 #[kithara::test(
     tokio,
@@ -148,9 +149,9 @@ async fn read_audio_some(audio: &mut RegisteredAudio<Stream<Hls>>, stage: &str) 
     timeout(Duration::from_secs(30)),
     hang_timeout_secs(3)
 )]
-async fn abr_switch_real_assets_does_not_hang(temp_dir: TestTempDir) {
+async fn abr_switch_on_production_ladder_does_not_hang(temp_dir: TestTempDir) {
     let server = TestServerHelper::new().await;
-    let url = server.asset("hls/master.m3u8");
+    let url = mixed_codec_ladder_url(&server, false).await;
 
     let cancel = CancelToken::never();
     let region = Region::default();
@@ -438,29 +439,29 @@ async fn packaged_abr_switch_keeps_player_continuity(temp_dir: TestTempDir) {
     timeout(Duration::from_secs(30)),
     hang_timeout_secs(5)
 )]
-#[case::drm_abr_auto_sw("drm/master.m3u8", true, DecoderBackend::Symphonia)]
+#[case::drm_abr_auto_sw(true, true, DecoderBackend::Symphonia)]
 #[cfg_attr(
     any(target_os = "macos", target_os = "ios"),
-    case::drm_abr_auto_hw("drm/master.m3u8", true, DecoderBackend::Apple)
+    case::drm_abr_auto_hw(true, true, DecoderBackend::Apple)
 )]
-#[case::hls_abr_auto_sw("hls/master.m3u8", true, DecoderBackend::Symphonia)]
+#[case::hls_abr_auto_sw(false, true, DecoderBackend::Symphonia)]
 #[cfg_attr(
     any(target_os = "macos", target_os = "ios"),
-    case::hls_abr_auto_hw("hls/master.m3u8", true, DecoderBackend::Apple)
+    case::hls_abr_auto_hw(false, true, DecoderBackend::Apple)
 )]
-#[case::drm_manual_v0_sw("drm/master.m3u8", false, DecoderBackend::Symphonia)]
+#[case::drm_manual_v0_sw(true, false, DecoderBackend::Symphonia)]
 #[cfg_attr(
     any(target_os = "macos", target_os = "ios"),
-    case::drm_manual_v0_hw("drm/master.m3u8", false, DecoderBackend::Apple)
+    case::drm_manual_v0_hw(true, false, DecoderBackend::Apple)
 )]
-#[case::hls_manual_v0_sw("hls/master.m3u8", false, DecoderBackend::Symphonia)]
+#[case::hls_manual_v0_sw(false, false, DecoderBackend::Symphonia)]
 #[cfg_attr(
     any(target_os = "macos", target_os = "ios"),
-    case::hls_manual_v0_hw("hls/master.m3u8", false, DecoderBackend::Apple)
+    case::hls_manual_v0_hw(false, false, DecoderBackend::Apple)
 )]
 async fn stream_continues_after_seek(
     temp_dir: TestTempDir,
-    #[case] path: &str,
+    #[case] encrypted: bool,
     #[case] abr_auto: bool,
     #[case] backend: DecoderBackend,
 ) {
@@ -468,7 +469,8 @@ async fn stream_continues_after_seek(
     kithara_integration_tests::apple_warmup::warm_if_apple(backend);
 
     let server = TestServerHelper::new().await;
-    let url = server.asset(path);
+    let url = mixed_codec_ladder_url(&server, encrypted).await;
+    let label = if encrypted { "DRM" } else { "HLS" };
 
     let cancel = CancelToken::never();
     let region = Region::default();
@@ -518,7 +520,7 @@ async fn stream_continues_after_seek(
             match audio.read(&mut buf) {
                 Ok(ReadOutcome::Frames { count, .. }) => warmup_samples += count.get() as u64,
                 Ok(ReadOutcome::Pending { .. }) => virtual_pace(Duration::from_millis(5)),
-                Ok(ReadOutcome::Eof { .. }) => panic!("[{path}] unexpected EOF during warmup"),
+                Ok(ReadOutcome::Eof { .. }) => panic!("[{label}] unexpected EOF during warmup"),
                 Err(e) => panic!("decode error during warmup: {e}"),
             }
         }
@@ -544,7 +546,7 @@ async fn stream_continues_after_seek(
             }
             assert!(
                 samples > 0,
-                "[{path}] seek to {target_secs}s must produce samples, got 0"
+                "[{label}] seek to {target_secs}s must produce samples, got 0"
             );
         }
 
@@ -563,7 +565,7 @@ async fn stream_continues_after_seek(
         }
         assert!(
             post_seek_samples > 0,
-            "[{path}] playback after seeks must continue, got 0 samples"
+            "[{label}] playback after seeks must continue, got 0 samples"
         );
     })
     .await
@@ -578,9 +580,9 @@ async fn stream_continues_after_seek(
     timeout(Duration::from_secs(20)),
     hang_timeout_secs(3)
 )]
-async fn fixed_variant_real_assets_plays_without_hang(temp_dir: TestTempDir) {
+async fn fixed_variant_on_production_ladder_plays_without_hang(temp_dir: TestTempDir) {
     let server = TestServerHelper::new().await;
-    let url = server.asset("hls/master.m3u8");
+    let url = mixed_codec_ladder_url(&server, false).await;
 
     let cancel = CancelToken::never();
     let region = Region::default();
@@ -650,11 +652,12 @@ async fn fixed_variant_real_assets_plays_without_hang(temp_dir: TestTempDir) {
     hang_timeout_secs(5),
     tracing("kithara_audio=warn,kithara_hls=warn,symphonia_format_isomp4=warn")
 )]
-#[case::drm("drm/master.m3u8")]
-#[case::hls("hls/master.m3u8")]
-async fn seek_after_eof_mmap_produces_samples(temp_dir: TestTempDir, #[case] path: &str) {
+#[case::drm(true)]
+#[case::hls(false)]
+async fn seek_after_eof_mmap_produces_samples(temp_dir: TestTempDir, #[case] encrypted: bool) {
     let server = TestServerHelper::new().await;
-    let url = server.asset(path);
+    let url = mixed_codec_ladder_url(&server, encrypted).await;
+    let label = if encrypted { "DRM" } else { "HLS" };
 
     let cancel = CancelToken::never();
     let region = Region::default();
@@ -695,7 +698,7 @@ async fn seek_after_eof_mmap_produces_samples(temp_dir: TestTempDir, #[case] pat
             match audio.read(&mut buf) {
                 Ok(ReadOutcome::Frames { count, .. }) => warmup_samples += count.get() as u64,
                 Ok(ReadOutcome::Pending { .. }) => virtual_pace(Duration::from_millis(5)),
-                Ok(ReadOutcome::Eof { .. }) => panic!("[{path}] unexpected EOF during warmup"),
+                Ok(ReadOutcome::Eof { .. }) => panic!("[{label}] unexpected EOF during warmup"),
                 Err(e) => panic!("decode error during warmup: {e}"),
             }
         }
@@ -708,7 +711,7 @@ async fn seek_after_eof_mmap_produces_samples(temp_dir: TestTempDir, #[case] pat
         for (idx, &target_secs) in seek_targets.iter().enumerate() {
             audio
                 .seek(Duration::from_secs_f64(target_secs))
-                .unwrap_or_else(|e| panic!("[{path}] seek #{idx} to {target_secs}s failed: {e}"));
+                .unwrap_or_else(|e| panic!("[{label}] seek #{idx} to {target_secs}s failed: {e}"));
 
             let mut samples = 0u64;
             while samples < samples_per_seek {
@@ -725,7 +728,7 @@ async fn seek_after_eof_mmap_produces_samples(temp_dir: TestTempDir, #[case] pat
             }
             assert!(
                 samples > 0,
-                "[{path}] seek #{idx} to {target_secs}s must produce samples, got 0"
+                "[{label}] seek #{idx} to {target_secs}s must produce samples, got 0"
             );
         }
     })
@@ -847,7 +850,7 @@ async fn abr_frozen_during_seek_resumes_after(temp_dir: TestTempDir) {
     use kithara::{audio::AudioRead, signal::AudioChunk};
 
     let server = TestServerHelper::new().await;
-    let url = server.asset("hls/master.m3u8");
+    let url = mixed_codec_ladder_url(&server, false).await;
 
     let region = Region::default();
     let worker = PlayWorker::new(
@@ -1038,7 +1041,7 @@ fn read_manual_cross_codec_phase(
 /// then stalls; `decode_next_chunk` hangs ~10s later. User experience:
 /// "audio disappeared, the slider kept moving, then the app crashed".
 ///
-/// `abr_switch_real_assets_does_not_hang` and `runtime_cross_codec_manual_switch_no_hang`
+/// `abr_switch_on_production_ladder_does_not_hang` and `runtime_cross_codec_manual_switch_no_hang`
 /// already cover the cross-codec path but their assertions accept
 /// `total_samples > 0` / `> 1000` — a single post-init buffer satisfies
 /// them, masking a stall. Sustained playback requires a much higher bar.
@@ -1050,9 +1053,9 @@ fn read_manual_cross_codec_phase(
 /// the bandwidth estimator may or may not commit the switch within the
 /// test window.
 ///
-/// Real assets: `assets/hls/master.m3u8` carries variants 0-2 AAC
-/// (mp4a.40.2) and variant 3 FLAC (fLaC) — 37 segments × 4s each =
-/// 148 s of audio. Reading 15 s post-switch must produce at least
+/// The mixed-codec ladder carries variants 0-2 AAC (mp4a.40.2) and
+/// variant 3 FLAC — 37 segments × 6 s each, so about 220 s of audio.
+/// Reading 15 s post-switch must produce at least
 /// `15 × 44_100 × 2 × 0.5 = 661_500` samples (50 % of nominal rate).
 #[kithara::test(
     tokio,
@@ -1063,7 +1066,7 @@ fn read_manual_cross_codec_phase(
 )]
 async fn manual_cross_codec_switch_sustains_post_switch_playback(temp_dir: TestTempDir) {
     let server = TestServerHelper::new().await;
-    let url = server.asset("hls/master.m3u8");
+    let url = mixed_codec_ladder_url(&server, false).await;
 
     let cancel = CancelToken::never();
     let bus = EventBus::new(8192);

--- a/tests/tests/kithara_hls/drm_stream_integrity.rs
+++ b/tests/tests/kithara_hls/drm_stream_integrity.rs
@@ -13,7 +13,9 @@ use kithara::{
     },
     stream::{SourcePhase, Stream},
 };
-use kithara_integration_tests::{TestServerHelper, TestTempDir, auto, temp_dir};
+use kithara_integration_tests::{
+    TestServerHelper, TestTempDir, auto, mixed_codec_ladder_url, temp_dir,
+};
 use tracing::{debug, error, info, warn};
 
 const fn is_known_box(tag: &[u8; 4]) -> bool {
@@ -195,27 +197,27 @@ fn assert_boxes_contiguous(boxes: &[(u64, u64, String)], label: &str) {
     timeout(Duration::from_secs(45)),
     hang_timeout_secs(3)
 )]
-#[case::hls_disk_v0("hls/master.m3u8", "HLS-disk-v0", false, 0)]
-#[case::hls_disk_v3("hls/master.m3u8", "HLS-disk-v3", false, 3)]
-#[case::hls_eph_v0("hls/master.m3u8", "HLS-eph-v0", true, 0)]
-#[case::hls_eph_v3("hls/master.m3u8", "HLS-eph-v3", true, 3)]
-#[case::drm_disk_v0("drm/master.m3u8", "DRM-disk-v0", false, 0)]
-#[case::drm_disk_v3("drm/master.m3u8", "DRM-disk-v3", false, 3)]
-#[case::drm_eph_v0("drm/master.m3u8", "DRM-eph-v0", true, 0)]
-#[case::drm_eph_v3("drm/master.m3u8", "DRM-eph-v3", true, 3)]
-#[case::hls_disk_auto("hls/master.m3u8", "HLS-disk-auto", false, 99)]
-#[case::hls_eph_auto("hls/master.m3u8", "HLS-eph-auto", true, 99)]
-#[case::drm_disk_auto("drm/master.m3u8", "DRM-disk-auto", false, 99)]
-#[case::drm_eph_auto("drm/master.m3u8", "DRM-eph-auto", true, 99)]
+#[case::hls_disk_v0("HLS-disk-v0", false, false, 0)]
+#[case::hls_disk_v3("HLS-disk-v3", false, false, 3)]
+#[case::hls_eph_v0("HLS-eph-v0", false, true, 0)]
+#[case::hls_eph_v3("HLS-eph-v3", false, true, 3)]
+#[case::drm_disk_v0("DRM-disk-v0", true, false, 0)]
+#[case::drm_disk_v3("DRM-disk-v3", true, false, 3)]
+#[case::drm_eph_v0("DRM-eph-v0", true, true, 0)]
+#[case::drm_eph_v3("DRM-eph-v3", true, true, 3)]
+#[case::hls_disk_auto("HLS-disk-auto", false, false, 99)]
+#[case::hls_eph_auto("HLS-eph-auto", false, true, 99)]
+#[case::drm_disk_auto("DRM-disk-auto", true, false, 99)]
+#[case::drm_eph_auto("DRM-eph-auto", true, true, 99)]
 async fn drm_stream_byte_integrity(
     temp_dir: TestTempDir,
-    #[case] path: &str,
     #[case] label: &str,
+    #[case] encrypted: bool,
     #[case] ephemeral: bool,
     #[case] abr_variant: usize,
 ) {
     let server = TestServerHelper::new().await;
-    let url = server.asset(path);
+    let url = mixed_codec_ladder_url(&server, encrypted).await;
     let cancel = CancelToken::never();
 
     let store = if ephemeral {

--- a/tests/tests/kithara_hls/idle_behavior.rs
+++ b/tests/tests/kithara_hls/idle_behavior.rs
@@ -13,7 +13,9 @@ use kithara::{
     platform::{sync::Arc, time::Duration},
     play::{PlayWorker, PlayWorkerConfig},
 };
-use kithara_integration_tests::{TestServerHelper, TestTempDir, temp_dir};
+use kithara_integration_tests::{
+    HlsFixtureBuilder, PackagedTestServer, TestServerHelper, TestTempDir, temp_dir,
+};
 
 /// Install a panic hook that flips `flag` when a panic message contains
 /// `marker`. The hook fires on every thread, so we can detect the
@@ -58,13 +60,12 @@ fn arm_panic_marker(marker: &'static str) -> Arc<AtomicBool> {
 async fn idle_does_not_panic_hang_detector(temp_dir: TestTempDir) {
     let watchdog_fired = arm_panic_marker("HangDetector");
 
-    let server = TestServerHelper::new().await;
-    let url = server.asset("hls/master.m3u8");
+    let server = PackagedTestServer::new().await;
     let region = Region::default();
     let worker = PlayWorker::new(
         PlayWorkerConfig::for_pools(region.byte_pool(), region.sample_pool()).build(),
     );
-    let hls_config = HlsConfig::for_url(url)
+    let hls_config = HlsConfig::for_url(server.url("/master.m3u8"))
         .store(
             AssetStore::builder()
                 .backend(StorageBackend::Disk {
@@ -147,11 +148,25 @@ fn count_files_recursive(root: &Path) -> usize {
 #[kithara::test(tokio, native, serial, timeout(Duration::from_secs(20)))]
 async fn idle_prefetch_is_capped(temp_dir: TestTempDir) {
     let server = TestServerHelper::new().await;
-    let url = server.asset("hls/master.m3u8");
-    // slq segments in the test fixture are ~50 KiB. 256 KiB ≈ 5
-    // segments worth of look-ahead — comfortably below the 37-segment
-    // variant length so a missing cap is unambiguously visible.
-    const LOOK_AHEAD_BYTES: u64 = 256 * 1024;
+    // A variant long enough that "stopped at the cap" and "drained the
+    // whole thing" cannot be confused. One variant at the encoder's
+    // default 128 kbit/s puts roughly 32 KiB in each 2 s segment, so the
+    // look-ahead below buys a handful of them out of SEGMENTS — the gap
+    // is wide enough that the exact segment size does not matter.
+    const SEGMENTS: usize = 24;
+    const LOOK_AHEAD_BYTES: u64 = 128 * 1024;
+    let created = server
+        .create_hls(
+            HlsFixtureBuilder::new()
+                .variant_count(1)
+                .segments_per_variant(SEGMENTS)
+                .segment_duration_secs(2.0)
+                .variant_bandwidths(vec![128_000])
+                .packaged_audio_aac_lc(44_100, 2),
+        )
+        .await
+        .expect("create the capped-prefetch fixture");
+    let url = created.master_url();
     // Shared bus so the downloader's per-fetch `DownloaderEvent`s reach a
     // root subscriber here — the real signal that prefetch is or is not
     // still running.
@@ -215,17 +230,17 @@ async fn idle_prefetch_is_capped(temp_dir: TestTempDir) {
 
     let files = count_files_recursive(temp_dir.path());
 
-    // Budget: ~5-7 media segs + init + 4 playlists + master. The `_index/`
-    // dir (availability.bin / lru.bin / pins.bin written by the asset
-    // store's flush hub) is bookkeeping, not prefetched media, so it is
-    // excluded from the count. 15 catches the "no cap" failure (which
-    // downloads all 37 segments + auxiliaries → 45+ files).
+    // Measured: the cap honored lands 10 files, and a look-ahead wide
+    // enough to cover the whole variant lands 28. The budget sits between
+    // them with room on both sides. The `_index/` dir (availability.bin /
+    // lru.bin / pins.bin written by the asset store's flush hub) is
+    // bookkeeping, not prefetched media, so it is excluded from the count.
     const PREFETCH_FILE_CAP: usize = 15;
     assert!(
         files <= PREFETCH_FILE_CAP,
         "expected idle prefetch capped at <={PREFETCH_FILE_CAP} files \
-         with look_ahead_bytes={LOOK_AHEAD_BYTES}, got {files} files on \
-         disk — HlsVariant::dispatch is draining the full segment queue \
-         without honoring the byte-ahead cap"
+         with look_ahead_bytes={LOOK_AHEAD_BYTES} over a {SEGMENTS}-segment \
+         variant, got {files} files on disk — HlsVariant::dispatch is \
+         draining the full segment queue without honoring the byte-ahead cap"
     );
 }

--- a/tests/tests/kithara_hls/live_stress_real_stream.rs
+++ b/tests/tests/kithara_hls/live_stress_real_stream.rs
@@ -26,7 +26,7 @@ use kithara::{
     stream::Stream,
 };
 use kithara_integration_tests::{
-    TestServerHelper, TestTempDir, Xorshift64, abr_fast, auto, temp_dir,
+    TestServerHelper, TestTempDir, Xorshift64, abr_fast, auto, mixed_codec_ladder_url, temp_dir,
 };
 use tracing::info;
 
@@ -186,10 +186,10 @@ fn snapshot(stats: &Arc<Mutex<LiveStats>>) -> LiveSnapshot {
 async fn build_live_audio(
     worker: &PlayWorker,
     server: &TestServerHelper,
-    path: &str,
+    encrypted: bool,
     cache_capacity: usize,
 ) -> RegisteredAudio<Stream<Hls>> {
-    let url = server.asset(path);
+    let url = mixed_codec_ladder_url(server, encrypted).await;
     let store = AssetStore::builder()
         .backend(StorageBackend::Memory)
         .pool(worker.byte_pool().clone())
@@ -323,7 +323,7 @@ async fn next_chunk(audio: &mut RegisteredAudio<Stream<Hls>>, stage: &str) -> Op
 )]
 async fn live_real_drm_playback_smoke() {
     let server = TestServerHelper::new().await;
-    let url = server.asset("drm/master.m3u8");
+    let url = mixed_codec_ladder_url(&server, true).await;
     info!(%url, "starting real DRM playback smoke");
     let region = Region::default();
     let worker = PlayWorker::new(
@@ -400,18 +400,18 @@ async fn live_real_drm_playback_smoke() {
         "kithara_audio=info,kithara::audio::pipeline::source=debug,kithara_hls=debug,kithara_stream=debug"
     )
 )]
-#[case::hls_sw("hls/master.m3u8", "HLS", DecoderBackend::Symphonia)]
+#[case::hls_sw(false, "HLS", DecoderBackend::Symphonia)]
 #[cfg_attr(
     any(target_os = "macos", target_os = "ios"),
-    case::hls_hw("hls/master.m3u8", "HLS", DecoderBackend::Apple)
+    case::hls_hw(false, "HLS", DecoderBackend::Apple)
 )]
-#[case::drm_sw("drm/master.m3u8", "DRM", DecoderBackend::Symphonia)]
+#[case::drm_sw(true, "DRM", DecoderBackend::Symphonia)]
 #[cfg_attr(
     any(target_os = "macos", target_os = "ios"),
-    case::drm_hw("drm/master.m3u8", "DRM", DecoderBackend::Apple)
+    case::drm_hw(true, "DRM", DecoderBackend::Apple)
 )]
 async fn live_ephemeral_revisit_sequence_regression(
-    #[case] path: &str,
+    #[case] encrypted: bool,
     #[case] label: &str,
     #[case] backend: DecoderBackend,
     _abr_fast: kithara::abr::AbrSettings,
@@ -420,7 +420,7 @@ async fn live_ephemeral_revisit_sequence_regression(
     kithara_integration_tests::apple_warmup::warm_if_apple(backend);
 
     let server = TestServerHelper::new().await;
-    let url = server.asset(path);
+    let url = mixed_codec_ladder_url(&server, encrypted).await;
     let region = Region::default();
     let worker = PlayWorker::new(
         PlayWorkerConfig::for_pools(region.byte_pool(), region.sample_pool()).build(),
@@ -648,10 +648,10 @@ async fn live_ephemeral_revisit_sequence_regression(
     hang_timeout_secs(3),
     tracing("kithara_audio=info,kithara_hls=info,kithara_stream=info")
 )]
-#[case::hls("hls/master.m3u8", "HLS")]
-#[case::drm("drm/master.m3u8", "DRM")]
+#[case::hls(false, "HLS")]
+#[case::drm(true, "DRM")]
 async fn live_real_stream_fixed_seek_window_regression(
-    #[case] path: &str,
+    #[case] encrypted: bool,
     #[case] label: &str,
     _abr_fast: kithara::abr::AbrSettings,
 ) {
@@ -660,7 +660,7 @@ async fn live_real_stream_fixed_seek_window_regression(
     let worker = PlayWorker::new(
         PlayWorkerConfig::for_pools(region.byte_pool(), region.sample_pool()).build(),
     );
-    let mut audio = build_live_audio(&worker, &server, path, 24).await;
+    let mut audio = build_live_audio(&worker, &server, encrypted, 24).await;
     let (stats, events_task) = spawn_live_stats_task(&mut audio);
 
     spawn_blocking(move || {
@@ -704,10 +704,10 @@ async fn live_real_stream_fixed_seek_window_regression(
     hang_timeout_secs(3),
     tracing("kithara_audio=info,kithara_hls=info,kithara_stream=info")
 )]
-#[case::hls("hls/master.m3u8", "HLS")]
-#[case::drm("drm/master.m3u8", "DRM")]
+#[case::hls(false, "HLS")]
+#[case::drm(true, "DRM")]
 async fn live_real_stream_random_seek_prefix_regression(
-    #[case] path: &str,
+    #[case] encrypted: bool,
     #[case] label: &str,
     _abr_fast: kithara::abr::AbrSettings,
 ) {
@@ -716,7 +716,7 @@ async fn live_real_stream_random_seek_prefix_regression(
     let worker = PlayWorker::new(
         PlayWorkerConfig::for_pools(region.byte_pool(), region.sample_pool()).build(),
     );
-    let mut audio = build_live_audio(&worker, &server, path, 24).await;
+    let mut audio = build_live_audio(&worker, &server, encrypted, 24).await;
     let (stats, events_task) = spawn_live_stats_task(&mut audio);
 
     spawn_blocking(move || {
@@ -758,11 +758,11 @@ async fn live_real_stream_random_seek_prefix_regression(
         "kithara_audio=info,kithara::audio::pipeline::source=debug,kithara_hls=debug,kithara_stream=debug"
     )
 )]
-#[case::hls("hls/master.m3u8", "HLS")]
-#[case::drm("drm/master.m3u8", "DRM")]
-async fn live_real_stream_seek_resume_native(#[case] path: &str, #[case] label: &str) {
+#[case::hls(false, "HLS")]
+#[case::drm(true, "DRM")]
+async fn live_real_stream_seek_resume_native(#[case] encrypted: bool, #[case] label: &str) {
     let server = TestServerHelper::new().await;
-    let url = server.asset(path);
+    let url = mixed_codec_ladder_url(&server, encrypted).await;
     let region = Region::default();
     let worker = PlayWorker::new(
         PlayWorkerConfig::for_pools(region.byte_pool(), region.sample_pool()).build(),
@@ -796,7 +796,7 @@ async fn live_real_stream_seek_resume_native(#[case] path: &str, #[case] label: 
         }
 
         for (seek_idx, seek_secs) in [30.0, 60.0, 10.0].into_iter().enumerate() {
-            info!(seek_idx, seek_secs, %path, label, "seeking real stream");
+            info!(seek_idx, seek_secs, label, "seeking real stream");
             audio
                 .seek(Duration::from_secs_f64(seek_secs))
                 .expect("seek must succeed");
@@ -818,11 +818,11 @@ async fn live_real_stream_seek_resume_native(#[case] path: &str, #[case] label: 
 
             assert!(
                 resumed_chunks > 0,
-                "expected playback to resume after {label} seek #{seek_idx} to {seek_secs}s ({path})"
+                "expected playback to resume after {label} seek #{seek_idx} to {seek_secs}s"
             );
             assert!(
                 seek_applied,
-                "expected {label} seek #{seek_idx} to land near {seek_secs}s on {path}, got {:.3}s",
+                "expected {label} seek #{seek_idx} to land near {seek_secs}s, got {:.3}s",
                 audio.position().as_secs_f64()
             );
         }
@@ -839,18 +839,12 @@ async fn live_real_stream_seek_resume_native(#[case] path: &str, #[case] label: 
     hang_timeout_secs(3),
     tracing("kithara_audio=info,kithara_hls=info")
 )]
-#[case::hls_ephemeral("hls/master.m3u8", "HLS", true)]
-#[case::drm_ephemeral("drm/master.m3u8", "DRM", true)]
-#[cfg_attr(
-    not(target_arch = "wasm32"),
-    case::hls_mmap("hls/master.m3u8", "HLS", false)
-)]
-#[cfg_attr(
-    not(target_arch = "wasm32"),
-    case::drm_mmap("drm/master.m3u8", "DRM", false)
-)]
+#[case::hls_ephemeral(false, "HLS", true)]
+#[case::drm_ephemeral(true, "DRM", true)]
+#[cfg_attr(not(target_arch = "wasm32"), case::hls_mmap(false, "HLS", false))]
+#[cfg_attr(not(target_arch = "wasm32"), case::drm_mmap(true, "DRM", false))]
 async fn live_stress_real_stream_seek_read_cache(
-    #[case] path: &str,
+    #[case] encrypted: bool,
     #[case] label: &str,
     #[case] ephemeral: bool,
     temp_dir: TestTempDir,
@@ -858,7 +852,7 @@ async fn live_stress_real_stream_seek_read_cache(
 ) {
     #[cfg(target_arch = "wasm32")]
     {
-        let _ = (path, label, ephemeral, temp_dir);
+        let _ = (encrypted, label, ephemeral, temp_dir);
         info!("browser seek stress is covered by selenium/trunk tests");
         return;
     }
@@ -866,7 +860,7 @@ async fn live_stress_real_stream_seek_read_cache(
     #[cfg(not(target_arch = "wasm32"))]
     {
         let server = TestServerHelper::new().await;
-        let url = server.asset(path);
+        let url = mixed_codec_ladder_url(&server, encrypted).await;
         let region = Region::default();
         let worker = PlayWorker::new(
             PlayWorkerConfig::for_pools(region.byte_pool(), region.sample_pool()).build(),
@@ -957,7 +951,7 @@ async fn live_stress_real_stream_seek_read_cache(
             }
         });
 
-        info!(ephemeral, %path, label, "Phase 1: warmup until ABR switch");
+        info!(ephemeral, label, "Phase 1: warmup until ABR switch");
         let stats_read = Arc::clone(&stats);
         let (audio, before_revisit, after_revisit, variant_match_checks, variant_match_hits) =
             spawn_blocking(move || {
@@ -1196,11 +1190,11 @@ async fn live_stress_real_stream_seek_read_cache(
     hang_timeout_secs(3),
     tracing("kithara_audio=info,kithara_hls=info,kithara_stream=info")
 )]
-#[case::hls("hls/master.m3u8", "HLS")]
-#[case::drm("drm/master.m3u8", "DRM")]
-async fn live_ephemeral_small_cache_playback(#[case] path: &str, #[case] label: &str) {
+#[case::hls(false, "HLS")]
+#[case::drm(true, "DRM")]
+async fn live_ephemeral_small_cache_playback(#[case] encrypted: bool, #[case] label: &str) {
     let server = TestServerHelper::new().await;
-    let url = server.asset(path);
+    let url = mixed_codec_ladder_url(&server, encrypted).await;
     let region = Region::default();
     let worker = PlayWorker::new(
         PlayWorkerConfig::for_pools(region.byte_pool(), region.sample_pool()).build(),
@@ -1228,7 +1222,10 @@ async fn live_ephemeral_small_cache_playback(#[case] path: &str, #[case] label: 
     #[cfg(target_arch = "wasm32")]
     let _ = audio.preload();
 
-    info!(%path, label, "Reading audio chunks to EOF with small ephemeral cache");
+    info!(
+        label,
+        "Reading audio chunks to EOF with small ephemeral cache"
+    );
 
     #[cfg(not(target_arch = "wasm32"))]
     let chunks_read = spawn_blocking(move || {
@@ -1256,7 +1253,7 @@ async fn live_ephemeral_small_cache_playback(#[case] path: &str, #[case] label: 
 
     assert!(
         chunks_read > 100,
-        "expected substantial {label} audio output from {path}, got only {chunks_read} chunks"
+        "expected substantial {label} audio output, got only {chunks_read} chunks"
     );
     info!(chunks_read, "Ephemeral small-cache playback completed");
 }
@@ -1277,24 +1274,24 @@ async fn live_ephemeral_small_cache_playback(#[case] path: &str, #[case] label: 
     hang_timeout_secs(3),
     tracing("kithara_audio=info,kithara_hls=info,kithara_stream=info")
 )]
-#[case::hls_sw("hls/master.m3u8", "HLS", DecoderBackend::Symphonia)]
+#[case::hls_sw(false, "HLS", DecoderBackend::Symphonia)]
 #[cfg_attr(
     any(target_os = "macos", target_os = "ios"),
-    case::hls_hw("hls/master.m3u8", "HLS", DecoderBackend::Apple)
+    case::hls_hw(false, "HLS", DecoderBackend::Apple)
 )]
-#[case::drm_sw("drm/master.m3u8", "DRM", DecoderBackend::Symphonia)]
+#[case::drm_sw(true, "DRM", DecoderBackend::Symphonia)]
 #[cfg_attr(
     any(target_os = "macos", target_os = "ios"),
-    case::drm_hw("drm/master.m3u8", "DRM", DecoderBackend::Apple)
+    case::drm_hw(true, "DRM", DecoderBackend::Apple)
 )]
 async fn live_ephemeral_small_cache_seek_stress(
-    #[case] path: &str,
+    #[case] encrypted: bool,
     #[case] label: &str,
     #[case] backend: DecoderBackend,
 ) {
     #[cfg(target_arch = "wasm32")]
     {
-        let _ = (path, label, backend);
+        let _ = (encrypted, label, backend);
         info!("browser seek stress is covered by selenium/trunk tests");
         return;
     }
@@ -1302,7 +1299,7 @@ async fn live_ephemeral_small_cache_seek_stress(
     #[cfg(not(target_arch = "wasm32"))]
     {
         let server = TestServerHelper::new().await;
-        let url = server.asset(path);
+        let url = mixed_codec_ladder_url(&server, encrypted).await;
         let region = Region::default();
         let worker = PlayWorker::new(
             PlayWorkerConfig::for_pools(region.byte_pool(), region.sample_pool()).build(),
@@ -1328,7 +1325,7 @@ async fn live_ephemeral_small_cache_seek_stress(
             .block_on_underrun(true)
             .build();
         let mut audio = worker.open(config).await.expect("audio creation");
-        info!(%path, label, "Warmup: reading initial chunks");
+        info!(label, "Warmup: reading initial chunks");
         spawn_blocking(move || {
             let _ = audio.preload();
             for i in 0..Consts::browser_usize(
@@ -1381,11 +1378,11 @@ async fn live_ephemeral_small_cache_seek_stress(
 
             assert!(
                 seeks_done >= 5,
-                "expected at least 5 {label} seeks on {path}, got {seeks_done}"
+                "expected at least 5 {label} seeks, got {seeks_done}"
             );
             assert!(
                 total_chunks > 20,
-                "expected substantial {label} audio after seeks on {path}, got only \
+                "expected substantial {label} audio after seeks, got only \
                  {total_chunks} chunks"
             );
             info!(

--- a/tests/tests/kithara_hls/red_flaky_small_cache_hot_refetch.rs
+++ b/tests/tests/kithara_hls/red_flaky_small_cache_hot_refetch.rs
@@ -10,7 +10,9 @@ use kithara::{
     platform::{time::Duration, tokio::task::spawn_blocking},
     play::{PlayWorker, PlayWorkerConfig},
 };
-use kithara_integration_tests::{TestServerHelper, auto, flash_pace::virtual_pace};
+use kithara_integration_tests::{
+    HlsFixtureBuilder, TestServerHelper, auto, flash_pace::virtual_pace,
+};
 use tracing::info;
 
 struct Consts;
@@ -24,6 +26,13 @@ impl Consts {
     /// a hot-refetch livelock parks the reader forever and trips the test
     /// timeout instead.
     const DRAIN_CHUNKS: usize = 400;
+    /// The ladder the drain runs over: two variants, since the reader opens
+    /// in `auto` mode and a single one leaves it nothing to weigh, and 60 s
+    /// of media so the drain budget above runs out before the track does.
+    /// Measured: the drain ends on its 400th chunk with EOF still ahead.
+    const VARIANTS: usize = 2;
+    const SEGMENTS: usize = 20;
+    const SEGMENT_SECS: f64 = 3.0;
 }
 
 #[kithara::test(
@@ -34,7 +43,17 @@ impl Consts {
 )]
 async fn red_flaky_small_cache_hot_refetch_behind_reader() {
     let server = TestServerHelper::new().await;
-    let url = server.asset("hls/master.m3u8");
+    let created = server
+        .create_hls(
+            HlsFixtureBuilder::new()
+                .variant_count(Consts::VARIANTS)
+                .segments_per_variant(Consts::SEGMENTS)
+                .segment_duration_secs(Consts::SEGMENT_SECS)
+                .packaged_audio_aac_lc(44_100, 2),
+        )
+        .await
+        .expect("create the ladder the drain runs over");
+    let url = created.master_url();
 
     let region = Region::default();
     let worker = PlayWorker::new(

--- a/tests/tests/kithara_hls/red_leak_native_drm_seek_resume.rs
+++ b/tests/tests/kithara_hls/red_leak_native_drm_seek_resume.rs
@@ -18,13 +18,29 @@ use kithara::{
         dl::{Downloader, DownloaderConfig},
     },
 };
-use kithara_integration_tests::{TestServerHelper, auto, waits::wait_thread_count_quiesced};
+use kithara_integration_tests::{
+    HlsFixtureBuilder, TestServerHelper, auto,
+    fixture_protocol::EncryptionRequest,
+    hls_fixture::{aes128_iv, aes128_key_bytes},
+    waits::wait_thread_count_quiesced,
+};
 use tracing::info;
+use url::Url;
 
 struct Consts;
 impl Consts {
     const ITERATIONS: usize = 4;
     const SEEK_TARGETS_SECS: &'static [f64] = &[30.0, 60.0, 10.0];
+    /// Encrypted ladder the cycle runs against: two variants so `auto` ABR
+    /// has somewhere to go, and long enough that every seek target above
+    /// lands inside the track.
+    const VARIANTS: usize = 2;
+    const SEGMENTS: usize = 12;
+    const SEGMENT_SECS: f64 = 6.0;
+
+    fn media_secs() -> f64 {
+        Self::SEGMENTS as f64 * Self::SEGMENT_SECS
+    }
 }
 
 async fn next_chunk_or_timeout(audio: &mut RegisteredAudio<Stream<Hls>>, label: &str) {
@@ -54,19 +70,18 @@ async fn preload_or_timeout(audio: &mut RegisteredAudio<Stream<Hls>>, label: &st
 }
 
 async fn run_drm_seek_resume_cycle(
-    server: &TestServerHelper,
+    url: &Url,
     downloader: &Downloader,
     shared_worker: &PlayWorker,
     iter_idx: usize,
 ) {
-    let url = server.asset("drm/master.m3u8");
     let store = AssetStore::builder()
         .backend(StorageBackend::Memory)
         .pool(shared_worker.byte_pool().clone())
         .cache_capacity(NonZeroUsize::new(8).expect("nonzero"))
         .build();
 
-    let hls_config = HlsConfig::for_url(url)
+    let hls_config = HlsConfig::for_url(url.clone())
         .store(store)
         .pool(shared_worker.byte_pool().clone())
         .downloader(downloader.clone())
@@ -118,7 +133,36 @@ async fn run_drm_seek_resume_cycle(
 )]
 async fn red_leak_native_drm_seek_resume_thread_budget()
 -> Result<(), Box<dyn StdError + Send + Sync>> {
+    // A seek past the end still reports success, so nothing downstream
+    // would notice the cycle exercising the past-EOF path instead of the
+    // seek path it exists to stress. Against the captured 220 s tree the
+    // targets were inside by a wide margin; on a fixture sized here, that
+    // has to be checked.
+    assert!(
+        Consts::SEEK_TARGETS_SECS
+            .iter()
+            .all(|&target| target < Consts::media_secs()),
+        "seek targets {:?} must land inside the {} s ladder",
+        Consts::SEEK_TARGETS_SECS,
+        Consts::media_secs(),
+    );
+
     let server = TestServerHelper::new().await;
+    let created = server
+        .create_hls(
+            HlsFixtureBuilder::new()
+                .variant_count(Consts::VARIANTS)
+                .segments_per_variant(Consts::SEGMENTS)
+                .segment_duration_secs(Consts::SEGMENT_SECS)
+                .packaged_audio_aac_lc(44_100, 2)
+                .encryption(EncryptionRequest {
+                    key_hex: hex::encode(aes128_key_bytes()),
+                    iv_hex: Some(hex::encode(aes128_iv())),
+                }),
+        )
+        .await
+        .expect("create the encrypted ladder");
+    let url = created.master_url();
     let cancel = CancelToken::never();
     let region = Region::default();
     let shared_worker = PlayWorker::new(
@@ -138,13 +182,13 @@ async fn red_leak_native_drm_seek_resume_thread_budget()
         .build(),
     );
 
-    run_drm_seek_resume_cycle(&server, &downloader, &shared_worker, 0).await;
+    run_drm_seek_resume_cycle(&url, &downloader, &shared_worker, 0).await;
     let threads_baseline = wait_thread_count_quiesced(Duration::from_secs(30)).await;
 
     info!(threads_baseline, "baseline after warmup DRM seek cycle");
 
     for i in 1..=Consts::ITERATIONS {
-        run_drm_seek_resume_cycle(&server, &downloader, &shared_worker, i).await;
+        run_drm_seek_resume_cycle(&url, &downloader, &shared_worker, i).await;
         let now = wait_thread_count_quiesced(Duration::from_secs(30)).await;
         info!(
             iter = i,

--- a/tests/tests/kithara_hls/stress_seek_abr.rs
+++ b/tests/tests/kithara_hls/stress_seek_abr.rs
@@ -14,11 +14,9 @@ use kithara::{
     stream::Stream,
 };
 use kithara_integration_tests::{
-    TestServerHelper, TestTempDir, abr_fast, auto, mixed_codec_ladder,
-    mixed_codec_ladder_encrypted, temp_dir,
+    TestServerHelper, TestTempDir, abr_fast, auto, mixed_codec_ladder_url, temp_dir,
 };
 use tracing::info;
-use url::Url;
 
 fn warmup_until_first_frame(audio: &mut RegisteredAudio<Stream<Hls>>, buf: &mut [f32]) -> u64 {
     let mut warmup_samples = 0u64;
@@ -78,23 +76,6 @@ fn run_rapid_random_seeks(audio: &mut RegisteredAudio<Stream<Hls>>, buf: &mut [f
     stats
 }
 
-/// The ladder both tests below open: the production-shaped 3 AAC + 1 FLAC
-/// spread, plain or AES-128. The FLAC variant is the far side of the codec
-/// boundary these tests exist to cross, and the length is what makes the
-/// deepest seek position above land inside the track.
-async fn ladder_url(server: &TestServerHelper, encrypted: bool) -> Url {
-    let ladder = if encrypted {
-        mixed_codec_ladder_encrypted()
-    } else {
-        mixed_codec_ladder()
-    };
-    server
-        .create_hls(ladder)
-        .await
-        .expect("create the ladder the seek stress runs over")
-        .master_url()
-}
-
 /// Stress test: 20 seconds of rapid seeking after ABR switch.
 ///
 /// Reproduces production bug: after ABR switch (V0 AAC → V3 FLAC),
@@ -116,7 +97,7 @@ async fn stress_seek_during_abr_switch_real_decoder(
     _abr_fast: kithara::abr::AbrSettings,
 ) {
     let server = TestServerHelper::new().await;
-    let url = ladder_url(&server, encrypted).await;
+    let url = mixed_codec_ladder_url(&server, encrypted).await;
     info!(label, %url, "Opening generated stream");
 
     let region = Region::default();
@@ -221,7 +202,7 @@ async fn seek_sequence_from_log_real_stream(
     _abr_fast: kithara::abr::AbrSettings,
 ) {
     let server = TestServerHelper::new().await;
-    let url = ladder_url(&server, encrypted).await;
+    let url = mixed_codec_ladder_url(&server, encrypted).await;
     let region = Region::default();
     let worker = PlayWorker::new(
         PlayWorkerConfig::for_pools(region.byte_pool(), region.sample_pool()).build(),

--- a/tests/tests/kithara_hls/stress_seek_abr.rs
+++ b/tests/tests/kithara_hls/stress_seek_abr.rs
@@ -13,8 +13,12 @@ use kithara::{
     play::{PlayWorker, PlayWorkerConfig, RegisteredAudio},
     stream::Stream,
 };
-use kithara_integration_tests::{TestServerHelper, TestTempDir, abr_fast, auto, temp_dir};
+use kithara_integration_tests::{
+    TestServerHelper, TestTempDir, abr_fast, auto, mixed_codec_ladder,
+    mixed_codec_ladder_encrypted, temp_dir,
+};
 use tracing::info;
+use url::Url;
 
 fn warmup_until_first_frame(audio: &mut RegisteredAudio<Stream<Hls>>, buf: &mut [f32]) -> u64 {
     let mut warmup_samples = 0u64;
@@ -74,6 +78,23 @@ fn run_rapid_random_seeks(audio: &mut RegisteredAudio<Stream<Hls>>, buf: &mut [f
     stats
 }
 
+/// The ladder both tests below open: the production-shaped 3 AAC + 1 FLAC
+/// spread, plain or AES-128. The FLAC variant is the far side of the codec
+/// boundary these tests exist to cross, and the length is what makes the
+/// deepest seek position above land inside the track.
+async fn ladder_url(server: &TestServerHelper, encrypted: bool) -> Url {
+    let ladder = if encrypted {
+        mixed_codec_ladder_encrypted()
+    } else {
+        mixed_codec_ladder()
+    };
+    server
+        .create_hls(ladder)
+        .await
+        .expect("create the ladder the seek stress runs over")
+        .master_url()
+}
+
 /// Stress test: 20 seconds of rapid seeking after ABR switch.
 ///
 /// Reproduces production bug: after ABR switch (V0 AAC → V3 FLAC),
@@ -86,17 +107,17 @@ fn run_rapid_random_seeks(audio: &mut RegisteredAudio<Stream<Hls>>, buf: &mut [f
     timeout(Duration::from_secs(120)),
     hang_timeout_secs(3)
 )]
-#[case::hls("hls/master.m3u8", "HLS")]
-#[case::drm("drm/master.m3u8", "DRM")]
+#[case::hls(false, "HLS")]
+#[case::drm(true, "DRM")]
 async fn stress_seek_during_abr_switch_real_decoder(
     temp_dir: TestTempDir,
-    #[case] path: &str,
+    #[case] encrypted: bool,
     #[case] label: &str,
     _abr_fast: kithara::abr::AbrSettings,
 ) {
     let server = TestServerHelper::new().await;
-    let url = server.asset(path);
-    info!(label, path, "Opening real stream");
+    let url = ladder_url(&server, encrypted).await;
+    info!(label, %url, "Opening generated stream");
 
     let region = Region::default();
     let worker = PlayWorker::new(
@@ -175,7 +196,7 @@ async fn stress_seek_during_abr_switch_real_decoder(
     .await;
 
     match result {
-        Ok(()) => info!(label, path, "Stress test passed"),
+        Ok(()) => info!(label, "Stress test passed"),
         Err(e) => panic!("spawn_blocking failed: {e}"),
     }
 }
@@ -191,16 +212,16 @@ async fn stress_seek_during_abr_switch_real_decoder(
     timeout(Duration::from_secs(120)),
     hang_timeout_secs(5)
 )]
-#[case::hls("hls/master.m3u8", "HLS")]
-#[case::drm("drm/master.m3u8", "DRM")]
+#[case::hls(false, "HLS")]
+#[case::drm(true, "DRM")]
 async fn seek_sequence_from_log_real_stream(
     temp_dir: TestTempDir,
-    #[case] path: &str,
+    #[case] encrypted: bool,
     #[case] label: &str,
     _abr_fast: kithara::abr::AbrSettings,
 ) {
     let server = TestServerHelper::new().await;
-    let url = server.asset(path);
+    let url = ladder_url(&server, encrypted).await;
     let region = Region::default();
     let worker = PlayWorker::new(
         PlayWorkerConfig::for_pools(region.byte_pool(), region.sample_pool()).build(),
@@ -257,7 +278,7 @@ async fn seek_sequence_from_log_real_stream(
     .await;
 
     match result {
-        Ok(()) => info!(label, path, "seek_sequence_from_log_real_stream passed"),
+        Ok(()) => info!(label, "seek_sequence_from_log_real_stream passed"),
         Err(e) => panic!("spawn_blocking failed: {e}"),
     }
 }

--- a/tests/tests/kithara_play/hls_seek_middle_stress_long.rs
+++ b/tests/tests/kithara_play/hls_seek_middle_stress_long.rs
@@ -21,7 +21,7 @@ use kithara::{
     stream::dl::{Downloader, DownloaderConfig},
 };
 use kithara_integration_tests::{
-    PackagedTestServer, SegmentGateHandle, TestServerHelper, Xorshift64,
+    HlsFixtureBuilder, PackagedTestServer, SegmentGateHandle, TestServerHelper, Xorshift64,
     offline::{OfflinePlayer, OfflineSession},
     temp_dir,
     waits::{
@@ -58,6 +58,12 @@ impl Consts {
     const SEEK_STOP_MARGIN: Duration = Duration::from_secs(5);
     const SEEK_MIN_SECONDS: f64 = 6.0;
     const SEEK_MAX_SECONDS: f64 = 160.0;
+    /// The ladder the seek stress runs over. One variant, because the config
+    /// below locks variant 0, and long enough to outlast `SEEK_MAX_SECONDS` -
+    /// every seek target has to be readable, so a shorter ladder would turn
+    /// the stress into a walk off the end.
+    const LADDER_SEGMENTS: usize = 28;
+    const LADDER_SEGMENT_SECS: f64 = 6.0;
     const MIN_RATE_CHANGES: usize = 3_000;
     const MIN_SEEKS: usize = 40;
     const MIN_OBSERVATIONS_PER_SEEK: usize = 4;
@@ -388,8 +394,26 @@ async fn hls_rate_seek_stress_keeps_playback_live(#[case] backend: DecoderBacken
     #[cfg(any(target_os = "macos", target_os = "ios"))]
     kithara_integration_tests::apple_warmup::warm_if_apple(backend);
 
+    let ladder_secs = Consts::LADDER_SEGMENTS as f64 * Consts::LADDER_SEGMENT_SECS;
+    assert!(
+        Consts::SEEK_MAX_SECONDS < ladder_secs,
+        "seek targets reach {} s but the ladder is only {ladder_secs} s",
+        Consts::SEEK_MAX_SECONDS,
+    );
+
     let server = TestServerHelper::new().await;
-    let master = server.asset("hls/master.m3u8");
+    let created = server
+        .create_hls(
+            HlsFixtureBuilder::new()
+                .variant_count(1)
+                .segments_per_variant(Consts::LADDER_SEGMENTS)
+                .segment_duration_secs(Consts::LADDER_SEGMENT_SECS)
+                .variant_bandwidths(vec![128_000])
+                .packaged_audio_aac_lc(44_100, 2),
+        )
+        .await
+        .expect("create the ladder the seek stress runs over");
+    let master = created.master_url();
     let temp = temp_dir();
     let shutdown = CancelScope::new(None);
     let shutdown_token = shutdown.token();

--- a/tests/tests/kithara_play/no_sync_real_media.rs
+++ b/tests/tests/kithara_play/no_sync_real_media.rs
@@ -26,14 +26,16 @@ use kithara::{
     warp::{StretchControls, StretchKind},
 };
 use kithara_integration_tests::{
-    TestServerHelper, TestTempDir, audio_artifact::write_audio_artifact, cochlea::CochleaReport,
-    memory_asset_store, offline::OfflineSession,
+    HlsFixtureBuilder, TestServerHelper, TestTempDir, audio_artifact::write_audio_artifact,
+    cochlea::CochleaReport, fixture_protocol::PackagedSignal, memory_asset_store,
+    offline::OfflineSession,
 };
 use kithara_test_fixtures::{SignalAsset, assets::by_name};
 use oracle::{AudioLevelReport, AudioRole, MatchedMixReport, SampleContinuityReport};
 use reference::capture_references;
 use runtime::{Deck, DeckObservation, EventPolicy};
 use serde::Serialize;
+use url::Url;
 
 const CHANNELS: u16 = 2;
 const SOURCE_RATE: u32 = 44_100;
@@ -54,6 +56,10 @@ const EXACT_ZERO_RUN_LIMIT_FRAMES: usize = 8;
 const MIN_BOUNDARY_JUMP: f32 = 0.05;
 const BOUNDARY_OUTLIER_RATIO: f32 = 6.0;
 const PRELOAD_TIMEOUT: Duration = Duration::from_secs(30);
+const HLS_LADDER_SEGMENTS: usize = 12;
+const HLS_LADDER_SEGMENT_SECS: f64 = 4.0;
+const HLS_SWEEP_START_HZ: f64 = 1_000.0;
+const HLS_SWEEP_END_HZ: f64 = 5_000.0;
 
 #[derive(Clone, Copy)]
 enum Media {
@@ -65,7 +71,7 @@ impl Media {
     const fn label(self) -> &'static str {
         match self {
             Self::Mp3(asset) => asset.name(),
-            Self::Hls => "hls/master.m3u8",
+            Self::Hls => "hls-sweep",
         }
     }
 }
@@ -190,12 +196,58 @@ async fn record_no_sync_real_media_artifacts() {
     run_real_media_matrix(true).await;
 }
 
+/// The one body every HLS deck reads.
+///
+/// It sweeps instead of holding a tone because `HLS_MP3_FOUR` puts two decks
+/// in this body `CAPTURE_START_STEP_SECS` apart, and the mix oracle solves a
+/// least-squares system over the deck stems: two windows of the same steady
+/// tone are near-collinear and leave that system singular. The sweep runs
+/// continuously across segments, so the two windows land in different bands,
+/// and its range clears the 440 Hz and 880 Hz tones the MP3 decks carry.
+async fn hls_ladder_url(server: &TestServerHelper) -> Url {
+    let deepest_capture = CAPTURE_START_SECS
+        + (CASES
+            .iter()
+            .map(|case| case.media.len())
+            .max()
+            .expect("the matrix has cases") as f64
+            - 1.0)
+            * CAPTURE_START_STEP_SECS
+        + f64::from(CAPTURE_SECS);
+    let ladder_secs = HLS_LADDER_SEGMENTS as f64 * HLS_LADDER_SEGMENT_SECS;
+    assert!(
+        ladder_secs > deepest_capture,
+        "the last deck captures through {deepest_capture} s but the ladder is only {ladder_secs} s",
+    );
+
+    server
+        .create_hls(
+            HlsFixtureBuilder::new()
+                .variant_count(1)
+                .segments_per_variant(HLS_LADDER_SEGMENTS)
+                .segment_duration_secs(HLS_LADDER_SEGMENT_SECS)
+                .variant_bandwidths(vec![128_000])
+                .packaged_audio_signal_aac_lc(
+                    SOURCE_RATE,
+                    CHANNELS,
+                    PackagedSignal::Sweep {
+                        start_hz: HLS_SWEEP_START_HZ,
+                        end_hz: HLS_SWEEP_END_HZ,
+                    },
+                ),
+        )
+        .await
+        .expect("create the ladder the HLS decks read")
+        .master_url()
+}
+
 async fn run_real_media_matrix(record_artifacts: bool) {
     let server = TestServerHelper::new().await;
+    let hls = hls_ladder_url(&server).await;
     let mut failures = Vec::new();
     for case in CASES {
         failures.extend(
-            run_case(case, &server, record_artifacts)
+            run_case(case, &hls, record_artifacts)
                 .await
                 .into_iter()
                 .map(|failure| format!("{}: {failure}", case.label)),
@@ -208,14 +260,14 @@ async fn run_real_media_matrix(record_artifacts: bool) {
     );
 }
 
-async fn run_case(case: &Case, server: &TestServerHelper, record_artifacts: bool) -> Vec<String> {
+async fn run_case(case: &Case, hls: &Url, record_artifacts: bool) -> Vec<String> {
     let session = Arc::new(OfflineSession::new_manual());
     let mut failures = Vec::new();
 
     let media_dir = TestTempDir::new();
     let mut decks = Vec::with_capacity(case.media.len());
     for (deck_index, media) in case.media.iter().copied().enumerate() {
-        decks.push(prepare_deck(case, deck_index, media, server, &media_dir, &session).await);
+        decks.push(prepare_deck(case, deck_index, media, hls, &media_dir, &session).await);
     }
 
     load_decks(case, &decks, &mut failures);
@@ -799,7 +851,7 @@ async fn prepare_deck(
     case: &Case,
     deck_index: usize,
     media: Media,
-    server: &TestServerHelper,
+    hls: &Url,
     media_dir: &TestTempDir,
     session: &Arc<OfflineSession>,
 ) -> Deck {
@@ -828,7 +880,7 @@ async fn prepare_deck(
             .to_str()
             .expect("temporary media path is UTF-8")
             .to_owned(),
-        Media::Hls => server.asset("hls/master.m3u8").to_string(),
+        Media::Hls => hls.to_string(),
     };
     let playback_config =
         ResourceConfig::for_src(ResourceConfig::parse_src(&src).unwrap_or_else(|error| {

--- a/tests/tests/kithara_queue/packaged_drm_seek.rs
+++ b/tests/tests/kithara_queue/packaged_drm_seek.rs
@@ -72,8 +72,24 @@ async fn wait_for_status(
     Err(format!("timeout waiting for {target:?}"))
 }
 
-/// Local mirror of the `track_plays_end_to_end` e2e seek scenario against
-/// `assets/drm` (byte-identical to the silvercomet `/drm/` stream): load →
+/// The encrypted ladder both runners below load: three AES-128 AAC variants,
+/// because the cases lock variant 2, over 37 × 6 s. Both runners build it
+/// from here so the only axis between the three tests is the CDN delay and
+/// the clock.
+fn encrypted_ladder() -> HlsFixtureBuilder {
+    HlsFixtureBuilder::new()
+        .variant_count(3)
+        .segments_per_variant(37)
+        .segment_duration_secs(6.0)
+        .variant_bandwidths(vec![66_005, 134_107, 269_930])
+        .packaged_audio_aac_lc(44_100, 2)
+        .encryption(EncryptionRequest {
+            key_hex: hex::encode(aes128_key_bytes()),
+            iv_hex: Some(hex::encode(aes128_iv())),
+        })
+}
+
+/// Local mirror of the `track_plays_end_to_end` e2e seek scenario: load →
 /// play past 0.5s → three seed-42 seeks, each of which must land near the
 /// target AND resume audible progress — the exact sequence that hung on
 /// the real CDN with `AbrMode::manual(2)`.
@@ -86,20 +102,23 @@ async fn wait_for_status(
 /// reproduce the production stall — that needs a mid-body network stall,
 /// pinned separately by `playlist_stall_fails_load` and the kithara-net
 /// `*_when_body_stalls` tests. This mirror pins the healthy-path contract
-/// on identical data across decoder/ABR-mode axes.
+/// across decoder/ABR-mode axes.
 async fn run_drm_seek(backend: DecoderBackend, abr: AbrMode, temp: TestTempDir) {
     install_tracing();
 
     let helper = TestServerHelper::new().await;
-    let url = helper.asset("drm/master.m3u8");
+    let created = helper
+        .create_hls(encrypted_ladder())
+        .await
+        .expect("create encrypted HLS fixture");
+    let url = created.master_url();
     run_seek_scenario(&url, backend, abr, temp).await;
 }
 
-/// Same scenario against a generated encrypted fixture mirroring the
-/// `assets/drm` geometry (37 × 6s segments, AES-128, 3 AAC variants) with a
-/// per-segment fetch delay modelling CDN RTT. The delay is engine-backed
-/// (virtual) under flash, so the "seek target segment is not yet available"
-/// window the real CDN opens is reproduced deterministically.
+/// Same scenario on the same ladder plus a per-segment fetch delay modelling
+/// CDN RTT. The delay is engine-backed (virtual) under flash, so the "seek
+/// target segment is not yet available" window the real CDN opens is
+/// reproduced deterministically.
 async fn run_delayed_drm_seek(
     backend: DecoderBackend,
     abr: AbrMode,
@@ -109,22 +128,11 @@ async fn run_delayed_drm_seek(
     install_tracing();
 
     let helper = TestServerHelper::new().await;
-    let builder = HlsFixtureBuilder::new()
-        .variant_count(3)
-        .segments_per_variant(37)
-        .segment_duration_secs(6.0)
-        .variant_bandwidths(vec![66_005, 134_107, 269_930])
-        .packaged_audio_aac_lc(44_100, 2)
-        .encryption(EncryptionRequest {
-            key_hex: hex::encode(aes128_key_bytes()),
-            iv_hex: Some(hex::encode(aes128_iv())),
-        })
-        .push_delay_rule(DelayRule {
+    let created = helper
+        .create_hls(encrypted_ladder().push_delay_rule(DelayRule {
             delay_ms,
             ..DelayRule::default()
-        });
-    let created = helper
-        .create_hls(builder)
+        }))
         .await
         .expect("create delayed encrypted HLS fixture");
     let url = created.master_url();

--- a/tests/tests/kithara_queue/packaged_drm_seek.rs
+++ b/tests/tests/kithara_queue/packaged_drm_seek.rs
@@ -18,10 +18,9 @@ use kithara::{
 };
 use kithara_app::{baked, config::AppConfig};
 use kithara_integration_tests::{
-    HlsFixtureBuilder, TestServerHelper, TestTempDir, Xorshift64,
-    fixture_protocol::{DelayRule, EncryptionRequest},
-    hls_fixture::{aes128_iv, aes128_key_bytes},
-    kithara,
+    TestServerHelper, TestTempDir, Xorshift64,
+    fixture_protocol::DelayRule,
+    kithara, mixed_codec_ladder_encrypted,
     offline::OfflineSession,
     temp_dir,
     waits::{wait_for_position_at_least, wait_for_position_near},
@@ -72,27 +71,13 @@ async fn wait_for_status(
     Err(format!("timeout waiting for {target:?}"))
 }
 
-/// The encrypted ladder both runners below load: three AES-128 AAC variants,
-/// because the cases lock variant 2, over 37 × 6 s. Both runners build it
-/// from here so the only axis between the three tests is the CDN delay and
-/// the clock.
-fn encrypted_ladder() -> HlsFixtureBuilder {
-    HlsFixtureBuilder::new()
-        .variant_count(3)
-        .segments_per_variant(37)
-        .segment_duration_secs(6.0)
-        .variant_bandwidths(vec![66_005, 134_107, 269_930])
-        .packaged_audio_aac_lc(44_100, 2)
-        .encryption(EncryptionRequest {
-            key_hex: hex::encode(aes128_key_bytes()),
-            iv_hex: Some(hex::encode(aes128_iv())),
-        })
-}
-
 /// Local mirror of the `track_plays_end_to_end` e2e seek scenario: load →
 /// play past 0.5s → three seed-42 seeks, each of which must land near the
 /// target AND resume audible progress — the exact sequence that hung on
 /// the real CDN with `AbrMode::manual(2)`.
+///
+/// Variant 2 is the top AAC of the production ladder, not its top variant:
+/// above it sits the FLAC one, which only the auto cases climb to.
 ///
 /// Track construction goes through `app_track_source`, the suite's mirror
 /// of the `kithara-app` `build_source` path used by the e2e (same shared
@@ -108,7 +93,7 @@ async fn run_drm_seek(backend: DecoderBackend, abr: AbrMode, temp: TestTempDir) 
 
     let helper = TestServerHelper::new().await;
     let created = helper
-        .create_hls(encrypted_ladder())
+        .create_hls(mixed_codec_ladder_encrypted())
         .await
         .expect("create encrypted HLS fixture");
     let url = created.master_url();
@@ -129,7 +114,7 @@ async fn run_delayed_drm_seek(
 
     let helper = TestServerHelper::new().await;
     let created = helper
-        .create_hls(encrypted_ladder().push_delay_rule(DelayRule {
+        .create_hls(mixed_codec_ladder_encrypted().push_delay_rule(DelayRule {
             delay_ms,
             ..DelayRule::default()
         }))

--- a/tests/tests/thread_budget.rs
+++ b/tests/tests/thread_budget.rs
@@ -13,7 +13,7 @@ use kithara::{
     play::{PlayWorker, PlayWorkerConfig},
 };
 use kithara_integration_tests::{
-    TestServerHelper, TestTempDir, kithara, temp_dir, waits::wait_thread_count_quiesced,
+    PackagedTestServer, TestTempDir, kithara, temp_dir, waits::wait_thread_count_quiesced,
 };
 use tracing::info;
 
@@ -78,7 +78,7 @@ fn thread_budget_audio_worker_is_one_thread() {
     hang_timeout_secs(3)
 )]
 async fn thread_budget_single_hls_pipeline(temp_dir: TestTempDir) {
-    let server = TestServerHelper::new().await;
+    let server = PackagedTestServer::new().await;
     let cancel = CancelToken::never();
 
     let before = active_named_thread_count();
@@ -91,7 +91,7 @@ async fn thread_budget_single_hls_pipeline(temp_dir: TestTempDir) {
         })
         .pool(byte_pool.clone())
         .build();
-    let hls_config = HlsConfig::for_url(server.asset("hls/master.m3u8"))
+    let hls_config = HlsConfig::for_url(server.url("/master.m3u8"))
         .store(store)
         .pool(byte_pool.clone())
         .cancel(cancel.clone())
@@ -132,7 +132,7 @@ async fn thread_budget_single_hls_pipeline(temp_dir: TestTempDir) {
     hang_timeout_secs(3)
 )]
 async fn thread_budget_three_tracks_shared_worker(temp_dir: TestTempDir) {
-    let server = TestServerHelper::new().await;
+    let server = PackagedTestServer::new().await;
     let cancel = CancelToken::never();
     let region = Region::default();
     let shared_worker = PlayWorker::new(
@@ -153,7 +153,7 @@ async fn thread_budget_three_tracks_shared_worker(temp_dir: TestTempDir) {
         .flush_hub(shared_hub.clone())
         .build();
 
-    let hls_config = HlsConfig::for_url(server.asset("hls/master.m3u8"))
+    let hls_config = HlsConfig::for_url(server.url("/master.m3u8"))
         .store(shared_store.clone())
         .pool(region.byte_pool())
         .cancel(cancel.clone())
@@ -165,7 +165,7 @@ async fn thread_budget_three_tracks_shared_worker(temp_dir: TestTempDir) {
         .await
         .expect("open first shared-worker track");
 
-    let hls_config2 = HlsConfig::for_url(server.asset("hls/master.m3u8"))
+    let hls_config2 = HlsConfig::for_url(server.url("/master.m3u8"))
         .store(shared_store.clone())
         .pool(region.byte_pool())
         .cancel(cancel.clone())
@@ -177,7 +177,7 @@ async fn thread_budget_three_tracks_shared_worker(temp_dir: TestTempDir) {
         .await
         .expect("open second shared-worker track");
 
-    let drm_config = HlsConfig::for_url(server.asset("drm/master.m3u8"))
+    let drm_config = HlsConfig::for_url(server.url("/master-encrypted.m3u8"))
         .store(shared_store)
         .pool(region.byte_pool())
         .cancel(cancel.clone())


### PR DESCRIPTION
## Summary

The HLS and DRM suites used to read a captured production tree checked into
`assets/hls` and `assets/drm`. Those bytes are a third-party packager's output,
and nothing in the suites was actually checking them for that: every suite site
reads the tree for its **geometry** — how many variants, what bandwidths, how
long a segment is, where the codec boundary sits — and then asserts about ABR,
seeking, caching, or memory. The repository already half-admitted this;
`packaged_drm_seek` ran a generated ladder next to the captured one and never
noticed a difference.

This branch moves every remaining suite site onto ladders the existing HLS
fixture generator builds at run time. They all share one shape,
`mixed_codec_ladder()`, which mirrors the production master rather than
inventing a new one: four variants at 66005/134107/269930/988758 bps, 37
segments of 6.0 s, the top variant FLAC and the rest AAC-LC. The DRM axis is a
flag on the same shape — `mixed_codec_ladder_encrypted()` — because the two
captured trees differed only in whether segments were encrypted. Tests that
need a different length narrow that one shape instead of describing a fresh
ladder, so a reader compares numbers against production, not against a
neighbouring test.

Length is chosen per test by a rule worth stating, because the obvious choice is
wrong: the constraint is **the budget the test itself declares**, not the
ladder. The full ladder is 888 s of audio across four variants; encoding it cold
took 18-23 s, which does not fit inside `thread_budget`'s declared 15/20 s. Tests
with a tight `timeout(...)` therefore take a shortened ladder, and only tests
without that pressure take the full one.

Two fixes ride along. `test_hls_playback_no_rss_leak` **could not fail**: its
warmup marker sat at 5 s inside a loop that ends at EOF, and nothing paces the
reader, so the drain finished in ~2.5 s and the marker was reached only when the
machine was loaded (three consecutive runs of the same fixture: 2.53 s, 2.56 s,
4.85 s). When it was missed, `warmup_rss.unwrap_or(final_rss)` made warmup equal
final and `growth < 5 MB` held for any stream at all. The measurement is now
indexed by read rather than by wall clock, refuses to score a drain that stopped
short of EOF, and pins the settling point it depends on (RSS reaches its plateau
at read 257; the ramp is fixed startup cost and does not grow with the stream).
Injecting a 1 MiB leak every 100th read now fails the test, which it did not
before. Separately, the mix oracle's HLS decks moved to a sweep rather than a
tone: two decks sit in the same body 8 s apart, and the oracle solves a
least-squares system over deck stems, which two windows of one steady tone leave
singular.

## Behavior / scope

- contract or behavior: no product behavior changes. Test fixtures move from
  captured bytes to generated ones; one perf-lane assertion that could not fail
  now can.
- affected area: `tests/` only — the HLS, DRM, ABR, queue, play, and perf
  suites, plus the shared fixture helper in `tests/src/hls_server.rs`.

## Validation

- `just test` - 4103 passed, 104 skipped, 62.5 s
- `cargo test -p kithara-integration-tests --features perf --test memory_rss -- --test-threads=1` - 2 passed. The perf lane carries `required-features = ["perf"]`, so `just test` does not build it and it needs this direct run.
- `just lint fast` - clean, 0 regressions and 0 new across 38 checks
- Every commit landed through the pre-commit hook; none were bypassed.

## Surface impact

- Public API: none. The integration-test crate gains `mixed_codec_ladder`,
  `mixed_codec_ladder_encrypted`, and `mixed_codec_ladder_url`; no product crate
  surface changed.
- Platform/runtime: none.
- Perf-sensitive paths: none in product code. The perf-lane test `memory_rss`
  changed, and its budget assertion now measures a ladder chosen to clear the
  RSS ramp.

## Risks / follow-ups

- `assets/hls` and `assets/drm` stay in the tree. This PR only moves the suite
  sites; shrinking the captured tree to the files that still need it is separate.
- Crate unit tests in `kithara-decode` and `kithara-audio` keep reading the
  captured bytes on purpose. They check how the decoder handles a third-party
  packager's output, which is the one thing a generator cannot stand in for.
- `tests/tests/integration_regressions/offline_resume.rs` is deferred. It is the
  only site that reads segment bytes off disk and re-serves them, and it needs
  per-chunk throttling the generator does not expose yet.
- `tests/tests/kithara_ffi_web/selenium.rs` is deferred with the browser lane.
- `tests/src/test_server.rs:307` still names `assets/hls/master.m3u8` in a doc
  comment; it goes with the tree it describes.
