### PR TITLE
fix(host): own output block and sample rate configuration

### DIFF
--- a/.config/just/deps.just
+++ b/.config/just/deps.just
@@ -3,7 +3,7 @@ set working-directory := "../.."
 
 deny:
     cargo fetch --locked
-    GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=http.version GIT_CONFIG_VALUE_0=HTTP/1.1 cargo deny fetch db || echo "RustSec refresh unavailable; validating the cached database" >&2
+    cargo deny fetch db || echo "RustSec refresh unavailable; validating the cached database" >&2
     cargo deny --offline check
 
 machete:

--- a/.config/just/deps.just
+++ b/.config/just/deps.just
@@ -2,7 +2,8 @@ set shell := ["bash", "-euo", "pipefail", "-c"]
 set working-directory := "../.."
 
 deny:
-    cargo deny fetch db || echo "RustSec refresh unavailable; validating the cached database" >&2
+    cargo fetch --locked
+    GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=http.version GIT_CONFIG_VALUE_0=HTTP/1.1 cargo deny fetch db || echo "RustSec refresh unavailable; validating the cached database" >&2
     cargo deny --offline check
 
 machete:

--- a/.gitlab/ci/pipeline.yml
+++ b/.gitlab/ci/pipeline.yml
@@ -32,6 +32,10 @@ stages:
 # instead by keeping the build directory between jobs.
 variables:
   CARGO_INCREMENTAL: "0"
+  # GitHub's HTTP/2 ref listing stalls in the Linux runner.
+  GIT_CONFIG_COUNT: "1"
+  GIT_CONFIG_KEY_0: http.version
+  GIT_CONFIG_VALUE_0: HTTP/1.1
   GIT_DEPTH: "0"
   # Cleaning the tree between jobs deleted the build directory with it, so
   # every job relinked the whole workspace and the compiler cache could only

