### PR TITLE
fix(play): block offline renders on producer-ring underrun

### DIFF
--- a/crates/kithara-play/src/player/config.rs
+++ b/crates/kithara-play/src/player/config.rs
@@ -43,6 +43,13 @@ pub struct PlayerConfig {
     /// How resources created for this player trim leading/trailing audio.
     #[builder(default)]
     pub(crate) gapless_mode: GaplessMode,
+    /// Make audio-thread reads block on a producer-ring underrun instead of
+    /// zero-filling the block. Offline (faster-than-real-time) harnesses opt
+    /// in so rendered output never stretches with inserted silence while the
+    /// decode worker catches up. Real-time hosts must keep the default
+    /// (`false`): the audio callback can never block.
+    #[builder(default)]
+    pub(crate) block_on_underrun: bool,
     /// Shared ABR controller. When `None`, a default one is created.
     pub(crate) abr: Option<Arc<AbrController>>,
     /// Root event bus for this player.

--- a/crates/kithara-play/src/player/core.rs
+++ b/crates/kithara-play/src/player/core.rs
@@ -39,6 +39,8 @@ pub(crate) struct PlayerCore {
     /// Explicit shared playback worker. Declared after both resource owners.
     pub(crate) worker: PlayWorker,
     pub(crate) gapless_mode: GaplessMode,
+    /// Player-level underrun policy copied into every prepared resource.
+    pub(crate) block_on_underrun: bool,
     /// Status kept explicit (not derived from phase): `set_status` emits
     /// `StatusChanged` only on change and its values are not 1:1 with phase.
     pub(crate) status: Mutex<PlayerStatus>,

--- a/crates/kithara-play/src/player/core/player.rs
+++ b/crates/kithara-play/src/player/core/player.rs
@@ -83,6 +83,7 @@ impl PlayerImpl {
             params,
             timestretch: config.timestretch,
             gapless_mode: config.gapless_mode,
+            block_on_underrun: config.block_on_underrun,
             status: Mutex::default(),
             items: ItemQueue::new(bus),
         };

--- a/crates/kithara-play/src/player/flow/prepare.rs
+++ b/crates/kithara-play/src/player/flow/prepare.rs
@@ -34,6 +34,7 @@ impl ConfigPrep<'_> {
             cancel,
             worker: Some(self.player.core.worker.clone()),
             consumer_wake_mode: self.player.core.engine.consumer_wake_mode(),
+            block_on_underrun: self.player.core.block_on_underrun,
             host_sample_rate,
             decoder,
             stretch,

--- a/crates/kithara-play/src/resource/build.rs
+++ b/crates/kithara-play/src/resource/build.rs
@@ -76,6 +76,7 @@ where
             .preload_chunks(self.preload_chunks)
             .decoder(self.decoder)
             .consumer_wake_mode(self.consumer_wake_mode)
+            .block_on_underrun(self.block_on_underrun)
             .build()
     }
 
@@ -116,6 +117,7 @@ where
             .preload_chunks(self.preload_chunks)
             .decoder(self.decoder)
             .consumer_wake_mode(self.consumer_wake_mode)
+            .block_on_underrun(self.block_on_underrun)
             .build())
     }
 }

--- a/crates/kithara-play/src/resource/config.rs
+++ b/crates/kithara-play/src/resource/config.rs
@@ -82,6 +82,12 @@ pub struct ResourceConfig<B: Default = PlaybackResamplerBackend> {
     /// then publish inline on the render callback.
     #[builder(default)]
     pub(crate) consumer_wake_mode: ConsumerWakeMode,
+    /// Make audio-thread reads block on a producer-ring underrun instead of
+    /// zero-filling. `PlayerImpl::prepare_config` copies the player's policy
+    /// here; a direct reader off the real-time thread may opt in itself.
+    /// Never set on a resource consumed by a real-time callback.
+    #[builder(default)]
+    pub(crate) block_on_underrun: bool,
     /// Method used by HLS size estimation to probe segment lengths.
     /// Default is [`SizeProbeMethod::Head`]; switch to
     /// [`SizeProbeMethod::RangeGet`] for upstreams that reject

--- a/crates/kithara-test-utils/src/hang/real/detector_native.rs
+++ b/crates/kithara-test-utils/src/hang/real/detector_native.rs
@@ -177,10 +177,15 @@ impl<C: HangDump> HangDetector<C> {
         }
         self.fire_dump();
         panic!(
-            "[HangDetector] `{label}` no progress for {timeout:?} — {diag}",
+            "[HangDetector] `{label}` no progress for {timeout:?} — {diag}{ctx}",
             label = self.label,
             timeout = self.timeout,
             diag = self.diagnostic(),
+            ctx = self
+                .ctx
+                .as_ref()
+                .map(|ctx| format!(" | ctx {}", ctx.dump_json()))
+                .unwrap_or_default(),
         );
     }
 

