### PR TITLE
fix(host): preserve backend-default sample-rate request

### DIFF
--- a/crates/kithara-host/src/session/native.rs
+++ b/crates/kithara-host/src/session/native.rs
@@ -135,7 +135,7 @@ fn start_stream_cpal(
     debug!(sample_rate, "[KITHARA-ROUTE] starting cpal stream");
     let config = firewheel::cpal::CpalConfig {
         output: firewheel::cpal::CpalOutputConfig {
-            desired_sample_rate: Some(sample_rate),
+            desired_sample_rate: NonZeroU32::new(sample_rate).map(NonZeroU32::get),
             ..Default::default()
         },
         ..Default::default()


### PR DESCRIPTION
## Summary
This extracts the backend-default sample-rate fix from #232 into an independently reviewable host change. A raw sample-rate request of `0` is now translated to the existing CPAL `None` contract instead of forwarding an invalid explicit zero rate.

## Behavior / scope
- contract or behavior: `0` keeps meaning “select the backend default sample rate” when the native stream starts or restarts
- affected area: native `kithara-host` CPAL stream configuration

## Validation
- mandatory pre-commit hook: `just lint fast`
- broad tests: delegated to this PR CI

## Surface impact
- Public API: none
- Platform/runtime: changed: native audio route startup and restart with a backend-default sample-rate request
- Perf-sensitive paths: none

## Risks / follow-ups
- none