--- a/crates/kithara-app/src/analysis.rs
+++ b/crates/kithara-app/src/analysis.rs
@@ -652,7 +652,12 @@ mod tests {
     fn queue() -> (AppHost, AppQueueControl) {
         let worker = AppWorker::new(PlayWorkerConfig::builder(test_pools()).build());
         let mut host = AppHost::new(HostConfig::builder().build()).expect("test host");
-        let player = PlayerImpl::new(PlayerConfig::builder().worker(worker).build());
+        let player = PlayerImpl::new(
+            PlayerConfig::builder()
+                .worker(worker)
+                .sample_rate(host.requested_sample_rate())
+                .build(),
+        );
         let queue = AppQueue::new(QueueConfig::builder().player(player).build());
         let queue = host.insert(queue).expect("host accepts queue");
         let control = queue.control().clone();

--- a/crates/kithara-app/src/broadcast/live.rs
+++ b/crates/kithara-app/src/broadcast/live.rs
@@ -144,8 +144,6 @@ fn ring_capacity(config: &BroadcastConfig, tap_lead: Duration) -> BroadcastResul
 
 #[cfg(test)]
 mod tests {
-    use std::num::NonZeroU32;
-
     use kithara::{
         audio::ConsumerWakeMode,
         platform::{
@@ -163,10 +161,6 @@ mod tests {
 
     /// The lead every test that does not measure the ring starts on air with.
     const TAP_LEAD: Duration = Duration::from_secs(2);
-
-    fn requested_rate() -> NonZeroU32 {
-        NonZeroU32::new(SampleRateSession::REQUESTED_RATE).expect("fixture sample rate is non-zero")
-    }
 
     struct SampleRateSession {
         sample_rate: AtomicU32,
@@ -230,7 +224,7 @@ mod tests {
 
     fn on_air(sample_rate: u32) -> (Stream, Arc<SampleRateSession>, CancelToken) {
         let dispatcher = Arc::new(SampleRateSession::new(sample_rate));
-        let session = SessionHandle::new(dispatcher.clone(), requested_rate());
+        let session = SessionHandle::new(dispatcher.clone());
         let shutdown = CancelToken::root();
         let config = measured_config(&session)
             .expect("sample-rate query")
@@ -242,7 +236,7 @@ mod tests {
     #[kithara::test]
     fn configuration_waits_for_the_measured_session_sample_rate() {
         let dispatcher = Arc::new(SampleRateSession::new(0));
-        let session = SessionHandle::new(dispatcher.clone(), requested_rate());
+        let session = SessionHandle::new(dispatcher.clone());
 
         assert!(measured_config(&session).unwrap().is_none());
         assert!(
@@ -266,8 +260,7 @@ mod tests {
             "the running stream holds the session's mix tap"
         );
 
-        release(&SessionHandle::new(dispatcher.clone(), requested_rate()))
-            .expect("release mix tap");
+        release(&SessionHandle::new(dispatcher.clone())).expect("release mix tap");
         Backend::stop(stream);
 
         assert!(

--- a/crates/kithara-app/src/broadcast/live.rs
+++ b/crates/kithara-app/src/broadcast/live.rs
@@ -144,6 +144,8 @@ fn ring_capacity(config: &BroadcastConfig, tap_lead: Duration) -> BroadcastResul
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroU32;
+
     use kithara::{
         audio::ConsumerWakeMode,
         platform::{
@@ -161,6 +163,10 @@ mod tests {
 
     /// The lead every test that does not measure the ring starts on air with.
     const TAP_LEAD: Duration = Duration::from_secs(2);
+
+    fn requested_rate() -> NonZeroU32 {
+        NonZeroU32::new(SampleRateSession::REQUESTED_RATE).expect("fixture sample rate is non-zero")
+    }
 
     struct SampleRateSession {
         sample_rate: AtomicU32,
@@ -224,7 +230,7 @@ mod tests {
 
     fn on_air(sample_rate: u32) -> (Stream, Arc<SampleRateSession>, CancelToken) {
         let dispatcher = Arc::new(SampleRateSession::new(sample_rate));
-        let session = SessionHandle::new(dispatcher.clone());
+        let session = SessionHandle::new(dispatcher.clone(), requested_rate());
         let shutdown = CancelToken::root();
         let config = measured_config(&session)
             .expect("sample-rate query")
@@ -236,7 +242,7 @@ mod tests {
     #[kithara::test]
     fn configuration_waits_for_the_measured_session_sample_rate() {
         let dispatcher = Arc::new(SampleRateSession::new(0));
-        let session = SessionHandle::new(dispatcher.clone());
+        let session = SessionHandle::new(dispatcher.clone(), requested_rate());
 
         assert!(measured_config(&session).unwrap().is_none());
         assert!(
@@ -260,7 +266,8 @@ mod tests {
             "the running stream holds the session's mix tap"
         );
 
-        release(&SessionHandle::new(dispatcher.clone())).expect("release mix tap");
+        release(&SessionHandle::new(dispatcher.clone(), requested_rate()))
+            .expect("release mix tap");
         Backend::stop(stream);
 
         assert!(

--- a/crates/kithara-app/src/deck.rs
+++ b/crates/kithara-app/src/deck.rs
@@ -103,6 +103,7 @@ impl Deck {
                 .cancel(cancel.clone())
                 .crossfade_duration(config.crossfade_seconds)
                 .eq_layout(generate_log_spaced_bands(config.eq_bands))
+                .sample_rate(host.requested_sample_rate())
                 .timestretch(Arc::clone(&timestretch))
                 .worker(config.worker.clone())
                 .build(),
@@ -325,6 +326,7 @@ mod tests {
         let player = PlayerImpl::new(
             PlayerConfig::builder()
                 .cancel(cancel.clone())
+                .sample_rate(host.requested_sample_rate())
                 .timestretch(Arc::clone(&timestretch))
                 .worker(worker.clone())
                 .build(),

--- a/crates/kithara-ffi/src/native/bridge/event_bridge.rs
+++ b/crates/kithara-ffi/src/native/bridge/event_bridge.rs
@@ -838,7 +838,12 @@ mod tests {
         let worker = FfiWorker::new(
             PlayWorkerConfig::builder(pools::build().expect("valid FFI pool policy")).build(),
         );
-        let player = PlayerImpl::new(PlayerConfig::builder().worker(worker).build());
+        let player = PlayerImpl::new(
+            PlayerConfig::builder()
+                .sample_rate(crate::native::session::requested_sample_rate())
+                .worker(worker)
+                .build(),
+        );
         let queue = FfiQueue::new(QueueConfig::builder().player(player).build());
         let owner = crate::native::session::insert(queue)
             .expect("INVARIANT: the FFI test Host accepts its allocated Queue");

--- a/crates/kithara-ffi/src/native/inner.rs
+++ b/crates/kithara-ffi/src/native/inner.rs
@@ -200,6 +200,7 @@ impl NativeInner {
         let player_config = PlayerConfig::builder()
             .eq_layout(generate_log_spaced_bands(eq_band_count as usize))
             .cancel(player_cancel.child())
+            .sample_rate(super::session::requested_sample_rate())
             .worker(worker)
             .build();
         let player = PlayerImpl::new(player_config);

--- a/crates/kithara-ffi/src/native/session.rs
+++ b/crates/kithara-ffi/src/native/session.rs
@@ -1,4 +1,4 @@
-use std::sync::OnceLock;
+use std::{num::NonZeroU32, sync::OnceLock};
 
 use kithara::{
     host::{HostConfig, HostOwned},
@@ -23,6 +23,10 @@ where
     P: PlayerControlSource<Schema = FfiPools>,
 {
     host().lock().insert(player)
+}
+
+pub(crate) fn requested_sample_rate() -> NonZeroU32 {
+    host().lock().requested_sample_rate()
 }
 
 pub(crate) fn remove<P>(player: &HostOwned<P>) -> Result<(), PlayError>

--- a/crates/kithara-ffi/src/web/worker.rs
+++ b/crates/kithara-ffi/src/web/worker.rs
@@ -98,6 +98,7 @@ pub(crate) fn worker_main(
         let queue_store = state.store.clone();
         let player = kithara::play::PlayerImpl::new(
             kithara::play::PlayerConfig::builder()
+                .sample_rate(host.requested_sample_rate())
                 .worker(worker)
                 .build(),
         );

--- a/crates/kithara-host/CONTEXT.md
+++ b/crates/kithara-host/CONTEXT.md
@@ -77,6 +77,12 @@ rejection or fallback state.
 
 ## Route and sample-rate invariant
 
+`HostConfig` is the only product default for the initial output sample rate.
+Each inserted Player is built for an explicit initial rate and the one-shot
+`SessionBinding` carries the Host rate; insertion rejects a mismatch before the
+Player can register or start. Session register/start commands derive their rate
+from that binding rather than accepting another caller-supplied value.
+
 Route changes keep the existing flow: the Host observes the device change and
 the Player receives the resulting sample-rate update through its current
 control path. Rebuilding the output graph is reserved for a physical route

--- a/crates/kithara-host/CONTEXT.md
+++ b/crates/kithara-host/CONTEXT.md
@@ -79,9 +79,10 @@ rejection or fallback state.
 
 `HostConfig` is the only product default for the initial output sample rate.
 Each inserted Player is built for an explicit initial rate and the one-shot
-`SessionBinding` carries the Host rate; insertion rejects a mismatch before the
-Player can register or start. Session register/start commands derive their rate
-from that binding rather than accepting another caller-supplied value.
+`SessionBinding` carries only the canonical Host dispatcher. Insertion queries
+that session and rejects a mismatch before the Player can register or start.
+Session register/start commands derive their rate from the same query rather
+than accepting another caller-supplied value.
 
 Route changes keep the existing flow: the Host observes the device change and
 the Player receives the resulting sample-rate update through its current

--- a/crates/kithara-host/src/host.rs
+++ b/crates/kithara-host/src/host.rs
@@ -26,20 +26,9 @@ use crate::{
     },
 };
 
-struct Defaults {
-    output_block_frames: NonZeroU32,
-    sample_rate: NonZeroU32,
-}
-
-const DEFAULTS: Defaults = Defaults {
-    output_block_frames: match NonZeroU32::new(128) {
-        Some(frames) => frames,
-        None => unreachable!(),
-    },
-    sample_rate: match NonZeroU32::new(44_100) {
-        Some(sample_rate) => sample_rate,
-        None => unreachable!(),
-    },
+const DEFAULT_SAMPLE_RATE: NonZeroU32 = match NonZeroU32::new(44_100) {
+    Some(sample_rate) => sample_rate,
+    None => unreachable!(),
 };
 
 /// Configuration for the shared output session owned by [`Host`].
@@ -49,13 +38,12 @@ const DEFAULTS: Defaults = Defaults {
 #[non_exhaustive]
 pub struct HostConfig {
     /// Initial device-rate hint. Physical route changes may update it later.
-    #[builder(default = DEFAULTS.sample_rate)]
+    #[builder(default = DEFAULT_SAMPLE_RATE)]
     #[field(get, copy)]
     sample_rate: NonZeroU32,
-    /// Desired CPAL output callback size in frames. The backend may clamp or ignore it.
-    #[builder(default = DEFAULTS.output_block_frames)]
+    /// Optional CPAL output callback-size override. `None` preserves Firewheel's default.
     #[field(get, copy)]
-    output_block_frames: NonZeroU32,
+    output_block_frames: Option<NonZeroU32>,
 }
 
 /// Typed command proxy for one player value exclusively resident in a Host.
@@ -343,12 +331,12 @@ mod tests {
     use super::*;
 
     #[kithara::test]
-    fn host_config_output_block_frames_default_and_override() {
+    fn host_config_preserves_output_block_default_and_allows_override() {
         let default = HostConfig::builder().build();
-        assert_eq!(default.output_block_frames(), DEFAULTS.output_block_frames);
+        assert_eq!(default.output_block_frames(), None);
 
-        let frames = NonZeroU32::new(256).expect("test block size is non-zero");
+        let frames = NonZeroU32::new(128).expect("test block size is non-zero");
         let configured = HostConfig::builder().output_block_frames(frames).build();
-        assert_eq!(configured.output_block_frames(), frames);
+        assert_eq!(configured.output_block_frames(), Some(frames));
     }
 }

--- a/crates/kithara-host/src/host.rs
+++ b/crates/kithara-host/src/host.rs
@@ -130,10 +130,7 @@ impl<S> Host<S> {
     {
         let grid_id = player.id();
         let dispatcher: Arc<dyn SessionDispatcher<S>> = self.dispatcher.clone();
-        player.attach_session(SessionBinding::new(
-            dispatcher,
-            self.requested_sample_rate(),
-        ))?;
+        player.attach_session(SessionBinding::new(dispatcher))?;
         Ok((grid_id, player.control()))
     }
 
@@ -221,13 +218,7 @@ impl<S> Host<S> {
     /// # Errors
     /// Returns an error when the canonical session cannot answer the query.
     pub fn sample_rate(&self) -> Result<SessionSampleRate, PlayError> {
-        match self.dispatcher.exec(Cmd::QuerySampleRate)? {
-            Reply::SampleRate(sample_rate) => Ok(sample_rate),
-            Reply::Err(error) => Err(error.into()),
-            _ => Err(PlayError::Internal(
-                "unexpected host reply for sample-rate query".into(),
-            )),
-        }
+        self.dispatcher.sample_rate()
     }
 
     /// Installs the single post-limiter mix tap.

--- a/crates/kithara-host/src/host.rs
+++ b/crates/kithara-host/src/host.rs
@@ -26,9 +26,20 @@ use crate::{
     },
 };
 
-const DEFAULT_SAMPLE_RATE: NonZeroU32 = match NonZeroU32::new(44_100) {
-    Some(sample_rate) => sample_rate,
-    None => unreachable!(),
+struct Defaults {
+    output_block_frames: NonZeroU32,
+    sample_rate: NonZeroU32,
+}
+
+const DEFAULTS: Defaults = Defaults {
+    output_block_frames: match NonZeroU32::new(128) {
+        Some(frames) => frames,
+        None => unreachable!(),
+    },
+    sample_rate: match NonZeroU32::new(44_100) {
+        Some(sample_rate) => sample_rate,
+        None => unreachable!(),
+    },
 };
 
 /// Configuration for the shared output session owned by [`Host`].
@@ -38,9 +49,13 @@ const DEFAULT_SAMPLE_RATE: NonZeroU32 = match NonZeroU32::new(44_100) {
 #[non_exhaustive]
 pub struct HostConfig {
     /// Initial device-rate hint. Physical route changes may update it later.
-    #[builder(default = DEFAULT_SAMPLE_RATE)]
+    #[builder(default = DEFAULTS.sample_rate)]
     #[field(get, copy)]
     sample_rate: NonZeroU32,
+    /// Desired CPAL output callback size in frames. The backend may clamp or ignore it.
+    #[builder(default = DEFAULTS.output_block_frames)]
+    #[field(get, copy)]
+    output_block_frames: NonZeroU32,
 }
 
 /// Typed command proxy for one player value exclusively resident in a Host.
@@ -318,5 +333,22 @@ fn require_topology_change(result: Result<SyncAdmission, PlayError>) -> Result<(
             "host topology operation did not change topology".into(),
         )),
         Err(error) => Err(error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use kithara_test_utils::kithara;
+
+    use super::*;
+
+    #[kithara::test]
+    fn host_config_output_block_frames_default_and_override() {
+        let default = HostConfig::builder().build();
+        assert_eq!(default.output_block_frames(), DEFAULTS.output_block_frames);
+
+        let frames = NonZeroU32::new(256).expect("test block size is non-zero");
+        let configured = HostConfig::builder().output_block_frames(frames).build();
+        assert_eq!(configured.output_block_frames(), frames);
     }
 }

--- a/crates/kithara-host/src/host.rs
+++ b/crates/kithara-host/src/host.rs
@@ -130,8 +130,17 @@ impl<S> Host<S> {
     {
         let grid_id = player.id();
         let dispatcher: Arc<dyn SessionDispatcher<S>> = self.dispatcher.clone();
-        player.attach_session(SessionBinding::new(dispatcher))?;
+        player.attach_session(SessionBinding::new(
+            dispatcher,
+            self.requested_sample_rate(),
+        ))?;
         Ok((grid_id, player.control()))
+    }
+
+    /// Returns the session rate used before the output device is measured.
+    #[must_use]
+    pub fn requested_sample_rate(&self) -> NonZeroU32 {
+        self.root_view.grid().axis().sample_rate()
     }
 
     fn attach_member(&self, member: PlayerMember) -> Result<(), PlayError> {
@@ -326,6 +335,7 @@ fn require_topology_change(result: Result<SyncAdmission, PlayError>) -> Result<(
 
 #[cfg(test)]
 mod tests {
+    use kithara_bufpool::testing::TestPools;
     use kithara_test_utils::kithara;
 
     use super::*;
@@ -338,5 +348,15 @@ mod tests {
         let frames = NonZeroU32::new(128).expect("test block size is non-zero");
         let configured = HostConfig::builder().output_block_frames(frames).build();
         assert_eq!(configured.output_block_frames(), Some(frames));
+    }
+
+    #[kithara::test]
+    fn host_root_owns_the_configured_sample_rate() {
+        let sample_rate = NonZeroU32::new(48_000).expect("test sample rate is non-zero");
+        let config = HostConfig::builder().sample_rate(sample_rate).build();
+        let root = Host::<TestPools>::session_root(config).expect("host root");
+
+        assert_eq!(root.sample_rate, sample_rate);
+        assert_eq!(root.view.grid().axis().sample_rate(), sample_rate);
     }
 }

--- a/crates/kithara-host/src/host/platform/native.rs
+++ b/crates/kithara-host/src/host/platform/native.rs
@@ -41,13 +41,19 @@ where
     /// # Errors
     /// Returns an error when a canonical grid identity cannot be allocated.
     pub fn new(config: HostConfig) -> Result<Self, PlayError> {
+        let output_block_frames = config.output_block_frames;
         let SessionRoot {
             id,
             sample_rate,
             group,
             view,
         } = Self::session_root(config)?;
-        let dispatcher = crate::session::native::spawn::<S>(group, view.clone(), sample_rate);
+        let dispatcher = crate::session::native::spawn::<S>(
+            group,
+            view.clone(),
+            sample_rate,
+            output_block_frames,
+        );
         Ok(Self::owner(id, view, dispatcher, Platform::owner()))
     }
 

--- a/crates/kithara-host/src/session/native.rs
+++ b/crates/kithara-host/src/session/native.rs
@@ -131,11 +131,13 @@ where
 fn start_stream_cpal(
     ctx: &mut FirewheelCtx<firewheel::cpal::CpalBackend>,
     sample_rate: u32,
+    output_block_frames: NonZeroU32,
 ) -> Result<(), String> {
     debug!(sample_rate, "[KITHARA-ROUTE] starting cpal stream");
     let config = firewheel::cpal::CpalConfig {
         output: firewheel::cpal::CpalOutputConfig {
             desired_sample_rate: NonZeroU32::new(sample_rate).map(NonZeroU32::get),
+            desired_block_frames: Some(output_block_frames.get()),
             ..Default::default()
         },
         ..Default::default()
@@ -160,12 +162,13 @@ pub(crate) fn spawn<S: HasPool<f32> + Send + Sync + 'static>(
     root: GroupState<PlayerMember>,
     root_view: RootView,
     sample_rate: NonZeroU32,
+    output_block_frames: NonZeroU32,
 ) -> Arc<dyn HostDispatcher<S>> {
     spawn_session_client::<firewheel::cpal::CpalBackend, S>(
         "kithara-engine",
         root,
         root_view,
         sample_rate,
-        start_stream_cpal,
+        move |ctx, sample_rate| start_stream_cpal(ctx, sample_rate, output_block_frames),
     )
 }

--- a/crates/kithara-host/src/session/native.rs
+++ b/crates/kithara-host/src/session/native.rs
@@ -131,17 +131,10 @@ where
 fn start_stream_cpal(
     ctx: &mut FirewheelCtx<firewheel::cpal::CpalBackend>,
     sample_rate: u32,
-    output_block_frames: NonZeroU32,
+    output_block_frames: Option<NonZeroU32>,
 ) -> Result<(), String> {
     debug!(sample_rate, "[KITHARA-ROUTE] starting cpal stream");
-    let config = firewheel::cpal::CpalConfig {
-        output: firewheel::cpal::CpalOutputConfig {
-            desired_sample_rate: NonZeroU32::new(sample_rate).map(NonZeroU32::get),
-            desired_block_frames: Some(output_block_frames.get()),
-            ..Default::default()
-        },
-        ..Default::default()
-    };
+    let config = cpal_config(sample_rate, output_block_frames);
     match ctx.start_stream(config) {
         Ok(()) => {
             debug!(sample_rate, "[KITHARA-ROUTE] cpal stream started");
@@ -158,11 +151,23 @@ fn start_stream_cpal(
     }
 }
 
+fn cpal_config(
+    sample_rate: u32,
+    output_block_frames: Option<NonZeroU32>,
+) -> firewheel::cpal::CpalConfig {
+    let mut config = firewheel::cpal::CpalConfig::default();
+    config.output.desired_sample_rate = NonZeroU32::new(sample_rate).map(NonZeroU32::get);
+    if let Some(frames) = output_block_frames {
+        config.output.desired_block_frames = Some(frames.get());
+    }
+    config
+}
+
 pub(crate) fn spawn<S: HasPool<f32> + Send + Sync + 'static>(
     root: GroupState<PlayerMember>,
     root_view: RootView,
     sample_rate: NonZeroU32,
-    output_block_frames: NonZeroU32,
+    output_block_frames: Option<NonZeroU32>,
 ) -> Arc<dyn HostDispatcher<S>> {
     spawn_session_client::<firewheel::cpal::CpalBackend, S>(
         "kithara-engine",
@@ -171,4 +176,24 @@ pub(crate) fn spawn<S: HasPool<f32> + Send + Sync + 'static>(
         sample_rate,
         move |ctx, sample_rate| start_stream_cpal(ctx, sample_rate, output_block_frames),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use kithara_test_utils::kithara;
+
+    use super::*;
+
+    #[kithara::test]
+    fn output_block_override_preserves_the_backend_default_or_sets_128() {
+        let inherited = cpal_config(44_100, None);
+        assert_eq!(
+            inherited.output.desired_block_frames,
+            firewheel::cpal::CpalOutputConfig::default().desired_block_frames
+        );
+
+        let frames = NonZeroU32::new(128).expect("test block size is non-zero");
+        let configured = cpal_config(44_100, Some(frames));
+        assert_eq!(configured.output.desired_block_frames, Some(128));
+    }
 }

--- a/crates/kithara-host/src/session/testing.rs
+++ b/crates/kithara-host/src/session/testing.rs
@@ -170,6 +170,20 @@ fn attach_player_with_id<B, S>(
     state.publish_root();
 }
 
+#[cfg(test)]
+pub(crate) fn fixture_member(grid_id: BeatGridId, sample_rate: NonZeroU32) -> PlayerMember {
+    let worker = PlayWorker::new(PlayWorkerConfig::builder(pools()).build());
+    let player = PlayerImpl::new(
+        PlayerConfig::builder()
+            .grid_id(grid_id)
+            .sample_rate(sample_rate)
+            .worker(worker)
+            .session(Arc::new(FixtureSession))
+            .build(),
+    );
+    target_member(player)
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 fn target_member<S>(player: PlayerImpl<S>) -> PlayerMember
 where

--- a/crates/kithara-host/src/session/testing.rs
+++ b/crates/kithara-host/src/session/testing.rs
@@ -59,15 +59,27 @@ where
     B: AudioBackend,
     S: HasPool<f32> + Send + Sync + 'static,
 {
-    pub const DEFAULT_SAMPLE_RATE: u32 = 44_100;
+    pub const DEFAULT_SAMPLE_RATE: NonZeroU32 =
+        match NonZeroU32::new(SessionState::<B, S>::DEFAULT_SAMPLE_RATE) {
+            Some(sample_rate) => sample_rate,
+            None => unreachable!(),
+        };
 
     #[must_use]
     pub fn new<F>(start_stream_fn: F) -> Self
     where
         F: FnMut(&mut FirewheelCtx<B>, u32) -> Result<(), String> + Send + 'static,
     {
+        Self::with_sample_rate(Self::DEFAULT_SAMPLE_RATE, start_stream_fn)
+    }
+
+    #[must_use]
+    pub fn with_sample_rate<F>(sample_rate: NonZeroU32, start_stream_fn: F) -> Self
+    where
+        F: FnMut(&mut FirewheelCtx<B>, u32) -> Result<(), String> + Send + 'static,
+    {
         Self {
-            state: state_for(start_stream_fn),
+            state: state_for(sample_rate, start_stream_fn),
         }
     }
 
@@ -104,17 +116,18 @@ where
     B: AudioBackend,
     F: FnMut(&mut FirewheelCtx<B>, u32) -> Result<(), String> + Send + 'static,
 {
-    state_for(start_stream_fn)
+    state_for(
+        GraphSession::<B, TestPools>::DEFAULT_SAMPLE_RATE,
+        start_stream_fn,
+    )
 }
 
-fn state_for<B, F, S>(start_stream_fn: F) -> SessionState<B, S>
+fn state_for<B, F, S>(sample_rate: NonZeroU32, start_stream_fn: F) -> SessionState<B, S>
 where
     B: AudioBackend,
     F: FnMut(&mut FirewheelCtx<B>, u32) -> Result<(), String> + Send + 'static,
 {
     let grid_id = BeatGridId::allocate().expect("fixture host grid id");
-    let sample_rate =
-        NonZeroU32::new(SessionState::<B, S>::DEFAULT_SAMPLE_RATE).expect("fixture sample rate");
     let root = GroupState::unavailable(
         grid_id,
         sample_rate,

--- a/crates/kithara-host/src/session/testing.rs
+++ b/crates/kithara-host/src/session/testing.rs
@@ -144,6 +144,7 @@ fn attach_player_with_id<B, S>(
     let player = PlayerImpl::new(
         PlayerConfig::builder()
             .grid_id(grid_id)
+            .sample_rate(state.root_view.grid().axis().sample_rate())
             .worker(worker)
             .session(Arc::new(FixtureSession))
             .build(),
@@ -167,20 +168,6 @@ fn attach_player_with_id<B, S>(
         .expect("fixture player attachment");
     assert!(matches!(admission, SyncAdmission::TopologyChanged { .. }));
     state.publish_root();
-}
-
-#[cfg(test)]
-pub(crate) fn fixture_member(grid_id: BeatGridId, sample_rate: NonZeroU32) -> PlayerMember {
-    let worker = PlayWorker::new(PlayWorkerConfig::builder(pools()).build());
-    let player = PlayerImpl::new(
-        PlayerConfig::builder()
-            .grid_id(grid_id)
-            .sample_rate(sample_rate)
-            .worker(worker)
-            .session(Arc::new(FixtureSession))
-            .build(),
-    );
-    target_member(player)
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/kithara-play/CONTEXT.md
+++ b/crates/kithara-play/CONTEXT.md
@@ -129,9 +129,10 @@ UI must not drift from the audio
 ## Engine Lifecycle
 
 `PlayerConfig.sample_rate` is mandatory and has no playback-layer default. It
-is the Player's initial session-rate contract; Host attachment must carry the
-same value through `SessionBinding`, and the session handle is the sole source
-for register/start commands. Tests pass their fixture rate explicitly.
+is the Player's initial session-rate contract; Host attachment queries the
+canonical dispatcher carried by `SessionBinding`, and that dispatcher is the
+sole rate source for validation and register/start commands. Tests pass their
+fixture rate explicitly.
 
 `EngineImpl::start` is **atomic single-start**: an internal `start_lock`
 serializes the `running` check-then-act, and `running` flips only after

--- a/crates/kithara-play/CONTEXT.md
+++ b/crates/kithara-play/CONTEXT.md
@@ -127,6 +127,12 @@ UI must not drift from the audio
 (`select_item_on_consumed_slot_errors_without_bookkeeping`).
 
 ## Engine Lifecycle
+
+`PlayerConfig.sample_rate` is mandatory and has no playback-layer default. It
+is the Player's initial session-rate contract; Host attachment must carry the
+same value through `SessionBinding`, and the session handle is the sole source
+for register/start commands. Tests pass their fixture rate explicitly.
+
 `EngineImpl::start` is **atomic single-start**: an internal `start_lock`
 serializes the `running` check-then-act, and `running` flips only after
 `session.start_player` fully succeeds. `ensure_engine_started` treats
@@ -345,4 +351,3 @@ arriving resource down the reselecting-current path, never to be enqueued.
 ## Testing And Integration
 The offline render backend for deterministic engine and player tests lives in
 `kithara-integration-tests::offline`, not here.
-

--- a/crates/kithara-play/src/engine/config.rs
+++ b/crates/kithara-play/src/engine/config.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, num::NonZeroU32};
 
 use bon::Builder;
 use kithara_bufpool::PoolRegion;
@@ -32,9 +32,8 @@ pub struct EngineConfig<S> {
     /// Number of output channels. Default: 2 (stereo).
     #[builder(default = 2)]
     pub(crate) channels: u16,
-    /// Sample rate passed to the runtime backend as a hint. Default: 44100.
-    #[builder(default = 44100)]
-    pub(crate) sample_rate: u32,
+    /// Initial output sample rate supplied by the owning player session.
+    pub(crate) sample_rate: NonZeroU32,
     /// Maximum number of concurrent player slots. Default: 4.
     #[builder(default = 4)]
     pub(crate) max_slots: usize,

--- a/crates/kithara-play/src/engine/core.rs
+++ b/crates/kithara-play/src/engine/core.rs
@@ -47,7 +47,9 @@ impl<S> EngineImpl<S> {
         let session = config
             .session
             .take()
-            .map_or_else(SessionHandle::pending, SessionHandle::new);
+            .map_or_else(SessionHandle::pending, |dispatcher| {
+                SessionHandle::new(dispatcher, config.sample_rate)
+            });
         let max_slots = config.max_slots;
         let eq_layout = Mutex::new(std::mem::take(&mut config.eq_layout));
         Self {
@@ -83,7 +85,7 @@ impl<S> EngineImpl<S> {
     }
 
     pub(crate) const fn configured_sample_rate(&self) -> u32 {
-        self.config.sample_rate
+        self.config.sample_rate.get()
     }
 
     pub(crate) fn consumer_wake_mode(&self) -> ConsumerWakeMode {
@@ -124,7 +126,6 @@ impl<S> EngineImpl<S> {
             self.bus.clone(),
             self.eq_layout.lock().clone(),
             self.pools().clone(),
-            self.config.sample_rate,
         )?;
         *player_id = Some(id);
         drop(player_id);
@@ -301,11 +302,11 @@ impl<S> EngineImpl<S> {
     /// instead of lazily on the first `step_track()` call.
     pub fn master_sample_rate(&self) -> u32 {
         if !self.running.load(Ordering::Acquire) {
-            return self.config.sample_rate;
+            return self.config.sample_rate.get();
         }
         self.session
             .sample_rate()
-            .map_or(self.config.sample_rate, SessionSampleRate::output)
+            .map_or_else(|_| self.config.sample_rate.get(), SessionSampleRate::output)
     }
 
     pub fn master_volume(&self) -> f32 {
@@ -356,13 +357,12 @@ impl<S> EngineImpl<S> {
 
         let player_id = self.ensure_player_id()?;
         let master_volume = self.master_volume.load(Ordering::Relaxed);
-        self.session
-            .start_player(player_id, self.config.sample_rate, master_volume)?;
+        self.session.start_player(player_id, master_volume)?;
 
         self.running.store(true, Ordering::Release);
 
         info!(
-            sample_rate = self.config.sample_rate,
+            sample_rate = self.config.sample_rate.get(),
             channels = self.config.channels,
             max_slots = self.config.max_slots,
             player_id,

--- a/crates/kithara-play/src/engine/core.rs
+++ b/crates/kithara-play/src/engine/core.rs
@@ -47,9 +47,7 @@ impl<S> EngineImpl<S> {
         let session = config
             .session
             .take()
-            .map_or_else(SessionHandle::pending, |dispatcher| {
-                SessionHandle::new(dispatcher, config.sample_rate)
-            });
+            .map_or_else(SessionHandle::pending, SessionHandle::new);
         let max_slots = config.max_slots;
         let eq_layout = Mutex::new(std::mem::take(&mut config.eq_layout));
         Self {
@@ -73,7 +71,17 @@ impl<S> EngineImpl<S> {
     }
 
     pub(crate) fn attach_session(&self, binding: SessionBinding<S>) -> Result<(), PlayError> {
+        self.validate_session_sample_rate(binding.requested_sample_rate()?.get())?;
         self.session.bind(binding)
+    }
+
+    fn validate_session_sample_rate(&self, session: u32) -> Result<(), PlayError> {
+        let player = self.configured_sample_rate();
+        if player == session {
+            Ok(())
+        } else {
+            Err(PlayError::SessionSampleRateMismatch { player, session })
+        }
     }
 
     pub(crate) const fn pools(&self) -> &PoolRegion<S> {
@@ -121,6 +129,7 @@ impl<S> EngineImpl<S> {
             return Ok(id);
         }
 
+        self.validate_session_sample_rate(self.session.requested_sample_rate()?.get())?;
         let id = self.session.register_player(
             self.config.grid_id,
             self.bus.clone(),

--- a/crates/kithara-play/src/engine/mix.rs
+++ b/crates/kithara-play/src/engine/mix.rs
@@ -82,7 +82,10 @@ mod tests {
     use crate::{
         PlayWorker, PlayWorkerConfig,
         player::PlayerConfig,
-        session::{Cmd, Reply, SessionDispatcher, testing::test_session},
+        session::{
+            Cmd, Reply, SessionDispatcher,
+            testing::{self, test_session},
+        },
         test_pools::{TestPools, pools},
     };
 
@@ -102,6 +105,7 @@ mod tests {
         let worker = PlayWorker::new(PlayWorkerConfig::builder(pools()).build());
         PlayerImpl::new(
             PlayerConfig::builder()
+                .sample_rate(testing::TEST_SAMPLE_RATE)
                 .worker(worker)
                 .session(session)
                 .build(),

--- a/crates/kithara-play/src/engine/mix.rs
+++ b/crates/kithara-play/src/engine/mix.rs
@@ -83,7 +83,7 @@ mod tests {
         PlayWorker, PlayWorkerConfig,
         player::PlayerConfig,
         session::{
-            Cmd, Reply, SessionDispatcher,
+            Cmd, Reply, SessionDispatcher, SessionSampleRate,
             testing::{self, test_session},
         },
         test_pools::{TestPools, pools},
@@ -92,8 +92,14 @@ mod tests {
     struct ForeignSession;
 
     impl SessionDispatcher<TestPools> for ForeignSession {
-        fn exec(&self, _cmd: Cmd<TestPools>) -> Result<Reply, PlayError> {
-            Ok(Reply::Ok)
+        fn exec(&self, cmd: Cmd<TestPools>) -> Result<Reply, PlayError> {
+            match cmd {
+                Cmd::QuerySampleRate => Ok(Reply::SampleRate(SessionSampleRate::new(
+                    None,
+                    testing::TEST_SAMPLE_RATE.get(),
+                ))),
+                _ => Ok(Reply::Ok),
+            }
         }
 
         fn consumer_wake_mode(&self) -> ConsumerWakeMode {

--- a/crates/kithara-play/src/error.rs
+++ b/crates/kithara-play/src/error.rs
@@ -96,6 +96,9 @@ pub enum PlayError {
     #[error("player is already attached to an audio session")]
     SessionAlreadyBound,
 
+    #[error("player sample rate {player} does not match audio session sample rate {session}")]
+    SessionSampleRateMismatch { player: u32, session: u32 },
+
     #[error("an audio session is already active on this thread")]
     SessionAlreadyActive,
 

--- a/crates/kithara-play/src/player/config.rs
+++ b/crates/kithara-play/src/player/config.rs
@@ -13,11 +13,6 @@ use crate::{
     session::SessionDispatcher,
 };
 
-const DEFAULT_SAMPLE_RATE: NonZeroU32 = match NonZeroU32::new(44_100) {
-    Some(sample_rate) => sample_rate,
-    None => unreachable!(),
-};
-
 fn allocate_grid_id() -> BeatGridId {
     let Ok(id) = BeatGridId::allocate() else {
         panic!("process-wide beat-grid identity space is exhausted");
@@ -74,10 +69,7 @@ pub struct PlayerConfig<S> {
     /// Secondary lead time before EOF at which the next queued item is loaded.
     #[builder(default = 3.5)]
     pub(crate) prefetch_duration: f32,
-    /// Sample rate passed to the engine/runtime backend as a hint.
-    /// Default: 44100. Offline/test harnesses set this to drive
-    /// deterministic render at a known rate.
-    #[builder(default = DEFAULT_SAMPLE_RATE)]
+    /// Initial output sample rate supplied by the owning session.
     pub(crate) sample_rate: NonZeroU32,
     /// Maximum concurrent slots in the engine. Default: 4.
     #[builder(default = 4)]

--- a/crates/kithara-play/src/player/core.rs
+++ b/crates/kithara-play/src/player/core.rs
@@ -124,14 +124,7 @@ impl<S> PlayerRuntime<S> {
     }
 
     pub(super) fn attach_session(&self, binding: SessionBinding<S>) -> Result<(), PlayError> {
-        self.with_open_result(|runtime| {
-            let player = runtime.core.engine.configured_sample_rate();
-            let session = binding.sample_rate().get();
-            if player != session {
-                return Err(PlayError::SessionSampleRateMismatch { player, session });
-            }
-            runtime.core.engine.attach_session(binding)
-        })
+        self.with_open_result(|runtime| runtime.core.engine.attach_session(binding))
     }
 
     pub(super) fn with_open<T>(&self, operation: impl FnOnce(&Self) -> T) -> Result<T, PlayError> {
@@ -236,11 +229,11 @@ impl<S> PlayerRuntime<S> {
 
 #[cfg(test)]
 mod tests {
-    use std::num::NonZeroU32;
     #[cfg(not(target_arch = "wasm32"))]
     use std::sync::mpsc::{RecvTimeoutError, channel};
 
     use kithara_assets::AssetStore;
+    use kithara_audio::ConsumerWakeMode;
     use kithara_decode::GaplessMode;
     use kithara_events::{Envelope, Event};
     use kithara_platform::{CancelToken, time::Duration};
@@ -254,7 +247,7 @@ mod tests {
         effects::eq::generate_log_spaced_bands,
         player::{PlayerConfig, PlayerControlSource},
         resource::{ResourceConfig, ResourceSrc},
-        session::{SessionBinding, testing},
+        session::{Cmd, Reply, SessionBinding, SessionDispatcher, SessionSampleRate, testing},
         test_pools::{TestPools, pools},
     };
 
@@ -277,6 +270,21 @@ mod tests {
 
     fn worker() -> PlayWorker<TestPools> {
         PlayWorker::new(PlayWorkerConfig::builder(pools()).build())
+    }
+
+    struct ForeignRateSession;
+
+    impl SessionDispatcher<TestPools> for ForeignRateSession {
+        fn exec(&self, cmd: Cmd<TestPools>) -> Result<Reply, PlayError> {
+            match cmd {
+                Cmd::QuerySampleRate => Ok(Reply::SampleRate(SessionSampleRate::new(None, 48_000))),
+                _ => Ok(Reply::Ok),
+            }
+        }
+
+        fn consumer_wake_mode(&self) -> ConsumerWakeMode {
+            ConsumerWakeMode::RealtimeDeferred
+        }
     }
 
     fn player() -> PlayerImpl<TestPools> {
@@ -714,11 +722,29 @@ mod tests {
                 .worker(worker())
                 .build(),
         );
-        let host_rate = NonZeroU32::new(48_000).expect("test sample rate is non-zero");
-        let binding = SessionBinding::new(testing::test_session(), host_rate);
+        let binding = SessionBinding::new(Arc::new(ForeignRateSession));
 
         assert!(matches!(
             PlayerControlSource::attach_session(&mut player, binding),
+            Err(PlayError::SessionSampleRateMismatch {
+                player: 44_100,
+                session: 48_000,
+            })
+        ));
+    }
+
+    #[kithara::test]
+    fn prebound_session_rejects_a_player_built_for_another_sample_rate() {
+        let player = PlayerImpl::new(
+            PlayerConfig::builder()
+                .sample_rate(testing::TEST_SAMPLE_RATE)
+                .worker(worker())
+                .session(Arc::new(ForeignRateSession))
+                .build(),
+        );
+
+        assert!(matches!(
+            player.core.engine.start(),
             Err(PlayError::SessionSampleRateMismatch {
                 player: 44_100,
                 session: 48_000,

--- a/crates/kithara-play/src/player/core.rs
+++ b/crates/kithara-play/src/player/core.rs
@@ -124,7 +124,14 @@ impl<S> PlayerRuntime<S> {
     }
 
     pub(super) fn attach_session(&self, binding: SessionBinding<S>) -> Result<(), PlayError> {
-        self.with_open_result(|runtime| runtime.core.engine.attach_session(binding))
+        self.with_open_result(|runtime| {
+            let player = runtime.core.engine.configured_sample_rate();
+            let session = binding.sample_rate().get();
+            if player != session {
+                return Err(PlayError::SessionSampleRateMismatch { player, session });
+            }
+            runtime.core.engine.attach_session(binding)
+        })
     }
 
     pub(super) fn with_open<T>(&self, operation: impl FnOnce(&Self) -> T) -> Result<T, PlayError> {
@@ -245,9 +252,9 @@ mod tests {
         PlayWorkerConfig,
         bridge::PlayerCmd,
         effects::eq::generate_log_spaced_bands,
-        player::{PlayerConfig, PlayerMember},
+        player::{PlayerConfig, PlayerControlSource},
         resource::{ResourceConfig, ResourceSrc},
-        session::testing,
+        session::{SessionBinding, testing},
         test_pools::{TestPools, pools},
     };
 
@@ -275,6 +282,7 @@ mod tests {
     fn player() -> PlayerImpl<TestPools> {
         PlayerImpl::new(
             PlayerConfig::builder()
+                .sample_rate(testing::TEST_SAMPLE_RATE)
                 .worker(worker())
                 .session(testing::test_session())
                 .build(),
@@ -363,6 +371,7 @@ mod tests {
     fn prepare_config_applies_player_gapless_mode() {
         let player = PlayerImpl::new(
             PlayerConfig::builder()
+                .sample_rate(testing::TEST_SAMPLE_RATE)
                 .worker(worker())
                 .session(testing::test_session())
                 .gapless_mode(GaplessMode::Disabled)
@@ -401,6 +410,7 @@ mod tests {
         let parent_master = CancelToken::never();
         let player = PlayerImpl::new(
             PlayerConfig::builder()
+                .sample_rate(testing::TEST_SAMPLE_RATE)
                 .worker(worker())
                 .session(testing::test_session())
                 .cancel(parent_master.clone())
@@ -501,6 +511,7 @@ mod tests {
     #[kithara::test]
     fn player_config_custom() {
         let config = PlayerConfig::builder()
+            .sample_rate(testing::TEST_SAMPLE_RATE)
             .worker(worker())
             .session(testing::test_session())
             .crossfade_duration(2.0)
@@ -509,7 +520,6 @@ mod tests {
             .eq_layout(generate_log_spaced_bands(5))
             .gapless_mode(GaplessMode::MediaOnly)
             .max_slots(2)
-            .sample_rate(NonZeroU32::new(44_100).expect("invariant: sample rate is non-zero"))
             .timestretch(StretchControls::new(1.0))
             .build();
         let player = PlayerImpl::new(config);
@@ -520,6 +530,7 @@ mod tests {
     fn eq_band_count_tracks_a_replacement_layout_before_start() {
         let player = PlayerImpl::new(
             PlayerConfig::builder()
+                .sample_rate(testing::TEST_SAMPLE_RATE)
                 .worker(worker())
                 .session(testing::test_session())
                 .eq_layout(generate_log_spaced_bands(3))
@@ -534,6 +545,7 @@ mod tests {
     #[kithara::test]
     fn player_config_builder() {
         let config = PlayerConfig::builder()
+            .sample_rate(testing::TEST_SAMPLE_RATE)
             .worker(worker())
             .session(testing::test_session())
             .max_slots(8)
@@ -609,6 +621,7 @@ mod tests {
     fn timestretch_is_address_stable_across_play_pause() {
         let player = PlayerImpl::new(
             PlayerConfig::builder()
+                .sample_rate(testing::TEST_SAMPLE_RATE)
                 .worker(worker())
                 .session(testing::test_session())
                 .build(),
@@ -662,6 +675,7 @@ mod tests {
         let worker = worker();
         let player = PlayerImpl::new(
             PlayerConfig::builder()
+                .sample_rate(testing::TEST_SAMPLE_RATE)
                 .worker(worker.clone())
                 .session(testing::test_session())
                 .build(),
@@ -683,11 +697,32 @@ mod tests {
     fn auto_advance_disabled_via_config() {
         let player = PlayerImpl::new(
             PlayerConfig::builder()
+                .sample_rate(testing::TEST_SAMPLE_RATE)
                 .worker(worker())
                 .session(testing::test_session())
                 .auto_advance_enabled(false)
                 .build(),
         );
         assert!(!player.auto_advance_enabled());
+    }
+
+    #[kithara::test]
+    fn host_rejects_a_player_built_for_another_sample_rate() {
+        let mut player = PlayerImpl::new(
+            PlayerConfig::builder()
+                .sample_rate(testing::TEST_SAMPLE_RATE)
+                .worker(worker())
+                .build(),
+        );
+        let host_rate = NonZeroU32::new(48_000).expect("test sample rate is non-zero");
+        let binding = SessionBinding::new(testing::test_session(), host_rate);
+
+        assert!(matches!(
+            PlayerControlSource::attach_session(&mut player, binding),
+            Err(PlayError::SessionSampleRateMismatch {
+                player: 44_100,
+                session: 48_000,
+            })
+        ));
     }
 }

--- a/crates/kithara-play/src/player/core/player.rs
+++ b/crates/kithara-play/src/player/core/player.rs
@@ -66,7 +66,7 @@ impl<S> PlayerImpl<S> {
             .eq_layout(config.eq_layout.clone())
             .grid_id(config.grid_id)
             .max_slots(config.max_slots)
-            .sample_rate(config.sample_rate.get())
+            .sample_rate(config.sample_rate)
             .pools(pools)
             .maybe_session(config.session.clone())
             .cancel(cancel.clone())

--- a/crates/kithara-play/src/player/flow/handover.rs
+++ b/crates/kithara-play/src/player/flow/handover.rs
@@ -266,6 +266,7 @@ mod tests {
     fn commit_next_without_arm_returns_not_ready() {
         let player = PlayerImpl::new(
             PlayerConfig::builder()
+                .sample_rate(testing::TEST_SAMPLE_RATE)
                 .worker(worker())
                 .session(testing::test_session())
                 .build(),
@@ -278,6 +279,7 @@ mod tests {
     fn commit_next_publishes_snapshot_before_current_item_changed() {
         let player = PlayerImpl::new(
             PlayerConfig::builder()
+                .sample_rate(testing::TEST_SAMPLE_RATE)
                 .worker(worker())
                 .session(testing::test_session())
                 .build(),

--- a/crates/kithara-play/src/player/flow/notify.rs
+++ b/crates/kithara-play/src/player/flow/notify.rs
@@ -332,6 +332,7 @@ mod tests {
         let worker = PlayWorker::new(PlayWorkerConfig::builder(pools()).build());
         let player = PlayerImpl::new(
             PlayerConfig::builder()
+                .sample_rate(testing::TEST_SAMPLE_RATE)
                 .worker(worker)
                 .session(testing::test_session())
                 .build(),

--- a/crates/kithara-play/src/player/flow/prepare.rs
+++ b/crates/kithara-play/src/player/flow/prepare.rs
@@ -118,6 +118,7 @@ mod tests {
             Arc::new(ImmediateSession(testing::test_session()));
         let player = PlayerImpl::new(
             PlayerConfig::builder()
+                .sample_rate(testing::TEST_SAMPLE_RATE)
                 .worker(worker())
                 .session(session)
                 .build(),
@@ -142,6 +143,7 @@ mod tests {
     fn prepare_config_overwrites_a_builder_declared_wake_mode() {
         let player = PlayerImpl::new(
             PlayerConfig::builder()
+                .sample_rate(testing::TEST_SAMPLE_RATE)
                 .worker(worker())
                 .session(testing::test_session())
                 .build(),

--- a/crates/kithara-play/src/player/flow/transport.rs
+++ b/crates/kithara-play/src/player/flow/transport.rs
@@ -258,6 +258,7 @@ mod tests {
         let worker = PlayWorker::new(PlayWorkerConfig::builder(pools()).build());
         PlayerImpl::new(
             PlayerConfig::builder()
+                .sample_rate(testing::TEST_SAMPLE_RATE)
                 .worker(worker)
                 .session(testing::test_session())
                 .build(),

--- a/crates/kithara-play/src/player/state/phase.rs
+++ b/crates/kithara-play/src/player/state/phase.rs
@@ -425,6 +425,7 @@ mod tests {
         let worker = PlayWorker::new(PlayWorkerConfig::builder(pools()).build());
         let player = PlayerImpl::new(
             PlayerConfig::builder()
+                .sample_rate(testing::TEST_SAMPLE_RATE)
                 .worker(worker)
                 .session(testing::test_session())
                 .build(),

--- a/crates/kithara-play/src/session/protocol.rs
+++ b/crates/kithara-play/src/session/protocol.rs
@@ -198,6 +198,8 @@ mod wire {
 }
 
 mod handle {
+    use std::num::NonZeroU32;
+
     use kithara_audio::ConsumerWakeMode;
     use kithara_bufpool::PoolRegion;
     use kithara_events::EventBus;
@@ -237,19 +239,30 @@ mod handle {
     ///
     /// The dispatcher is deliberately inaccessible: decorators may only pass
     /// this capability down to their resident Player.
-    pub struct SessionBinding<S>(Arc<dyn SessionDispatcher<S>>);
+    pub struct SessionBinding<S> {
+        dispatcher: Arc<dyn SessionDispatcher<S>>,
+        sample_rate: NonZeroU32,
+    }
 
     impl<S> SessionBinding<S> {
         /// Wraps the canonical session for one Host insertion.
         #[doc(hidden)]
         #[must_use]
-        pub fn new(dispatcher: Arc<dyn SessionDispatcher<S>>) -> Self {
-            Self(dispatcher)
+        pub fn new(dispatcher: Arc<dyn SessionDispatcher<S>>, sample_rate: NonZeroU32) -> Self {
+            Self {
+                dispatcher,
+                sample_rate,
+            }
+        }
+
+        #[must_use]
+        pub(crate) const fn sample_rate(&self) -> NonZeroU32 {
+            self.sample_rate
         }
     }
 
     struct SessionSlot<S> {
-        dispatcher: Mutex<Option<Arc<dyn SessionDispatcher<S>>>>,
+        binding: Mutex<Option<SessionBinding<S>>>,
     }
 
     pub struct SessionHandle<S>(Arc<SessionSlot<S>>);
@@ -262,26 +275,26 @@ mod handle {
 
     impl<S> SessionHandle<S> {
         #[must_use]
-        pub fn new(dispatcher: Arc<dyn SessionDispatcher<S>>) -> Self {
+        pub fn new(dispatcher: Arc<dyn SessionDispatcher<S>>, sample_rate: NonZeroU32) -> Self {
             Self(Arc::new(SessionSlot {
-                dispatcher: Mutex::new(Some(dispatcher)),
+                binding: Mutex::new(Some(SessionBinding::new(dispatcher, sample_rate))),
             }))
         }
 
         #[must_use]
         pub(crate) fn pending() -> Self {
             Self(Arc::new(SessionSlot {
-                dispatcher: Mutex::default(),
+                binding: Mutex::default(),
             }))
         }
 
         pub(crate) fn bind(&self, binding: SessionBinding<S>) -> Result<(), PlayError> {
-            let mut dispatcher = self.0.dispatcher.lock();
-            if dispatcher.is_some() {
+            let mut current = self.0.binding.lock();
+            if current.is_some() {
                 return Err(PlayError::SessionAlreadyBound);
             }
-            *dispatcher = Some(binding.0);
-            drop(dispatcher);
+            *current = Some(binding);
+            drop(current);
             Ok(())
         }
 
@@ -296,9 +309,19 @@ mod handle {
 
         pub fn dispatcher(&self) -> Result<Arc<dyn SessionDispatcher<S>>, PlayError> {
             self.0
-                .dispatcher
+                .binding
                 .lock()
-                .clone()
+                .as_ref()
+                .map(|binding| Arc::clone(&binding.dispatcher))
+                .ok_or(PlayError::SessionUnbound)
+        }
+
+        fn requested_sample_rate(&self) -> Result<NonZeroU32, PlayError> {
+            self.0
+                .binding
+                .lock()
+                .as_ref()
+                .map(SessionBinding::sample_rate)
                 .ok_or(PlayError::SessionUnbound)
         }
 
@@ -346,8 +369,8 @@ mod handle {
             bus: EventBus,
             eq_layout: Vec<EqBandConfig>,
             pools: PoolRegion<S>,
-            sample_rate: u32,
         ) -> Result<PlayerId, PlayError> {
+            let sample_rate = self.requested_sample_rate()?.get();
             match self.exec_ok(Cmd::RegisterPlayer {
                 grid_id,
                 bus,
@@ -419,9 +442,9 @@ mod handle {
         pub fn start_player(
             &self,
             player_id: PlayerId,
-            sample_rate: u32,
             master_volume: f32,
         ) -> Result<(), PlayError> {
+            let sample_rate = self.requested_sample_rate()?.get();
             self.exec_ok(Cmd::StartPlayer {
                 master_volume,
                 player_id,
@@ -450,14 +473,31 @@ pub use wire::{AllocatedSlot, Cmd, PlayerId, PlayerLevel, Reply, SessionError, S
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        num::NonZeroU32,
+        sync::atomic::{AtomicU32, Ordering},
+    };
+
     use kithara_audio::ConsumerWakeMode;
+    use kithara_events::EventBus;
     use kithara_platform::sync::Arc;
     use kithara_test_utils::kithara;
+    use kithara_warp::BeatGridId;
 
     use super::{Cmd, Reply, SessionBinding, SessionDispatcher, SessionHandle};
-    use crate::{PlayError, test_pools::TestPools};
+    use crate::{
+        PlayError,
+        test_pools::{TestPools, pools},
+    };
 
     struct DefaultSession;
+
+    #[derive(Default)]
+    struct RateCapture(AtomicU32);
+
+    fn sample_rate() -> NonZeroU32 {
+        NonZeroU32::new(48_000).expect("fixture sample rate is non-zero")
+    }
 
     impl SessionDispatcher<TestPools> for DefaultSession {
         fn exec(&self, _cmd: Cmd<TestPools>) -> Result<Reply, PlayError> {
@@ -469,9 +509,30 @@ mod tests {
         }
     }
 
+    impl SessionDispatcher<TestPools> for RateCapture {
+        fn exec(&self, cmd: Cmd<TestPools>) -> Result<Reply, PlayError> {
+            match cmd {
+                Cmd::RegisterPlayer { sample_rate, .. } => {
+                    self.0.store(sample_rate, Ordering::Relaxed);
+                    Ok(Reply::PlayerRegistered(1))
+                }
+                Cmd::StartPlayer { sample_rate, .. } => {
+                    self.0.store(sample_rate, Ordering::Relaxed);
+                    Ok(Reply::Ok)
+                }
+                _ => Ok(Reply::Ok),
+            }
+        }
+
+        fn consumer_wake_mode(&self) -> ConsumerWakeMode {
+            ConsumerWakeMode::RealtimeDeferred
+        }
+    }
+
     #[kithara::test]
     fn session_handle_delegates_explicit_consumer_wake_mode() {
-        let handle: SessionHandle<TestPools> = SessionHandle::new(Arc::new(DefaultSession));
+        let handle: SessionHandle<TestPools> =
+            SessionHandle::new(Arc::new(DefaultSession), sample_rate());
 
         assert_eq!(
             handle.consumer_wake_mode(),
@@ -492,7 +553,7 @@ mod tests {
         ));
 
         handle
-            .bind(SessionBinding::new(Arc::new(DefaultSession)))
+            .bind(SessionBinding::new(Arc::new(DefaultSession), sample_rate()))
             .expect("bind canonical session");
         assert_eq!(
             handle.consumer_wake_mode(),
@@ -500,8 +561,29 @@ mod tests {
         );
         assert!(matches!(handle.exec(Cmd::Tick), Ok(Reply::Ok)));
         assert!(matches!(
-            handle.bind(SessionBinding::new(Arc::new(DefaultSession))),
+            handle.bind(SessionBinding::new(Arc::new(DefaultSession), sample_rate())),
             Err(PlayError::SessionAlreadyBound)
         ));
+    }
+
+    #[kithara::test]
+    fn session_commands_use_the_bound_host_rate() {
+        let capture = Arc::new(RateCapture::default());
+        let dispatcher: Arc<dyn SessionDispatcher<TestPools>> = capture.clone();
+        let handle = SessionHandle::new(dispatcher, sample_rate());
+
+        let player_id = handle
+            .register_player(
+                BeatGridId::allocate().expect("player id"),
+                EventBus::default(),
+                Vec::new(),
+                pools(),
+            )
+            .expect("register player");
+        assert_eq!(capture.0.load(Ordering::Relaxed), sample_rate().get());
+
+        capture.0.store(0, Ordering::Relaxed);
+        handle.start_player(player_id, 1.0).expect("start player");
+        assert_eq!(capture.0.load(Ordering::Relaxed), sample_rate().get());
     }
 }

--- a/crates/kithara-play/src/session/protocol.rs
+++ b/crates/kithara-play/src/session/protocol.rs
@@ -211,7 +211,7 @@ mod handle {
 
     #[cfg(any(test, feature = "probe"))]
     use super::wire::PlayerLevel;
-    use super::wire::{AllocatedSlot, Cmd, PlayerId, Reply, SessionSampleRate};
+    use super::wire::{AllocatedSlot, Cmd, PlayerId, Reply, SessionError, SessionSampleRate};
     use crate::{api::SlotId, effects::eq::EqBandConfig, error::PlayError};
 
     /// Handle used by resident players to reach their session owner.
@@ -233,6 +233,22 @@ mod handle {
                 reply => Ok(reply),
             }
         }
+
+        fn sample_rate(&self) -> Result<SessionSampleRate, PlayError> {
+            match self.exec_ok(Cmd::QuerySampleRate)? {
+                Reply::SampleRate(sample_rate) => Ok(sample_rate),
+                _ => Err(PlayError::Internal(
+                    "unexpected reply for session sample rate query".into(),
+                )),
+            }
+        }
+
+        fn requested_sample_rate(&self) -> Result<NonZeroU32, PlayError> {
+            let requested = self.sample_rate()?.requested;
+            NonZeroU32::new(requested).ok_or(PlayError::Session(SessionError::InvalidSampleRate(
+                requested,
+            )))
+        }
     }
 
     /// Opaque one-shot capability used to attach a Player to its session.
@@ -241,23 +257,18 @@ mod handle {
     /// this capability down to their resident Player.
     pub struct SessionBinding<S> {
         dispatcher: Arc<dyn SessionDispatcher<S>>,
-        sample_rate: NonZeroU32,
     }
 
     impl<S> SessionBinding<S> {
         /// Wraps the canonical session for one Host insertion.
         #[doc(hidden)]
         #[must_use]
-        pub fn new(dispatcher: Arc<dyn SessionDispatcher<S>>, sample_rate: NonZeroU32) -> Self {
-            Self {
-                dispatcher,
-                sample_rate,
-            }
+        pub fn new(dispatcher: Arc<dyn SessionDispatcher<S>>) -> Self {
+            Self { dispatcher }
         }
 
-        #[must_use]
-        pub(crate) const fn sample_rate(&self) -> NonZeroU32 {
-            self.sample_rate
+        pub(crate) fn requested_sample_rate(&self) -> Result<NonZeroU32, PlayError> {
+            self.dispatcher.requested_sample_rate()
         }
     }
 
@@ -275,9 +286,9 @@ mod handle {
 
     impl<S> SessionHandle<S> {
         #[must_use]
-        pub fn new(dispatcher: Arc<dyn SessionDispatcher<S>>, sample_rate: NonZeroU32) -> Self {
+        pub fn new(dispatcher: Arc<dyn SessionDispatcher<S>>) -> Self {
             Self(Arc::new(SessionSlot {
-                binding: Mutex::new(Some(SessionBinding::new(dispatcher, sample_rate))),
+                binding: Mutex::new(Some(SessionBinding::new(dispatcher))),
             }))
         }
 
@@ -316,13 +327,11 @@ mod handle {
                 .ok_or(PlayError::SessionUnbound)
         }
 
-        fn requested_sample_rate(&self) -> Result<NonZeroU32, PlayError> {
-            self.0
-                .binding
-                .lock()
-                .as_ref()
-                .map(SessionBinding::sample_rate)
-                .ok_or(PlayError::SessionUnbound)
+        delegate::delegate! {
+            to self.dispatcher()? {
+                pub(crate) fn requested_sample_rate(&self) -> Result<NonZeroU32, PlayError>;
+                pub fn sample_rate(&self) -> Result<SessionSampleRate, PlayError>;
+            }
         }
 
         #[must_use]
@@ -352,15 +361,6 @@ mod handle {
                 reason: reason.to_owned(),
             })
             .map(|_| ())
-        }
-
-        pub fn sample_rate(&self) -> Result<SessionSampleRate, PlayError> {
-            match self.exec_ok(Cmd::QuerySampleRate)? {
-                Reply::SampleRate(sample_rate) => Ok(sample_rate),
-                _ => Err(PlayError::Internal(
-                    "unexpected reply for session sample rate query".into(),
-                )),
-            }
         }
 
         pub fn register_player(
@@ -484,7 +484,7 @@ mod tests {
     use kithara_test_utils::kithara;
     use kithara_warp::BeatGridId;
 
-    use super::{Cmd, Reply, SessionBinding, SessionDispatcher, SessionHandle};
+    use super::{Cmd, Reply, SessionBinding, SessionDispatcher, SessionHandle, SessionSampleRate};
     use crate::{
         PlayError,
         test_pools::{TestPools, pools},
@@ -512,6 +512,10 @@ mod tests {
     impl SessionDispatcher<TestPools> for RateCapture {
         fn exec(&self, cmd: Cmd<TestPools>) -> Result<Reply, PlayError> {
             match cmd {
+                Cmd::QuerySampleRate => Ok(Reply::SampleRate(SessionSampleRate::new(
+                    None,
+                    sample_rate().get(),
+                ))),
                 Cmd::RegisterPlayer { sample_rate, .. } => {
                     self.0.store(sample_rate, Ordering::Relaxed);
                     Ok(Reply::PlayerRegistered(1))
@@ -531,8 +535,7 @@ mod tests {
 
     #[kithara::test]
     fn session_handle_delegates_explicit_consumer_wake_mode() {
-        let handle: SessionHandle<TestPools> =
-            SessionHandle::new(Arc::new(DefaultSession), sample_rate());
+        let handle: SessionHandle<TestPools> = SessionHandle::new(Arc::new(DefaultSession));
 
         assert_eq!(
             handle.consumer_wake_mode(),
@@ -553,7 +556,7 @@ mod tests {
         ));
 
         handle
-            .bind(SessionBinding::new(Arc::new(DefaultSession), sample_rate()))
+            .bind(SessionBinding::new(Arc::new(DefaultSession)))
             .expect("bind canonical session");
         assert_eq!(
             handle.consumer_wake_mode(),
@@ -561,7 +564,7 @@ mod tests {
         );
         assert!(matches!(handle.exec(Cmd::Tick), Ok(Reply::Ok)));
         assert!(matches!(
-            handle.bind(SessionBinding::new(Arc::new(DefaultSession), sample_rate())),
+            handle.bind(SessionBinding::new(Arc::new(DefaultSession))),
             Err(PlayError::SessionAlreadyBound)
         ));
     }
@@ -570,7 +573,7 @@ mod tests {
     fn session_commands_use_the_bound_host_rate() {
         let capture = Arc::new(RateCapture::default());
         let dispatcher: Arc<dyn SessionDispatcher<TestPools>> = capture.clone();
-        let handle = SessionHandle::new(dispatcher, sample_rate());
+        let handle = SessionHandle::new(dispatcher);
 
         let player_id = handle
             .register_player(

--- a/crates/kithara-play/src/session/testing.rs
+++ b/crates/kithara-play/src/session/testing.rs
@@ -1,4 +1,7 @@
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::{
+    num::NonZeroU32,
+    sync::atomic::{AtomicU64, Ordering},
+};
 
 use kithara_audio::ConsumerWakeMode;
 use kithara_platform::sync::{Arc, Mutex};
@@ -7,6 +10,11 @@ use super::{AllocatedSlot, Cmd, Reply, SessionDispatcher, SessionSampleRate};
 use crate::{
     PlayError, SessionDuckingMode, SharedEq, SlotId,
     bridge::{NodeInputs, slot_channels},
+};
+
+pub(crate) const TEST_SAMPLE_RATE: NonZeroU32 = match NonZeroU32::new(44_100) {
+    Some(sample_rate) => sample_rate,
+    None => unreachable!(),
 };
 
 struct TestSession {

--- a/crates/kithara-queue/src/config.rs
+++ b/crates/kithara-queue/src/config.rs
@@ -84,13 +84,17 @@ mod tests {
     use kithara_test_utils::kithara;
 
     use super::*;
-    use crate::{queue::test_session, test_pools::pools};
+    use crate::{
+        queue::{TEST_SAMPLE_RATE, test_session},
+        test_pools::pools,
+    };
 
     #[kithara::test]
     fn default_config_has_reasonable_loader_cap() {
         let worker = PlayWorker::new(PlayWorkerConfig::builder(pools()).build());
         let player = PlayerImpl::new(
             PlayerConfig::builder()
+                .sample_rate(TEST_SAMPLE_RATE)
                 .worker(worker)
                 .session(test_session())
                 .build(),

--- a/crates/kithara-queue/src/loader.rs
+++ b/crates/kithara-queue/src/loader.rs
@@ -411,6 +411,7 @@ mod tests {
             let worker = PlayWorker::new(PlayWorkerConfig::builder(pools()).build());
             let player = PlayerImpl::new(
                 PlayerConfig::builder()
+                    .sample_rate(crate::queue::TEST_SAMPLE_RATE)
                     .worker(worker)
                     .session(crate::queue::test_session())
                     .build(),

--- a/crates/kithara-queue/src/queue/mod.rs
+++ b/crates/kithara-queue/src/queue/mod.rs
@@ -27,7 +27,7 @@ pub mod test_utils;
 mod types;
 
 #[cfg(test)]
-pub(crate) use state::tests::test_session;
+pub(crate) use state::tests::{TEST_SAMPLE_RATE, test_session};
 
 pub use self::{
     state::{Queue, QueueControl},

--- a/crates/kithara-queue/src/queue/state.rs
+++ b/crates/kithara-queue/src/queue/state.rs
@@ -371,6 +371,7 @@ where
 pub(crate) mod tests {
     use core::sync::atomic::{AtomicU64, Ordering};
     use std::{
+        num::NonZeroU32,
         sync::mpsc::{self, RecvTimeoutError},
         thread,
     };
@@ -390,6 +391,11 @@ pub(crate) mod tests {
 
     use super::*;
     use crate::test_pools::{TestPools, pools};
+
+    pub(crate) const TEST_SAMPLE_RATE: NonZeroU32 = match NonZeroU32::new(44_100) {
+        Some(sample_rate) => sample_rate,
+        None => unreachable!(),
+    };
 
     /// No queue test ever streams bytes, so the store is here to be wired, not
     /// to hold anything. The default backend would map a file under the shared
@@ -450,6 +456,7 @@ pub(crate) mod tests {
         let worker = PlayWorker::new(PlayWorkerConfig::builder(pools()).build());
         PlayerImpl::new(
             PlayerConfig::builder()
+                .sample_rate(TEST_SAMPLE_RATE)
                 .worker(worker)
                 .session(test_session())
                 .build(),

--- a/crates/kithara-stretch/CONTEXT.md
+++ b/crates/kithara-stretch/CONTEXT.md
@@ -11,6 +11,10 @@ play-configured `PoolRegion<S>` through `ElasticConfig<S>`; `kithara-signal` own
 Decoder sample-rate conversion remains in the decode/audio seam. This crate must
 not create a default or global pool.
 
+The `perf` feature keeps `hotpath` load-bearing through `kithara::measure_block!`.
+That proc macro expands to `hotpath::measure_block!`; cargo-machete cannot see the
+expanded dependency, so the manifest records this single scanner exception.
+
 - `ElasticEngine` is the sole backend contract. Exact source/output frame counts control time;
   `set_pitch` remains independent, and `prime` / `flush` / `reset` define stream lifecycle.
 - `StretchKind` is the compiled backend selector. Persisted discriminants are stable regardless of

--- a/crates/kithara-stretch/Cargo.toml
+++ b/crates/kithara-stretch/Cargo.toml
@@ -9,6 +9,9 @@ description = "Time-stretch DSP contracts and backend adapters."
 keywords = ["audio", "dsp", "time-stretch", "pitch", "playback"]
 categories = ["multimedia::audio"]
 
+[package.metadata.cargo-machete]
+ignored = ["hotpath"]
+
 [features]
 default = ["stretch-signalsmith"]
 perf = ["dep:hotpath", "hotpath/hotpath"]

--- a/tests/src/offline/harness.rs
+++ b/tests/src/offline/harness.rs
@@ -15,7 +15,7 @@ use kithara::{
     warp::StretchControls,
 };
 
-use super::OfflineSession;
+use super::{OfflineSession, session::OFFLINE_BLOCK_FRAMES};
 use crate::bufpool_ext::{TestPools, pools};
 
 pub struct OfflinePlayerHarness {
@@ -44,7 +44,12 @@ pub struct OfflinePlayerOptions {
 
 impl OfflinePlayerHarness {
     pub fn with_sample_rate(options: OfflinePlayerOptions, sample_rate: u32) -> Self {
-        let session = Arc::new(OfflineSession::new_manual());
+        let sample_rate =
+            NonZeroU32::new(sample_rate).expect("offline player sample rate must be non-zero");
+        let session = Arc::new(OfflineSession::new_manual_with(
+            sample_rate,
+            OFFLINE_BLOCK_FRAMES,
+        ));
         let session_dispatcher = Arc::clone(&session) as Arc<dyn SessionDispatcher<TestPools>>;
         let pools = pools();
         let worker = PlayWorker::new(PlayWorkerConfig::builder(pools).build());
@@ -52,9 +57,7 @@ impl OfflinePlayerHarness {
             .crossfade_duration(options.crossfade_duration)
             .gapless_mode(options.gapless_mode)
             .block_on_underrun(options.block_on_underrun)
-            .sample_rate(
-                NonZeroU32::new(sample_rate).expect("offline player sample rate must be non-zero"),
-            )
+            .sample_rate(sample_rate)
             .session(Arc::clone(&session_dispatcher))
             .worker(worker)
             .maybe_eq_layout(options.eq_layout)

--- a/tests/src/offline/session.rs
+++ b/tests/src/offline/session.rs
@@ -1,4 +1,4 @@
-use std::ops::RangeInclusive;
+use std::{num::NonZeroU32, ops::RangeInclusive};
 
 use kithara::{
     audio::ConsumerWakeMode,
@@ -51,7 +51,7 @@ pub fn offline_gain_window(window_secs: f64) -> RangeInclusive<f64> {
     let default_rate = GraphSession::<OfflineBackend, TestPools>::DEFAULT_SAMPLE_RATE;
     let block_frames = f64::from(u32::try_from(OFFLINE_BLOCK_FRAMES).unwrap_or(u32::MAX));
     let park_ms = f64::from(u32::try_from(OFFLINE_PARK_MS).unwrap_or(u32::MAX));
-    let rate = (block_frames / f64::from(default_rate)) / (park_ms / 1_000.0);
+    let rate = (block_frames / f64::from(default_rate.get())) / (park_ms / 1_000.0);
     GAIN_FLOOR_SECS..=(rate * (window_secs + ENDPOINT_SLACK_SECS))
 }
 
@@ -81,7 +81,11 @@ where
     /// thread never calls [`render`](Self::render).
     #[must_use]
     pub fn new() -> Self {
-        Self::spawn(true, OFFLINE_BLOCK_FRAMES)
+        Self::spawn(
+            true,
+            OFFLINE_BLOCK_FRAMES,
+            GraphSession::<OfflineBackend, S>::DEFAULT_SAMPLE_RATE,
+        )
     }
 
     /// Manual mode: the worker only dispatches commands; the audio
@@ -94,7 +98,16 @@ where
     /// Manual mode with the audio callback size used by the scenario.
     #[must_use]
     pub fn new_manual_with_block_frames(block_frames: usize) -> Self {
-        Self::spawn(false, block_frames)
+        Self::new_manual_with(
+            GraphSession::<OfflineBackend, S>::DEFAULT_SAMPLE_RATE,
+            block_frames,
+        )
+    }
+
+    /// Manual mode with the output rate and audio callback size used by the scenario.
+    #[must_use]
+    pub fn new_manual_with(sample_rate: NonZeroU32, block_frames: usize) -> Self {
+        Self::spawn(false, block_frames, sample_rate)
     }
 
     /// Convenience: `Arc<dyn SessionDispatcher>` over a fresh
@@ -116,12 +129,12 @@ where
         Arc::new(Self::new_manual())
     }
 
-    fn spawn(auto_render: bool, block_frames: usize) -> Self {
+    fn spawn(auto_render: bool, block_frames: usize, sample_rate: NonZeroU32) -> Self {
         let block_frames = u32::try_from(block_frames).expect("offline block size fits u32");
         assert!(block_frames > 0, "offline block size must be non-zero");
         let (cmd_tx, cmd_rx) = mpsc::channel::<OfflineMsg<S>>();
         let handle = spawn_named("kithara-engine-offline-instance", move || {
-            offline_session_thread(&cmd_rx, auto_render, block_frames);
+            offline_session_thread(&cmd_rx, auto_render, block_frames, sample_rate);
         });
         Self {
             cmd_tx: Mutex::new(cmd_tx),
@@ -240,12 +253,14 @@ fn offline_session_thread<S>(
     cmd_rx: &mpsc::Receiver<OfflineMsg<S>>,
     auto_render: bool,
     block_frames: u32,
+    sample_rate: NonZeroU32,
 ) where
     S: HasPool<f32> + Send + Sync + 'static,
 {
-    let mut state = GraphSession::<OfflineBackend, S>::new(move |ctx, sample_rate| {
-        start_stream_offline(ctx, sample_rate, block_frames)
-    });
+    let mut state = GraphSession::<OfflineBackend, S>::with_sample_rate(
+        sample_rate,
+        move |ctx, sample_rate| start_stream_offline(ctx, sample_rate, block_frames),
+    );
     if auto_render {
         run_auto(
             &mut state,

--- a/tests/src/test_defaults.rs
+++ b/tests/src/test_defaults.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroU32;
+
 use kithara::platform::{sync::Arc, time::Duration};
 use kithara_test_fixtures::signal;
 
@@ -80,6 +82,11 @@ pub struct Consts;
 impl Consts {
     /// Default sample rate for generated WAV / expected streams.
     pub const SAMPLE_RATE: u32 = SawWav::DEFAULT.sample_rate;
+    /// Typed form passed explicitly into playback configuration.
+    pub const NON_ZERO_SAMPLE_RATE: NonZeroU32 = match NonZeroU32::new(Self::SAMPLE_RATE) {
+        Some(sample_rate) => sample_rate,
+        None => unreachable!(),
+    };
     /// Default channel count.
     pub const CHANNELS: u16 = SawWav::DEFAULT.channels;
     /// Default packaged HLS segment size (bytes).

--- a/tests/src/user_sim/harness.rs
+++ b/tests/src/user_sim/harness.rs
@@ -30,6 +30,7 @@ use crate::{
     bufpool_ext::{TestPools, pools},
     kithara,
     offline::OfflineSession,
+    test_defaults::Consts,
     user_sim::actions::Action,
 };
 
@@ -147,6 +148,7 @@ impl SimHarness {
         let worker = PlayWorker::new(PlayWorkerConfig::builder(pools.clone()).build());
         let player = PlayerImpl::new(
             PlayerConfig::builder()
+                .sample_rate(Consts::NON_ZERO_SAMPLE_RATE)
                 .worker(worker)
                 .session(Arc::clone(&session) as Arc<dyn SessionDispatcher<TestPools>>)
                 .build(),

--- a/tests/tests/integration_regressions/cache_commit_grows.rs
+++ b/tests/tests/integration_regressions/cache_commit_grows.rs
@@ -17,6 +17,7 @@ use kithara_integration_tests::{
     kithara,
     offline::OfflineSession,
     temp_dir,
+    test_defaults::Consts as Shared,
 };
 use kithara_test_fixtures::assets::signal_mp3_track_sine440_187s;
 
@@ -141,6 +142,7 @@ async fn played_tracks_land_in_the_disk_cache(temp_dir: TestTempDir) {
     );
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .worker(kithara::play::PlayWorker::new(
                 kithara::play::PlayWorkerConfig::builder(pools.clone()).build(),
             ))

--- a/tests/tests/integration_regressions/commands_survive_switch_storm.rs
+++ b/tests/tests/integration_regressions/commands_survive_switch_storm.rs
@@ -22,6 +22,7 @@ use kithara_integration_tests::{
     kithara,
     offline::OfflineSession,
     temp_dir,
+    test_defaults::Consts as Shared,
     waits::{wait_for_event, wait_for_loader_done_event},
 };
 use kithara_test_fixtures::assets::signal_mp3_track_sine440_187s;
@@ -131,6 +132,7 @@ async fn commands_still_work_after_a_switch_storm(temp_dir: TestTempDir) {
         .build();
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .worker(kithara::play::PlayWorker::new(
                 kithara::play::PlayWorkerConfig::builder(pools).build(),
             ))

--- a/tests/tests/integration_regressions/loaded_ranges_absolute.rs
+++ b/tests/tests/integration_regressions/loaded_ranges_absolute.rs
@@ -20,6 +20,7 @@ use kithara_integration_tests::{
     kithara,
     offline::OfflineSession,
     temp_dir,
+    test_defaults::Consts as Shared,
     waits::{wait_for_event, wait_for_loader_done_event},
 };
 use kithara_test_fixtures::assets::signal_mp3_track_sine440_187s;
@@ -116,6 +117,7 @@ async fn progressive_download_fills_the_buffer_bar(temp_dir: TestTempDir) {
         .build();
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .worker(kithara::play::PlayWorker::new(
                 kithara::play::PlayWorkerConfig::builder(pools).build(),
             ))

--- a/tests/tests/integration_regressions/offline_resume.rs
+++ b/tests/tests/integration_regressions/offline_resume.rs
@@ -21,6 +21,7 @@ use kithara_integration_tests::{
     kithara,
     offline::OfflineSession,
     temp_dir,
+    test_defaults::Consts as Shared,
     waits::{wait_for_event, wait_for_loader_done_event, wait_for_position_event},
 };
 use kithara_test_fixtures::hls::long_plain;
@@ -188,6 +189,7 @@ async fn resumes_after_outage(
         .build();
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .worker(kithara::play::PlayWorker::new(
                 kithara::play::PlayWorkerConfig::builder(pools).build(),
             ))

--- a/tests/tests/integration_regressions/resume_from_saved_position.rs
+++ b/tests/tests/integration_regressions/resume_from_saved_position.rs
@@ -20,6 +20,7 @@ use kithara_integration_tests::{
     kithara,
     offline::OfflineSession,
     temp_dir,
+    test_defaults::Consts as Shared,
     waits::{wait_for_event, wait_for_loader_done_event, wait_for_position_event},
 };
 use kithara_test_fixtures::SignalAsset;
@@ -40,6 +41,7 @@ fn spawn_ticker(queue: Arc<Queue<TestPools>>) -> tokio::task::JoinHandle<()> {
 fn new_queue(pools: &Pools, store: AssetStore<TestPools>) -> Arc<Queue<TestPools>> {
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .worker(kithara::play::PlayWorker::new(
                 kithara::play::PlayWorkerConfig::builder(pools.clone()).build(),
             ))

--- a/tests/tests/integration_regressions/select_after_play_consumed_the_load.rs
+++ b/tests/tests/integration_regressions/select_after_play_consumed_the_load.rs
@@ -34,6 +34,7 @@ use kithara_integration_tests::{
     kithara,
     offline::OfflineSession,
     temp_dir,
+    test_defaults::Consts as Shared,
     waits::wait_for_event,
 };
 use kithara_test_fixtures::assets::signal_mp3_track_sine440_187s;
@@ -126,6 +127,7 @@ async fn a_track_play_consumed_mid_load_can_be_selected_again(temp_dir: TestTemp
         .build();
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .worker(kithara::play::PlayWorker::new(
                 kithara::play::PlayWorkerConfig::builder(pools).build(),
             ))

--- a/tests/tests/integration_regressions/transient_failure_no_permanent_skip.rs
+++ b/tests/tests/integration_regressions/transient_failure_no_permanent_skip.rs
@@ -21,6 +21,7 @@ use kithara_integration_tests::{
     kithara,
     offline::OfflineSession,
     temp_dir,
+    test_defaults::Consts as Shared,
     waits::{wait_for_event, wait_for_loader_done_event, wait_for_position_event},
 };
 use kithara_test_fixtures::assets::signal_mp3_track_sine440_187s;
@@ -109,6 +110,7 @@ async fn transient_failure_does_not_kill_the_track(temp_dir: TestTempDir) {
         .build();
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .worker(kithara::play::PlayWorker::new(
                 kithara::play::PlayWorkerConfig::builder(pools).build(),
             ))

--- a/tests/tests/kithara_play/engine_cpal_tests.rs
+++ b/tests/tests/kithara_play/engine_cpal_tests.rs
@@ -14,6 +14,7 @@ use kithara::{
         SessionDispatcher, player::Player,
     },
 };
+use kithara_integration_tests::test_defaults::Consts as Shared;
 
 use super::engine_session_contract as contract;
 use crate::bufpool_ext::{TestPools, pools};
@@ -96,6 +97,7 @@ fn run_contract(max_slots: usize, contract: impl FnOnce(&EngineImpl<TestPools>))
     let session: Arc<dyn SessionDispatcher<TestPools>> = Arc::new(CpalGraphSession::new());
     let mut player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .max_slots(max_slots)
             .worker(PlayWorker::new(PlayWorkerConfig::builder(pools()).build()))
             .session(session)

--- a/tests/tests/kithara_play/engine_offline_tests.rs
+++ b/tests/tests/kithara_play/engine_offline_tests.rs
@@ -6,7 +6,7 @@ use kithara::{
     play::{EngineConfig, EngineImpl},
     warp::BeatGridId,
 };
-use kithara_integration_tests::offline::OfflineSession;
+use kithara_integration_tests::{offline::OfflineSession, test_defaults::Consts as Shared};
 
 use super::engine_session_contract as contract;
 use crate::bufpool_ext::{TestPools, pools};
@@ -14,6 +14,7 @@ use crate::bufpool_ext::{TestPools, pools};
 fn engine(max_slots: usize) -> EngineImpl<TestPools> {
     EngineImpl::new(
         EngineConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .grid_id(BeatGridId::allocate().expect("offline engine grid id"))
             .max_slots(max_slots)
             .pools(pools())

--- a/tests/tests/kithara_play/engine_tests.rs
+++ b/tests/tests/kithara_play/engine_tests.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroU32;
+
 use kithara::{
     self,
     audio::ConsumerWakeMode,
@@ -10,6 +12,7 @@ use kithara::{
     },
     warp::{BeatGrid, BeatGridId},
 };
+use kithara_integration_tests::test_defaults::Consts as Shared;
 
 use crate::bufpool_ext::{TestPools, pools};
 
@@ -32,6 +35,7 @@ fn slot_id(value: u64) -> SlotId {
 fn make_engine() -> EngineImpl<TestPools> {
     EngineImpl::new(
         EngineConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .grid_id(BeatGridId::allocate().expect("fixture grid id"))
             .session(Arc::new(FixtureSession))
             .pools(pools())
@@ -43,6 +47,7 @@ fn make_engine() -> EngineImpl<TestPools> {
 fn insert_player(host: &mut Host<TestPools>) -> HostOwned<PlayerImpl<TestPools>> {
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(host.requested_sample_rate())
             .worker(PlayWorker::new(PlayWorkerConfig::builder(pools()).build()))
             .build(),
     );
@@ -79,7 +84,7 @@ fn engine_config_builder() {
         .grid_id(BeatGridId::allocate().expect("fixture grid id"))
         .session(Arc::new(FixtureSession))
         .max_slots(8)
-        .sample_rate(48000)
+        .sample_rate(NonZeroU32::new(48_000).expect("fixture sample rate is non-zero"))
         .channels(1)
         .eq_layout(kithara::play::effects::eq::generate_log_spaced_bands(5))
         .pools(pools())
@@ -136,7 +141,7 @@ fn engine_master_sample_rate_returns_config_when_stopped() {
     let config = EngineConfig::builder()
         .grid_id(BeatGridId::allocate().expect("fixture grid id"))
         .session(Arc::new(FixtureSession))
-        .sample_rate(48000)
+        .sample_rate(NonZeroU32::new(48_000).expect("fixture sample rate is non-zero"))
         .pools(pools())
         .build();
     let engine = EngineImpl::new(config, EventBus::default());

--- a/tests/tests/kithara_play/hls_seek_middle_stress_long.rs
+++ b/tests/tests/kithara_play/hls_seek_middle_stress_long.rs
@@ -445,6 +445,7 @@ async fn hls_rate_seek_stress_keeps_playback_live(#[case] backend: DecoderBacken
     );
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .worker(worker)
             .session(OfflineSession::arc_auto())
             .cancel(shutdown_token.child())

--- a/tests/tests/kithara_play/live_remote_network.rs
+++ b/tests/tests/kithara_play/live_remote_network.rs
@@ -272,6 +272,7 @@ async fn player_mp3_duration_matches_app_flow(
     let mut host = Host::new(HostConfig::builder().build()).expect("create playback host");
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(host.requested_sample_rate())
             .worker(PlayWorker::new(PlayWorkerConfig::builder(pools).build()))
             .build(),
     );

--- a/tests/tests/kithara_play/no_sync_real_media.rs
+++ b/tests/tests/kithara_play/no_sync_real_media.rs
@@ -262,7 +262,8 @@ async fn run_real_media_matrix(record_artifacts: bool) {
 }
 
 async fn run_case(case: &Case, hls: &Url, record_artifacts: bool) -> Vec<String> {
-    let session = Arc::new(OfflineSession::new_manual());
+    let sample_rate = NonZeroU32::new(case.host_rate).expect("host sample rate must be non-zero");
+    let session = Arc::new(OfflineSession::new_manual_with(sample_rate, BLOCK_FRAMES));
     let mut failures = Vec::new();
 
     let media_dir = TestTempDir::new();

--- a/tests/tests/kithara_play/player_internal.rs
+++ b/tests/tests/kithara_play/player_internal.rs
@@ -19,7 +19,9 @@ use kithara::{
     },
     signal::AudioSpec,
 };
-use kithara_integration_tests::{audio_mock::TestPcmReader, offline::OfflineSession};
+use kithara_integration_tests::{
+    audio_mock::TestPcmReader, offline::OfflineSession, test_defaults::Consts as Shared,
+};
 
 use crate::bufpool_ext::{TestPools, pools};
 
@@ -60,6 +62,7 @@ fn make_offline_player(crossfade_duration: f32) -> (PlayerImpl<TestPools>, Arc<O
     let bus = EventBus::default();
     let session = Arc::new(OfflineSession::new_manual());
     let player_config = PlayerConfig::builder()
+        .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
         .bus(bus)
         .crossfade_duration(crossfade_duration)
         .worker(PlayWorker::new(PlayWorkerConfig::builder(pools()).build()))
@@ -71,6 +74,7 @@ fn make_offline_player(crossfade_duration: f32) -> (PlayerImpl<TestPools>, Arc<O
 
 fn default_player_config() -> PlayerConfig<TestPools> {
     PlayerConfig::builder()
+        .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
         .worker(PlayWorker::new(PlayWorkerConfig::builder(pools()).build()))
         .session(OfflineSession::arc_manual())
         .build()
@@ -288,6 +292,7 @@ fn replacing_current_item_re_announces_on_next_play() {
 async fn player_play_without_audio_hardware_logs_warning() {
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .worker(PlayWorker::new(PlayWorkerConfig::builder(pools()).build()))
             .session(OfflineSession::arc_auto())
             .build(),

--- a/tests/tests/kithara_play/resource_regressions.rs
+++ b/tests/tests/kithara_play/resource_regressions.rs
@@ -602,6 +602,7 @@ async fn player_worker_hls_then_unavailable_mp3_then_mp3_recovery(
     let region = pools();
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .worker(play_worker(&region))
             .session(OfflineSession::arc_manual())
             .build(),
@@ -1016,6 +1017,7 @@ async fn player_worker_hls_then_mp3_reopen_keeps_backward_seek(
     let region = pools();
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .worker(play_worker(&region))
             .session(OfflineSession::arc_manual())
             .build(),

--- a/tests/tests/kithara_play/sync_product_matrix.rs
+++ b/tests/tests/kithara_play/sync_product_matrix.rs
@@ -250,10 +250,10 @@ impl ProductHarness {
     ) -> Self {
         let server = TestServerHelper::new().await;
         let sources = sources(provider, case.decks, &server).await;
-        let session = Arc::new(OfflineSession::new_manual_with_block_frames(block_frames));
+        let sample_rate = NonZeroU32::new(case.sample_rate).expect("fixture sample rate");
+        let session = Arc::new(OfflineSession::new_manual_with(sample_rate, block_frames));
         let dispatcher: Arc<dyn SessionDispatcher<TestPools>> = session.clone();
         let worker = PlayWorker::new(PlayWorkerConfig::builder(pools()).build());
-        let sample_rate = NonZeroU32::new(case.sample_rate).expect("fixture sample rate");
         let mut decks = Vec::with_capacity(sources.len());
         let mut ids = Vec::with_capacity(sources.len());
         for (index, source) in sources.into_iter().enumerate() {

--- a/tests/tests/kithara_queue/cold_seek_cpal.rs
+++ b/tests/tests/kithara_queue/cold_seek_cpal.rs
@@ -119,7 +119,12 @@ async fn cpal_cold_seek_silvercomet_hls(#[case] backend: DecoderBackend) {
 
     let worker = PlayWorker::new(PlayWorkerConfig::builder(pools()).build());
     let mut host = Host::new(HostConfig::builder().build()).expect("create playback host");
-    let player = PlayerImpl::new(PlayerConfig::builder().worker(worker).build());
+    let player = PlayerImpl::new(
+        PlayerConfig::builder()
+            .sample_rate(host.requested_sample_rate())
+            .worker(worker)
+            .build(),
+    );
     let queue = Queue::new(QueueConfig::builder().player(player).build());
     let queue = Arc::new(host.insert(queue).expect("attach queue to playback host"));
     queue.set_volume(kithara_integration_tests::e2e::volume());

--- a/tests/tests/kithara_queue/cold_seek_middle.rs
+++ b/tests/tests/kithara_queue/cold_seek_middle.rs
@@ -18,7 +18,7 @@ use kithara::{
 use kithara_integration_tests::{
     HlsFixtureBuilder, PackagedTestServer, TestServerHelper, TestTempDir,
     fixture_protocol::DelayRule, kithara, offline::OfflineSession, temp_dir,
-    waits::wait_for_position_event,
+    test_defaults::Consts as Shared, waits::wait_for_position_event,
 };
 
 use crate::bufpool_ext::{TestPools, pools};
@@ -77,6 +77,7 @@ fn build_queue_with_tick(
 ) {
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .worker(PlayWorker::new(PlayWorkerConfig::builder(pools()).build()))
             .session(OfflineSession::arc_auto())
             .build(),
@@ -234,6 +235,7 @@ async fn run_seek_scenario(urls: &[&str], select_index: usize, temp: TestTempDir
 
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .worker(PlayWorker::new(PlayWorkerConfig::builder(pools()).build()))
             .session(OfflineSession::arc_auto())
             .build(),

--- a/tests/tests/kithara_queue/cpal_cold_seek_synthetic.rs
+++ b/tests/tests/kithara_queue/cpal_cold_seek_synthetic.rs
@@ -15,6 +15,7 @@ use kithara_integration_tests::{
     kithara,
     offline::OfflineSession,
     temp_dir,
+    test_defaults::Consts as Shared,
     waits::{wait_for_loader_done, wait_for_position_at_least},
 };
 
@@ -62,6 +63,7 @@ async fn cold_seek_far_segment_hls_offline(#[case] backend: DecoderBackend) {
 
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .worker(PlayWorker::new(PlayWorkerConfig::builder(pools()).build()))
             .session(OfflineSession::arc_auto())
             .build(),

--- a/tests/tests/kithara_queue/false_eof_rapid_scrub.rs
+++ b/tests/tests/kithara_queue/false_eof_rapid_scrub.rs
@@ -20,7 +20,9 @@ use kithara_app::{
     config::AppConfig,
     pools::{AppPools, build as app_pools},
 };
-use kithara_integration_tests::{TestTempDir, kithara, offline::OfflineSession};
+use kithara_integration_tests::{
+    TestTempDir, kithara, offline::OfflineSession, test_defaults::Consts as Shared,
+};
 use kithara_test_utils::probe::capture::{Recorder, install as install_recorder};
 
 /// `cdn-hls-slicer.zvuk.com` → `zvuk-prod` provider in baked `app.yaml`.
@@ -89,6 +91,7 @@ async fn build_ctx() -> Ctx {
         .build();
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .worker(worker)
             .session(OfflineSession::arc_auto())
             .build(),

--- a/tests/tests/kithara_queue/file_replay_from_warm_cache.rs
+++ b/tests/tests/kithara_queue/file_replay_from_warm_cache.rs
@@ -22,6 +22,7 @@ use kithara_integration_tests::{
     TestServerHelper, TestTempDir, kithara,
     offline::OfflineSession,
     temp_dir,
+    test_defaults::Consts as Shared,
     waits::{wait_for_loader_done, wait_for_position_at_least},
 };
 use kithara_test_fixtures::SignalAsset;
@@ -61,6 +62,7 @@ fn build_session(cache_path: &Path) -> Session {
         .build();
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .worker(PlayWorker::new(
                 PlayWorkerConfig::builder(pools.clone()).build(),
             ))

--- a/tests/tests/kithara_queue/hls_seek_cancels_stale_fetches.rs
+++ b/tests/tests/kithara_queue/hls_seek_cancels_stale_fetches.rs
@@ -21,7 +21,8 @@ use kithara::{
 };
 use kithara_integration_tests::{
     HlsFixtureBuilder, TestServerHelper, TestTempDir, fixture_protocol::DelayRule, kithara,
-    offline::OfflineSession, temp_dir, waits::wait_for_loader_done,
+    offline::OfflineSession, temp_dir, test_defaults::Consts as Shared,
+    waits::wait_for_loader_done,
 };
 use kithara_test_utils::probe::capture as probe_capture;
 use url::Url;
@@ -118,6 +119,7 @@ fn build_queue_with_tick(
     let store = kithara_integration_tests::disk_asset_store(temp_dir.path());
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .worker(PlayWorker::new(PlayWorkerConfig::builder(pools()).build()))
             .session(OfflineSession::arc_auto())
             .build(),

--- a/tests/tests/kithara_queue/hls_seek_near_end_stress.rs
+++ b/tests/tests/kithara_queue/hls_seek_near_end_stress.rs
@@ -21,6 +21,7 @@ use kithara_integration_tests::{
     HlsFixtureBuilder, TestServerHelper, TestTempDir, kithara,
     offline::OfflineSession,
     temp_dir,
+    test_defaults::Consts as Shared,
     waits::{wait_for_loader_done_event, wait_for_position_event},
 };
 use url::Url;
@@ -132,6 +133,7 @@ fn build_queue_with_tick(
     let store = kithara_integration_tests::disk_asset_store(temp_dir.path());
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .worker(PlayWorker::new(PlayWorkerConfig::builder(pools()).build()))
             .session(OfflineSession::arc_auto())
             .build(),

--- a/tests/tests/kithara_queue/hls_variant_playlists_concurrent.rs
+++ b/tests/tests/kithara_queue/hls_variant_playlists_concurrent.rs
@@ -21,6 +21,7 @@ use kithara::{
 };
 use kithara_integration_tests::{
     HlsFixtureBuilder, TestServerHelper, TestTempDir, kithara, offline::OfflineSession, temp_dir,
+    test_defaults::Consts as Shared,
 };
 use kithara_test_utils::probe::capture as probe_capture;
 use url::Url;
@@ -76,6 +77,7 @@ fn build_queue_with_tick(
     let store = kithara_integration_tests::disk_asset_store(temp_dir.path());
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .worker(PlayWorker::new(PlayWorkerConfig::builder(pools()).build()))
             .session(OfflineSession::arc_auto())
             .build(),

--- a/tests/tests/kithara_queue/loader_lanes.rs
+++ b/tests/tests/kithara_queue/loader_lanes.rs
@@ -23,6 +23,7 @@ use kithara_integration_tests::{
     BehaviorHandle, Content, Delivery, FixtureBehavior, TestServerHelper, TestTempDir, kithara,
     offline::OfflineSession,
     temp_dir,
+    test_defaults::Consts as Shared,
     waits::{wait_for_loader_done, wait_for_position_at_least, wait_for_position_event},
 };
 use kithara_test_fixtures::assets::signal_mp3_track_sine440_187s;
@@ -102,6 +103,7 @@ fn build_queue_with_tick(
     let store = kithara_integration_tests::disk_asset_store(temp_dir.path());
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .worker(PlayWorker::new(PlayWorkerConfig::builder(pools()).build()))
             .session(OfflineSession::arc_auto())
             .build(),

--- a/tests/tests/kithara_queue/loader_starvation.rs
+++ b/tests/tests/kithara_queue/loader_starvation.rs
@@ -26,7 +26,8 @@ use kithara::{
 };
 use kithara_integration_tests::{
     Content, Delivery, FixtureBehavior, HlsFixtureBuilder, TestServerHelper, TestTempDir, kithara,
-    offline::OfflineSession, temp_dir, waits::wait_for_loader_done,
+    offline::OfflineSession, temp_dir, test_defaults::Consts as Shared,
+    waits::wait_for_loader_done,
 };
 use url::Url;
 
@@ -95,6 +96,7 @@ fn build_queue_with_tick(
     let store = kithara_integration_tests::disk_asset_store(temp_dir.path());
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .worker(PlayWorker::new(PlayWorkerConfig::builder(pools()).build()))
             .session(OfflineSession::arc_auto())
             .build(),

--- a/tests/tests/kithara_queue/local_track_plays.rs
+++ b/tests/tests/kithara_queue/local_track_plays.rs
@@ -23,6 +23,7 @@ use kithara_integration_tests::{
     kithara,
     offline::{OfflineSession, offline_gain_window},
     temp_dir,
+    test_defaults::Consts as Shared,
     waits::{wait_for_loader_done_event, wait_for_position_event, wait_for_position_near_event},
 };
 use kithara_test_fixtures::SignalAsset;
@@ -188,6 +189,7 @@ fn build_queue_with_tick(
     let store = kithara_integration_tests::disk_asset_store(temp_dir.path());
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .worker(PlayWorker::new(PlayWorkerConfig::builder(pools()).build()))
             .session(OfflineSession::arc_auto())
             .build(),

--- a/tests/tests/kithara_queue/packaged_drm_seek.rs
+++ b/tests/tests/kithara_queue/packaged_drm_seek.rs
@@ -26,6 +26,7 @@ use kithara_integration_tests::{
     kithara, mixed_codec_ladder_encrypted,
     offline::OfflineSession,
     temp_dir,
+    test_defaults::Consts as Shared,
     waits::{wait_for_position_at_least, wait_for_position_near},
 };
 use url::Url;
@@ -166,6 +167,7 @@ async fn run_seek_scenario(url: &Url, backend: DecoderBackend, abr: AbrMode, tem
 
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .worker(worker)
             .session(OfflineSession::<AppPools>::arc_auto())
             .build(),

--- a/tests/tests/kithara_queue/play_before_the_load_lands.rs
+++ b/tests/tests/kithara_queue/play_before_the_load_lands.rs
@@ -9,7 +9,8 @@ use kithara::{
     stream::dl::{Downloader, DownloaderConfig},
 };
 use kithara_integration_tests::{
-    TestServerHelper, kithara, offline::OfflineSession, temp_dir, waits::wait_for_position_event,
+    TestServerHelper, kithara, offline::OfflineSession, temp_dir, test_defaults::Consts as Shared,
+    waits::wait_for_position_event,
 };
 use kithara_test_fixtures::SignalAsset;
 
@@ -38,6 +39,7 @@ async fn play_issued_before_the_load_lands_still_starts_the_track() {
     let store = kithara_integration_tests::disk_asset_store(temp.path());
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .worker(PlayWorker::new(PlayWorkerConfig::builder(pools()).build()))
             .session(OfflineSession::arc_auto())
             .build(),

--- a/tests/tests/kithara_queue/playback_warms_its_own_analysis.rs
+++ b/tests/tests/kithara_queue/playback_warms_its_own_analysis.rs
@@ -17,7 +17,7 @@ use kithara::{
 };
 use kithara_integration_tests::{
     TestServerHelper, analysis_pass::stalled_reader, kithara, offline::OfflineSession, temp_dir,
-    waits::wait_until,
+    test_defaults::Consts as Shared, waits::wait_until,
 };
 use kithara_test_fixtures::SignalAsset;
 
@@ -46,6 +46,7 @@ async fn playback_feeds_the_pass_opened_for_the_track_it_plays() {
     let worker = PlayWorker::new(PlayWorkerConfig::builder(pools.clone()).build());
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .worker(worker)
             .session(OfflineSession::arc_auto())
             .build(),

--- a/tests/tests/kithara_queue/playlist_stall_fails_load.rs
+++ b/tests/tests/kithara_queue/playlist_stall_fails_load.rs
@@ -16,7 +16,7 @@ use kithara::{
 };
 use kithara_integration_tests::{
     Content, Delivery, FixtureBehavior, TestServerHelper, TestTempDir, kithara,
-    offline::OfflineSession, temp_dir,
+    offline::OfflineSession, temp_dir, test_defaults::Consts as Shared,
 };
 
 use crate::bufpool_ext::{TestPools, pools};
@@ -105,6 +105,7 @@ async fn stalled_master_playlist_fails_load(temp_dir: TestTempDir) {
 
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .worker(PlayWorker::new(
                 PlayWorkerConfig::builder(pools.clone()).build(),
             ))

--- a/tests/tests/kithara_queue/rapid_scrub_decode_failure.rs
+++ b/tests/tests/kithara_queue/rapid_scrub_decode_failure.rs
@@ -23,6 +23,7 @@ use kithara_integration_tests::{
     kithara,
     offline::OfflineSession,
     temp_dir,
+    test_defaults::Consts as Shared,
 };
 
 use crate::bufpool_ext::{TestPools, pools};
@@ -263,6 +264,7 @@ impl Harness {
             .build();
         let player = PlayerImpl::new(
             PlayerConfig::builder()
+                .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
                 .worker(PlayWorker::new(PlayWorkerConfig::builder(pools).build()))
                 .session(OfflineSession::arc_auto())
                 .build(),

--- a/tests/tests/kithara_queue/real_playlist.rs
+++ b/tests/tests/kithara_queue/real_playlist.rs
@@ -24,6 +24,7 @@ use kithara_app::{
 use kithara_integration_tests::{
     TestTempDir, Xorshift64, kithara,
     offline::{OfflineSession, offline_gain_window},
+    test_defaults::Consts as Shared,
     waits::{wait_for_position_at_least, wait_for_position_near},
 };
 
@@ -101,6 +102,7 @@ async fn shared_test_ctx() -> &'static TestCtx {
                 .build();
             let player = PlayerImpl::new(
                 PlayerConfig::builder()
+                    .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
                     .worker(worker)
                     .session(OfflineSession::arc_auto())
                     .build(),

--- a/tests/tests/kithara_queue/track_replay_after_switch.rs
+++ b/tests/tests/kithara_queue/track_replay_after_switch.rs
@@ -23,6 +23,7 @@ use kithara_integration_tests::{
     kithara,
     offline::OfflineSession,
     temp_dir,
+    test_defaults::Consts as Shared,
 };
 use kithara_test_fixtures::SignalAsset;
 use url::Url;
@@ -137,6 +138,7 @@ fn build_queue_with_tick_cf(
     let store = kithara_integration_tests::disk_asset_store(temp_dir.path());
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .worker(PlayWorker::new(PlayWorkerConfig::builder(pools()).build()))
             .session(OfflineSession::arc_auto())
             .crossfade_duration(crossfade_seconds)

--- a/tests/tests/kithara_queue/track_switch_race.rs
+++ b/tests/tests/kithara_queue/track_switch_race.rs
@@ -37,7 +37,7 @@ use kithara::{
 };
 use kithara_integration_tests::{
     CreatedHls, HlsFixtureBuilder, InitGateHandle, TestServerHelper, TestTempDir, kithara,
-    offline::OfflineSession, temp_dir,
+    offline::OfflineSession, temp_dir, test_defaults::Consts as Shared,
 };
 use url::Url;
 
@@ -120,6 +120,7 @@ fn build_queue_with_tick(
     let store = kithara_integration_tests::disk_asset_store(temp_dir.path());
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .worker(PlayWorker::new(PlayWorkerConfig::builder(pools()).build()))
             .session(OfflineSession::arc_auto())
             .build(),
@@ -166,6 +167,7 @@ fn build_queue_no_tick(
     let store = kithara_integration_tests::disk_asset_store(temp_dir.path());
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .worker(PlayWorker::new(PlayWorkerConfig::builder(pools()).build()))
             .session(OfflineSession::arc_auto())
             .build(),

--- a/tests/tests/kithara_queue/user_simulation/prod_network.rs
+++ b/tests/tests/kithara_queue/user_simulation/prod_network.rs
@@ -32,6 +32,7 @@ use kithara_app::{
 use kithara_integration_tests::{
     TestTempDir, kithara,
     offline::OfflineSession,
+    test_defaults::Consts as Shared,
     user_sim::{actions::Action, scenarios},
 };
 
@@ -100,6 +101,7 @@ async fn run_prod_drm_scenario(url: &str, actions: Vec<Action>) {
     let prod = build_prod_ctx();
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .worker(prod.config.worker.clone())
             .session(OfflineSession::arc_auto())
             .build(),
@@ -360,6 +362,7 @@ async fn user_sim_prod_drm_rapid_scrub_no_warmup_no_advance() {
     let prod = build_prod_ctx();
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .worker(prod.config.worker.clone())
             .session(OfflineSession::arc_auto())
             .build(),
@@ -427,6 +430,7 @@ async fn run_prod_drm_scenario_no_warmup(url: &str, ratio: f64) {
     let prod = build_prod_ctx();
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .worker(prod.config.worker.clone())
             .session(OfflineSession::arc_auto())
             .build(),
@@ -715,6 +719,7 @@ async fn run_multi_track_select_seek_end_hang(urls: &[&str], label: &str) {
     let session = Arc::new(OfflineSession::<AppPools>::new_manual());
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .worker(prod.config.worker.clone())
             .session(Arc::clone(&session) as Arc<dyn SessionDispatcher<AppPools>>)
             .build(),

--- a/tests/tests/kithara_queue/user_simulation/tests.rs
+++ b/tests/tests/kithara_queue/user_simulation/tests.rs
@@ -17,7 +17,7 @@ use kithara::{
 };
 use kithara_integration_tests::{
     HlsFixtureBuilder, TestServerHelper, fixture_protocol::EncryptionRequest, kithara,
-    offline::OfflineSession, temp_dir,
+    offline::OfflineSession, temp_dir, test_defaults::Consts as Shared,
 };
 use kithara_test_fixtures::SignalAsset;
 use url::Url;
@@ -423,6 +423,7 @@ async fn user_sim_seek_immediately_after_loaded(#[case] kind: TrackKind, #[case]
     .build();
     let player = PlayerImpl::new(
         PlayerConfig::builder()
+            .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .worker(worker)
             .session(OfflineSession::arc_auto())
             .build(),

--- a/tests/tests/kithara_queue/zvuk_drm_trace.rs
+++ b/tests/tests/kithara_queue/zvuk_drm_trace.rs
@@ -21,7 +21,9 @@ use kithara_app::{
     pools::{AppPools, build as app_pools},
     sources::build_source,
 };
-use kithara_integration_tests::{TestTempDir, kithara, offline::OfflineSession};
+use kithara_integration_tests::{
+    TestTempDir, kithara, offline::OfflineSession, test_defaults::Consts as Shared,
+};
 use tracing_subscriber::EnvFilter;
 
 /// Real-network DRM trace harness. Loads a single zvq.me DRM master
@@ -90,6 +92,7 @@ async fn shared_ctx() -> &'static Ctx {
             .build();
         let player = PlayerImpl::new(
             PlayerConfig::builder()
+                .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
                 .session(OfflineSession::arc_auto())
                 .worker(worker)
                 .build(),

--- a/tests/tests/kithara_queue/zvuk_prod_drm_e2e.rs
+++ b/tests/tests/kithara_queue/zvuk_prod_drm_e2e.rs
@@ -22,7 +22,8 @@ use kithara_app::{
     pools::{AppPools, build as app_pools},
 };
 use kithara_integration_tests::{
-    TestTempDir, kithara, offline::OfflineSession, waits::wait_for_position_at_least,
+    TestTempDir, kithara, offline::OfflineSession, test_defaults::Consts as Shared,
+    waits::wait_for_position_at_least,
 };
 
 /// Production zvuk DRM track. Server: `cdn-hls-slicer.zvuk.com`,
@@ -73,6 +74,7 @@ async fn shared_ctx() -> &'static Ctx {
             .build();
         let player = PlayerImpl::new(
             PlayerConfig::builder()
+                .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
                 .worker(worker)
                 .session(OfflineSession::arc_auto())
                 .build(),

--- a/tests/tests/kithara_queue/zvuk_stage_drm_e2e.rs
+++ b/tests/tests/kithara_queue/zvuk_stage_drm_e2e.rs
@@ -22,7 +22,8 @@ use kithara_app::{
     pools::{AppPools, build as app_pools},
 };
 use kithara_integration_tests::{
-    TestTempDir, kithara, offline::OfflineSession, waits::wait_for_position_at_least,
+    TestTempDir, kithara, offline::OfflineSession, test_defaults::Consts as Shared,
+    waits::wait_for_position_at_least,
 };
 
 /// Staging zvq.me DRM track — `zvuk-stage` provider in `app.yaml`.
@@ -69,6 +70,7 @@ async fn shared_ctx() -> &'static Ctx {
             .build();
         let player = PlayerImpl::new(
             PlayerConfig::builder()
+                .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
                 .worker(worker)
                 .session(OfflineSession::arc_auto())
                 .build(),


### PR DESCRIPTION
## Summary

This extracts Host output configuration from #232 into one independently reviewable change.

- `HostConfig::output_block_frames` is an optional CPAL request; `None` preserves the Firewheel/CPAL behavior that existed before the Warp work. A 128-frame block is selected explicitly by latency tests or applications, never as a product default.
- `HostConfig` is the only product default for the initial output sample rate. `SessionBinding` carries only the canonical Host dispatcher; Player validation, registration, and start derive the rate by querying that session. `PlayerConfig` and `EngineConfig` no longer choose their own defaults.
- Host insertion rejects a Player built for a different initial rate. Pre-bound offline/test sessions are checked before registration. App, native FFI, wasm Worker, Queue, and test fixtures pass the owning Host or fixture rate explicitly.

## Validation

- mandatory pre-commit `lint-fast`: passed
- scoped production Clippy for `kithara-play`, `kithara-host`, and `kithara-app`: passed
- `kithara-app` broadcast test target compilation: passed
- focused Host output/rate contracts: 7 passed
- focused Player/session propagation and attached/pre-bound mismatch contracts: 3 passed
- broad platform and regression validation: delegated to this PR CI

## Surface impact

- Public API: `HostConfig::builder().output_block_frames(...)` adds the optional callback-size request; `Host::requested_sample_rate()` exposes the initial session rate for composition.
- Playback configuration: `PlayerConfig.sample_rate` and `EngineConfig.sample_rate` are mandatory `NonZeroU32` values with no lower-layer default.
- Session protocol: register/start commands query the canonical session dispatcher instead of reading copied binding metadata or accepting another caller-provided value.
- Platform/runtime: native and wasm/FFI composition paths are updated; decoder resampling, asset sample rates, and route-change behavior are unchanged.

## Risks / follow-ups

- Actual device callback geometry remains backend-controlled and must be measured at runtime.
- CI is the acceptance gate for broad regressions and platform combinations.