### PR TITLE
refactor(worker): build dispatcher config with bon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5452,6 +5452,7 @@ dependencies = [
 name = "kithara-worker"
 version = "0.0.1-alpha4"
 dependencies = [
+ "bon",
  "criterion",
  "delegate",
  "fieldwork",

--- a/crates/kithara-analysis/src/tests/node.rs
+++ b/crates/kithara-analysis/src/tests/node.rs
@@ -109,7 +109,11 @@ where
                 .with_max_compute_tasks(compute_tasks)
                 .with_owned_pool(RayonConfig::new(compute_tasks, "analysis-node-test")),
         );
-        let dispatcher = worker.dispatcher(DispatcherConfig::new("analysis-node-test"));
+        let dispatcher = worker.dispatcher(
+            DispatcherConfig::builder()
+                .name("analysis-node-test")
+                .build(),
+        );
         let pending = dispatcher
             .reserve(TaskConfig::new().with_max_compute_tasks(compute_tasks))
             .expect("test analysis task is reserved");

--- a/crates/kithara-analysis/src/worker/handle.rs
+++ b/crates/kithara-analysis/src/worker/handle.rs
@@ -110,17 +110,17 @@ impl AnalysisWorker {
                 ));
             (Worker::new(worker_config), None)
         };
-        let mut dispatcher_config = DispatcherConfig::new("kithara-analysis")
-            .with_capacity(capacity)
-            .with_fairness_yield_interval(fairness_yield_interval)
-            .with_idle_timeout(idle_timeout)
-            .with_observer(AnalysisObserver::default())
-            .with_slow_tick_threshold(slow_tick_threshold)
-            .with_task_burst(task_burst)
-            .with_wait_timeout(wait_timeout);
-        if let Some(cancel) = dispatcher_cancel {
-            dispatcher_config = dispatcher_config.with_cancel(cancel);
-        }
+        let dispatcher_config = DispatcherConfig::builder()
+            .name("kithara-analysis")
+            .capacity(capacity)
+            .fairness_yield_interval(fairness_yield_interval)
+            .idle_timeout(idle_timeout)
+            .observer(AnalysisObserver::default())
+            .slow_tick_threshold(slow_tick_threshold)
+            .task_burst(task_burst)
+            .wait_timeout(wait_timeout)
+            .maybe_cancel(dispatcher_cancel)
+            .build();
         let dispatcher = base.dispatcher(dispatcher_config);
         let _ = builder.take_detector();
         let fingerprint = builder.fingerprint();

--- a/crates/kithara-app/src/analysis.rs
+++ b/crates/kithara-app/src/analysis.rs
@@ -698,7 +698,9 @@ mod tests {
             pools,
             NonZeroUsize::MIN,
             Duration::from_secs(u64::from(chunk_seconds().get())),
-            DispatcherConfig::new("analysis-persistence-controller-test"),
+            DispatcherConfig::builder()
+                .name("analysis-persistence-controller-test")
+                .build(),
             TaskConfig::new(),
         ))
         .expect("persistence fixture starts")

--- a/crates/kithara-app/src/gui/frontend.rs
+++ b/crates/kithara-app/src/gui/frontend.rs
@@ -179,7 +179,9 @@ impl GuiFrontend {
             config.worker.pools().clone(),
             NonZeroUsize::new(8).unwrap_or(NonZeroUsize::MIN),
             Duration::from_secs(u64::from(config.analysis_chunk_seconds.get())),
-            DispatcherConfig::new("kithara-analysis-persistence"),
+            DispatcherConfig::builder()
+                .name("kithara-analysis-persistence")
+                .build(),
             TaskConfig::new(),
         ))?;
 

