### PR TITLE
ci(bridge): name the default branch on each side separately

### DIFF
--- a/.config/bridge/config.example.toml
+++ b/.config/bridge/config.example.toml
@@ -1,6 +1,10 @@
-branch = "main"
+# The two sides name their default branch differently: GitLab follows the
+# corporate contour with `develop`, GitHub keeps `main`. The bridge fast-
+# forwards one onto the other, so each side has to be named for itself.
+github_branch = "main"
 github_repo = "zvuk/kithara"
 github_token_file = "/path/to/github-token"
+gitlab_branch = "develop"
 gitlab_project_id = 1
 gitlab_project_path = "group/kithara"
 gitlab_token_file = "/path/to/gitlab-token"

--- a/docs/guides/ci-host.md
+++ b/docs/guides/ci-host.md
@@ -75,23 +75,27 @@ Copy `.config/bridge/config.example.toml` to
 to UID 504 (`kithara-sync`), mode `0600`. The GitHub token needs
 `Contents: write`, `Pull requests: read` and `Commit statuses: write`. Validate
 with `ci bridge validate` (no network mutation), then `ci host activate-bridge`.
+`github_branch` and `gitlab_branch` are separate keys because the sides
+disagree — GitLab `develop`, GitHub `main` — and a swap is silent: GitHub
+answers an unknown base with an empty pull list.
 
 The daemon keeps running the executable that was installed, not the one on
-`main`: a fix changes nothing until `ci host install-services` reinstalls it
+`develop`: a fix changes nothing until `ci host install-services` reinstalls it
 from a reviewed GitLab commit, then `activate-bridge` and `activate`. launchd
 keeps the definition it loaded, so skipping `activate` silently leaves the
 maintenance agents on the old cadence; `launchctl print` reports what is loaded.
 
-The bridge moves `main` only by fast-forward, in whichever direction is behind,
-and never synthesizes a replacement commit or force-pushes a diverged branch.
+The bridge moves either default branch only by fast-forward, in whichever
+direction is behind, and never synthesizes a replacement commit or force-pushes
+a diverged branch.
 
-GitHub pull requests are verified before merge. While both `main` refs are
+GitHub pull requests are verified before merge. While both default branches are
 equal, the bridge reserves the exact head and base pair, publishes one
 quarantine ref, and starts its GitLab pipeline; the result lands on the head
 commit under the status context `kithara/gitlab-verification`. Branch protection
 must require that context on `main` and forbid direct pushes and bypasses, or
-the verifier is advisory. Once `main` moves, the next attempt reserves against
-the new base with a new ref.
+the verifier is advisory. Once the default branch moves, the next attempt
+reserves against the new base with a new ref.
 
 A pull request changing a CI control path is rejected before a pipeline exists;
 port it through a GitLab merge request: the code judging pull requests changes
@@ -163,7 +167,22 @@ sitting `pending` while the pipeline reads as hung.
 
 ## GitLab project settings
 
-Protect `main`, release tags, the `release` environment, and the runner, release
-and bridge credentials. Keep release publication manual and restricted to
-maintainers. Give the nightly and weekly schedules the kind variable
+Protect `develop`, release tags, the `release` environment, and the runner,
+release and bridge credentials. Keep release publication manual and restricted
+to maintainers. Give the nightly and weekly schedules the kind variable
 `.gitlab-ci.yml` reads.
+
+### Renaming the default branch
+
+Pipeline rules read `$CI_DEFAULT_BRANCH`, so the repository needs no edit; what
+follows the name is outside it, and the order matters:
+
+1. Create the branch, then move the default-branch setting — until it moves, a
+   push to the new branch dispatches as the `branch` kind, not the `main`
+   kind.
+2. Protect it before deleting the old one: protected variables reach protected
+   branches only, so release jobs fail on a missing secret instead.
+3. Repoint the schedules; a schedule keeps the branch it was created with.
+4. Retarget open merge requests, which GitLab closes with their target branch.
+5. Set `gitlab_branch` on the host, then `ci host activate-bridge`.
+6. Delete the old branch last.

--- a/xtask/src/ci/bridge/api.rs
+++ b/xtask/src/ci/bridge/api.rs
@@ -94,7 +94,7 @@ impl Github {
             &Method::GET,
             &format!(
                 "/repos/{}/git/ref/heads/{}",
-                self.config.github_repo, self.config.branch
+                self.config.github_repo, self.config.github_branch
             ),
             None,
         )?;
