### PR TITLE
fix(tests): route prod_network at the module suite_network declares

### DIFF
--- a/tests/tests/kithara_queue/user_simulation/prod_network.rs
+++ b/tests/tests/kithara_queue/user_simulation/prod_network.rs
@@ -49,10 +49,10 @@ const PROD_DRM_TRACK_ALT: &str = "https://cdn-hls-slicer.zvuk.com/drm/track/5807
 /// the binary uses. The resolver picks up baked credentials and the
 /// `zvuk-prod` keyserver provider.
 fn prod_drm_spec(url: &str, ctx: &ProdCtx) -> TrackSource<AppPools> {
-    crate::kithara::queue::app_track_source(
+    crate::kithara_queue::app_track_source(
         url,
         &ctx.config,
-        crate::kithara::queue::app_disk_asset_store(&ctx.config, ctx.cache.path()),
+        crate::kithara_queue::app_disk_asset_store(&ctx.config, ctx.cache.path()),
         DecoderBackend::Symphonia,
         AbrMode::Auto(None),
         None,


### PR DESCRIPTION
## Summary
The `suite_network` integration-test executable does not compile on `main`, and
has not for some time. `prod_network.rs` reaches the suite's source helper
through `crate::kithara::queue::`, but `suite_network.rs` declares the module as
`mod kithara_queue`. That is two `E0433`, and because they are name-resolution
errors in a file the suite includes, they take the whole executable down rather
than one test. This changes the two paths and nothing else.

What is worth a reviewer's attention is less the fix than why it survived to
`main`: nothing in the repository builds this target. `just test` runs the
`workspace` lane, whose `default_features` are empty, while `suite_network`
carries `required-features = ["network"]`. The Clippy gate misses it from the
other side — `crates/kithara-devtools/src/clippy.rs:19` runs `cargo clippy
--workspace -- -D warnings` with no `--all-targets`, so no integration-test
target is compiled there either. Eight test targets sit in that gap:
`suite_harness`, `suite_broadcast`, `suite_e2e`, `suite_network`,
`suite_network_manual`, `suite_integration_regressions`, `suite_perf`, and
`memory_rss`. A recommendation for a cheap compile-only probe is in
`Risks / follow-ups`; this PR deliberately does not implement it.

The rooted path is kept rather than switched to the `super::` idiom the sibling
files use. This file sits one level deeper than they do, and
`crate::kithara_queue::` resolves identically whether it is mounted from
`suite_network.rs`'s inline `mod user_simulation` or from
`kithara_queue/mod.rs`; `super::super::` would only work from the first.

## Behavior / scope
- contract or behavior: none. Test-only path correction; no production code and
  no test assertion changes.
- affected area: `tests/tests/kithara_queue/user_simulation/prod_network.rs`,
  compiled only into `suite_network`.

## Validation
- `cargo check -p kithara-integration-tests --all-targets --features network` —
  reproduced both `E0433` before the change; `0 errors` after.
- `cargo check -p kithara-integration-tests --all-targets --features network-manual` —
  `0 errors`; the sibling `required-features` lane was already clean.
- `cargo check -p kithara-integration-tests --all-targets --features network,network-manual,harness,e2e,integration-regressions,broadcast` —
  `0 errors`.
- `cargo check -p kithara-integration-tests --test suite_perf --test memory_rss --features perf` —
  `0 errors`.
- `just lint fast` — `0 regression(s), 0 new across 36 check(s)`.
- `just test` — `4099 tests run: 4099 passed, 199 skipped`.
- not run: `suite_network` itself is not executed here. It needs
  `KITHARA_DRM_PROD_*` in the build environment and reaches the public zvuk CDN,
  so this PR claims it compiles, not that it passes.

## Surface impact
- Public API: none
- Platform/runtime: none
- Perf-sensitive paths: none

## Risks / follow-ups
- The class of rot is not fixed, only this instance. A cheap compile-only probe
  over the `required-features` suites would close it, and three constraints
  matter for whoever implements it. It must be per-target: `cargo check -p
  kithara-integration-tests --all-targets --features perf` fails with `queries
  overflow the depth limit!` in `suite_light`, because `hotpath` instrumentation
  lands on a suite that is not the perf suite, while the per-target form above is
  clean. It should be driven from `[test.lanes.*]` in `.config/xtask.toml`, which
  already pairs each target with its features, rather than from a second
  hand-written list that would rot the same way. And it should use `cargo check`
  rather than `--no-run`, which still does full codegen and linking. Measured
  cost: the five `[]`-valued features unify into one invocation, ~15 s on a warm
  workspace; `broadcast` and `perf` alter the dependency graph and need their
  own. Cold cost on the CI image is unmeasured.
- It should not go into `just lint fast`: `.pre-commit-config.yaml` makes that
  the prek pre-commit entry, so it runs on every commit, and the probe compiles
  test targets in feature sets a working build does not have.
- A prerequisite for any `-D warnings` probe: `--features broadcast` surfaces
  `unused import: kithara_integration_tests::test_defaults` at
  `tests/tests/common/mod.rs:1`. `suite_broadcast` declares `mod common` but no
  broadcast test uses `test_defaults`. Left untouched here as out of scope.
- The gap is wider than `required-features`. With no `--all-targets`, the Clippy
  gate compiles no test target at all; the default-feature suites at least get
  compile coverage from `just test`, the `required-features` ones get none from
  either side. Widening Clippy is a separate and much larger change, since it
  would surface the accumulated test-code lint debt in one go.
