### PR TITLE
feat(output,record): add live master recording

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5180,6 +5180,7 @@ dependencies = [
  "kithara-file",
  "kithara-hls",
  "kithara-net",
+ "kithara-output",
  "kithara-platform",
  "kithara-play",
  "kithara-signal",
@@ -5227,9 +5228,13 @@ name = "kithara-record"
 version = "0.0.1-alpha4"
 dependencies = [
  "bon",
+ "kithara-bufpool",
  "kithara-encode",
  "kithara-output",
+ "kithara-platform",
  "kithara-test-utils",
+ "kithara-worker",
+ "ringbuf 0.5.0",
  "thiserror 2.0.18",
 ]
 

--- a/crates/kithara-host/Cargo.toml
+++ b/crates/kithara-host/Cargo.toml
@@ -20,7 +20,7 @@ default = [
 ]
 backend-cpal = ["firewheel/cpal"]
 backend-web-audio = ["dep:firewheel-web-audio"]
-offline = ["dep:kithara-output", "dep:kithara-signal", "dep:kithara-worker"]
+offline = ["dep:kithara-signal", "dep:kithara-worker"]
 wasm-bindgen = ["firewheel/wasm-bindgen"]
 client-reqwest = ["kithara-play/client-reqwest"]
 client-wreq = ["kithara-play/client-wreq"]
@@ -41,7 +41,7 @@ probe = ["kithara-play/probe"]
 kithara-audio = { workspace = true, default-features = false }
 kithara-bufpool = { workspace = true }
 kithara-events = { workspace = true }
-kithara-output = { workspace = true, optional = true }
+kithara-output = { workspace = true }
 kithara-platform = { workspace = true }
 kithara-play = { workspace = true, default-features = false }
 kithara-signal = { workspace = true, optional = true }

--- a/crates/kithara-host/src/host.rs
+++ b/crates/kithara-host/src/host.rs
@@ -1,6 +1,7 @@
 use std::{marker::PhantomData, num::NonZeroU32, ops::Deref};
 
 use kithara_bufpool::HasPool;
+use kithara_output::OutputGroup;
 use kithara_platform::sync::Arc;
 #[cfg(any(test, feature = "probe"))]
 use kithara_play::TransportRevision;
@@ -285,7 +286,26 @@ impl<S> Host<S> {
     /// # Errors
     /// Returns an error when a tap is active or graph dispatch fails.
     pub fn enable_mix_tap(&self, writer: MixTapWriter) -> Result<(), PlayError> {
-        self.exec_play_ok(Cmd::EnableMixTap { writer })
+        let mut outputs = OutputGroup::new();
+        outputs.push(writer);
+        self.enable_outputs(outputs)
+    }
+
+    /// Installs one post-limiter group for simultaneous independent outputs.
+    ///
+    /// # Errors
+    /// Returns an error when an output group is active or graph dispatch fails.
+    pub fn enable_outputs(&self, outputs: OutputGroup) -> Result<(), PlayError> {
+        match self
+            .dispatcher
+            .exec_host(HostCmd::EnableOutput { outputs })?
+        {
+            HostReply::Ok => Ok(()),
+            HostReply::Err(error) => Err(error),
+            _ => Err(PlayError::Internal(
+                "unexpected host reply for output group".into(),
+            )),
+        }
     }
 
     /// Removes the post-limiter mix tap.

--- a/crates/kithara-host/src/rt/tap.rs
+++ b/crates/kithara-host/src/rt/tap.rs
@@ -1,4 +1,4 @@
-use core::num::{NonZeroU32, NonZeroUsize};
+use core::num::NonZeroU32;
 
 use firewheel::{
     StreamInfo,
@@ -9,26 +9,18 @@ use firewheel::{
         ProcBuffers, ProcExtra, ProcInfo, ProcStreamCtx, ProcessStatus,
     },
 };
-use kithara_platform::sync::{
-    Arc, Mutex,
-    atomic::{AtomicU64, Ordering},
-};
+use kithara_output::{LiveOutput, OutputGroup};
+use kithara_platform::sync::Mutex;
 use kithara_test_utils::kithara;
-use ringbuf::{
-    HeapProd,
-    traits::{Observer, Producer},
-};
-
-use crate::bridge::MixTapWriter;
 
 pub(crate) struct TapNode {
-    writer: Mutex<Option<MixTapWriter>>,
+    outputs: Mutex<Option<OutputGroup>>,
 }
 
 impl TapNode {
-    pub(crate) fn new(writer: MixTapWriter) -> Self {
+    pub(crate) fn new(outputs: OutputGroup) -> Self {
         Self {
-            writer: Mutex::new(Some(writer)),
+            outputs: Mutex::new(Some(outputs)),
         }
     }
 }
@@ -41,7 +33,7 @@ impl AudioNode for TapNode {
         _config: &Self::Configuration,
         cx: ConstructProcessorContext,
     ) -> impl AudioNodeProcessor {
-        TapProcessor::new(self.writer.lock().take(), cx.stream_info.sample_rate)
+        TapProcessor::new(self.outputs.lock().take(), cx.stream_info.sample_rate)
     }
 
     fn info(&self, _config: &Self::Configuration) -> AudioNodeInfo {
@@ -55,23 +47,21 @@ impl AudioNode for TapNode {
 }
 
 struct TapProcessor {
+    outputs: Option<OutputGroup>,
     sample_rate: NonZeroU32,
-    writer: Option<(HeapProd<f32>, Arc<AtomicU64>)>,
 }
 
 impl TapProcessor {
-    const STEREO: NonZeroUsize = NonZeroUsize::new(2).expect("BUG: 2 is non-zero");
-
-    fn new(writer: Option<MixTapWriter>, sample_rate: NonZeroU32) -> Self {
+    fn new(outputs: Option<OutputGroup>, sample_rate: NonZeroU32) -> Self {
         Self {
+            outputs,
             sample_rate,
-            writer: writer.map(Into::into),
         }
     }
 
     fn adopt_rate(&mut self, sample_rate: NonZeroU32) {
         if sample_rate != self.sample_rate {
-            self.writer = None;
+            self.outputs = None;
             self.sample_rate = sample_rate;
         }
     }
@@ -90,45 +80,29 @@ impl AudioNodeProcessor for TapProcessor {
         _events: &mut ProcEvents,
         _extra: &mut ProcExtra,
     ) -> ProcessStatus {
-        let Some((pcm, drops)) = self.writer.as_mut() else {
+        let Some(outputs) = self.outputs.as_mut() else {
             return ProcessStatus::ClearAllOutputs;
         };
-        let stereo = Self::STEREO.get();
         let [left, right, ..] = buffers.inputs else {
-            drops.fetch_add(dropped_samples(info.frames, 0, stereo), Ordering::Relaxed);
+            outputs.write_stereo(info.frames, &[], &[]);
             return ProcessStatus::ClearAllOutputs;
         };
-        let frames = info
-            .frames
-            .min(pcm.vacant_len() / stereo)
-            .min(left.len())
-            .min(right.len());
-        let interleaved = left[..frames]
-            .iter()
-            .zip(&right[..frames])
-            .flat_map(|(&left, &right)| [left, right]);
-        let pushed = pcm.push_iter(interleaved);
-        let dropped = dropped_samples(info.frames, pushed, stereo);
-        if dropped > 0 {
-            drops.fetch_add(dropped, Ordering::Relaxed);
-        }
+        outputs.write_stereo(info.frames, left, right);
 
         ProcessStatus::ClearAllOutputs
     }
 }
 
-fn dropped_samples(frames: usize, pushed: usize, stereo: usize) -> u64 {
-    u64::try_from(frames * stereo - pushed).unwrap_or(u64::MAX)
-}
-
 #[cfg(test)]
 mod tests {
+    use kithara_platform::sync::{Arc, atomic::AtomicU64};
     use ringbuf::{
         HeapRb,
         traits::{Observer, Split},
     };
 
     use super::*;
+    use crate::bridge::MixTapWriter;
 
     fn rate(hz: u32) -> NonZeroU32 {
         NonZeroU32::new(hz).expect("test rate is non-zero")
@@ -140,7 +114,9 @@ mod tests {
 
         let (pcm, cons) = HeapRb::<f32>::new(CAPACITY).split();
         let writer = MixTapWriter::new(pcm, Arc::new(AtomicU64::new(0)));
-        let mut processor = TapProcessor::new(Some(writer), rate(44_100));
+        let mut outputs = OutputGroup::new();
+        outputs.push(writer);
+        let mut processor = TapProcessor::new(Some(outputs), rate(44_100));
 
         processor.adopt_rate(rate(44_100));
         assert!(cons.write_is_held(), "an equal rate keeps the feed running");

--- a/crates/kithara-host/src/session/dispatch.rs
+++ b/crates/kithara-host/src/session/dispatch.rs
@@ -26,6 +26,8 @@ where
         HostCmd::ApplyMix { levels } => {
             apply_mix(state, &levels).map_or_else(HostReply::Err, |()| HostReply::Ok)
         }
+        HostCmd::EnableOutput { outputs } => tap::enable(state, outputs)
+            .map_or_else(|error| HostReply::Err(error.into()), |()| HostReply::Ok),
         HostCmd::Shutdown => HostReply::Ok,
     }
 }
@@ -162,10 +164,14 @@ where
             Ok(()) => Reply::Ok,
             Err(err) => Reply::Err(err),
         },
-        Cmd::EnableMixTap { writer } => match tap::enable(state, writer) {
-            Ok(()) => Reply::Ok,
-            Err(err) => Reply::Err(err),
-        },
+        Cmd::EnableMixTap { writer } => {
+            let mut outputs = kithara_output::OutputGroup::new();
+            outputs.push(writer);
+            match tap::enable(state, outputs) {
+                Ok(()) => Reply::Ok,
+                Err(err) => Reply::Err(err),
+            }
+        }
         Cmd::DisableMixTap => {
             tap::disable(state);
             Reply::Ok
@@ -409,6 +415,7 @@ mod tests {
     use firewheel::{FirewheelCtx, StreamInfo, processor::FirewheelProcessor};
     use kithara_bufpool::testing::{TestPools, pools};
     use kithara_events::EventBus;
+    use kithara_output::OutputGroup;
     use kithara_platform::sync::{
         Arc,
         atomic::{AtomicU64, AtomicUsize, Ordering},
@@ -1269,7 +1276,7 @@ mod tests {
     }
 
     #[kithara::test]
-    fn mix_tap_rejects_a_second_consumer_and_is_cleared_by_idle_teardown() {
+    fn output_group_is_one_tap_and_is_cleared_by_idle_teardown() {
         route_loss(RouteLossProbe::reset);
 
         let mut state = test_state(start_route_loss_stream);
@@ -1277,14 +1284,12 @@ mod tests {
         start_player_cmd(&mut state, id);
 
         let drops = Arc::new(AtomicU64::new(0));
+        let mut outputs = OutputGroup::new();
+        outputs.push(mix_tap_writer(&drops));
+        outputs.push(mix_tap_writer(&drops));
         assert!(matches!(
-            run_cmd(
-                &mut state,
-                Cmd::EnableMixTap {
-                    writer: mix_tap_writer(&drops),
-                },
-            ),
-            Reply::Ok
+            run_host_cmd(&mut state, HostCmd::EnableOutput { outputs },),
+            HostReply::Ok
         ));
         assert!(
             matches!(state.mix_tap, Some(MixTap::Installed(_))),

--- a/crates/kithara-host/src/session/graph.rs
+++ b/crates/kithara-host/src/session/graph.rs
@@ -3,6 +3,7 @@ use firewheel::{
     dsp::volume::amp_to_linear_volume_clamped, node::NodeID, nodes::volume::VolumeNode,
 };
 use kithara_bufpool::HasPool;
+use kithara_output::OutputGroup;
 use kithara_warp::{BeatGrid, MapAxis};
 use tracing::{debug, warn};
 
@@ -13,7 +14,7 @@ use super::{
 };
 use crate::{
     api::{SessionDuckingMode, SlotId},
-    bridge::{MixTapWriter, slot_channels},
+    bridge::slot_channels,
     effects::eq::{EqBandConfig, EqConfig, GainDb},
     rt::{MasterEqNode, PlayerNode, TapNode},
 };
@@ -73,16 +74,16 @@ pub(super) mod tap {
 
     pub(in crate::session) fn enable<B: AudioBackend, S>(
         state: &mut SessionState<B, S>,
-        writer: MixTapWriter,
+        outputs: OutputGroup,
     ) -> Result<(), SessionError> {
         if state.mix_tap.is_some() {
             return Err(SessionError::MixTapActive);
         }
         let Some(limiter_id) = state.session_limiter_node_id else {
-            state.mix_tap = Some(MixTap::Requested(writer));
+            state.mix_tap = Some(MixTap::Requested(outputs));
             return Ok(());
         };
-        install(state, limiter_id, writer)
+        install(state, limiter_id, outputs)
     }
 
     pub(in crate::session) fn disable<B: AudioBackend, S>(state: &mut SessionState<B, S>) {
@@ -104,19 +105,19 @@ pub(super) mod tap {
         state: &mut SessionState<B, S>,
         limiter_id: NodeID,
     ) -> Result<(), SessionError> {
-        let Some(MixTap::Requested(writer)) = state.mix_tap.take() else {
+        let Some(MixTap::Requested(outputs)) = state.mix_tap.take() else {
             return Ok(());
         };
-        install(state, limiter_id, writer)
+        install(state, limiter_id, outputs)
     }
 
     fn install<B: AudioBackend, S>(
         state: &mut SessionState<B, S>,
         limiter_id: NodeID,
-        writer: MixTapWriter,
+        outputs: OutputGroup,
     ) -> Result<(), SessionError> {
         let fw_ctx = state.ctx.as_mut().ok_or(SessionError::NoContext)?;
-        let tap_id = fw_ctx.add_node(TapNode::new(writer), None);
+        let tap_id = fw_ctx.add_node(TapNode::new(outputs), None);
         if let Err(err) = connect_stereo(fw_ctx, limiter_id, tap_id, "connect limiter->mix_tap") {
             if let Err(remove_err) = fw_ctx.remove_node(tap_id) {
                 warn!(?remove_err, "failed to remove the unconnected mix tap node");

--- a/crates/kithara-host/src/session/protocol.rs
+++ b/crates/kithara-host/src/session/protocol.rs
@@ -1,4 +1,5 @@
 use firewheel::FirewheelCtx;
+use kithara_output::OutputGroup;
 use kithara_platform::sync::mpsc;
 pub(crate) use kithara_play::{
     AllocatedSlot, Cmd, PlayerId, PlayerLevel, Reply, SessionDispatcher, SessionError,
@@ -19,6 +20,7 @@ pub(crate) enum HostCmd<S> {
     Play(Cmd<S>),
     Sync(SyncCmd),
     ApplyMix { levels: Box<[HostLevel]> },
+    EnableOutput { outputs: OutputGroup },
     Shutdown,
 }
 

--- a/crates/kithara-host/src/session/state.rs
+++ b/crates/kithara-host/src/session/state.rs
@@ -7,6 +7,7 @@ use firewheel::{
 };
 use kithara_bufpool::PoolRegion;
 use kithara_events::EventBus;
+use kithara_output::OutputGroup;
 use kithara_platform::sync::Arc;
 use kithara_play::{GroupState, player::PlayerMember};
 use kithara_warp::{
@@ -23,7 +24,7 @@ use super::{
 };
 use crate::{
     api::{SessionDuckingMode, SlotId},
-    bridge::{MixTapWriter, SharedEq},
+    bridge::SharedEq,
     effects::eq::{EqBandConfig, GainDb},
     rt::{LimiterNode, MasterEqNode},
 };
@@ -145,7 +146,7 @@ pub(super) fn prepare_eq_layout(eq_layout: Vec<EqBandConfig>) -> (Vec<EqBandConf
 }
 
 pub(super) enum MixTap {
-    Requested(MixTapWriter),
+    Requested(OutputGroup),
     Installed(NodeID),
 }
 

--- a/crates/kithara-output/src/lib.rs
+++ b/crates/kithara-output/src/lib.rs
@@ -2,8 +2,10 @@
 
 //! Neutral master-output and finite offline-rendering protocols.
 
+mod live;
 mod offline;
 
+pub use live::{LiveOutput, OutputGroup};
 pub use offline::{
     OfflineRenderError, OfflineRenderReport, OfflineRenderRequest, OfflineRenderer, RenderSink,
     RenderSinkError,

--- a/crates/kithara-output/src/live.rs
+++ b/crates/kithara-output/src/live.rs
@@ -1,0 +1,39 @@
+/// Real-time receiver for one planar stereo master block.
+///
+/// Implementations must not allocate, block, or perform I/O in this call.
+pub trait LiveOutput: Send + 'static {
+    /// Receive up to `frames` samples from each planar channel.
+    fn write_stereo(&mut self, frames: usize, left: &[f32], right: &[f32]);
+}
+
+/// One master-output endpoint that fans each block out to independent outputs.
+#[derive(Default)]
+pub struct OutputGroup {
+    outputs: Vec<Box<dyn LiveOutput>>,
+}
+
+impl OutputGroup {
+    /// Create an empty group. Outputs are added before the group reaches RT.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            outputs: Vec::new(),
+        }
+    }
+
+    /// Append one output endpoint.
+    pub fn push<O>(&mut self, output: O)
+    where
+        O: LiveOutput,
+    {
+        self.outputs.push(Box::new(output));
+    }
+}
+
+impl LiveOutput for OutputGroup {
+    fn write_stereo(&mut self, frames: usize, left: &[f32], right: &[f32]) {
+        for output in &mut self.outputs {
+            output.write_stereo(frames, left, right);
+        }
+    }
+}

--- a/crates/kithara-play/Cargo.toml
+++ b/crates/kithara-play/Cargo.toml
@@ -92,6 +92,7 @@ kithara-events = { workspace = true }
 kithara-file = { workspace = true, default-features = false }
 kithara-hls = { workspace = true, default-features = false }
 kithara-net = { workspace = true, default-features = false }
+kithara-output = { workspace = true }
 kithara-platform = { workspace = true }
 kithara-signal = { workspace = true }
 kithara-stream = { workspace = true, default-features = false }

--- a/crates/kithara-play/src/bridge/channels.rs
+++ b/crates/kithara-play/src/bridge/channels.rs
@@ -1,10 +1,17 @@
 use kithara_audio::SeekBegin;
 use kithara_events::TrackId;
+use kithara_output::LiveOutput;
 use kithara_platform::{
-    sync::{Arc, atomic::AtomicU64},
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
     time::Duration,
 };
-use ringbuf::{HeapCons, HeapProd, HeapRb, traits::Split};
+use ringbuf::{
+    HeapCons, HeapProd, HeapRb,
+    traits::{Observer, Producer, Split},
+};
 use smallvec::SmallVec;
 
 use super::PlaybackShared;
@@ -39,6 +46,29 @@ impl MixTapWriter {
 impl From<MixTapWriter> for (HeapProd<f32>, Arc<AtomicU64>) {
     fn from(writer: MixTapWriter) -> Self {
         (writer.samples, writer.drops)
+    }
+}
+
+impl LiveOutput for MixTapWriter {
+    fn write_stereo(&mut self, frames: usize, left: &[f32], right: &[f32]) {
+        let stereo = 2;
+        let writable = frames
+            .min(left.len())
+            .min(right.len())
+            .min(self.samples.vacant_len() / stereo);
+        let pushed = self.samples.push_iter(
+            left[..writable]
+                .iter()
+                .zip(&right[..writable])
+                .flat_map(|(&left, &right)| [left, right]),
+        );
+        let dropped = frames.saturating_mul(stereo).saturating_sub(pushed);
+        if dropped > 0 {
+            self.drops.fetch_add(
+                u64::try_from(dropped).unwrap_or(u64::MAX),
+                Ordering::Relaxed,
+            );
+        }
     }
 }
 

--- a/crates/kithara-record/Cargo.toml
+++ b/crates/kithara-record/Cargo.toml
@@ -10,14 +10,19 @@ keywords = ["audio", "recording", "encoding"]
 categories = ["multimedia::audio"]
 
 [dependencies]
+kithara-bufpool = { workspace = true }
 kithara-encode = { workspace = true, default-features = false }
 kithara-output = { workspace = true }
+kithara-platform = { workspace = true }
+kithara-worker = { workspace = true }
 
 bon = { workspace = true }
+ringbuf = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-kithara-test-utils = { workspace = true }
+kithara-bufpool = { workspace = true, features = ["test-utils"] }
+kithara-test-utils = { workspace = true, features = ["client-reqwest", "probe", "tls-rustls"] }
 
 [lints]
 workspace = true

--- a/crates/kithara-record/src/config.rs
+++ b/crates/kithara-record/src/config.rs
@@ -1,10 +1,33 @@
+use std::num::{NonZeroU32, NonZeroU64, NonZeroUsize};
+
 use bon::Builder;
 use kithara_encode::EncodeConfig;
+use kithara_platform::time::Duration;
+use kithara_worker::Priority;
+
+struct Defaults;
+
+impl Defaults {
+    const BUFFER_FRAMES: NonZeroUsize = match NonZeroUsize::new(96_000) {
+        Some(value) => value,
+        None => unreachable!(),
+    };
+    const DISPATCHER_CAPACITY: NonZeroUsize = NonZeroUsize::MIN;
+    const FAIRNESS_YIELD_INTERVAL: NonZeroU32 = match NonZeroU32::new(16) {
+        Some(value) => value,
+        None => unreachable!(),
+    };
+    const TICK_FRAMES: NonZeroUsize = match NonZeroUsize::new(1_024) {
+        Some(value) => value,
+        None => unreachable!(),
+    };
+}
 
 /// Configuration for one independently playable recording part.
 #[derive(Clone, Debug, Builder)]
 #[non_exhaustive]
 pub struct RecordingConfig {
+    #[builder(default = default_encode_config())]
     encode: EncodeConfig,
 }
 
@@ -14,4 +37,52 @@ impl RecordingConfig {
     pub const fn encode(&self) -> &EncodeConfig {
         &self.encode
     }
+}
+
+fn default_encode_config() -> EncodeConfig {
+    EncodeConfig::builder()
+        .sample_rate(48_000)
+        .channels(2)
+        .build()
+}
+
+/// Bounded live-recorder and worker scheduling configuration.
+#[derive(Builder)]
+#[non_exhaustive]
+pub struct LiveRecordingConfig {
+    /// Encoding and container profile for every independently playable part.
+    #[builder(default = RecordingConfig::builder().build())]
+    pub(crate) recording: RecordingConfig,
+    /// Maximum stereo PCM frames waiting between RT and the encoder worker.
+    #[builder(default = Defaults::BUFFER_FRAMES)]
+    pub(crate) buffer_frames: NonZeroUsize,
+    /// Maximum stereo PCM frames encoded during one worker tick.
+    #[builder(default = Defaults::TICK_FRAMES)]
+    pub(crate) tick_frames: NonZeroUsize,
+    /// Optional exact frame count at which each part rotates automatically.
+    pub(crate) rotation_frames: Option<NonZeroU64>,
+    /// Maximum tasks admitted to the recorder dispatcher.
+    #[builder(default = Defaults::DISPATCHER_CAPACITY)]
+    pub(crate) dispatcher_capacity: NonZeroUsize,
+    /// Consecutive progress passes before the dispatcher yields.
+    #[builder(default = Defaults::FAIRNESS_YIELD_INTERVAL)]
+    pub(crate) fairness_yield_interval: NonZeroU32,
+    /// Dispatcher park duration when the recorder has no work.
+    #[builder(default = Duration::from_millis(100))]
+    pub(crate) idle_timeout: Duration,
+    /// Threshold for reporting a slow recorder tick.
+    #[builder(default = Duration::from_millis(10))]
+    pub(crate) slow_tick_threshold: Duration,
+    /// Maximum consecutive recorder ticks in one dispatcher visit.
+    #[builder(default = NonZeroU32::MIN)]
+    pub(crate) task_burst: NonZeroU32,
+    /// Dispatcher wait duration between deferred RT wakes.
+    #[builder(default = Duration::from_millis(10))]
+    pub(crate) wait_timeout: Duration,
+    /// Recorder task priority.
+    #[builder(default = Priority::new(0))]
+    pub(crate) priority: Priority,
+    /// Maximum compute jobs admitted for the recorder task.
+    #[builder(default = NonZeroUsize::MIN)]
+    pub(crate) max_compute_tasks: NonZeroUsize,
 }

--- a/crates/kithara-record/src/error.rs
+++ b/crates/kithara-record/src/error.rs
@@ -1,6 +1,8 @@
 use std::error::Error;
 
+use kithara_bufpool::PoolError;
 use kithara_encode::EncodeError;
+use kithara_worker::TaskError;
 use thiserror::Error;
 
 /// Failure while encoding or publishing one recording part.
@@ -31,3 +33,51 @@ pub enum RecordingError<E: Error + 'static> {
 
 /// Result produced by a recording core using sink error `E`.
 pub type RecordingResult<T, E> = Result<T, RecordingError<E>>;
+
+/// Terminal live-recorder failure.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum LiveRecordingError {
+    /// Live master output is stereo, but the selected profile is not.
+    #[error("live recording requires 2 channels, got {0}")]
+    ChannelCount(u16),
+    /// A configured frame or sample capacity cannot be represented.
+    #[error("live recording capacity overflow")]
+    CapacityOverflow,
+    /// The composition-owned sample pool rejected recorder scratch.
+    #[error(transparent)]
+    Pool(#[from] PoolError),
+    /// The bounded RT-to-worker PCM ring ran out of room.
+    #[error("live recording PCM buffer of {buffer_frames} frames overflowed")]
+    BufferOverflow {
+        /// Configured ring capacity.
+        buffer_frames: usize,
+    },
+    /// The destination could not open a new part.
+    #[error("live recording failed to open part {part}: {source}")]
+    OpenPart {
+        /// One-based part sequence number.
+        part: u64,
+        /// Destination acquisition failure.
+        #[source]
+        source: Box<dyn Error + Send + Sync>,
+    },
+    /// Encoding or publication of one part failed.
+    #[error("live recording part {part} failed: {source}")]
+    Part {
+        /// One-based part sequence number.
+        part: u64,
+        /// Encoding, container, or destination failure.
+        #[source]
+        source: Box<dyn Error + Send + Sync>,
+    },
+    /// Total live frame count cannot be represented.
+    #[error("live recording frame count overflow")]
+    FrameCountOverflow,
+    /// The recorder task was cancelled before a clean finish.
+    #[error("live recording cancelled")]
+    Cancelled,
+    /// Worker admission or lifecycle failure.
+    #[error(transparent)]
+    Worker(#[from] TaskError),
+}

--- a/crates/kithara-record/src/lib.rs
+++ b/crates/kithara-record/src/lib.rs
@@ -5,10 +5,12 @@
 mod config;
 mod core;
 mod error;
+mod live;
 mod sink;
 
 pub use core::RecordingCore;
 
-pub use config::RecordingConfig;
-pub use error::{RecordingError, RecordingResult};
-pub use sink::RecordingSink;
+pub use config::{LiveRecordingConfig, RecordingConfig};
+pub use error::{LiveRecordingError, RecordingError, RecordingResult};
+pub use live::{LiveRecorder, LiveRecordingHandle, LiveRecordingReport, RecordingOutput};
+pub use sink::{PartSinkFactory, RecordingSink};

--- a/crates/kithara-record/src/live.rs
+++ b/crates/kithara-record/src/live.rs
@@ -1,0 +1,257 @@
+use kithara_bufpool::{HasPool, PoolRegion};
+use kithara_output::LiveOutput;
+use kithara_platform::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, AtomicU64, Ordering},
+};
+use kithara_worker::{Dispatcher, DispatcherConfig, TaskConfig, TaskHandle, Wake, Worker};
+use ringbuf::{
+    HeapProd, HeapRb,
+    traits::{Observer, Producer, Split},
+};
+
+use self::task::RecordingTask;
+use crate::{LiveRecordingConfig, LiveRecordingError, PartSinkFactory};
+
+mod task;
+
+struct Consts;
+
+impl Consts {
+    const CHANNELS: u16 = 2;
+    const NO_CUT: u64 = u64::MAX;
+    const STEREO: usize = 2;
+}
+
+/// Completed live-recording counts.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct LiveRecordingReport {
+    /// Total complete stereo frames committed across all parts.
+    pub frames: u64,
+    /// Number of independently playable parts committed.
+    pub parts: u64,
+}
+
+type ResultSlot = Arc<Mutex<Option<Result<LiveRecordingReport, LiveRecordingError>>>>;
+
+#[derive(Default)]
+struct Control {
+    accepting: AtomicBool,
+    cut_at: AtomicU64,
+    cut_requested: AtomicBool,
+    finish_requested: AtomicBool,
+    overflowed: AtomicBool,
+    result: ResultSlot,
+    writing: AtomicBool,
+    written_frames: AtomicU64,
+}
+
+impl Control {
+    fn finish(&self) {
+        self.accepting.store(false, Ordering::Release);
+        self.finish_requested.store(true, Ordering::Release);
+    }
+}
+
+/// RT endpoint copied into the Host master-output group.
+pub struct RecordingOutput {
+    control: Arc<Control>,
+    pcm: HeapProd<f32>,
+    wake: Wake,
+}
+
+impl RecordingOutput {
+    fn overflow(&self) {
+        self.control.overflowed.store(true, Ordering::Release);
+        self.control.accepting.store(false, Ordering::Release);
+        self.wake.defer();
+    }
+}
+
+impl LiveOutput for RecordingOutput {
+    fn write_stereo(&mut self, frames: usize, left: &[f32], right: &[f32]) {
+        if frames == 0 || !self.control.accepting.load(Ordering::Acquire) {
+            return;
+        }
+        self.control.writing.store(true, Ordering::Release);
+        if !self.control.accepting.load(Ordering::Acquire) {
+            self.control.writing.store(false, Ordering::Release);
+            return;
+        }
+        let Some(samples) = frames.checked_mul(Consts::STEREO) else {
+            self.control.writing.store(false, Ordering::Release);
+            self.overflow();
+            return;
+        };
+        if left.len() < frames || right.len() < frames || self.pcm.vacant_len() < samples {
+            self.control.writing.store(false, Ordering::Release);
+            self.overflow();
+            return;
+        }
+
+        if self.control.cut_requested.swap(false, Ordering::AcqRel) {
+            let at = self.control.written_frames.load(Ordering::Acquire);
+            if self
+                .control
+                .cut_at
+                .compare_exchange(Consts::NO_CUT, at, Ordering::Release, Ordering::Relaxed)
+                .is_err()
+            {
+                self.control.cut_requested.store(true, Ordering::Release);
+            }
+        }
+
+        let pushed = self.pcm.push_iter(
+            left[..frames]
+                .iter()
+                .zip(&right[..frames])
+                .flat_map(|(&left, &right)| [left, right]),
+        );
+        if pushed != samples {
+            self.control.writing.store(false, Ordering::Release);
+            self.overflow();
+            return;
+        }
+        let Ok(frames) = u64::try_from(frames) else {
+            self.control.writing.store(false, Ordering::Release);
+            self.overflow();
+            return;
+        };
+        if self
+            .control
+            .written_frames
+            .fetch_update(Ordering::Release, Ordering::Relaxed, |written| {
+                written.checked_add(frames)
+            })
+            .is_err()
+        {
+            self.control.writing.store(false, Ordering::Release);
+            self.overflow();
+            return;
+        }
+        self.control.writing.store(false, Ordering::Release);
+        self.wake.defer();
+    }
+}
+
+impl Drop for RecordingOutput {
+    fn drop(&mut self) {
+        self.control.finish();
+        self.wake.defer();
+    }
+}
+
+/// Off-RT recording controls and completion observation.
+pub struct LiveRecordingHandle {
+    control: Arc<Control>,
+    dispatcher: Dispatcher,
+    task: TaskHandle,
+    wake: Wake,
+}
+
+impl LiveRecordingHandle {
+    /// Request a part boundary before the next observable audio block.
+    pub fn cut(&self) {
+        if self.control.accepting.load(Ordering::Acquire) {
+            self.control.cut_requested.store(true, Ordering::Release);
+        }
+    }
+
+    /// Stop accepting PCM and take the terminal result when it is ready.
+    #[must_use]
+    pub fn finish(&self) -> Option<Result<LiveRecordingReport, LiveRecordingError>> {
+        self.control.finish();
+        self.wake.wake();
+        self.control.result.lock().take()
+    }
+}
+
+impl Drop for LiveRecordingHandle {
+    fn drop(&mut self) {
+        self.task.cancel();
+        self.dispatcher.shutdown();
+    }
+}
+
+/// Starts one bounded live-recorder worker and its RT endpoint.
+pub struct LiveRecorder;
+
+impl LiveRecorder {
+    /// Start recording into parts opened by `factory`.
+    ///
+    /// # Errors
+    /// Returns an invalid configuration or worker admission failure.
+    pub fn start<F, S>(
+        worker: &Worker,
+        pools: &PoolRegion<S>,
+        config: LiveRecordingConfig,
+        factory: F,
+    ) -> Result<(RecordingOutput, LiveRecordingHandle), LiveRecordingError>
+    where
+        F: PartSinkFactory,
+        S: HasPool<f32> + Send + Sync + 'static,
+    {
+        if config.recording.encode().channels != Consts::CHANNELS {
+            return Err(LiveRecordingError::ChannelCount(
+                config.recording.encode().channels,
+            ));
+        }
+        let buffer_frames = config.buffer_frames.get();
+        let buffer_samples = buffer_frames
+            .checked_mul(Consts::STEREO)
+            .ok_or(LiveRecordingError::CapacityOverflow)?;
+        let tick_samples = config
+            .tick_frames
+            .get()
+            .checked_mul(Consts::STEREO)
+            .ok_or(LiveRecordingError::CapacityOverflow)?;
+        let scratch = pools.get_with_len::<f32>(tick_samples)?;
+        let (pcm_tx, pcm_rx) = HeapRb::new(buffer_samples).split();
+        let dispatcher = worker.dispatcher(
+            DispatcherConfig::builder()
+                .name("kithara-record")
+                .capacity(config.dispatcher_capacity)
+                .fairness_yield_interval(config.fairness_yield_interval)
+                .idle_timeout(config.idle_timeout)
+                .slow_tick_threshold(config.slow_tick_threshold)
+                .task_burst(config.task_burst)
+                .wait_timeout(config.wait_timeout)
+                .build(),
+        );
+        let wake = dispatcher.wake_handle();
+        let control = Arc::new(Control {
+            accepting: AtomicBool::new(true),
+            cut_at: AtomicU64::new(Consts::NO_CUT),
+            ..Control::default()
+        });
+        let task_control = Arc::clone(&control);
+        let task = dispatcher.register(
+            TaskConfig::new()
+                .with_max_compute_tasks(config.max_compute_tasks)
+                .with_priority(config.priority),
+            move |_| {
+                RecordingTask::new(
+                    config,
+                    factory,
+                    pcm_rx,
+                    task_control,
+                    buffer_frames,
+                    scratch,
+                )
+            },
+        )?;
+        let output = RecordingOutput {
+            control: Arc::clone(&control),
+            pcm: pcm_tx,
+            wake: wake.clone(),
+        };
+        let handle = LiveRecordingHandle {
+            control,
+            dispatcher,
+            task,
+            wake,
+        };
+        Ok((output, handle))
+    }
+}

--- a/crates/kithara-record/src/live/task.rs
+++ b/crates/kithara-record/src/live/task.rs
@@ -1,0 +1,248 @@
+use std::num::NonZeroU64;
+
+use kithara_bufpool::SampleBuffer;
+use kithara_platform::sync::{Arc, atomic::Ordering};
+use kithara_worker::{Task, TickResult};
+use ringbuf::{
+    HeapCons,
+    traits::{Consumer, Observer},
+};
+
+use super::{Consts, Control, LiveRecordingReport};
+use crate::{
+    LiveRecordingConfig, LiveRecordingError, PartSinkFactory, RecordingConfig, RecordingCore,
+};
+
+pub(super) struct RecordingTask<F>
+where
+    F: PartSinkFactory,
+{
+    buffer_frames: usize,
+    config: RecordingConfig,
+    control: Arc<Control>,
+    core: Option<RecordingCore<F::Sink>>,
+    factory: F,
+    frames: u64,
+    part_frames: u64,
+    parts: u64,
+    pcm: HeapCons<f32>,
+    rotation_frames: Option<NonZeroU64>,
+    scratch: Option<SampleBuffer>,
+}
+
+impl<F> RecordingTask<F>
+where
+    F: PartSinkFactory,
+{
+    pub(super) fn new(
+        config: LiveRecordingConfig,
+        factory: F,
+        pcm: HeapCons<f32>,
+        control: Arc<Control>,
+        buffer_frames: usize,
+        scratch: SampleBuffer,
+    ) -> Self {
+        Self {
+            buffer_frames,
+            config: config.recording,
+            control,
+            core: None,
+            factory,
+            frames: 0,
+            part_frames: 0,
+            parts: 0,
+            pcm,
+            rotation_frames: config.rotation_frames,
+            scratch: Some(scratch),
+        }
+    }
+
+    fn open_part(&mut self) -> Result<(), LiveRecordingError> {
+        if self.core.is_some() {
+            return Ok(());
+        }
+        let part = self
+            .parts
+            .checked_add(1)
+            .ok_or(LiveRecordingError::FrameCountOverflow)?;
+        let sink = self
+            .factory
+            .open(part)
+            .map_err(|source| LiveRecordingError::OpenPart {
+                part,
+                source: Box::new(source),
+            })?;
+        let core = RecordingCore::new(&self.config, sink, None).map_err(|source| {
+            LiveRecordingError::Part {
+                part,
+                source: Box::new(source),
+            }
+        })?;
+        self.core = Some(core);
+        Ok(())
+    }
+
+    fn finish_part(&mut self) -> Result<(), LiveRecordingError> {
+        if self.part_frames == 0 {
+            return Ok(());
+        }
+        let part = self
+            .parts
+            .checked_add(1)
+            .ok_or(LiveRecordingError::FrameCountOverflow)?;
+        let Some(core) = self.core.take() else {
+            return Err(LiveRecordingError::FrameCountOverflow);
+        };
+        core.finish().map_err(|source| LiveRecordingError::Part {
+            part,
+            source: Box::new(source),
+        })?;
+        self.parts = part;
+        self.part_frames = 0;
+        Ok(())
+    }
+
+    fn push(&mut self, samples: &[f32]) -> Result<(), LiveRecordingError> {
+        let frames = u64::try_from(samples.len() / Consts::STEREO)
+            .map_err(|_| LiveRecordingError::FrameCountOverflow)?;
+        self.open_part()?;
+        let part = self
+            .parts
+            .checked_add(1)
+            .ok_or(LiveRecordingError::FrameCountOverflow)?;
+        self.core
+            .as_mut()
+            .ok_or(LiveRecordingError::FrameCountOverflow)?
+            .push(samples)
+            .map_err(|source| LiveRecordingError::Part {
+                part,
+                source: Box::new(source),
+            })?;
+        self.frames = self
+            .frames
+            .checked_add(frames)
+            .ok_or(LiveRecordingError::FrameCountOverflow)?;
+        self.part_frames = self
+            .part_frames
+            .checked_add(frames)
+            .ok_or(LiveRecordingError::FrameCountOverflow)?;
+        Ok(())
+    }
+
+    fn clear_cut(&self, at: u64) {
+        self.control
+            .cut_at
+            .compare_exchange(at, Consts::NO_CUT, Ordering::AcqRel, Ordering::Relaxed)
+            .ok();
+    }
+
+    fn process(&mut self, samples: &[f32]) -> Result<(), LiveRecordingError> {
+        let mut sample = 0;
+        while sample < samples.len() {
+            let cut_at = self.control.cut_at.load(Ordering::Acquire);
+            if cut_at <= self.frames {
+                self.finish_part()?;
+                self.clear_cut(cut_at);
+                continue;
+            }
+            let available_frames = (samples.len() - sample) / Consts::STEREO;
+            let mut take = u64::try_from(available_frames)
+                .map_err(|_| LiveRecordingError::FrameCountOverflow)?;
+            if cut_at != Consts::NO_CUT {
+                take = take.min(cut_at - self.frames);
+            }
+            if let Some(rotation) = self.rotation_frames {
+                take = take.min(rotation.get() - self.part_frames);
+            }
+            let take = usize::try_from(take).map_err(|_| LiveRecordingError::FrameCountOverflow)?;
+            let end = sample
+                .checked_add(
+                    take.checked_mul(Consts::STEREO)
+                        .ok_or(LiveRecordingError::FrameCountOverflow)?,
+                )
+                .ok_or(LiveRecordingError::FrameCountOverflow)?;
+            self.push(&samples[sample..end])?;
+            sample = end;
+
+            let cut_at = self.control.cut_at.load(Ordering::Acquire);
+            if cut_at == self.frames {
+                self.finish_part()?;
+                self.clear_cut(cut_at);
+            } else if self
+                .rotation_frames
+                .is_some_and(|rotation| self.part_frames == rotation.get())
+            {
+                self.finish_part()?;
+            }
+        }
+        Ok(())
+    }
+
+    fn publish(&self, result: Result<LiveRecordingReport, LiveRecordingError>) {
+        let mut slot = self.control.result.lock();
+        if slot.is_none() {
+            *slot = Some(result);
+        }
+    }
+
+    fn fail(&mut self, error: LiveRecordingError) -> TickResult {
+        self.control.accepting.store(false, Ordering::Release);
+        self.core.take();
+        self.publish(Err(error));
+        TickResult::Done
+    }
+}
+
+impl<F> Task for RecordingTask<F>
+where
+    F: PartSinkFactory,
+{
+    fn on_cancel(&mut self) {
+        self.core.take();
+        self.publish(Err(LiveRecordingError::Cancelled));
+    }
+
+    fn tick(&mut self) -> TickResult {
+        if self.control.overflowed.load(Ordering::Acquire) {
+            return self.fail(LiveRecordingError::BufferOverflow {
+                buffer_frames: self.buffer_frames,
+            });
+        }
+
+        let Some(mut scratch) = self.scratch.take() else {
+            return self.fail(LiveRecordingError::Cancelled);
+        };
+        let samples = self.pcm.occupied_len().min(scratch.len());
+        let samples = samples - samples % Consts::STEREO;
+        let taken = self.pcm.pop_slice(&mut scratch[..samples]);
+        let processed = self.process(&scratch[..taken]);
+        self.scratch = Some(scratch);
+        if let Err(error) = processed {
+            return self.fail(error);
+        }
+
+        let finished = self.control.finish_requested.load(Ordering::Acquire)
+            && !self.control.writing.load(Ordering::Acquire)
+            && self.pcm.is_empty();
+        if finished {
+            if self.control.overflowed.load(Ordering::Acquire) {
+                return self.fail(LiveRecordingError::BufferOverflow {
+                    buffer_frames: self.buffer_frames,
+                });
+            }
+            if let Err(error) = self.finish_part() {
+                return self.fail(error);
+            }
+            self.publish(Ok(LiveRecordingReport {
+                frames: self.frames,
+                parts: self.parts,
+            }));
+            return TickResult::Done;
+        }
+        if taken > 0 {
+            TickResult::Progress
+        } else {
+            TickResult::Waiting
+        }
+    }
+}

--- a/crates/kithara-record/src/sink.rs
+++ b/crates/kithara-record/src/sink.rs
@@ -24,3 +24,15 @@ pub trait RecordingSink: Send + 'static {
     /// Discard the open transaction. Calling this more than once is harmless.
     fn abort(&mut self);
 }
+
+/// Opens the transactional destination for each independently playable part.
+pub trait PartSinkFactory: Send + 'static {
+    /// Concrete transaction used by the recording core.
+    type Sink: RecordingSink;
+
+    /// Open one part by its one-based sequence number.
+    ///
+    /// # Errors
+    /// Returns the destination's acquisition failure.
+    fn open(&mut self, part: u64) -> Result<Self::Sink, <Self::Sink as RecordingSink>::Error>;
+}

--- a/crates/kithara-record/tests/live.rs
+++ b/crates/kithara-record/tests/live.rs
@@ -1,0 +1,289 @@
+use std::{
+    io,
+    num::{NonZeroU64, NonZeroUsize},
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+};
+
+use kithara_bufpool::testing::pools;
+use kithara_encode::EncodeConfig;
+use kithara_output::{LiveOutput, OutputGroup};
+use kithara_platform::{
+    sync::{Arc, Mutex},
+    thread,
+    time::{Duration, Instant},
+};
+use kithara_record::{
+    LiveRecorder, LiveRecordingConfig, LiveRecordingError, LiveRecordingHandle,
+    LiveRecordingReport, PartSinkFactory, RecordingConfig, RecordingSink,
+};
+use kithara_test_utils::kithara;
+use kithara_worker::{Worker, WorkerConfig};
+
+#[derive(Clone, Default)]
+struct Parts(Arc<Mutex<Vec<Vec<u8>>>>);
+
+struct TestFactory {
+    parts: Parts,
+}
+
+impl PartSinkFactory for TestFactory {
+    type Sink = TestSink;
+
+    fn open(&mut self, _part: u64) -> Result<Self::Sink, io::Error> {
+        Ok(TestSink {
+            bytes: Vec::new(),
+            parts: self.parts.clone(),
+        })
+    }
+}
+
+struct TestSink {
+    bytes: Vec<u8>,
+    parts: Parts,
+}
+
+impl RecordingSink for TestSink {
+    type Error = io::Error;
+    type Output = ();
+
+    fn write_at(&mut self, offset: u64, bytes: &[u8]) -> Result<(), Self::Error> {
+        let offset = usize::try_from(offset).map_err(io::Error::other)?;
+        let end = offset
+            .checked_add(bytes.len())
+            .ok_or_else(|| io::Error::other("test sink length overflow"))?;
+        self.bytes.resize(self.bytes.len().max(end), 0);
+        self.bytes[offset..end].copy_from_slice(bytes);
+        Ok(())
+    }
+
+    fn commit(&mut self, final_len: u64) -> Result<Self::Output, Self::Error> {
+        let final_len = usize::try_from(final_len).map_err(io::Error::other)?;
+        self.bytes.truncate(final_len);
+        self.parts.0.lock().push(self.bytes.clone());
+        Ok(())
+    }
+
+    fn abort(&mut self) {
+        self.bytes.clear();
+    }
+}
+
+fn write(output: &mut impl LiveOutput, frames: &[(f32, f32)]) {
+    let left: Vec<_> = frames.iter().map(|frame| frame.0).collect();
+    let right: Vec<_> = frames.iter().map(|frame| frame.1).collect();
+    output.write_stereo(frames.len(), &left, &right);
+}
+
+fn wav_samples(bytes: &[u8]) -> Vec<f32> {
+    assert_eq!(&bytes[0..4], b"RIFF");
+    assert_eq!(&bytes[8..12], b"WAVE");
+    assert_eq!(&bytes[36..40], b"data");
+    let data_len = u32::from_le_bytes(bytes[40..44].try_into().expect("WAV data length"));
+    assert_eq!(bytes.len(), 44 + data_len as usize);
+    bytes[44..]
+        .chunks_exact(4)
+        .map(|sample| f32::from_le_bytes(sample.try_into().expect("one f32 sample")))
+        .collect()
+}
+
+fn wait_result(handle: &LiveRecordingHandle) -> Result<LiveRecordingReport, LiveRecordingError> {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        if let Some(result) = handle.finish() {
+            return result;
+        }
+        assert!(Instant::now() < deadline, "live recorder did not finish");
+        thread::yield_now();
+    }
+}
+
+#[kithara::test(native, flash(false))]
+fn manual_cut_and_rotation_publish_exact_independent_parts() {
+    let parts = Parts::default();
+    let config = LiveRecordingConfig::builder()
+        .recording(RecordingConfig::builder().build())
+        .buffer_frames(NonZeroUsize::new(32).expect("test buffer frames"))
+        .tick_frames(NonZeroUsize::new(8).expect("test tick frames"))
+        .rotation_frames(NonZeroU64::new(4).expect("test rotation frames"))
+        .build();
+    let worker = Worker::new(WorkerConfig::new());
+    let pools = pools();
+    let (mut output, handle) = LiveRecorder::start(
+        &worker,
+        &pools,
+        config,
+        TestFactory {
+            parts: parts.clone(),
+        },
+    )
+    .expect("start live recorder");
+
+    write(&mut output, &[(1.0, 101.0), (2.0, 102.0), (3.0, 103.0)]);
+    handle.cut();
+    write(&mut output, &[(4.0, 104.0), (5.0, 105.0), (6.0, 106.0)]);
+    write(&mut output, &[(7.0, 107.0), (8.0, 108.0), (9.0, 109.0)]);
+    let report = wait_result(&handle).expect("finish live recorder");
+
+    assert_eq!(report.frames, 9);
+    assert_eq!(report.parts, 3);
+    let parts = parts.0.lock();
+    assert_eq!(parts.len(), 3);
+    assert_eq!(wav_samples(&parts[0]), [1.0, 101.0, 2.0, 102.0, 3.0, 103.0]);
+    assert_eq!(
+        wav_samples(&parts[1]),
+        [4.0, 104.0, 5.0, 105.0, 6.0, 106.0, 7.0, 107.0]
+    );
+    assert_eq!(wav_samples(&parts[2]), [8.0, 108.0, 9.0, 109.0]);
+}
+
+#[derive(Clone)]
+struct Lifecycle {
+    aborted: Arc<AtomicBool>,
+    opened: Arc<AtomicBool>,
+}
+
+struct LifecycleFactory {
+    lifecycle: Lifecycle,
+    fail_write: bool,
+}
+
+impl PartSinkFactory for LifecycleFactory {
+    type Sink = LifecycleSink;
+
+    fn open(&mut self, _part: u64) -> Result<Self::Sink, io::Error> {
+        self.lifecycle.opened.store(true, Ordering::Release);
+        Ok(LifecycleSink {
+            fail_write: self.fail_write,
+            lifecycle: self.lifecycle.clone(),
+        })
+    }
+}
+
+struct LifecycleSink {
+    fail_write: bool,
+    lifecycle: Lifecycle,
+}
+
+impl RecordingSink for LifecycleSink {
+    type Error = io::Error;
+    type Output = ();
+
+    fn write_at(&mut self, _offset: u64, _bytes: &[u8]) -> Result<(), Self::Error> {
+        if self.fail_write {
+            return Err(io::Error::other("injected sink failure"));
+        }
+        Ok(())
+    }
+
+    fn commit(&mut self, _final_len: u64) -> Result<Self::Output, Self::Error> {
+        Ok(())
+    }
+
+    fn abort(&mut self) {
+        self.lifecycle.aborted.store(true, Ordering::Release);
+    }
+}
+
+fn lifecycle() -> Lifecycle {
+    Lifecycle {
+        aborted: Arc::new(AtomicBool::new(false)),
+        opened: Arc::new(AtomicBool::new(false)),
+    }
+}
+
+fn wait_true(value: &AtomicBool, message: &str) {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while !value.load(Ordering::Acquire) {
+        assert!(Instant::now() < deadline, "{message}");
+        thread::yield_now();
+    }
+}
+
+#[kithara::test(native, flash(false))]
+fn bounded_overflow_aborts_the_open_part() {
+    let lifecycle = lifecycle();
+    let config = LiveRecordingConfig::builder()
+        .buffer_frames(NonZeroUsize::MIN)
+        .tick_frames(NonZeroUsize::MIN)
+        .build();
+    let worker = Worker::new(WorkerConfig::new());
+    let pools = pools();
+    let (mut output, handle) = LiveRecorder::start(
+        &worker,
+        &pools,
+        config,
+        LifecycleFactory {
+            lifecycle: lifecycle.clone(),
+            fail_write: false,
+        },
+    )
+    .expect("start live recorder");
+
+    write(&mut output, &[(1.0, -1.0)]);
+    wait_true(&lifecycle.opened, "recorder did not open its first part");
+    write(&mut output, &[(2.0, -2.0), (3.0, -3.0)]);
+
+    let result = wait_result(&handle);
+    assert!(
+        matches!(
+            result,
+            Err(LiveRecordingError::BufferOverflow { buffer_frames: 1 })
+        ),
+        "unexpected overflow result: {result:?}"
+    );
+    assert!(lifecycle.aborted.load(Ordering::Acquire));
+}
+
+struct FrameProbe(Arc<AtomicUsize>);
+
+impl LiveOutput for FrameProbe {
+    fn write_stereo(&mut self, frames: usize, _left: &[f32], _right: &[f32]) {
+        self.0.fetch_add(frames, Ordering::Relaxed);
+    }
+}
+
+#[kithara::test(native, flash(false))]
+fn sink_failure_does_not_stop_a_sibling_output() {
+    let lifecycle = lifecycle();
+    let config = LiveRecordingConfig::builder()
+        .recording(
+            RecordingConfig::builder()
+                .encode(
+                    EncodeConfig::builder()
+                        .sample_rate(48_000)
+                        .channels(2)
+                        .packet_frames(1)
+                        .build(),
+                )
+                .build(),
+        )
+        .buffer_frames(NonZeroUsize::new(8).expect("test buffer frames"))
+        .tick_frames(NonZeroUsize::MIN)
+        .build();
+    let worker = Worker::new(WorkerConfig::new());
+    let pools = pools();
+    let (output, handle) = LiveRecorder::start(
+        &worker,
+        &pools,
+        config,
+        LifecycleFactory {
+            lifecycle: lifecycle.clone(),
+            fail_write: true,
+        },
+    )
+    .expect("start live recorder");
+    let sibling_frames = Arc::new(AtomicUsize::new(0));
+    let mut outputs = OutputGroup::new();
+    outputs.push(output);
+    outputs.push(FrameProbe(Arc::clone(&sibling_frames)));
+
+    write(&mut outputs, &[(1.0, -1.0)]);
+    assert!(matches!(
+        wait_result(&handle),
+        Err(LiveRecordingError::Part { part: 1, .. })
+    ));
+    write(&mut outputs, &[(2.0, -2.0)]);
+
+    assert_eq!(sibling_frames.load(Ordering::Relaxed), 2);
+    assert!(lifecycle.aborted.load(Ordering::Acquire));
+}


### PR DESCRIPTION
## Summary
This adds optional live recording of the canonical post-limiter master signal. The host now installs an `OutputGroup` at the existing master tap, while `kithara-record` moves encoding and sink I/O onto a bounded `kithara-worker` task. Recordings use the configured `kithara-encode` profile and are committed as independently playable parts through the existing recording sink contract.

## Behavior / scope
- contract or behavior: fan each planar stereo master block out to independent `LiveOutput` endpoints; drain recorder PCM from a bounded ring buffer; support manual cuts, configured frame-based rotation, explicit finish, and transactional commit/abort.
- affected area: `kithara-host`, `kithara-output`, `kithara-play`, and `kithara-record`, including live recorder configuration and integration tests.

## Validation
- local heavy validation: not run, per the campaign constraint; commit-time hooks completed for `16ec120a465ce7bee7ca89f2ce8694c6bc4c033d`.
- [exact-head GitHub CI](https://github.com/gerasim13/kithara/actions/runs/33686973494): success.
- [exact-head linux-secrets dispatch](https://github.com/gerasim13/kithara/actions/runs/33693589115): success.
- [GitLab quarantine pipeline](https://gitlab.zvq.me/disrupt/kithara/-/pipelines/2131590): success.

## Surface impact
- Public API: changed: adds `LiveOutput`, `OutputGroup`, `Host::enable_outputs`, and live recorder configuration/control/report/factory APIs.
- Platform/runtime: changed: host/play master-output routing and the recorder worker path; the workspace Linux and WASM lanes pass.
- Perf-sensitive paths: changed: the post-limiter callback now fans out bounded writes and deferred wakes; encoding and sink I/O remain off the audio thread.

## Risks / follow-ups
- Recording fails on bounded-buffer overflow instead of blocking the audio thread; buffer, tick, rotation, and worker scheduling limits are configurable through the `bon` builder.
- Broadcast migration and output preservation across route changes remain in stacked PRs #262 and #263.