@@ -110,7 +110,7 @@ impl Github {
         let pulls = response
             .as_array()
             .context("GitHub commit pulls response was not an array")?;
-        Ok(merged_pull_number(pulls, sha, &self.config.branch))
+        Ok(merged_pull_number(pulls, sha, &self.config.github_branch))
     }
 
     pub(super) fn open_pull_requests(&self) -> Result<Vec<PullRequest>> {
@@ -122,7 +122,7 @@ impl Github {
                 &Method::GET,
                 &format!(
                     "/repos/{}/pulls?state=open&base={}&per_page={PAGE_SIZE}&page={page}",
-                    self.config.github_repo, self.config.branch
+                    self.config.github_repo, self.config.github_branch
                 ),
                 None,
             )?;
@@ -134,7 +134,7 @@ impl Github {
                     .pointer("/base/ref")
                     .and_then(Value::as_str)
                     .context("GitHub pull response has no base branch")?;
-                if branch != self.config.branch {
+                if branch != self.config.github_branch {
                     continue;
                 }
                 result.push(pull_request(pull)?);
@@ -196,7 +196,7 @@ impl Gitlab {
     pub(super) fn head(&self) -> Result<String> {
         let response = self.request(
             &Method::GET,
-            &format!("repository/branches/{}", self.config.branch),
+            &format!("repository/branches/{}", self.config.gitlab_branch),
             None,
         )?;
         string_field(&response, &["commit", "id"], "GitLab branch SHA")

--- a/xtask/src/ci/bridge/command.rs
+++ b/xtask/src/ci/bridge/command.rs
@@ -59,7 +59,13 @@ pub(super) struct BridgeConfig {
     pub(super) gitlab_project_path: String,
     pub(super) gitlab_username: String,
     pub(super) gitlab_token_file: PathBuf,
-    pub(super) branch: String,
+    /// The default branch on each side, named separately.
+    ///
+    /// One key served both while the two repositories agreed on the name. They
+    /// no longer do: GitLab calls its default branch `develop` and GitHub calls
+    /// its own `main`, and a single value cannot be right for both.
+    pub(super) github_branch: String,
+    pub(super) gitlab_branch: String,
     pub(super) state_dir: PathBuf,
     /// GitHub logins whose pull requests may change the CI control paths
     /// directly.
@@ -109,8 +115,13 @@ impl BridgeConfig {
         {
             bail!("gitlab_url must be an HTTPS origin without credentials or query");
         }
-        if !simple_branch(&self.branch) {
-            bail!("branch must be one simple branch name");
+        for (label, branch) in [
+            ("github_branch", &self.github_branch),
+            ("gitlab_branch", &self.gitlab_branch),
+        ] {
+            if !simple_branch(branch) {
+                bail!("{label} must be one simple branch name");
+            }
         }
         if self.gitlab_username.is_empty()
             || !self

--- a/xtask/src/ci/bridge/git.rs
+++ b/xtask/src/ci/bridge/git.rs
@@ -60,7 +60,7 @@ impl GitRepo {
                 &github_url,
                 &format!(
                     "+refs/heads/{}:refs/heads/bridge/github",
-                    self.config.branch
+                    self.config.github_branch
                 ),
             ],
             Some(github.git_header()),
@@ -79,7 +79,7 @@ impl GitRepo {
                 &gitlab_url,
                 &format!(
                     "+refs/heads/{}:refs/heads/bridge/gitlab",
-                    self.config.branch
+                    self.config.gitlab_branch
                 ),
             ],
             Some(gitlab.git_header()),
@@ -367,7 +367,7 @@ impl GitRepo {
             &[
                 "push",
                 &url,
-                &format!("{sha}:refs/heads/{}", self.config.branch),
+                &format!("{sha}:refs/heads/{}", self.config.github_branch),
             ],
             Some(github.git_header()),
         )?;
@@ -532,7 +532,8 @@ mod tests {
             gitlab_project_path: "group/repo".into(),
             gitlab_username: "bot".into(),
             gitlab_token_file: state.join("gitlab.token"),
-            branch: "main".into(),
+            github_branch: "main".into(),
+            gitlab_branch: "develop".into(),
             state_dir: state.to_path_buf(),
             trusted_authors: Vec::new(),
         }

--- a/xtask/src/ci/bridge/model.rs
+++ b/xtask/src/ci/bridge/model.rs
@@ -116,6 +116,17 @@ pub(super) fn direction_for(
     Ok(Direction::Diverged)
 }
 
+/// The default branch on each side of the bridge.
+///
+/// The two are separate values because the repositories disagree on the name.
+/// Crossing them is silent rather than loud: GitHub answers an unknown base
+/// with an empty pull list, so a swap would leave the bridge idling.
+#[derive(Clone, Copy, Debug)]
+pub(super) struct Branches<'a> {
+    pub(super) github: &'a str,
+    pub(super) gitlab: &'a str,
+}
+
 pub(super) fn validate_sha(value: &str) -> bool {
     value.len() == 40 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
 }

--- a/xtask/src/ci/bridge/reconcile.rs
+++ b/xtask/src/ci/bridge/reconcile.rs
@@ -13,7 +13,8 @@ use super::{
     git::{GitRepo, Judged},
     ledger::{Ledger, LedgerEntry},
     model::{
-        Direction, PipelineObservation, PullRequest, VerificationState, direction_for, validate_sha,
+        Branches, Direction, PipelineObservation, PullRequest, VerificationState, direction_for,
+        validate_sha,
     },
 };
 
@@ -109,7 +110,7 @@ impl Bridge {
                      other. Synchronization stopped."
                 );
                 self.gitlab
-                    .ensure_issue("GitHub and GitLab main branches diverged", &detail)?;
+                    .ensure_issue("GitHub and GitLab default branches diverged", &detail)?;
                 bail!("GitHub and GitLab histories diverged");
             }
         }
@@ -132,7 +133,10 @@ impl Bridge {
         fast_forward_github_import(
             github_sha,
             gitlab_base_sha,
-            &self.config.branch,
+            Branches {
+                github: &self.config.github_branch,
+                gitlab: &self.config.gitlab_branch,
+            },
             |sha| self.github.merged_pull_request(sha),
             || {
                 self.repo.fetch(&self.github, &self.gitlab)?;
@@ -140,7 +144,7 @@ impl Bridge {
             },
             |detail| {
                 self.gitlab
-                    .ensure_issue("Untrusted direct GitHub main update", detail)
+                    .ensure_issue("Untrusted direct GitHub default-branch update", detail)
             },
             |sha, branch| self.repo.push_gitlab(&self.gitlab, sha, branch),
         )
@@ -460,16 +464,17 @@ fn observe_verification(
 fn fast_forward_github_import(
     github_sha: &str,
     gitlab_base_sha: &str,
-    branch: &str,
+    branches: Branches<'_>,
     merged_pull_request: impl FnOnce(&str) -> Result<Option<u64>>,
     refresh_heads: impl FnOnce() -> Result<(String, String)>,
     report_untrusted: impl FnOnce(&str) -> Result<()>,
     push_gitlab: impl FnOnce(&str, &str) -> Result<()>,
 ) -> Result<()> {
     let Some(pull_number) = merged_pull_request(github_sha)? else {
+        let github_branch = branches.github;
         let detail = format!(
             "GitHub head {github_sha} is not associated with a merged pull request targeting \
-             {branch}"
+             {github_branch}"
         );
         report_untrusted(&detail)?;
         bail!("{detail}");
@@ -483,7 +488,7 @@ fn fast_forward_github_import(
         );
     }
 
-    push_gitlab(github_sha, branch)
+    push_gitlab(github_sha, branches.gitlab)
 }
 
 fn require_sha(owner: &str, sha: &str) -> Result<()> {

--- a/xtask/src/ci/bridge/reconcile_tests.rs
+++ b/xtask/src/ci/bridge/reconcile_tests.rs
@@ -376,7 +376,10 @@ fn a_merged_github_head_is_only_fast_forwarded() {
     fast_forward_github_import(
         github_sha,
         gitlab_sha,
-        "main",
+        Branches {
+            github: "main",
+            gitlab: "develop",
+        },
         {
             let actions = Rc::clone(&actions);
             move |_| {
@@ -409,7 +412,7 @@ fn a_merged_github_head_is_only_fast_forwarded() {
         [
             ImportAction::CheckProvenance,
             ImportAction::RefreshHeads,
-            ImportAction::Push(format!("{github_sha}:main")),
+            ImportAction::Push(format!("{github_sha}:develop")),
         ]
     );
 }
@@ -422,7 +425,10 @@ fn changed_heads_stop_the_import_before_the_push() {
     let error = fast_forward_github_import(
         github_sha,
         gitlab_sha,
-        "main",
+        Branches {
+            github: "main",
+            gitlab: "develop",
+        },
         |_| Ok(Some(427)),
         || {
             Ok((
@@ -446,7 +452,10 @@ fn a_direct_github_update_opens_an_incident_without_a_push() {
     let error = fast_forward_github_import(
         github_sha,
         "89abcdef0123456789abcdef0123456789abcdef",
-        "main",
+        Branches {
+            github: "main",
+            gitlab: "develop",
+        },
         |_| Ok(None),
         || panic!("an untrusted head must not refresh for promotion"),
         {
@@ -541,7 +550,7 @@ fn a_quarantine_ref_judged_against_the_current_base_is_kept() {
 
 #[test]
 fn a_branch_that_is_not_a_verification_run_is_never_swept() {
-    let refs = ["main".to_owned(), "laba/419-connectivity".to_owned()];
+    let refs = ["develop".to_owned(), "laba/419-connectivity".to_owned()];
 
     assert_eq!(
         superseded_quarantine_refs(&refs, CURRENT_BASE),
@@ -565,7 +574,7 @@ fn the_older_quarantine_naming_scheme_is_swept_by_the_same_rule() {
 fn a_sweep_drops_every_branch_a_moved_base_left_behind() {
     let stale = quarantine_ref(PULL_HEAD, OLDER_BASE, 1);
     let live = quarantine_ref(PULL_HEAD, CURRENT_BASE, 2);
-    let listed = vec![stale.clone(), live, "main".to_owned()];
+    let listed = vec![stale.clone(), live, "develop".to_owned()];
     let deleted = RefCell::new(Vec::new());
 
     sweep_quarantine_refs(


### PR DESCRIPTION
## Description

GitLab renames its default branch to `develop` for consistency with the rest of the corporate contour. GitHub keeps `main`.

The pipeline rules themselves are already rename-safe: `.gitlab-ci.yml` compares against `$CI_DEFAULT_BRANCH` and dispatches by `KITHARA_PIPELINE_KIND`, so no rule mentions the branch by name. (The pipeline kind `main` is a homonym, not a reference to the branch.) The one thing that does break is the bridge: it carried a single `branch` key and used it for both repositories at nine call sites. That worked only while the two sides agreed on the name — with `develop` on one side it would ask GitHub for `develop` and GitLab for `main`.

Split into `github_branch` and `gitlab_branch`, threaded through the import as a `Branches` value (which keeps `fast_forward_github_import` inside the 7-argument budget rather than raising the threshold). Crossing the two would be silent rather than loud — GitHub answers an unknown base with an empty pull list, so a swapped pair leaves the bridge idling — so the tests pin the asymmetry: the import pushes to GitLab's name while the provenance message names GitHub's. `deny_unknown_fields` turns the old `branch` key into a load failure instead of a side quietly pointed at a branch that is not there.

`docs/guides/ci-host.md` gains the ordered runbook for the rename itself: the failure modes are all outside the repository (a schedule keeps the branch it was created with, protected variables reach protected branches only, GitLab closes merge requests with their target branch), and the order matters.

Not in scope: `crates/kithara-devtools` still hardcodes `origin/main` in `touched.rs` and `health.rs`. Their lanes (`linux-support`, `quality-health`) appear only in the GitHub workflows, where `origin` stays `main`, so nothing breaks — but making them remote-aware needs a decision about what the base ref is when `origin` may be either remote, and `AGENTS.md` forbids papering that over with a fallback chain.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring (no functional changes)
- [x] Documentation
- [ ] Other (describe):

## Checklist

- [x] `cargo fmt --all --check` passes — via `just fmt`
- [x] `cargo clippy --workspace -- -D warnings` passes — via `just lint fast` (exit 0)
- [x] Tests added/updated — `reconcile_tests.rs` pins the per-side names; `just test run --lane=tooling`: 1660 passed, 3 skipped
- [x] No `unwrap()`/`expect()` in production code
- [x] Documentation updated (if applicable)

Also run: `just lint style` — 0 deny, 0 regression(s), 0 new (the `doc_size` ratchet from #259 keeps `ci-host.md` under its 10000-byte warn threshold; it lands at 9969).