--- a/crates/kithara-app/src/wave_cache/persistence.rs
+++ b/crates/kithara-app/src/wave_cache/persistence.rs
@@ -590,7 +590,9 @@ mod tests {
             pools.clone(),
             NonZeroUsize::MIN,
             Duration::from_secs(Consts::CHUNK_FRAMES),
-            DispatcherConfig::new("analysis-persistence-test"),
+            DispatcherConfig::builder()
+                .name("analysis-persistence-test")
+                .build(),
             TaskConfig::new(),
         ))
         .expect("persistence actor starts");

--- a/crates/kithara-play/src/worker/core.rs
+++ b/crates/kithara-play/src/worker/core.rs
@@ -58,17 +58,17 @@ impl<S> PlayWorker<S> {
             (Worker::new(worker_config), None)
         };
         let id = WORKER_ID.fetch_add(1, Ordering::Relaxed);
-        let mut dispatcher_config = DispatcherConfig::new(format!("kithara-play-worker-{id}"))
-            .with_capacity(capacity)
-            .with_fairness_yield_interval(fairness_yield_interval)
-            .with_idle_timeout(idle_timeout)
-            .with_observer(PlaybackObserver::default())
-            .with_slow_tick_threshold(slow_tick_threshold)
-            .with_task_burst(task_burst)
-            .with_wait_timeout(wait_timeout);
-        if let Some(cancel) = dispatcher_cancel {
-            dispatcher_config = dispatcher_config.with_cancel(cancel);
-        }
+        let dispatcher_config = DispatcherConfig::builder()
+            .name(format!("kithara-play-worker-{id}"))
+            .capacity(capacity)
+            .fairness_yield_interval(fairness_yield_interval)
+            .idle_timeout(idle_timeout)
+            .observer(PlaybackObserver::default())
+            .slow_tick_threshold(slow_tick_threshold)
+            .task_burst(task_burst)
+            .wait_timeout(wait_timeout)
+            .maybe_cancel(dispatcher_cancel)
+            .build();
         let dispatcher = base.dispatcher(dispatcher_config);
         Self(Arc::new(WorkerOwner {
             dispatcher,

--- a/crates/kithara-play/src/worker/node/scheduler_tests.rs
+++ b/crates/kithara-play/src/worker/node/scheduler_tests.rs
@@ -186,9 +186,11 @@ impl PlaybackScheduler {
     fn start(name: String, cancel: CancelToken, capacity: std::num::NonZeroUsize) -> Self {
         let worker = Worker::new(WorkerConfig::new().with_cancel(cancel));
         let dispatcher = worker.dispatcher(
-            DispatcherConfig::new(name)
-                .with_capacity(capacity)
-                .with_observer(crate::worker::scheduler::PlaybackObserver::default()),
+            DispatcherConfig::builder()
+                .name(name)
+                .capacity(capacity)
+                .observer(crate::worker::scheduler::PlaybackObserver::default())
+                .build(),
         );
         Self {
             dispatcher,

--- a/crates/kithara-worker/Cargo.toml
+++ b/crates/kithara-worker/Cargo.toml
@@ -17,6 +17,7 @@ kithara-platform = { workspace = true }
 kithara-test-macros = { workspace = true }
 kithara-test-utils = { workspace = true, features = ["client-reqwest", "probe", "tls-rustls"], optional = true }
 
+bon = { workspace = true }
 delegate = { workspace = true }
 fieldwork = { workspace = true }
 

--- a/crates/kithara-worker/benches/dispatcher.rs
+++ b/crates/kithara-worker/benches/dispatcher.rs
@@ -37,7 +37,11 @@ impl Task for Countdown {
 
 fn bench_dispatcher(c: &mut Criterion) {
     let worker = Worker::new(WorkerConfig::new());
-    let dispatcher = worker.dispatcher(DispatcherConfig::new("kithara-worker-bench"));
+    let dispatcher = worker.dispatcher(
+        DispatcherConfig::builder()
+            .name("kithara-worker-bench")
+            .build(),
+    );
     let mut group = c.benchmark_group("dispatcher");
     group.sample_size(50);
     group.throughput(Throughput::Elements(

--- a/crates/kithara-worker/src/config/dispatcher.rs
+++ b/crates/kithara-worker/src/config/dispatcher.rs
@@ -1,55 +1,35 @@
 use std::num::{NonZeroU32, NonZeroUsize};
 
+use bon::Builder;
 use kithara_platform::{CancelGroup, time::Duration};
 
 use crate::{Observer, observer::Event};
 
 /// Scheduler thread budgets and observer.
 #[non_exhaustive]
-#[derive(fieldwork::Fieldwork)]
-#[fieldwork(opt_in, with)]
+#[derive(Builder)]
+#[builder(state_mod(vis = "pub"))]
 pub struct DispatcherConfig {
+    #[builder(
+        default = Box::new(NoopObserver),
+        with = |observer: impl Observer| Box::new(observer)
+    )]
     pub(crate) observer: Box<dyn Observer>,
-    #[field(with)]
+    #[builder(default = Duration::from_millis(100))]
     pub(crate) idle_timeout: Duration,
-    #[field(with)]
+    #[builder(default = Duration::from_millis(10))]
     pub(crate) slow_tick_threshold: Duration,
-    #[field(with)]
+    #[builder(default = Duration::from_millis(10))]
     pub(crate) wait_timeout: Duration,
-    #[field(with)]
+    #[builder(default = NonZeroU32::new(16).unwrap_or(NonZeroU32::MIN))]
     pub(crate) fairness_yield_interval: NonZeroU32,
-    #[field(with)]
+    #[builder(default = NonZeroU32::new(32).unwrap_or(NonZeroU32::MIN))]
     pub(crate) task_burst: NonZeroU32,
-    #[field(with)]
+    #[builder(default = NonZeroUsize::new(64).unwrap_or(NonZeroUsize::MIN))]
     pub(crate) capacity: NonZeroUsize,
-    #[field(with, option_set_some)]
     pub(crate) cancel: Option<CancelGroup>,
+    #[builder(into)]
     pub(crate) name: String,
-}
-
-impl DispatcherConfig {
-    /// Create scheduler settings with conservative general-purpose budgets.
-    #[must_use]
-    pub fn new<N: Into<String>>(name: N) -> Self {
-        Self {
-            cancel: None,
-            capacity: NonZeroUsize::new(64).unwrap_or(NonZeroUsize::MIN),
-            fairness_yield_interval: NonZeroU32::new(16).unwrap_or(NonZeroU32::MIN),
-            idle_timeout: Duration::from_millis(100),
-            name: name.into(),
-            observer: Box::new(NoopObserver),
-            slow_tick_threshold: Duration::from_millis(10),
-            task_burst: NonZeroU32::new(32).unwrap_or(NonZeroU32::MIN),
-            wait_timeout: Duration::from_millis(10),
-        }
-    }
-
-    /// Replace the no-op observer for this dispatcher.
-    #[must_use]
-    pub fn with_observer<O: Observer>(mut self, observer: O) -> Self {
-        self.observer = Box::new(observer);
-        self
-    }
 }
 
 struct NoopObserver;

--- a/crates/kithara-worker/src/dispatcher/tests.rs
+++ b/crates/kithara-worker/src/dispatcher/tests.rs
@@ -316,8 +316,10 @@ fn scheduler_does_not_busy_spin_on_backpressure() {
     let (first_tick, first_tick_rx) = mpsc::channel();
     let worker = crate::Worker::new(crate::WorkerConfig::new());
     let dispatcher = worker.dispatcher(
-        DispatcherConfig::new("backpressure-park-test")
-            .with_wait_timeout(Duration::from_millis(20)),
+        DispatcherConfig::builder()
+            .name("backpressure-park-test")
+            .wait_timeout(Duration::from_millis(20))
+            .build(),
     );
     let handle = dispatcher
         .register(TaskConfig::new(), {
@@ -442,7 +444,11 @@ fn shutdown_recycles_cancelled_tasks_before_drop() {
 fn shutdown_cancels_and_recycles_a_queued_never_run_task_once() {
     let recorder = probe_capture::install();
     let worker = crate::Worker::new(crate::WorkerConfig::new());
-    let dispatcher = worker.dispatcher(DispatcherConfig::new("queued-shutdown-test"));
+    let dispatcher = worker.dispatcher(
+        DispatcherConfig::builder()
+            .name("queued-shutdown-test")
+            .build(),
+    );
     let (started, started_rx) = mpsc::channel();
     let (release, release_rx) = mpsc::channel();
     let blocker = dispatcher
@@ -493,7 +499,11 @@ fn shutdown_cancels_and_recycles_a_queued_never_run_task_once() {
 #[kithara::test(native, flash(false))]
 fn shutdown_closes_task_admission_before_returning() {
     let worker = crate::Worker::new(crate::WorkerConfig::new());
-    let dispatcher = worker.dispatcher(DispatcherConfig::new("closed-admission-test"));
+    let dispatcher = worker.dispatcher(
+        DispatcherConfig::builder()
+            .name("closed-admission-test")
+            .build(),
+    );
 
     dispatcher.shutdown();
 
@@ -579,8 +589,12 @@ fn fairness_streak_yields_at_the_configured_interval_and_resets_on_waits() {
 #[kithara::test(native, flash(false))]
 fn configured_capacity_rejects_a_second_reservation() {
     let worker = crate::Worker::new(crate::WorkerConfig::new());
-    let dispatcher =
-        worker.dispatcher(DispatcherConfig::new("capacity-test").with_capacity(NonZeroUsize::MIN));
+    let dispatcher = worker.dispatcher(
+        DispatcherConfig::builder()
+            .name("capacity-test")
+            .capacity(NonZeroUsize::MIN)
+            .build(),
+    );
     let first = dispatcher
         .reserve(TaskConfig::new())
         .expect("first reserve");
@@ -596,8 +610,12 @@ fn configured_capacity_rejects_a_second_reservation() {
 #[kithara::test(native, flash(false))]
 fn task_handle_drop_releases_capacity_for_immediate_ordered_replacement() {
     let worker = crate::Worker::new(crate::WorkerConfig::new());
-    let dispatcher = worker
-        .dispatcher(DispatcherConfig::new("replacement-test").with_capacity(NonZeroUsize::MIN));
+    let dispatcher = worker.dispatcher(
+        DispatcherConfig::builder()
+            .name("replacement-test")
+            .capacity(NonZeroUsize::MIN)
+            .build(),
+    );
     let first = dispatcher
         .register(TaskConfig::new(), |_| FixedTask(TickResult::Backpressured))
         .expect("first task");
@@ -614,14 +632,29 @@ fn task_handle_drop_releases_capacity_for_immediate_ordered_replacement() {
 }
 
 #[kithara::test(native, flash(false))]
-fn non_zero_budget_types_are_accepted_by_every_budget_setter() {
-    let _ = DispatcherConfig::new("budget-test")
-        .with_capacity(NonZeroUsize::MIN)
-        .with_fairness_yield_interval(NonZeroU32::MIN)
-        .with_idle_timeout(Duration::ZERO)
-        .with_slow_tick_threshold(Duration::ZERO)
-        .with_task_burst(NonZeroU32::MIN)
-        .with_wait_timeout(Duration::ZERO);
+fn dispatcher_builder_uses_scheduler_defaults() {
+    let config = DispatcherConfig::builder().name("defaults-test").build();
+
+    assert_eq!(config.capacity.get(), 64);
+    assert_eq!(config.fairness_yield_interval.get(), 16);
+    assert_eq!(config.idle_timeout, Duration::from_millis(100));
+    assert_eq!(config.slow_tick_threshold, Duration::from_millis(10));
+    assert_eq!(config.task_burst.get(), 32);
+    assert_eq!(config.wait_timeout, Duration::from_millis(10));
+    assert!(config.cancel.is_none());
+}
+
+#[kithara::test(native, flash(false))]
+fn non_zero_budget_types_are_accepted_by_the_dispatcher_builder() {
+    let _ = DispatcherConfig::builder()
+        .name("budget-test")
+        .capacity(NonZeroUsize::MIN)
+        .fairness_yield_interval(NonZeroU32::MIN)
+        .idle_timeout(Duration::ZERO)
+        .slow_tick_threshold(Duration::ZERO)
+        .task_burst(NonZeroU32::MIN)
+        .wait_timeout(Duration::ZERO)
+        .build();
 }
 
 #[kithara::test(native, flash(false))]
@@ -629,9 +662,16 @@ fn dispatcher_cancel_group_does_not_cancel_worker_or_sibling_dispatcher() {
     let worker = crate::Worker::new(crate::WorkerConfig::new());
     let domain = CancelScope::new(None);
     let first = worker.dispatcher(
-        DispatcherConfig::new("first-dispatcher").with_cancel(CancelGroup::from(domain.token())),
+        DispatcherConfig::builder()
+            .name("first-dispatcher")
+            .cancel(CancelGroup::from(domain.token()))
+            .build(),
     );
-    let sibling = worker.dispatcher(DispatcherConfig::new("sibling-dispatcher"));
+    let sibling = worker.dispatcher(
+        DispatcherConfig::builder()
+            .name("sibling-dispatcher")
+            .build(),
+    );
 
     domain.cancel();
 
@@ -644,7 +684,10 @@ fn dispatcher_cancel_group_does_not_cancel_worker_or_sibling_dispatcher() {
 fn external_cancel_is_task_local_and_control_cancel_uses_dispatcher_thread() {
     let worker = crate::Worker::new(crate::WorkerConfig::new());
     let dispatcher = worker.dispatcher(
-        DispatcherConfig::new("task-cancel-test").with_wait_timeout(Duration::from_secs(30)),
+        DispatcherConfig::builder()
+            .name("task-cancel-test")
+            .wait_timeout(Duration::from_secs(30))
+            .build(),
     );
     let domain = CancelScope::new(None);
     let (events, received) = mpsc::channel();
@@ -720,7 +763,10 @@ fn a_panicking_task_does_not_stop_its_sibling() {
     let worker = crate::Worker::new(crate::WorkerConfig::new());
     let (panicked, observed_panic) = mpsc::channel();
     let dispatcher = worker.dispatcher(
-        DispatcherConfig::new("panic-isolation-test").with_observer(PanicObserver { panicked }),
+        DispatcherConfig::builder()
+            .name("panic-isolation-test")
+            .observer(PanicObserver { panicked })
+            .build(),
     );
     let panic_handle = dispatcher
         .register(TaskConfig::new(), |_| PanicTask)

--- a/crates/kithara-worker/src/worker.rs
+++ b/crates/kithara-worker/src/worker.rs
@@ -105,7 +105,8 @@ mod tests {
                 .with_owned_pool(RayonConfig::new(NonZeroUsize::MIN, "owned-compute-test")),
         );
         assert!(!worker.inner.compute.pool().owned_is_initialized());
-        let dispatcher = worker.dispatcher(DispatcherConfig::new("owned-pool-test"));
+        let dispatcher =
+            worker.dispatcher(DispatcherConfig::builder().name("owned-pool-test").build());
         let pending = dispatcher
             .reserve(TaskConfig::new())
             .expect("task reservation");
@@ -160,7 +161,11 @@ mod tests {
             .recv_timeout(Instant::now() + Duration::from_secs(2))
             .expect("pool thread must be occupied");
         let worker = Worker::new(WorkerConfig::new().with_pool(pool));
-        let dispatcher = worker.dispatcher(DispatcherConfig::new("accepted-payload-test"));
+        let dispatcher = worker.dispatcher(
+            DispatcherConfig::builder()
+                .name("accepted-payload-test")
+                .build(),
+        );
         let pending = dispatcher
             .reserve(TaskConfig::new())
             .expect("task reservation");
@@ -190,7 +195,8 @@ mod tests {
     #[kithara::test(native, flash(false))]
     fn disabled_compute_is_unavailable_and_budgets_saturate_without_queueing() {
         let disabled = Worker::new(WorkerConfig::new());
-        let disabled_dispatcher = disabled.dispatcher(DispatcherConfig::new("disabled-test"));
+        let disabled_dispatcher =
+            disabled.dispatcher(DispatcherConfig::builder().name("disabled-test").build());
         let disabled_task = disabled_dispatcher
             .reserve(TaskConfig::new())
             .expect("disabled task reservation");
@@ -212,7 +218,11 @@ mod tests {
                 .with_pool(pool)
                 .with_max_compute_tasks(NonZeroUsize::MIN),
         );
-        let dispatcher = worker.dispatcher(DispatcherConfig::new("compute-budget-test"));
+        let dispatcher = worker.dispatcher(
+            DispatcherConfig::builder()
+                .name("compute-budget-test")
+                .build(),
+        );
         let first = dispatcher
             .reserve(TaskConfig::new().with_max_compute_tasks(NonZeroUsize::MIN))
             .expect("first task reservation");
@@ -270,7 +280,11 @@ mod tests {
             NonZeroUsize::MIN,
             "cancelled-compute-test",
         )));
-        let dispatcher = worker.dispatcher(DispatcherConfig::new("cancelled-compute-test"));
+        let dispatcher = worker.dispatcher(
+            DispatcherConfig::builder()
+                .name("cancelled-compute-test")
+                .build(),
+        );
         let pending = dispatcher
             .reserve(TaskConfig::new())
             .expect("task reservation");
@@ -296,7 +310,11 @@ mod tests {
                 .with_cancel(parent_token.clone())
                 .with_owned_pool(RayonConfig::new(NonZeroUsize::MIN, "cancel-compute-test")),
         );
-        let dispatcher = worker.dispatcher(DispatcherConfig::new("cancel-lineage-test"));
+        let dispatcher = worker.dispatcher(
+            DispatcherConfig::builder()
+                .name("cancel-lineage-test")
+                .build(),
+        );
         let pending = dispatcher
             .reserve(TaskConfig::new())
             .expect("task reservation");
@@ -352,7 +370,8 @@ mod tests {
     #[kithara::test(native, flash(false))]
     fn final_worker_drop_cancels_derived_dispatchers_and_tasks() {
         let worker = Worker::new(WorkerConfig::new());
-        let dispatcher = worker.dispatcher(DispatcherConfig::new("worker-drop-test"));
+        let dispatcher =
+            worker.dispatcher(DispatcherConfig::builder().name("worker-drop-test").build());
         let pending = dispatcher
             .reserve(TaskConfig::new())
             .expect("task reservation");


### PR DESCRIPTION
## Summary
This extracts the worker configuration cleanup from #232 into an independently reviewable change. Dispatcher defaults now live on the owning `DispatcherConfig` fields, and every dispatcher is constructed through the typed Bon builder instead of mixing `new` with generated `with_*` setters.

## Behavior / scope
- contract or behavior: preserve existing dispatcher defaults and runtime behavior while replacing the construction API with `DispatcherConfig::builder()`
- affected area: `kithara-worker` plus existing dispatcher construction sites in analysis, app, and play

## Validation
- mandatory pre-commit hook: `just lint fast`
- broad tests: delegated to this PR CI

## Surface impact
- Public API: changed: `DispatcherConfig::new` and its `with_*` setters are replaced by the Bon builder
- Platform/runtime: none
- Perf-sensitive paths: none; worker construction only

## Risks / follow-ups
- intentionally excludes Warp, transport, latency, and scheduler-behavior WIP from #232