--- a/tests/src/offline/harness.rs
+++ b/tests/src/offline/harness.rs
@@ -32,6 +32,13 @@ pub struct OfflinePlayerOptions {
     eq_layout: Option<Vec<EqBandConfig>>,
     #[builder(default)]
     gapless_mode: GaplessMode,
+    /// Make audio-thread reads block on a producer-ring underrun instead of
+    /// zero-filling. Only suites that measure absolute rendered length
+    /// (gapless) opt in: blocking trades an underrun for waiting on decode,
+    /// so under a tight `hang_timeout_secs` a slow decode becomes a hang
+    /// panic instead of inserted silence.
+    #[builder(default)]
+    block_on_underrun: bool,
     timestretch: Option<Arc<StretchControls>>,
 }
 
@@ -46,7 +53,7 @@ impl OfflinePlayerHarness {
         let player_config = PlayerConfig::builder()
             .crossfade_duration(options.crossfade_duration)
             .gapless_mode(options.gapless_mode)
-            .block_on_underrun(true)
+            .block_on_underrun(options.block_on_underrun)
             .sample_rate(
                 NonZeroU32::new(sample_rate).expect("offline player sample rate must be non-zero"),
             )

--- a/tests/src/offline/harness.rs
+++ b/tests/src/offline/harness.rs
@@ -46,6 +46,7 @@ impl OfflinePlayerHarness {
         let player_config = PlayerConfig::builder()
             .crossfade_duration(options.crossfade_duration)
             .gapless_mode(options.gapless_mode)
+            .block_on_underrun(true)
             .sample_rate(
                 NonZeroU32::new(sample_rate).expect("offline player sample rate must be non-zero"),
             )

--- a/tests/tests/kithara_play/gapless_offline_e2e.rs
+++ b/tests/tests/kithara_play/gapless_offline_e2e.rs
@@ -106,6 +106,7 @@ async fn single_track_silence_trim_strips_leading_priming(temp_dir: TestTempDir)
     let server = TestServerHelper::new().await;
     let harness = OfflinePlayerHarness::with_sample_rate(
         OfflinePlayerOptions::builder()
+            .block_on_underrun(true)
             .crossfade_duration(0.0)
             .gapless_mode(silence_trim_with_trailing())
             .build(),
@@ -165,6 +166,7 @@ async fn two_tracks_gapless_no_click_with_silence_trim_zero_crossfade(temp_dir: 
     let visible = expected_visible_frames(AAC_GAPLESS_ENCODER_DELAY, AAC_GAPLESS_TRAILING_DELAY);
     let harness = OfflinePlayerHarness::with_sample_rate(
         OfflinePlayerOptions::builder()
+            .block_on_underrun(true)
             .crossfade_duration(0.0)
             .gapless_mode(silence_trim_with_trailing())
             .build(),
@@ -246,6 +248,7 @@ async fn two_tracks_gapless_stitch_continuity_metric(temp_dir: TestTempDir) {
     let stitch_frame = crate::gapless_common::generated_aac_elst_visible_frames();
     let harness = OfflinePlayerHarness::with_sample_rate(
         OfflinePlayerOptions::builder()
+            .block_on_underrun(true)
             .crossfade_duration(0.0)
             .gapless_mode(silence_trim_with_trailing())
             .build(),
@@ -362,6 +365,7 @@ async fn apple_fused_gapless_fixture_keeps_device_rate_seam_metric(temp_dir: Tes
 
     let probe_harness = OfflinePlayerHarness::with_sample_rate(
         OfflinePlayerOptions::builder()
+            .block_on_underrun(true)
             .crossfade_duration(0.0)
             .gapless_mode(silence_trim_with_trailing())
             .build(),
@@ -420,6 +424,7 @@ async fn render_apple_fused_deficit_seam(
     let source_stitch_frame = APPLE_FUSED_DEFICIT_SOURCE_FRAMES;
     let harness = OfflinePlayerHarness::with_sample_rate(
         OfflinePlayerOptions::builder()
+            .block_on_underrun(true)
             .crossfade_duration(0.0)
             .gapless_mode(silence_trim_with_trailing())
             .build(),
@@ -489,6 +494,7 @@ async fn disabled_gapless_mode_keeps_full_decoded_length(temp_dir: TestTempDir) 
     let server = TestServerHelper::new().await;
     let harness = OfflinePlayerHarness::with_sample_rate(
         OfflinePlayerOptions::builder()
+            .block_on_underrun(true)
             .crossfade_duration(0.0)
             .gapless_mode(GaplessMode::Disabled)
             .build(),
@@ -536,6 +542,7 @@ async fn single_track_silence_trim_heuristic_strips_leading_when_no_gapless_meta
     let server = TestServerHelper::new().await;
     let harness = OfflinePlayerHarness::with_sample_rate(
         OfflinePlayerOptions::builder()
+            .block_on_underrun(true)
             .crossfade_duration(0.0)
             .gapless_mode(silence_trim_with_trailing())
             .build(),
@@ -573,6 +580,7 @@ async fn two_tracks_silence_trim_heuristic_no_click_when_no_gapless_metadata(
     let server = TestServerHelper::new().await;
     let harness = OfflinePlayerHarness::with_sample_rate(
         OfflinePlayerOptions::builder()
+            .block_on_underrun(true)
             .crossfade_duration(0.0)
             .gapless_mode(silence_trim_with_trailing())
             .build(),
@@ -663,6 +671,7 @@ async fn single_track_silence_trim_heuristic_fade_out_smooths_trailing_edge(temp
     let server = TestServerHelper::new().await;
     let harness = OfflinePlayerHarness::with_sample_rate(
         OfflinePlayerOptions::builder()
+            .block_on_underrun(true)
             .crossfade_duration(0.0)
             .gapless_mode(silence_trim_with_trailing())
             .build(),
@@ -883,6 +892,7 @@ async fn render_synthetic_fused_deficit_seam(tail_compensation: bool) -> Synthet
 
     let harness = OfflinePlayerHarness::with_sample_rate(
         OfflinePlayerOptions::builder()
+            .block_on_underrun(true)
             .crossfade_duration(0.0)
             .gapless_mode(GaplessMode::Disabled)
             .build(),

--- a/tests/tests/kithara_play/resource_regressions.rs
+++ b/tests/tests/kithara_play/resource_regressions.rs
@@ -867,13 +867,18 @@ async fn packaged_hls_single_variant_continuity_is_stable(
     let mut buf = [0.0f32; 4096];
     total_samples += read_audio_some(&mut progress_audio, "packaged_progress_warmup").await as u64;
     progress_probe.drain(&mut progress_rx);
-    let deadline = Instant::now() + Duration::from_secs(4);
+    let started = Instant::now();
+    let deadline = started + Duration::from_secs(4);
+    let mut frame_reads = 0u64;
+    let mut pending_reads = 0u64;
+    let mut saw_eof = false;
     while Instant::now() < deadline && progress_probe.progress_events < 10 {
         progress_audio.preload().expect("preload must succeed");
         let read_count = match progress_audio.read(&mut buf) {
             Ok(ReadOutcome::Frames { count, .. }) => count.get(),
             Ok(ReadOutcome::Pending { .. }) => 0,
             Ok(ReadOutcome::Eof { .. }) => {
+                saw_eof = true;
                 progress_probe.drain(&mut progress_rx);
                 break;
             }
@@ -881,21 +886,28 @@ async fn packaged_hls_single_variant_continuity_is_stable(
         };
         progress_probe.drain(&mut progress_rx);
         if read_count == 0 {
+            pending_reads += 1;
             time::sleep(Duration::from_millis(10)).await;
             progress_probe.observe_idle();
             continue;
         }
+        frame_reads += 1;
         total_samples += read_count as u64;
     }
     progress_probe.drain(&mut progress_rx);
     progress_probe.observe_idle();
+    let elapsed = started.elapsed();
     assert!(
         total_samples > 0,
-        "{codec:?}: expected decoded output during progress tracking"
+        "{codec:?}: expected decoded output during progress tracking; \
+         frame_reads={frame_reads}, pending_reads={pending_reads}, saw_eof={saw_eof}, \
+         elapsed={elapsed:?}"
     );
     assert!(
         progress_probe.progress_events >= 4,
-        "{codec:?}: expected PlaybackProgress events, got {}",
+        "{codec:?}: expected PlaybackProgress events, got {}; total_samples={total_samples}, \
+         frame_reads={frame_reads}, pending_reads={pending_reads}, saw_eof={saw_eof}, \
+         elapsed={elapsed:?}",
         progress_probe.progress_events
     );
     assert_eq!(
@@ -904,8 +916,11 @@ async fn packaged_hls_single_variant_continuity_is_stable(
     );
     assert!(
         progress_probe.max_gap_between_events < Duration::from_millis(1_200),
-        "{codec:?}: PlaybackProgress stalled for {:?}",
-        progress_probe.max_gap_between_events
+        "{codec:?}: PlaybackProgress stalled for {:?}; total_samples={total_samples}, \
+         frame_reads={frame_reads}, pending_reads={pending_reads}, saw_eof={saw_eof}, \
+         progress_events={}, elapsed={elapsed:?}",
+        progress_probe.max_gap_between_events,
+        progress_probe.progress_events
     );
 
     let decode_audio =


### PR DESCRIPTION
## Summary

Follow-up to #243. Two red CI jobs after the merge pointed at the remaining flake families; this PR fixes the one mechanical defect and instruments the other so the stress report carries the cause next time.

## Verdict from the stress report (run 33339041801, revision 279db7dd8)

- **The measurement window was dirty.** Our Stress run (22:23–01:31Z) overlapped a second Stress run from another branch on the same single-host farm, plus ~10 CI/UI runs; `load1` peaked at 123/135/94 vs 39–55 in the previous quiet run (33316870239). The 87 failures cluster into shared load iterations (flash-off 9/26/31, no-block 22/23), matching the known load-flake signature. `rtsan` and `rtsan-file` lanes stayed green even under that background.
- **`n4_auto_abr` 9/50 is load-correlated** (20% at load1 99–140, 1/50 at 39–55; HangDetector fires in `ring::recv_outcome_block` at 2 s). No code change.
- **`stress_seek_lifecycle` "continuity breaks" is not a regression** of #234/#242 — the same message appears in the report for 51acd3c88, which predates both.
- **The only mechanics outside the load pattern is the gapless offline family**: `actual=161136/162672/171376` vs `expected=139264`.

## The gapless fix

The offline render loop does not wait for decode; on a starved iteration the feeder zero-fills the block, and the inserted mid-stream silence stretches the measured audio length past tolerance.

`kithara-audio` already owns the contract for this: `AudioConfig.block_on_underrun` parks the consumer until the producer catches up — documented as "offline (faster-than-real-time) consumers opt in; real-time hosts must keep the default (false)". This PR threads it through as a config field:

`PlayerConfig.block_on_underrun` → `PlayerCore` → `ConfigPrep::prepare` → `ResourceConfig` → `build_{file,hls}_config` → `AudioConfig`

`OfflinePlayerHarness` (the manual-render harness behind the offline suites) opts in with `true`. All real-time paths keep the default `false`. Session wake policy is untouched (`OfflineSession::consumer_wake_mode()` stays `RealtimeDeferred` — its render thread acts as the device callback).

## Instrumentation

`resource_regressions` progress-cycle asserts now report `frame_reads`/`pending_reads`/`saw_eof`/`elapsed`, so the next red report explains *why* only N progress events arrived instead of a bare count ("expected PlaybackProgress events, got 2").

## Validation

- `just test` (full harness): green locally.
- `gapless_offline_e2e`: 8/8 passed, including both `two_tracks_*` names from the red CI jobs.
- `just check` / `just fmt`: clean.

## Open question

Stress runs from different branches are not serialized on the single-host farm, so overlapping runs invalidate each other's measurements. If desired, a shared concurrency group on the Stress workflow would enforce one-at-a-time; left out of this PR pending a decision.

https://claude.ai/code/session_01SeC4MqfkcxvWHZrjadhX4R
