### PR TITLE
feat(host,play,warp): add transport render observability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5442,6 +5442,7 @@ dependencies = [
  "kithara-platform",
  "kithara-signal",
  "kithara-stretch",
+ "kithara-test-macros",
  "kithara-test-utils",
  "kithara-workspace-hack",
  "num-traits",

--- a/crates/kithara-audio/src/audio/core.rs
+++ b/crates/kithara-audio/src/audio/core.rs
@@ -273,6 +273,7 @@ impl<S: kithara_platform::maybe_send::MaybeSend> AudioRead for Audio<S> {
         self.sync_seek();
         self.ring.preloaded = true;
         let chunk = if let Some(chunk) = self.ring.current_chunk.take() {
+            self.ring.current_source_span = None;
             Some(chunk)
         } else {
             let was_playing = self.ring.phase == super::ConsumerPhase::Playing;
@@ -286,7 +287,7 @@ impl<S: kithara_platform::maybe_send::MaybeSend> AudioRead for Audio<S> {
                 self.session.playhead.position(),
                 self.ring.validator.epoch,
             );
-            chunk
+            chunk.map(|(chunk, _source_span)| chunk)
         };
         let Some(chunk) = chunk else {
             return chunk_outcome(self.ring.phase, self.position());

--- a/crates/kithara-audio/src/audio/cursor.rs
+++ b/crates/kithara-audio/src/audio/cursor.rs
@@ -11,6 +11,7 @@ use super::{
     event::AudioEvents,
     ring::{RecvCtx, RingConsumer},
 };
+use crate::SourceSpan;
 
 #[derive(Clone, Copy)]
 pub(super) struct CursorRead {
@@ -56,6 +57,7 @@ impl ChunkCursor {
     fn copy_into(
         &mut self,
         chunk: &AudioChunk,
+        source_span: Option<SourceSpan>,
         output: &mut [f32],
         playhead: &dyn PlayheadWrite,
     ) -> Result<CopyOutcome, DecodeError> {
@@ -66,6 +68,8 @@ impl ChunkCursor {
             return Ok(CopyOutcome {
                 samples: 0,
                 finished: true,
+                output_frames: 0,
+                source_span: None,
             });
         }
 
@@ -76,6 +80,8 @@ impl ChunkCursor {
             return Ok(CopyOutcome {
                 samples: 0,
                 finished: false,
+                output_frames: 0,
+                source_span: None,
             });
         }
 
@@ -85,12 +91,19 @@ impl ChunkCursor {
         let consumed_total = consumed + take_frames;
         self.current_chunk_consumed_frames = consumed_total;
         let finished = take_frames == remaining_frames;
+        let source_span = source_span
+            .and_then(|span| source_subspan(span, consumed, consumed_total, total_frames));
         if finished {
             playhead.advance(&chunk_position(&chunk.meta));
         } else {
             playhead.advance_partial(interpolated_position(chunk.meta, consumed_total));
         }
-        Ok(CopyOutcome { finished, samples })
+        Ok(CopyOutcome {
+            finished,
+            output_frames: take_frames,
+            samples,
+            source_span,
+        })
     }
 
     #[kithara::measure]
@@ -118,15 +131,40 @@ impl ChunkCursor {
 
         let mut written = 0;
         let mut last_output_meta = None;
+        let mut source_span = None;
+        let mut source_output_frames = 0_u64;
         while written < buf.len() {
             hang_tick!();
 
             if let Some(chunk) = ring.current_chunk.as_ref() {
-                let copied = self.copy_into(chunk, &mut buf[written..], playhead)?;
+                let chunk_source_span = ring.current_source_span;
+                if written > 0
+                    && !source_spans_coalesce(
+                        source_span,
+                        source_output_frames,
+                        chunk_source_span,
+                        u64::from(chunk.meta.frames),
+                    )
+                {
+                    break;
+                }
+                let copied =
+                    self.copy_into(chunk, chunk_source_span, &mut buf[written..], playhead)?;
                 if copied.samples > 0 {
                     hang_reset!();
                     last_output_meta = Some(chunk.meta);
                     written += copied.samples;
+                    if let Some(next) = copied.source_span {
+                        source_span = source_span.map_or(Some(next), |current| {
+                            SourceSpan::new(current.start(), next.end(), current.sample_rate())
+                        });
+                        source_output_frames = source_output_frames
+                            .checked_add(copied.output_frames)
+                            .ok_or(DecodeError::SampleCountOverflow {
+                                frames: source_output_frames,
+                                channels: 1,
+                            })?;
+                    }
                 }
                 if copied.finished {
                     ring.recycle_current();
@@ -162,7 +200,11 @@ impl ChunkCursor {
             );
             return Ok(CursorRead {
                 last_output_meta,
-                outcome: ReadOutcome::Frames { count, position },
+                outcome: ReadOutcome::Frames {
+                    count,
+                    position,
+                    source_span,
+                },
             });
         }
 
@@ -205,7 +247,12 @@ impl ChunkCursor {
         let result = self.read(ring, events, playhead, recv, &mut interleaved[..]);
         let result = match result {
             Ok(mut read) => {
-                if let ReadOutcome::Frames { count, position } = read.outcome {
+                if let ReadOutcome::Frames {
+                    count,
+                    position,
+                    source_span,
+                } = read.outcome
+                {
                     let actual_frames = count.get() / channels;
                     debug_assert!(actual_frames <= frames);
                     let input = InterleavedView::new(
@@ -219,7 +266,11 @@ impl ChunkCursor {
                             position,
                             reason: PendingReason::Buffering,
                         },
-                        |count| ReadOutcome::Frames { position, count },
+                        |count| ReadOutcome::Frames {
+                            position,
+                            count,
+                            source_span,
+                        },
                     );
                 }
                 Ok(read)
@@ -233,7 +284,62 @@ impl ChunkCursor {
 
 struct CopyOutcome {
     finished: bool,
+    output_frames: u64,
     samples: usize,
+    source_span: Option<SourceSpan>,
+}
+
+fn source_spans_coalesce(
+    current: Option<SourceSpan>,
+    current_output_frames: u64,
+    next: Option<SourceSpan>,
+    next_output_frames: u64,
+) -> bool {
+    let (Some(current), Some(next)) = (current, next) else {
+        return current.is_none() && next.is_none();
+    };
+    if current.end() != next.start()
+        || current.sample_rate() != next.sample_rate()
+        || current_output_frames == 0
+        || next_output_frames == 0
+    {
+        return false;
+    }
+    let Some(current_source_frames) = current.end().checked_sub(current.start()) else {
+        return false;
+    };
+    let Some(next_source_frames) = next.end().checked_sub(next.start()) else {
+        return false;
+    };
+    u128::from(current_source_frames)
+        .checked_mul(u128::from(next_output_frames))
+        .zip(u128::from(next_source_frames).checked_mul(u128::from(current_output_frames)))
+        .is_some_and(|(current_slope, next_slope)| current_slope == next_slope)
+}
+
+fn source_subspan(
+    span: SourceSpan,
+    output_start: u64,
+    output_end: u64,
+    output_frames: u64,
+) -> Option<SourceSpan> {
+    if output_frames == 0 || output_start > output_end || output_end > output_frames {
+        return None;
+    }
+    let source_frames = span.end().checked_sub(span.start())?;
+    let source_at = |output_frame: u64| {
+        let offset = u128::from(source_frames)
+            .checked_mul(u128::from(output_frame))?
+            .checked_div(u128::from(output_frames))?;
+        span.start().checked_add(u64::try_from(offset).ok()?)
+    };
+    let start = source_at(output_start)?;
+    let end = if output_end == output_frames {
+        span.end()
+    } else {
+        source_at(output_end)?
+    };
+    SourceSpan::new(start, end, span.sample_rate())
 }
 
 fn frames_to_samples(frames: u64, channels: u64) -> Result<usize, DecodeError> {
@@ -282,7 +388,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        ConsumerWakeMode,
+        ConsumerWakeMode, SourceEnd,
         audio::{Fetch, ThreadWake, connect, ring::RingParts},
         test_pools::{Pools, pools, sample_buffer},
     };
@@ -332,12 +438,125 @@ mod tests {
                 &mut buf,
             )
             .expect("partial read succeeds");
-        let ReadOutcome::Frames { count, position } = read.outcome else {
+        let ReadOutcome::Frames {
+            count,
+            position,
+            source_span,
+        } = read.outcome
+        else {
             panic!("expected frames from partial resampled chunk");
         };
         assert_eq!(count.get(), 200);
         assert_eq!(position, duration);
+        assert_eq!(source_span, None);
         assert_eq!(cursor.current_chunk_consumed_frames, 100);
+    }
+
+    #[kithara::test]
+    fn reads_preserve_each_rendered_source_span() {
+        let pools = pools();
+        let rate = NonZeroU32::new(48_000).expect("test rate");
+        let spec = AudioSpec::new(1, rate);
+        let (mut data_tx, data_rx) = connect::<Fetch<AudioChunk>>(4, None);
+        let (trash_tx, _trash_rx) = connect::<AudioChunk>(8, None);
+        let mut ring = RingConsumer::new(RingParts {
+            trash_tx,
+            audio_rx: data_rx,
+            reader_wake: Arc::new(ThreadWake::default()),
+            epoch: Arc::new(AtomicU64::new(0)),
+            block_on_underrun: false,
+            consumer_wake_mode: ConsumerWakeMode::RealtimeDeferred,
+        });
+        ring.preloaded = true;
+        let mut first = timed_chunk(&pools, spec, 3, Duration::ZERO, Duration::from_millis(3));
+        first.meta.frame_offset = 100;
+        let mut second = timed_chunk(
+            &pools,
+            spec,
+            2,
+            Duration::from_millis(3),
+            Duration::from_millis(5),
+        );
+        second.meta.frame_offset = 106;
+        let mut changed = timed_chunk(
+            &pools,
+            spec,
+            2,
+            Duration::from_millis(5),
+            Duration::from_millis(7),
+        );
+        changed.meta.frame_offset = 110;
+        data_tx
+            .try_push(Fetch::rendered(first, 0, SourceEnd::new(106, rate)))
+            .expect("first rendered chunk reaches ring");
+        data_tx
+            .try_push(Fetch::rendered(second, 0, SourceEnd::new(110, rate)))
+            .expect("second rendered chunk reaches ring");
+        data_tx
+            .try_push(Fetch::rendered(changed, 0, SourceEnd::new(115, rate)))
+            .expect("changed-slope rendered chunk reaches ring");
+
+        let playhead = PlayheadState::new();
+        let mut cursor = ChunkCursor::new(&pools, spec).expect("cursor scratch fits test pools");
+        let mut events = AudioEvents::test();
+        let mut output = [0.0; 8];
+        let first_read = cursor
+            .read(
+                &mut ring,
+                &mut events,
+                &playhead,
+                RecvCtx {
+                    cancel: None,
+                    worker: None,
+                    abr: None,
+                },
+                &mut output,
+            )
+            .expect("first read succeeds");
+        let ReadOutcome::Frames {
+            count, source_span, ..
+        } = first_read.outcome
+        else {
+            panic!("expected first rendered frames");
+        };
+        assert_eq!(count.get(), 5);
+        assert_eq!(source_span, SourceSpan::new(100, 110, rate));
+
+        let second_read = cursor
+            .read(
+                &mut ring,
+                &mut events,
+                &playhead,
+                RecvCtx {
+                    cancel: None,
+                    worker: None,
+                    abr: None,
+                },
+                &mut output[..1],
+            )
+            .expect("partial changed-slope read succeeds");
+        let ReadOutcome::Frames { source_span, .. } = second_read.outcome else {
+            panic!("expected partial changed-slope frames");
+        };
+        assert_eq!(source_span, SourceSpan::new(110, 112, rate));
+
+        let final_read = cursor
+            .read(
+                &mut ring,
+                &mut events,
+                &playhead,
+                RecvCtx {
+                    cancel: None,
+                    worker: None,
+                    abr: None,
+                },
+                &mut output,
+            )
+            .expect("final changed-slope read succeeds");
+        let ReadOutcome::Frames { source_span, .. } = final_read.outcome else {
+            panic!("expected final rendered frames");
+        };
+        assert_eq!(source_span, SourceSpan::new(112, 115, rate));
     }
 
     #[kithara::test]

--- a/crates/kithara-audio/src/audio/ring.rs
+++ b/crates/kithara-audio/src/audio/ring.rs
@@ -12,10 +12,11 @@ use super::{
     ThreadWake, WakeSignal, connect, cursor::ChunkCursor, event::ReaderOutputWake,
     park::receive_is_nonblocking,
 };
+use crate::{SourceEnd, SourceSpan};
 
 enum FetchOutcome {
     Continue,
-    Return(Option<AudioChunk>),
+    Return(Option<(AudioChunk, Option<SourceSpan>)>),
 }
 
 pub(super) enum RecvOutcome {
@@ -37,6 +38,7 @@ pub(super) struct RingConsumer {
     pub(super) phase: ConsumerPhase,
     pub(super) validator: EpochValidator,
     pub(super) current_chunk: Option<AudioChunk>,
+    pub(super) current_source_span: Option<SourceSpan>,
     pub(super) preloaded: bool,
     _epoch: Arc<AtomicU64>,
     reader_wake: Arc<ThreadWake>,
@@ -68,6 +70,7 @@ impl RingConsumer {
             validator: EpochValidator::default(),
             phase: ConsumerPhase::Buffering,
             current_chunk: None,
+            current_source_span: None,
             trash_tx: parts.trash_tx,
             reader_wake: parts.reader_wake,
             _epoch: parts.epoch,
@@ -131,11 +134,12 @@ impl RingConsumer {
     }
 
     pub(super) fn fill(&mut self, cursor: &mut ChunkCursor, ctx: RecvCtx<'_>) -> bool {
-        let Some(chunk) = self.recv_valid_chunk(ctx) else {
+        let Some((chunk, source_span)) = self.recv_valid_chunk(ctx) else {
             return false;
         };
         cursor.begin_chunk(&chunk);
         self.current_chunk = Some(chunk);
+        self.current_source_span = source_span;
         self.promote_playing();
         true
     }
@@ -159,7 +163,12 @@ impl RingConsumer {
                 };
                 FetchOutcome::Return(None)
             }
-            Fetch::Data { data, .. } => FetchOutcome::Return(Some(data)),
+            Fetch::Data {
+                data, source_end, ..
+            } => {
+                let source_span = source_span(&data, source_end);
+                FetchOutcome::Return(Some((data, source_span)))
+            }
         }
     }
 
@@ -221,7 +230,10 @@ impl RingConsumer {
     }
 
     #[kithara::hang_watchdog]
-    pub(super) fn recv_valid_chunk(&mut self, ctx: RecvCtx<'_>) -> Option<AudioChunk> {
+    pub(super) fn recv_valid_chunk(
+        &mut self,
+        ctx: RecvCtx<'_>,
+    ) -> Option<(AudioChunk, Option<SourceSpan>)> {
         if self.phase.is_terminal() {
             return None;
         }
@@ -250,6 +262,7 @@ impl RingConsumer {
     }
 
     pub(super) fn recycle_current(&mut self) {
+        self.current_source_span = None;
         if let Some(chunk) = self.current_chunk.take() {
             self.discard(chunk);
         }
@@ -267,21 +280,38 @@ impl RingConsumer {
             "PCM ring preserved a fetch from a future seek epoch"
         );
         match fetch {
-            Fetch::Data { data, .. } => {
+            Fetch::Data {
+                data, source_end, ..
+            } => {
+                self.current_source_span = source_span(&data, source_end);
                 cursor.begin_chunk(&data);
                 self.current_chunk = Some(data);
                 self.phase = ConsumerPhase::Playing;
             }
             Fetch::NaturalEof { .. } => {
+                self.current_source_span = None;
                 self.phase = ConsumerPhase::AtEof;
             }
             Fetch::Failure { .. } => {
+                self.current_source_span = None;
                 self.phase = ConsumerPhase::Failed {
                     source: FailureSource::ProducerAfterSeek,
                 };
             }
         }
     }
+}
+
+fn source_span(data: &AudioChunk, source_end: Option<SourceEnd>) -> Option<SourceSpan> {
+    let source_end = source_end?;
+    if source_end.sample_rate() != data.meta.spec.sample_rate {
+        return None;
+    }
+    SourceSpan::new(
+        data.meta.frame_offset,
+        source_end.frame(),
+        source_end.sample_rate(),
+    )
 }
 
 pub(super) fn create_channels(
@@ -392,7 +422,9 @@ mod tests {
         }
 
         fn recv(&mut self) -> Option<AudioChunk> {
-            self.ring.recv_valid_chunk(empty_ctx())
+            self.ring
+                .recv_valid_chunk(empty_ctx())
+                .map(|(chunk, _source_span)| chunk)
         }
 
         fn chunk(&self, samples: &[f32]) -> AudioChunk {

--- a/crates/kithara-audio/src/lib.rs
+++ b/crates/kithara-audio/src/lib.rs
@@ -30,7 +30,7 @@ pub use kithara_resampler::{
 };
 pub use pipeline::{
     config::{AudioConfig, AudioDecoderConfig, ConsumerWakeMode, DecoderResamplerSettings},
-    fetch::{EpochValidator, Fetch, SourceEnd},
+    fetch::{EpochValidator, Fetch, SourceEnd, SourceSpan},
     track::{TrackStep, WaitingReason},
 };
 pub use producer::PreloadGate;

--- a/crates/kithara-audio/src/pipeline/fetch.rs
+++ b/crates/kithara-audio/src/pipeline/fetch.rs
@@ -21,6 +21,37 @@ impl SourceEnd {
     }
 }
 
+/// Exact decoded-source interval represented by rendered PCM.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, fieldwork::Fieldwork)]
+#[fieldwork(opt_in, get)]
+#[non_exhaustive]
+pub struct SourceSpan {
+    /// Inclusive decoded source frame.
+    #[field(get, copy)]
+    start: u64,
+    /// Exclusive decoded source frame.
+    #[field(get, copy)]
+    end: u64,
+    /// Sample rate of the decoded source coordinate.
+    #[field(get, copy)]
+    sample_rate: NonZeroU32,
+}
+
+impl SourceSpan {
+    /// Construct a decoded-source interval.
+    #[must_use]
+    pub const fn new(start: u64, end: u64, sample_rate: NonZeroU32) -> Option<Self> {
+        if start > end {
+            return None;
+        }
+        Some(Self {
+            start,
+            end,
+            sample_rate,
+        })
+    }
+}
+
 /// Fetch result from a worker source.
 #[derive(Debug)]
 pub enum Fetch<C> {
@@ -121,5 +152,12 @@ mod tests {
         assert!(!validator.is_valid(&first));
         assert!(!validator.is_valid(&stale));
         assert!(validator.is_valid(&next));
+    }
+
+    #[kithara::test]
+    fn source_span_rejects_an_inverted_interval() {
+        let rate = NonZeroU32::new(48_000).expect("test sample rate");
+
+        assert_eq!(SourceSpan::new(2, 1, rate), None);
     }
 }

--- a/crates/kithara-audio/src/traits/outcome.rs
+++ b/crates/kithara-audio/src/traits/outcome.rs
@@ -3,6 +3,8 @@ use std::num::NonZeroUsize;
 use kithara_platform::time::Duration;
 use kithara_signal::AudioChunk;
 
+use crate::SourceSpan;
+
 /// Reason a [`ReadOutcome::Pending`] / [`ChunkOutcome::Pending`] was
 /// returned — i.e. why the reader did not advance this call. Each
 /// variant maps to a distinct caller action; there is no overlap and
@@ -39,6 +41,8 @@ pub enum ReadOutcome {
     Frames {
         count: NonZeroUsize,
         position: Duration,
+        /// Exact decoded-source interval represented by these frames.
+        source_span: Option<SourceSpan>,
     },
     /// Reader is alive but produced no frames this call. See
     /// [`PendingReason`] for the precise cause and required caller

--- a/crates/kithara-host/src/session/graph.rs
+++ b/crates/kithara-host/src/session/graph.rs
@@ -356,7 +356,7 @@ pub(super) mod slots {
         player.next_slot_id += 1;
         let shared_eq = player.shared_eq.clone();
         let (inputs, control) = slot_channels(shared_eq);
-        let player_node = PlayerNode::new(inputs, player.pools.clone());
+        let player_node = PlayerNode::new(inputs, player.pools.clone()).with_session_context();
         let player_node_id = fw_ctx.add_node(player_node, None);
         let slot_volume = VolumeNode::from_linear(1.0);
         let slot_volume_memo = Memo::new(slot_volume);

--- a/crates/kithara-host/src/session/transport/node.rs
+++ b/crates/kithara-host/src/session/transport/node.rs
@@ -8,7 +8,9 @@ use firewheel::{
         NodeID, ProcBuffers, ProcExtra, ProcInfo, ProcStreamCtx, ProcessStatus,
     },
 };
+use kithara_play::rt::{install_render_context, invalidate_render_context, publish_render_context};
 use kithara_test_utils::kithara::rtsan_forbid_blocking;
+use kithara_warp::{RenderContext, SessionFrame};
 use triple_buffer::{Output, triple_buffer};
 
 use super::{
@@ -16,7 +18,8 @@ use super::{
         SessionGridGeneration, TransportCommitEvent, TransportCommitStamp, TransportObservation,
     },
     process::{
-        TransportCommitState, TransportObservationInput, process_transport, restart_transport,
+        TransportCommitState, TransportFrame, TransportObservationInput, process_transport,
+        restart_transport,
     },
 };
 use crate::api::TransportRevision;
@@ -30,6 +33,7 @@ pub(crate) fn install<B: AudioBackend>(
     let store = ctx
         .proc_store_mut()
         .ok_or("session transport store is unavailable while the stream is running")?;
+    install_render_context(store)?;
     store
         .insert(TransportCommitState::new(session_grid))
         .map_err(|_| "session transport state store slot already exists")?;
@@ -123,15 +127,46 @@ impl AudioNodeProcessor for SessionTransportProcessor {
         events: &mut ProcEvents,
         extra: &mut ProcExtra,
     ) -> ProcessStatus {
-        if let Err(error) = process_transport(info, events, &mut extra.store) {
-            let _ = extra.logger.try_error(error.message());
+        let processed = process_transport(info, events, &mut extra.store);
+        let context = processed
+            .as_ref()
+            .ok()
+            .and_then(|transport| build(info, transport));
+        let invalid = context.is_none();
+        let replaced = match context {
+            Some(context) => publish_render_context(&mut extra.store, context),
+            None => invalidate_render_context(&mut extra.store),
+        };
+        if let Err(error) = replaced {
+            let _ = extra.logger.try_error(error);
+        } else if invalid {
+            let message = processed
+                .err()
+                .map_or("render context is invalid", |error| error.message());
+            let _ = extra.logger.try_error(message);
         }
         ProcessStatus::ClearAllOutputs
     }
 
     fn stream_stopped(&mut self, context: &mut ProcStreamCtx) {
+        if invalidate_render_context(context.store).is_err() {
+            let _ = context
+                .logger
+                .try_error("render context store slot is missing");
+        }
         if let Err(error) = restart_transport(context.store) {
             let _ = context.logger.try_error(error.message());
         }
     }
+}
+
+fn build(info: &ProcInfo, transport: &TransportFrame) -> Option<RenderContext> {
+    let output_frames = info.clock_samples_range();
+    RenderContext::new(
+        SessionFrame::new(output_frames.start.0)..SessionFrame::new(output_frames.end.0),
+        info.sample_rate,
+        transport.session_beats.clone(),
+        transport.session_epoch,
+        transport.transport_revision,
+    )
 }

--- a/crates/kithara-host/src/session/transport/process.rs
+++ b/crates/kithara-host/src/session/transport/process.rs
@@ -4,7 +4,7 @@ use firewheel::{
     event::ProcEvents,
     node::{ProcInfo, ProcStore},
 };
-use kithara_warp::{SessionAnchor, SessionBeat, SessionFrame};
+use kithara_warp::{SessionAnchor, SessionBeat, SessionEpoch, SessionFrame};
 use triple_buffer::Input;
 
 use super::commit::{
@@ -16,6 +16,13 @@ use crate::api::{SessionTransportSnapshot, Tempo, TransportRevision};
 #[derive(Clone, Copy, Debug)]
 struct RenderBoundary {
     frame: SessionFrame,
+}
+
+#[derive(Debug)]
+pub(super) struct TransportFrame {
+    pub(super) session_beats: Option<Range<SessionBeat>>,
+    pub(super) session_epoch: SessionEpoch,
+    pub(super) transport_revision: Option<TransportRevision>,
 }
 
 #[derive(Debug)]
@@ -46,11 +53,11 @@ impl TransportObservationInput {
     }
 }
 
-pub(crate) fn process_transport(
+pub(super) fn process_transport(
     info: &ProcInfo,
     events: &mut ProcEvents,
     store: &mut ProcStore,
-) -> Result<(), TransportProcessError> {
+) -> Result<TransportFrame, TransportProcessError> {
     let result = store
         .try_get_mut::<TransportCommitState>()
         .ok_or(TransportProcessError::MissingState)?
@@ -353,14 +360,18 @@ impl TransportCommitState {
         &mut self,
         info: &ProcInfo,
         events: &mut ProcEvents,
-    ) -> Result<(), TransportProcessError> {
+    ) -> Result<TransportFrame, TransportProcessError> {
         self.reanchor(info)?;
         self.validate_frame(info)?;
         self.apply_events(info, events)?;
         let session_beats = self.session_beats(info)?;
         self.boundary = Self::next_boundary(info, self.active, self.boundary)?;
         self.snapshot = self.next_snapshot(session_beats.as_ref())?;
-        Ok(())
+        Ok(TransportFrame {
+            session_beats,
+            session_epoch: self.session_grid.epoch(),
+            transport_revision: self.active.map(|commit| commit.revision()),
+        })
     }
 
     fn reanchor(&mut self, info: &ProcInfo) -> Result<(), TransportProcessError> {

--- a/crates/kithara-host/src/session/transport/tests.rs
+++ b/crates/kithara-host/src/session/transport/tests.rs
@@ -12,9 +12,11 @@ use firewheel::{
     },
 };
 use kithara_platform::time::Duration;
+use kithara_play::rt::{install_render_context, read_render_context};
 use kithara_test_utils::kithara;
 use kithara_warp::{
-    Beat, BeatGridId, BeatGridQuery, BeatsPerMinute, MapPoint, MapPosition, SessionFrame,
+    Beat, BeatGridId, BeatGridQuery, BeatsPerMinute, MapPoint, MapPosition, SessionEpoch,
+    SessionFrame,
 };
 use triple_buffer::{Output, triple_buffer};
 
@@ -82,7 +84,8 @@ fn proc_extra() -> (ProcExtra, Output<TransportObservation>) {
     );
     let initial = TransportObservation::new(None, None, session_grid);
     let (observation_input, observation_output) = triple_buffer(&initial);
-    let mut store = ProcStore::with_capacity(2);
+    let mut store = ProcStore::with_capacity(3);
+    assert!(install_render_context(&mut store).is_ok());
     assert!(
         store
             .insert(TransportCommitState::new(session_grid))
@@ -154,7 +157,7 @@ fn process_result(
     second: Option<NodeEventType>,
 ) -> Result<(), TransportProcessError> {
     with_events(first, second, |events| {
-        process_transport(info, events, &mut extra.store)
+        process_transport(info, events, &mut extra.store).map(|_| ())
     })
 }
 
@@ -202,6 +205,89 @@ fn active_harness() -> (
         Some(TransportCommitResult::Applied(TransportRevision::first()))
     );
     (processor, extra, output, active)
+}
+
+#[kithara::test]
+fn transport_frame_carries_the_exact_processed_musical_context() {
+    let (_processor, mut extra, _output, active) = active_harness();
+    let frame = with_events(None, None, |events| {
+        process_transport(&proc_info_at(block_frame(1)), events, &mut extra.store)
+    })
+    .expect("invariant: the next contiguous transport block is valid");
+    let beats = frame
+        .session_beats
+        .expect("invariant: the active playing transport has a beat range");
+
+    assert_eq!(frame.session_epoch, SessionEpoch::new(0));
+    assert_eq!(frame.transport_revision, Some(active.revision()));
+    assert!((f64::from(beats.start) - 0.02).abs() <= f64::EPSILON);
+    assert!((f64::from(beats.end) - 0.04).abs() <= f64::EPSILON);
+}
+
+#[kithara::test]
+fn pre_process_publishes_the_exact_render_context() {
+    let (_processor, extra, _output, active) = active_harness();
+    let info = proc_info_at(0);
+    let context = read_render_context(&extra.store, &info)
+        .expect("invariant: the pre-process node published this exact block");
+
+    assert_eq!(
+        context.output_frames(),
+        &(SessionFrame::new(0)..SessionFrame::new(block_frame(1)))
+    );
+    assert_eq!(context.sample_rate(), sample_rate());
+    assert_eq!(context.session_epoch(), SessionEpoch::new(0));
+    assert_eq!(context.transport_revision(), Some(active.revision()));
+    let beats = context
+        .session_beats()
+        .expect("invariant: active transport carries a musical range");
+    assert!(f64::from(beats.start).abs() <= f64::EPSILON);
+    assert!((f64::from(beats.end) - 0.02).abs() <= f64::EPSILON);
+}
+
+#[kithara::test]
+fn inactive_transport_is_a_valid_render_context() {
+    let (mut extra, _output) = proc_extra();
+    let info = proc_info_at(0);
+    process_node(
+        &mut SessionTransportProcessor,
+        &info,
+        &mut extra,
+        None,
+        None,
+    );
+
+    let context = read_render_context(&extra.store, &info)
+        .expect("invariant: inactive transport still publishes the session axis");
+    assert_eq!(context.session_epoch(), SessionEpoch::new(0));
+    assert_eq!(context.transport_revision(), None);
+    assert_eq!(context.session_beats(), None);
+}
+
+#[kithara::test]
+fn stale_subblock_cannot_reuse_the_full_render_context() {
+    let (_processor, extra, _output, _active) = active_harness();
+    let mut subblock = proc_info_at(0);
+    subblock.frames /= 2;
+
+    assert_eq!(
+        read_render_context(&extra.store, &subblock),
+        Err("render context does not match the player process block")
+    );
+}
+
+#[kithara::test]
+fn invalid_transport_block_replaces_the_previous_render_context() {
+    let (mut processor, mut extra, _output, _active) = active_harness();
+    let info = proc_info_at(0);
+    assert!(read_render_context(&extra.store, &info).is_ok());
+
+    process_node(&mut processor, &info, &mut extra, None, None);
+
+    assert_eq!(
+        read_render_context(&extra.store, &info),
+        Err("render context is invalid")
+    );
 }
 
 #[kithara::test]
@@ -276,6 +362,10 @@ fn route_restart_advances_session_epoch_and_grid_revision() {
         store: &mut extra.store,
         logger: &mut extra.logger,
     });
+    assert_eq!(
+        read_render_context(&extra.store, &proc_info_at(0)),
+        Err("render context is invalid")
+    );
     let boundary = observation(&mut output);
     assert_eq!(boundary.snapshot(), None);
     let boundary_generation = boundary.session_grid();

--- a/crates/kithara-play/Cargo.toml
+++ b/crates/kithara-play/Cargo.toml
@@ -70,7 +70,7 @@ stretch-signalsmith = ["kithara-warp/stretch-signalsmith"]
 stretch-bungee = ["kithara-warp/stretch-bungee"]
 # Re-export of testing helpers (engine module + macro mocks).
 # Offline backend lives in `kithara-integration-tests::offline` since 2026-05-07.
-probe = ["kithara-worker/probe"]
+probe = ["kithara-warp/probe", "kithara-worker/probe"]
 mock = ["dep:unimock"]
 perf = [
     "dep:hotpath",

--- a/crates/kithara-play/src/resource/reader.rs
+++ b/crates/kithara-play/src/resource/reader.rs
@@ -10,7 +10,9 @@ use kithara_events::EventBus;
 use kithara_platform::{CancelToken, sync::Arc, time::Duration};
 use kithara_signal::AudioSpec;
 use kithara_stream::{Stream, StreamType};
-use kithara_warp::{StretchControls, WarpConfig};
+use kithara_warp::{
+    PresentationFrontier, RenderContext, RenderPublisher, StretchControls, WarpConfig,
+};
 use tracing::warn;
 
 use super::{ResourceConfig, SourceType};
@@ -71,6 +73,7 @@ pub struct Resource {
     #[field(with)]
     playback_rate: PlaybackRate,
     reader: ReaderOwner,
+    render_publisher: Option<RenderPublisher>,
 }
 
 /// Cancels the wrapped per-track token on drop. A `Resource` field rather than
@@ -227,6 +230,7 @@ impl Resource {
             priority: None,
             playback_rate: PlaybackRate::Fixed,
             reader: ReaderOwner(CancelGuard(None), inner),
+            render_publisher: None,
         };
         if preload && let Err(error) = resource.reader.1.preload() {
             warn!(src = %resource.src, %error, "resource preload failed");
@@ -251,15 +255,31 @@ impl Resource {
         crate::RegisteredAudio<Stream<T>, S>: AudioReader + 'static,
     {
         let warp_controls = Arc::clone(config.warp().stretch());
-        let audio = worker.open(config).await?;
+        let mut audio = worker.open(config).await?;
         let priority = audio.priority();
+        let render_publisher = audio.take_publisher().ok_or(DecodeError::InvalidData {
+            detail: "registered Warp publisher was already taken",
+        })?;
         let mut resource = Self::from_reader(audio, Some(src))
             .with_playback_rate(PlaybackRate::for_warp(warp_controls));
         if let Err(error) = resource.preload().await {
             warn!(src = %resource.src, %error, "resource preload failed");
         }
         resource.priority = Some(priority);
+        resource.render_publisher = Some(render_publisher);
         Ok(resource)
+    }
+
+    pub(crate) fn clear_render(&self) {
+        if let Some(publisher) = &self.render_publisher {
+            publisher.clear();
+        }
+    }
+
+    pub(crate) fn publish_render(&self, context: &RenderContext, frontier: PresentationFrontier) {
+        if let Some(publisher) = &self.render_publisher {
+            publisher.publish(context, frontier);
+        }
     }
 
     pub(crate) fn apply_playback_rate(&self, rate: f32) -> f32 {
@@ -389,6 +409,7 @@ mod tests {
     use kithara_platform::{CancelToken, sync::Arc};
     use kithara_signal::AudioSpec;
     use kithara_test_utils::kithara;
+    use kithara_warp::{SessionEpoch, SessionFrame, Warp};
     use ringbuf::traits::{Consumer, Producer};
 
     use super::*;
@@ -515,6 +536,7 @@ mod tests {
             Ok(ReadOutcome::Frames {
                 count: NonZeroUsize::new(samples).expect("non-zero stereo sample count"),
                 position: self.position_duration(),
+                source_span: None,
             })
         }
         fn read_planar<'a>(
@@ -531,6 +553,7 @@ mod tests {
             Ok(ReadOutcome::Frames {
                 count: frames,
                 position: self.position_duration(),
+                source_span: None,
             })
         }
 
@@ -787,5 +810,38 @@ mod tests {
 
         assert!(!track.is_cancelled());
         assert_eq!(state.load(Ordering::SeqCst), DropState::BEFORE_CANCEL);
+    }
+
+    #[kithara::test(native, flash(false))]
+    fn seek_withdraws_the_resident_warp_context() {
+        let mut warp = Warp::new((), &WarpConfig::builder().build());
+        let publisher = warp
+            .take_publisher()
+            .expect("fixture Warp owns its publisher");
+        let reader = publisher.reader();
+        let mut resource = Resource::from_reader(EofReader::with_frames(1), None);
+        let context = RenderContext::new(
+            SessionFrame::new(0)..SessionFrame::new(1),
+            NonZeroU32::new(Consts::SAMPLE_RATE).expect("static sample rate"),
+            None,
+            SessionEpoch::new(1),
+            None,
+        )
+        .expect("fixture context is valid");
+        publisher.publish(
+            &context,
+            PresentationFrontier::builder()
+                .source(1)
+                .output(SessionFrame::new(0))
+                .build(),
+        );
+        assert!(reader.load().is_some());
+        resource.render_publisher = Some(publisher);
+        let mut resource = PlayerResource::new(resource, Arc::from("seek"), &pools())
+            .unwrap_or_else(|error| panic!("test player resource: {error}"));
+
+        resource.reset_for_seek();
+
+        assert!(reader.load().is_none());
     }
 }

--- a/crates/kithara-play/src/rt/context.rs
+++ b/crates/kithara-play/src/rt/context.rs
@@ -1,0 +1,93 @@
+use firewheel::node::{ProcInfo, ProcStore};
+use kithara_warp::RenderContext;
+
+#[derive(Debug, Default)]
+enum RenderContextSlot {
+    #[default]
+    Unwritten,
+    Ready(RenderContext),
+    Invalid,
+}
+
+/// Installs the preallocated slot shared by the Host transport writer and its
+/// session-created Player nodes.
+///
+/// # Errors
+///
+/// Returns an error when the slot has already been installed.
+#[doc(hidden)]
+pub fn install_render_context(store: &mut ProcStore) -> Result<(), &'static str> {
+    store
+        .insert(RenderContextSlot::default())
+        .map_err(|_| "render context store slot already exists")
+}
+
+/// Replaces the shared session render context for the current graph block.
+///
+/// # Errors
+///
+/// Returns an error when the Host did not install the slot before stream start.
+#[doc(hidden)]
+pub fn publish_render_context(
+    store: &mut ProcStore,
+    context: RenderContext,
+) -> Result<(), &'static str> {
+    replace(store, RenderContextSlot::Ready(context))
+}
+
+/// Invalidates the shared context so a later Player node cannot reuse an older
+/// graph block.
+///
+/// # Errors
+///
+/// Returns an error when the Host did not install the slot before stream start.
+#[doc(hidden)]
+pub fn invalidate_render_context(store: &mut ProcStore) -> Result<(), &'static str> {
+    replace(store, RenderContextSlot::Invalid)
+}
+
+fn replace(store: &mut ProcStore, next: RenderContextSlot) -> Result<(), &'static str> {
+    let slot = store
+        .try_get_mut::<RenderContextSlot>()
+        .ok_or("render context store slot is missing")?;
+    *slot = next;
+    Ok(())
+}
+
+/// Reads the context written for this exact process block.
+///
+/// # Errors
+///
+/// Returns an allocation-free diagnostic when the slot is absent, invalid, or
+/// does not match `info` exactly.
+#[doc(hidden)]
+pub fn read_render_context<'a>(
+    store: &'a ProcStore,
+    info: &ProcInfo,
+) -> Result<&'a RenderContext, &'static str> {
+    let slot = store
+        .try_get::<RenderContextSlot>()
+        .ok_or("render context store slot is missing")?;
+    let context = match slot {
+        RenderContextSlot::Unwritten => {
+            return Err("render context was not written before player processing");
+        }
+        RenderContextSlot::Ready(context) => context,
+        RenderContextSlot::Invalid => return Err("render context is invalid"),
+    };
+    let frames = i64::try_from(info.frames)
+        .map_err(|_| "render context does not match the player process block")?;
+    let end = info
+        .clock_samples
+        .0
+        .checked_add(frames)
+        .ok_or("render context does not match the player process block")?;
+    let output_frames = context.output_frames();
+    if context.sample_rate() != info.sample_rate
+        || i64::from(output_frames.start) != info.clock_samples.0
+        || i64::from(output_frames.end) != end
+    {
+        return Err("render context does not match the player process block");
+    }
+    Ok(context)
+}

--- a/crates/kithara-play/src/rt/mod.rs
+++ b/crates/kithara-play/src/rt/mod.rs
@@ -1,4 +1,5 @@
 mod command;
+mod context;
 mod eq;
 mod node;
 mod processor;
@@ -6,6 +7,9 @@ mod render;
 mod slots;
 pub mod track;
 
+pub use context::{
+    install_render_context, invalidate_render_context, publish_render_context, read_render_context,
+};
 pub use eq::MasterEqNode;
 pub use node::PlayerNode;
 pub use processor::{PlayerNodeProcessor, StreamShape};

--- a/crates/kithara-play/src/rt/node.rs
+++ b/crates/kithara-play/src/rt/node.rs
@@ -10,7 +10,7 @@ use firewheel::{
 use kithara_bufpool::{HasPool, PoolRegion};
 use kithara_platform::sync::{Arc, Mutex};
 
-use super::processor::{PlayerNodeProcessor, StreamShape};
+use super::processor::{ContextRequirement, PlayerNodeProcessor, StreamShape};
 use crate::bridge::{NodeInputs, SharedEq, slot_channels};
 
 /// A player source node that outputs mixed audio from loaded tracks.
@@ -29,6 +29,9 @@ pub struct PlayerNode<S> {
     /// Typed pool facade for scratch buffer allocation.
     #[diff(skip)]
     pools: PoolRegion<S>,
+
+    #[diff(skip)]
+    context_requirement: ContextRequirement,
 }
 
 /// A runtime parameter patch for [`PlayerNode`].
@@ -61,6 +64,7 @@ impl<S> Clone for PlayerNode<S> {
             active: self.active,
             inputs: Arc::clone(&self.inputs),
             pools: self.pools.clone(),
+            context_requirement: self.context_requirement,
         }
     }
 }
@@ -72,7 +76,17 @@ impl<S> PlayerNode<S> {
             pools,
             active: true,
             inputs: Arc::new(Mutex::new(Some(inputs))),
+            context_requirement: ContextRequirement::Standalone,
         }
+    }
+
+    /// Requires the Host-written render context when constructing this node's
+    /// processor. Standalone nodes retain their context-free contract.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn with_session_context(mut self) -> Self {
+        self.context_requirement = ContextRequirement::Session;
+        self
     }
 }
 
@@ -98,7 +112,12 @@ where
             .lock()
             .take()
             .unwrap_or_else(|| slot_channels(SharedEq::new(0)).0);
-        PlayerNodeProcessor::new(inputs, shape, &self.pools)
+        PlayerNodeProcessor::with_context_requirement(
+            inputs,
+            shape,
+            &self.pools,
+            self.context_requirement,
+        )
     }
 
     fn info(&self, _config: &Self::Configuration) -> AudioNodeInfo {

--- a/crates/kithara-play/src/rt/processor.rs
+++ b/crates/kithara-play/src/rt/processor.rs
@@ -5,17 +5,21 @@ use firewheel::{
     StreamInfo,
     dsp::fade::FadeCurve,
     event::ProcEvents,
-    node::{AudioNodeProcessor, ProcBuffers, ProcExtra, ProcInfo, ProcStreamCtx, ProcessStatus},
+    node::{
+        AudioNodeProcessor, ProcBuffers, ProcExtra, ProcInfo, ProcStore, ProcStreamCtx,
+        ProcessStatus,
+    },
 };
 use kithara_bufpool::{HasPool, PoolRegion};
 use kithara_events::TrackId;
 use kithara_platform::sync::Arc;
 use kithara_test_utils::kithara;
+use kithara_warp::RenderContext;
 use num_traits::cast::AsPrimitive;
 use ringbuf::{HeapCons, HeapProd, traits::Producer};
 use smallvec::SmallVec;
 
-use super::track::PlayerTrack;
+use super::{context::read_render_context, track::PlayerTrack};
 use crate::{
     bridge::{
         NodeInputs, PlaybackShared, PlayerCmd, PlayerNotification, TrackState, TrackTransition,
@@ -27,6 +31,13 @@ use crate::{
 pub(crate) enum CrossfadeCurve {
     #[default]
     EqualPower,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(super) enum ContextRequirement {
+    #[default]
+    Standalone,
+    Session,
 }
 
 const fn map_curve(curve: CrossfadeCurve) -> FadeCurve {
@@ -75,6 +86,7 @@ pub struct PlayerNodeProcessor {
     trash_tx: HeapProd<PlayerTrack>,
     /// Last effective rate successfully delivered to the control thread.
     last_notified_rate: f32,
+    context_requirement: ContextRequirement,
 }
 
 /// Stream dimensions needed to pre-size RT scratch buffers.
@@ -97,6 +109,18 @@ impl PlayerNodeProcessor {
     where
         S: HasPool<f32>,
     {
+        Self::with_context_requirement(inputs, shape, pools, ContextRequirement::Standalone)
+    }
+
+    pub(super) fn with_context_requirement<S>(
+        inputs: NodeInputs,
+        shape: StreamShape,
+        pools: &PoolRegion<S>,
+        context_requirement: ContextRequirement,
+    ) -> Self
+    where
+        S: HasPool<f32>,
+    {
         let last_notified_rate = inputs.playback.rate.load(Ordering::Relaxed);
         Self {
             last_notified_rate,
@@ -110,6 +134,7 @@ impl PlayerNodeProcessor {
             prefetch_duration: 0.0,
             tracks: TrackSlots::default(),
             tracks_transitions: VecDeque::with_capacity(Self::MAX_TRACKS),
+            context_requirement,
         }
     }
 
@@ -214,7 +239,18 @@ impl PlayerNodeProcessor {
         frames: usize,
         is_playing: bool,
     ) -> (bool, Option<(f64, f64)>) {
+        self.render_with_context(None, buffers, frames, is_playing)
+    }
+
+    fn render_with_context(
+        &mut self,
+        context: Option<&RenderContext>,
+        buffers: &mut ProcBuffers,
+        frames: usize,
+        is_playing: bool,
+    ) -> (bool, Option<(f64, f64)>) {
         self.render.render_audio(
+            context,
             RenderTargets {
                 tracks: &mut self.tracks,
                 notification_tx: &mut self.notif_tx,
@@ -225,6 +261,17 @@ impl PlayerNodeProcessor {
             frames,
             is_playing,
         )
+    }
+
+    fn render_context<'a>(
+        &self,
+        store: &'a ProcStore,
+        info: &ProcInfo,
+    ) -> Result<Option<&'a RenderContext>, &'static str> {
+        match self.context_requirement {
+            ContextRequirement::Standalone => Ok(None),
+            ContextRequirement::Session => read_render_context(store, info).map(Some),
+        }
     }
 
     fn retire(&mut self, track: PlayerTrack) {
@@ -332,7 +379,7 @@ impl AudioNodeProcessor for PlayerNodeProcessor {
         info: &ProcInfo,
         mut buffers: ProcBuffers,
         _events: &mut ProcEvents,
-        _extra: &mut ProcExtra,
+        extra: &mut ProcExtra,
     ) -> ProcessStatus {
         self.playback.process_count.fetch_add(1, Ordering::Relaxed);
 
@@ -342,8 +389,16 @@ impl AudioNodeProcessor for PlayerNodeProcessor {
 
         let is_playing = self.playback.playing.load(Ordering::SeqCst);
 
+        let context = match self.render_context(&extra.store, info) {
+            Ok(context) => context,
+            Err(reason) => {
+                let _ = extra.logger.try_error(reason);
+                return ProcessStatus::ClearAllOutputs;
+            }
+        };
+
         let (playback_started, leading_outcome_pos_dur) =
-            self.render_audio(&mut buffers, info.frames, is_playing);
+            self.render_with_context(context, &mut buffers, info.frames, is_playing);
 
         self.update_position_duration(leading_outcome_pos_dur);
         self.refresh_effective_rate();
@@ -358,6 +413,13 @@ impl AudioNodeProcessor for PlayerNodeProcessor {
 
 #[cfg(test)]
 mod tests {
+    use firewheel::{
+        clock::InstantSamples,
+        mask::{ConnectedMask, ConstantMask, SilenceMask},
+        node::{ProcStore, StreamStatus},
+    };
+    use kithara_platform::time::Duration;
+    use kithara_warp::{RenderContext, SessionEpoch, SessionFrame, TransportRevision};
     use ringbuf::traits::{Consumer, Producer};
 
     use super::*;
@@ -373,6 +435,73 @@ mod tests {
             max_block_frames: NonZeroU32::new(512).expect("static block size"),
         };
         (PlayerNodeProcessor::new(inputs, shape, &pools()), control)
+    }
+
+    fn session_processor() -> PlayerNodeProcessor {
+        let (inputs, _control) = slot_channels(SharedEq::new(0));
+        let shape = StreamShape {
+            sample_rate: NonZeroU32::new(44_100).expect("static sample rate"),
+            max_block_frames: NonZeroU32::new(512).expect("static block size"),
+        };
+        PlayerNodeProcessor::with_context_requirement(
+            inputs,
+            shape,
+            &pools(),
+            ContextRequirement::Session,
+        )
+    }
+
+    fn proc_info() -> ProcInfo {
+        ProcInfo {
+            sample_rate: NonZeroU32::new(44_100).expect("static sample rate"),
+            frames: 512,
+            in_silence_mask: SilenceMask::default(),
+            out_silence_mask: SilenceMask::default(),
+            in_constant_mask: ConstantMask::default(),
+            out_constant_mask: ConstantMask::default(),
+            in_connected_mask: ConnectedMask::default(),
+            out_connected_mask: ConnectedMask::default(),
+            prev_output_was_silent: true,
+            sample_rate_recip: f64::from(44_100).recip(),
+            clock_samples: InstantSamples(0),
+            duration_since_stream_start: Duration::ZERO,
+            stream_status: StreamStatus::empty(),
+            dropped_frames: 0,
+        }
+    }
+
+    #[kithara::test]
+    fn session_processors_read_the_same_host_context() {
+        let mut store = ProcStore::with_capacity(1);
+        super::super::install_render_context(&mut store)
+            .expect("invariant: fixture installs one context slot");
+        super::super::publish_render_context(
+            &mut store,
+            RenderContext::new(
+                SessionFrame::new(0)..SessionFrame::new(512),
+                NonZeroU32::new(44_100).expect("static sample rate"),
+                None,
+                SessionEpoch::new(3),
+                Some(TransportRevision::first()),
+            )
+            .expect("invariant: fixture context is valid"),
+        )
+        .expect("invariant: fixture context slot exists");
+        let info = proc_info();
+        let left = session_processor();
+        let right = session_processor();
+        let left = left
+            .render_context(&store, &info)
+            .expect("session context")
+            .expect("required context");
+        let right = right
+            .render_context(&store, &info)
+            .expect("session context")
+            .expect("required context");
+
+        assert!(std::ptr::eq(left, right));
+        assert_eq!(left.session_epoch(), SessionEpoch::new(3));
+        assert_eq!(left.transport_revision(), Some(TransportRevision::first()));
     }
 
     #[kithara::test]

--- a/crates/kithara-play/src/rt/render.rs
+++ b/crates/kithara-play/src/rt/render.rs
@@ -10,6 +10,7 @@ use firewheel::{
     param::smoother::SmootherConfig,
 };
 use kithara_bufpool::{HasPool, PoolRegion, SampleBuffer};
+use kithara_warp::RenderContext;
 use num_traits::cast::AsPrimitive;
 use ringbuf::HeapProd;
 use smallvec::SmallVec;
@@ -80,6 +81,7 @@ impl RenderPass {
     /// Render audio for all active tracks into the output buffers.
     pub(crate) fn render_audio(
         &mut self,
+        context: Option<&RenderContext>,
         targets: RenderTargets<'_>,
         buffers: &mut ProcBuffers,
         frames: usize,
@@ -160,10 +162,9 @@ impl RenderPass {
             }
 
             let mut read_outcome = {
-                let Some(outcome) = tracks
-                    .at_mut(*track_handle)
-                    .map(|track| track.read(&mut read_bufs, &mut mix_bufs, 0..frames, &mut sink))
-                else {
+                let Some(outcome) = tracks.at_mut(*track_handle).map(|track| {
+                    track.render(context, &mut read_bufs, &mut mix_bufs, 0..frames, &mut sink)
+                }) else {
                     continue;
                 };
                 playback_started = true;
@@ -192,7 +193,13 @@ impl RenderPass {
                     }
 
                     let Some(outcome) = tracks.at_mut(*next_handle).map(|track| {
-                        track.read(&mut read_bufs, &mut mix_bufs, offset..frames, &mut sink)
+                        track.render(
+                            context,
+                            &mut read_bufs,
+                            &mut mix_bufs,
+                            offset..frames,
+                            &mut sink,
+                        )
                     }) else {
                         continue;
                     };
@@ -221,7 +228,13 @@ impl RenderPass {
                             continue;
                         };
                         next_track.play();
-                        next_track.read(&mut read_bufs, &mut mix_bufs, offset..frames, &mut sink);
+                        next_track.render(
+                            context,
+                            &mut read_bufs,
+                            &mut mix_bufs,
+                            offset..frames,
+                            &mut sink,
+                        );
                         break;
                     }
                 }

--- a/crates/kithara-play/src/rt/track/feeder.rs
+++ b/crates/kithara-play/src/rt/track/feeder.rs
@@ -1,8 +1,10 @@
-use std::{num::NonZeroU32, ops::Range};
+use std::{collections::VecDeque, num::NonZeroU32, ops::Range};
 
+use kithara_audio::{SourceEnd, SourceSpan};
 use kithara_bufpool::{HasPool, PoolError, PoolRegion, SampleBuffer};
 use kithara_platform::{maybe_send::WasmSend, sync::Arc};
 use kithara_signal::FrameCount;
+use kithara_warp::{PresentationFrontier, RenderContext};
 
 #[rustfmt::skip]
 use crate::resource::Resource;
@@ -25,6 +27,42 @@ pub struct PlayerResource {
     failed: bool,
     write_len: usize,
     write_pos: usize,
+    source_spans: VecDeque<SourceWindow>,
+    last_source_end: Option<SourceEnd>,
+}
+
+#[derive(Clone, Copy)]
+struct SourceWindow {
+    frames: usize,
+    source: Option<SourceSpan>,
+}
+
+impl SourceWindow {
+    fn take(&mut self, frames: usize) -> Option<SourceEnd> {
+        let source_end = match self.source {
+            Some(source) if frames >= self.frames => {
+                self.source = None;
+                Some(SourceEnd::new(source.end(), source.sample_rate()))
+            }
+            Some(source) => {
+                let split = partial_source_end(source, frames, self.frames);
+                self.source = split
+                    .and_then(|split| SourceSpan::new(split, source.end(), source.sample_rate()));
+                split.map(|split| SourceEnd::new(split, source.sample_rate()))
+            }
+            None => None,
+        };
+        self.frames = self.frames.saturating_sub(frames);
+        source_end
+    }
+}
+
+fn partial_source_end(source: SourceSpan, frames: usize, span_frames: usize) -> Option<u64> {
+    let source_frames = source.end().checked_sub(source.start())?;
+    let numerator = u128::from(source_frames).checked_mul(u128::try_from(frames).ok()?)?;
+    let denominator = u128::try_from(span_frames).ok()?;
+    let consumed = u64::try_from(numerator.checked_div(denominator)?).ok()?;
+    source.start().checked_add(consumed)
 }
 
 /// Result of a bounded audio-thread read from [`PlayerResource`].
@@ -77,10 +115,12 @@ impl PlayerResource {
 
         Ok(Self {
             channel_buffers: [left, right],
+            source_spans: VecDeque::with_capacity(buffer_frames),
             src,
             resource: WasmSend::new(resource),
             write_len: 0,
             write_pos: 0,
+            last_source_end: None,
             eof_seen: false,
             failed: false,
         })
@@ -119,23 +159,27 @@ impl PlayerResource {
             let right = &mut right_buf[0][self.write_pos..self.write_pos + avail];
             let mut planar: [&mut [f32]; Self::STEREO_CHANNELS] = [left, right];
 
-            let n = match self.resource.get_mut().read_planar(&mut planar) {
-                Ok(kithara_audio::ReadOutcome::Frames { count, .. }) => count.get(),
-                Ok(kithara_audio::ReadOutcome::Pending { .. }) => 0,
+            let (n, source) = match self.resource.get_mut().read_planar(&mut planar) {
+                Ok(kithara_audio::ReadOutcome::Frames {
+                    count, source_span, ..
+                }) => (count.get(), source_span),
+                Ok(kithara_audio::ReadOutcome::Pending { .. }) => (0, None),
                 Ok(kithara_audio::ReadOutcome::Eof { .. }) => {
                     self.eof_seen = true;
                     eof_reached = true;
-                    0
+                    (0, None)
                 }
                 Err(_) => {
                     metrics.record_decode_error();
                     self.failed = true;
-                    0
+                    (0, None)
                 }
             };
             if n == 0 {
                 break;
             }
+            self.source_spans
+                .push_back(SourceWindow { frames: n, source });
             self.write_len += n;
             self.write_pos += n;
         }
@@ -160,6 +204,32 @@ impl PlayerResource {
         self.write_len
             .saturating_add(callback_frames)
             .min(self.channel_buffers[0].len())
+    }
+
+    fn consume_source(&mut self, mut frames: usize) {
+        let mut source_end = self.last_source_end;
+        while frames > 0 {
+            let Some(mut span) = self.source_spans.pop_front() else {
+                break;
+            };
+            let consumed = frames.min(span.frames);
+            source_end = span.take(consumed);
+            frames -= consumed;
+            if span.frames > 0 {
+                self.source_spans.push_front(span);
+            }
+        }
+        if frames > 0 {
+            source_end = None;
+        }
+        self.last_source_end = source_end;
+    }
+
+    pub(crate) fn presentation_source_end(&self, sample_rate: NonZeroU32) -> Option<SourceEnd> {
+        let source_end = self.last_source_end?;
+        (source_end.sample_rate() == sample_rate
+            && source_end.sample_rate() == self.resource.get().spec().sample_rate)
+            .then_some(source_end)
     }
 
     /// Read audio frames into the output buffers for the given range.
@@ -200,6 +270,8 @@ impl PlayerResource {
                 output[1][..frames_to_write]
                     .copy_from_slice(&self.channel_buffers[1][..frames_to_write]);
             }
+
+            self.consume_source(frames_to_write);
 
             if tail_size > 0 {
                 self.channel_buffers[0]
@@ -251,6 +323,9 @@ impl PlayerResource {
         self.resource.get_mut().sync_seek();
         self.write_len = 0;
         self.write_pos = 0;
+        self.source_spans.clear();
+        self.last_source_end = None;
+        self.resource.get().clear_render();
         self.eof_seen = false;
         self.failed = false;
     }
@@ -275,6 +350,12 @@ impl PlayerResource {
             pub(crate) fn set_host_sample_rate(&self, sample_rate: NonZeroU32);
             /// Update the scheduling priority hint for the shared worker.
             pub(crate) fn set_service_class(&self, class: ServiceClass);
+            pub(crate) fn clear_render(&self);
+            pub(crate) fn publish_render(
+                &self,
+                context: &RenderContext,
+                frontier: PresentationFrontier,
+            );
         }
     }
 }
@@ -305,5 +386,18 @@ mod tests {
             spec.sample_count(frames),
             Ok(SampleCount::new(frames.get() * 2))
         );
+    }
+
+    #[kithara::test]
+    fn partial_scratch_consumption_advances_the_exact_source_span() {
+        let rate = NonZeroU32::new(48_000).expect("fixture sample rate is non-zero");
+        let mut span = SourceWindow {
+            frames: 10,
+            source: SourceSpan::new(100, 130, rate),
+        };
+
+        assert_eq!(span.take(4), Some(SourceEnd::new(112, rate)));
+        assert_eq!(span.source.map(|source| source.start()), Some(112));
+        assert_eq!(span.take(6), Some(SourceEnd::new(130, rate)));
     }
 }

--- a/crates/kithara-play/src/rt/track/read.rs
+++ b/crates/kithara-play/src/rt/track/read.rs
@@ -1,7 +1,7 @@
 use std::ops::Range;
 
 use kithara_platform::sync::Arc;
-use kithara_warp::RenderContext;
+use kithara_warp::{PresentationFrontier, RenderContext};
 use num_traits::cast::AsPrimitive;
 use ringbuf::{HeapProd, traits::Producer};
 
@@ -58,9 +58,25 @@ impl PlayerTrack {
         range: Range<usize>,
         sink: &mut RtSink<'_>,
     ) -> TrackReadOutcome {
-        if context.is_some_and(|context| context.for_output_range(range.clone()).is_none()) {
+        let Some(context) = context else {
+            self.resource.clear_render();
+            return self.read(scratch_bufs, mix_bufs, range, sink);
+        };
+        if context.sample_rate().get() != self.sample_rate {
+            self.resource.clear_render();
             self.handle_failed_end(sink.notifications);
             return TrackReadOutcome::Failed;
+        }
+        let Some(context) = context.for_output_range(range.clone()) else {
+            self.resource.clear_render();
+            self.handle_failed_end(sink.notifications);
+            return TrackReadOutcome::Failed;
+        };
+        if let Some(source) = self.resource.presentation_source_end(context.sample_rate()) {
+            self.resource
+                .publish_render(&context, presentation_frontier(&context, source.frame()));
+        } else {
+            self.resource.clear_render();
         }
         self.read(scratch_bufs, mix_bufs, range, sink)
     }
@@ -355,5 +371,41 @@ impl PlayerTrack {
             current => current,
         };
         self.set_state(new_state);
+    }
+}
+
+fn presentation_frontier(context: &RenderContext, source: u64) -> PresentationFrontier {
+    PresentationFrontier::builder()
+        .source(source)
+        .output(context.output_frames().start)
+        .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU32;
+
+    use kithara_test_utils::kithara;
+    use kithara_warp::{RenderContext, SessionEpoch, SessionFrame};
+
+    use super::presentation_frontier;
+
+    #[kithara::test]
+    fn publication_uses_the_derived_subrange_start() {
+        let context = RenderContext::new(
+            SessionFrame::new(1_000)..SessionFrame::new(1_200),
+            NonZeroU32::new(48_000).expect("fixture sample rate is non-zero"),
+            None,
+            SessionEpoch::new(1),
+            None,
+        )
+        .expect("fixture context is valid")
+        .for_output_range(40..80)
+        .expect("fixture subrange is valid");
+
+        let frontier = presentation_frontier(&context, 8_000);
+
+        assert_eq!(frontier.source(), 8_000);
+        assert_eq!(frontier.output(), SessionFrame::new(1_040));
     }
 }

--- a/crates/kithara-play/src/rt/track/read.rs
+++ b/crates/kithara-play/src/rt/track/read.rs
@@ -1,6 +1,7 @@
 use std::ops::Range;
 
 use kithara_platform::sync::Arc;
+use kithara_warp::RenderContext;
 use num_traits::cast::AsPrimitive;
 use ringbuf::{HeapProd, traits::Producer};
 
@@ -49,6 +50,21 @@ pub enum TrackReadOutcome {
 }
 
 impl PlayerTrack {
+    pub(crate) fn render(
+        &mut self,
+        context: Option<&RenderContext>,
+        scratch_bufs: &mut [&mut [f32]],
+        mix_bufs: &mut [&mut [f32]],
+        range: Range<usize>,
+        sink: &mut RtSink<'_>,
+    ) -> TrackReadOutcome {
+        if context.is_some_and(|context| context.for_output_range(range.clone()).is_none()) {
+            self.handle_failed_end(sink.notifications);
+            return TrackReadOutcome::Failed;
+        }
+        self.read(scratch_bufs, mix_bufs, range, sink)
+    }
+
     /// Advance the media clock by `frames` of mixed output.
     ///
     /// The mix output runs on the output clock; one output frame carries the

--- a/crates/kithara-play/src/worker/reader.rs
+++ b/crates/kithara-play/src/worker/reader.rs
@@ -8,7 +8,7 @@ use kithara_decode::{DecodeError, TrackMetadata};
 use kithara_events::EventBus;
 use kithara_platform::{maybe_send::MaybeSend, sync::Arc, time::Duration};
 use kithara_signal::AudioSpec;
-use kithara_warp::Warp;
+use kithara_warp::{RenderPublisher, Warp};
 use kithara_worker::{TaskControl, TaskHandle};
 
 use super::{PlayWorker, scheduler::ServiceClass};
@@ -65,6 +65,10 @@ impl<T, S> RegisteredAudio<T, S> {
 
     pub(crate) fn priority(&self) -> TrackPriority {
         self._lease.priority()
+    }
+
+    pub(crate) fn take_publisher(&mut self) -> Option<RenderPublisher> {
+        self.warp.take_publisher()
     }
 }
 

--- a/crates/kithara-warp/Cargo.toml
+++ b/crates/kithara-warp/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["multimedia::audio"]
 [features]
 default = []
 perf = ["kithara-stretch?/perf"]
+probe = ["dep:kithara-test-utils"]
 render = ["dep:kithara-bufpool"]
 stretch-signalsmith = ["dep:kithara-stretch", "kithara-stretch/stretch-signalsmith", "render"]
 stretch-bungee = ["dep:kithara-stretch", "kithara-stretch/stretch-bungee", "render"]
@@ -20,6 +21,8 @@ stretch-bungee = ["dep:kithara-stretch", "kithara-stretch/stretch-bungee", "rend
 kithara-bufpool = { workspace = true, optional = true }
 kithara-platform = { workspace = true }
 kithara-signal = { workspace = true }
+kithara-test-macros = { workspace = true }
+kithara-test-utils = { workspace = true, features = ["client-reqwest", "probe", "tls-rustls"], optional = true }
 
 arc-swap = { workspace = true }
 bon = { workspace = true }

--- a/crates/kithara-warp/src/lib.rs
+++ b/crates/kithara-warp/src/lib.rs
@@ -40,7 +40,9 @@ pub use sync::{
     any(feature = "stretch-signalsmith", feature = "stretch-bungee")
 ))]
 pub use temporal::StretchKind;
-pub use temporal::{ActiveRegion, GridSegment, RegionPlan, RegionPlanError, StretchControls};
+pub use temporal::{
+    ActiveRegion, GridSegment, RegionPlan, RegionPlanError, RenderContext, StretchControls,
+};
 #[cfg(feature = "render")]
 pub use warp::WarpRenderer;
 pub use warp::{Warp, WarpConfig, WarpCursor, WarpMap, supports_playback_rate};

--- a/crates/kithara-warp/src/lib.rs
+++ b/crates/kithara-warp/src/lib.rs
@@ -8,7 +8,7 @@ mod coordinate;
 mod segment;
 mod sync;
 mod temporal;
-#[cfg(test)]
+#[cfg(all(test, feature = "render"))]
 pub(crate) use kithara_bufpool::testing as test_pools;
 mod warp;
 
@@ -41,7 +41,8 @@ pub use sync::{
 ))]
 pub use temporal::StretchKind;
 pub use temporal::{
-    ActiveRegion, GridSegment, RegionPlan, RegionPlanError, RenderContext, StretchControls,
+    ActiveRegion, GridSegment, RegionPlan, RegionPlanError, RenderContext, RenderPublisher,
+    RenderReader, RenderSnapshot, StretchControls,
 };
 #[cfg(feature = "render")]
 pub use warp::WarpRenderer;

--- a/crates/kithara-warp/src/sync/revision.rs
+++ b/crates/kithara-warp/src/sync/revision.rs
@@ -153,6 +153,10 @@ impl LoadGeneration {
 pub struct TransportRevision(NonZeroU64);
 
 impl TransportRevision {
+    pub(crate) const fn from_raw(value: NonZeroU64) -> Self {
+        Self(value)
+    }
+
     /// Returns the next committed revision, or `None` on exhaustion.
     #[must_use]
     pub fn checked_next(self) -> Option<Self> {

--- a/crates/kithara-warp/src/temporal/context.rs
+++ b/crates/kithara-warp/src/temporal/context.rs
@@ -1,0 +1,186 @@
+use std::{num::NonZeroU32, ops::Range};
+
+use num_traits::ToPrimitive;
+
+use crate::{SessionBeat, SessionEpoch, SessionFrame, TransportRevision};
+
+/// Immutable session position for one output subrange.
+#[derive(Clone, Debug, PartialEq, fieldwork::Fieldwork)]
+#[fieldwork(get)]
+#[non_exhaustive]
+pub struct RenderContext {
+    /// The exact half-open session-output frame range.
+    output_frames: Range<SessionFrame>,
+    /// The sample rate defining [`Self::output_frames`].
+    #[field(get, copy)]
+    sample_rate: NonZeroU32,
+    /// The corresponding half-open musical range when transport is playing.
+    session_beats: Option<Range<SessionBeat>>,
+    /// The generation of the session frame axis.
+    #[field(get, copy)]
+    session_epoch: SessionEpoch,
+    /// The committed transport revision, including paused transport.
+    #[field(get, copy)]
+    transport_revision: Option<TransportRevision>,
+}
+
+impl RenderContext {
+    /// Creates a context whose output and musical ranges describe the same render pass.
+    #[must_use]
+    pub fn new(
+        output_frames: Range<SessionFrame>,
+        sample_rate: NonZeroU32,
+        session_beats: Option<Range<SessionBeat>>,
+        session_epoch: SessionEpoch,
+        transport_revision: Option<TransportRevision>,
+    ) -> Option<Self> {
+        let output_is_ordered = output_frames.start <= output_frames.end;
+        let beats_are_ordered = session_beats
+            .as_ref()
+            .is_none_or(|beats| beats.start <= beats.end);
+        let transport_matches_beats = session_beats.is_none() || transport_revision.is_some();
+        (output_is_ordered && beats_are_ordered && transport_matches_beats).then_some(Self {
+            output_frames,
+            sample_rate,
+            session_beats,
+            session_epoch,
+            transport_revision,
+        })
+    }
+
+    /// Derives the same context for a half-open range relative to this output block.
+    #[must_use]
+    pub fn for_output_range(&self, range: Range<usize>) -> Option<Self> {
+        let output_start = i64::from(self.output_frames.start);
+        let total_frames = i64::from(self.output_frames.end).checked_sub(output_start)?;
+        let total_frames = usize::try_from(total_frames).ok()?;
+        if range.start > range.end || range.end > total_frames {
+            return None;
+        }
+        let output_start = output_start.checked_add(i64::try_from(range.start).ok()?)?;
+        let output_end =
+            i64::from(self.output_frames.start).checked_add(i64::try_from(range.end).ok()?)?;
+        let session_beats = match self.session_beats.as_ref() {
+            Some(beats) => Some(beat_subrange(beats, range, total_frames)?),
+            None => None,
+        };
+        Self::new(
+            SessionFrame::new(output_start)..SessionFrame::new(output_end),
+            self.sample_rate,
+            session_beats,
+            self.session_epoch,
+            self.transport_revision,
+        )
+    }
+}
+
+fn beat_subrange(
+    beats: &Range<SessionBeat>,
+    range: Range<usize>,
+    total_frames: usize,
+) -> Option<Range<SessionBeat>> {
+    if total_frames == 0 {
+        return (range.is_empty() && range.start == 0).then_some(beats.start..beats.start);
+    }
+    let span = f64::from(beats.end) - f64::from(beats.start);
+    let total = total_frames.to_f64()?;
+    let start = f64::from(beats.start) + span * range.start.to_f64()? / total;
+    let end = f64::from(beats.start) + span * range.end.to_f64()? / total;
+    Some(SessionBeat::new(start).ok()?..SessionBeat::new(end).ok()?)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU32;
+
+    use kithara_test_utils::kithara;
+
+    use super::RenderContext;
+    use crate::{SessionBeat, SessionEpoch, SessionFrame, TransportRevision};
+
+    const BLOCK_FRAMES: usize = 480;
+
+    fn beat(value: f64) -> SessionBeat {
+        SessionBeat::new(value).expect("invariant: fixture beat is finite")
+    }
+
+    fn sample_rate() -> NonZeroU32 {
+        NonZeroU32::new(48_000).expect("invariant: fixture sample rate is non-zero")
+    }
+
+    fn context() -> RenderContext {
+        RenderContext::new(
+            SessionFrame::new(0)..SessionFrame::new(BLOCK_FRAMES as i64),
+            sample_rate(),
+            Some(beat(0.0)..beat(0.02)),
+            SessionEpoch::new(7),
+            Some(TransportRevision::first()),
+        )
+        .expect("invariant: fixture ranges and transport agree")
+    }
+
+    #[kithara::test]
+    fn rejects_beats_without_a_transport_revision() {
+        assert!(
+            RenderContext::new(
+                SessionFrame::new(0)..SessionFrame::new(BLOCK_FRAMES as i64),
+                sample_rate(),
+                Some(beat(0.0)..beat(0.02)),
+                SessionEpoch::new(0),
+                None,
+            )
+            .is_none()
+        );
+    }
+
+    #[kithara::test]
+    fn rejects_unordered_output_and_beat_ranges() {
+        assert!(
+            RenderContext::new(
+                SessionFrame::new(1)..SessionFrame::new(0),
+                sample_rate(),
+                None,
+                SessionEpoch::new(0),
+                None,
+            )
+            .is_none()
+        );
+        assert!(
+            RenderContext::new(
+                SessionFrame::new(0)..SessionFrame::new(1),
+                sample_rate(),
+                Some(beat(1.0)..beat(0.0)),
+                SessionEpoch::new(0),
+                Some(TransportRevision::first()),
+            )
+            .is_none()
+        );
+    }
+
+    #[kithara::test]
+    fn derives_exact_output_subrange() {
+        let second_half = context()
+            .for_output_range(BLOCK_FRAMES / 2..BLOCK_FRAMES)
+            .expect("invariant: second half is inside the block");
+
+        assert_eq!(
+            second_half.output_frames(),
+            &(SessionFrame::new(240)..SessionFrame::new(480))
+        );
+        assert_eq!(second_half.session_beats(), Some(&(beat(0.01)..beat(0.02))));
+        assert_eq!(second_half.session_epoch(), SessionEpoch::new(7));
+        assert_eq!(
+            second_half.transport_revision(),
+            Some(TransportRevision::first())
+        );
+    }
+
+    #[kithara::test]
+    fn rejects_output_range_outside_the_block() {
+        assert!(
+            context()
+                .for_output_range(BLOCK_FRAMES..BLOCK_FRAMES + 1)
+                .is_none()
+        );
+    }
+}

--- a/crates/kithara-warp/src/temporal/live.rs
+++ b/crates/kithara-warp/src/temporal/live.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use kithara_platform::sync::Arc;
+use kithara_test_macros as kithara;
 use portable_atomic::{AtomicI64, AtomicU32, AtomicU64, Ordering, fence};
 
 use crate::{
@@ -155,6 +156,14 @@ impl RenderPublisher {
             /// Withdraws the current context at a session-axis discontinuity.
             pub fn clear(&self);
             /// Publishes the exact callback context and its current presentation base.
+            #[kithara::probe(
+                session_epoch = u64::from(context.session_epoch()),
+                transport_revision = context.transport_revision().map_or(0, u64::from),
+                output_start = i64::from(context.output_frames().start),
+                output_end = i64::from(context.output_frames().end),
+                source = frontier.source(),
+                presentation_frame = i64::from(frontier.output())
+            )]
             pub fn publish(&self, context: &RenderContext, frontier: PresentationFrontier);
         }
     }

--- a/crates/kithara-warp/src/temporal/live.rs
+++ b/crates/kithara-warp/src/temporal/live.rs
@@ -1,0 +1,292 @@
+use std::{
+    hint::spin_loop,
+    num::{NonZeroU32, NonZeroU64},
+};
+
+use kithara_platform::sync::Arc;
+use portable_atomic::{AtomicI64, AtomicU32, AtomicU64, Ordering, fence};
+
+use crate::{
+    PresentationFrontier, RenderContext, SessionBeat, SessionEpoch, SessionFrame, TransportRevision,
+};
+
+const SEQLOCK_PHASES: u64 = 2;
+
+#[derive(Debug, Default)]
+struct RenderCell {
+    version: AtomicU64,
+    output_start: AtomicI64,
+    output_end: AtomicI64,
+    sample_rate: AtomicU32,
+    beat_start: AtomicU64,
+    beat_end: AtomicU64,
+    beats_present: AtomicU32,
+    session_epoch: AtomicU64,
+    transport_revision: AtomicU64,
+    frontier_source: AtomicU64,
+    frontier_output: AtomicI64,
+}
+
+impl RenderCell {
+    fn clear(&self) {
+        self.write(|cell| cell.sample_rate.store(0, Ordering::Relaxed));
+    }
+
+    fn load(&self) -> Option<RenderSnapshot> {
+        loop {
+            let before = self.version.load(Ordering::Acquire);
+            if before == 0 {
+                return None;
+            }
+            if !before.is_multiple_of(SEQLOCK_PHASES) {
+                spin_loop();
+                continue;
+            }
+            let raw = RawSnapshot {
+                output_start: self.output_start.load(Ordering::Relaxed),
+                output_end: self.output_end.load(Ordering::Relaxed),
+                sample_rate: self.sample_rate.load(Ordering::Relaxed),
+                beat_start: self.beat_start.load(Ordering::Relaxed),
+                beat_end: self.beat_end.load(Ordering::Relaxed),
+                beats_present: self.beats_present.load(Ordering::Relaxed) != 0,
+                session_epoch: self.session_epoch.load(Ordering::Relaxed),
+                transport_revision: self.transport_revision.load(Ordering::Relaxed),
+                frontier_source: self.frontier_source.load(Ordering::Relaxed),
+                frontier_output: self.frontier_output.load(Ordering::Relaxed),
+            };
+            fence(Ordering::Acquire);
+            if self.version.load(Ordering::Acquire) == before {
+                return raw.build();
+            }
+            spin_loop();
+        }
+    }
+
+    fn publish(&self, context: &RenderContext, frontier: PresentationFrontier) {
+        self.write(|cell| {
+            let output = context.output_frames();
+            cell.output_start
+                .store(i64::from(output.start), Ordering::Relaxed);
+            cell.output_end
+                .store(i64::from(output.end), Ordering::Relaxed);
+            match context.session_beats() {
+                Some(beats) => {
+                    cell.beat_start
+                        .store(f64::from(beats.start).to_bits(), Ordering::Relaxed);
+                    cell.beat_end
+                        .store(f64::from(beats.end).to_bits(), Ordering::Relaxed);
+                    cell.beats_present.store(1, Ordering::Relaxed);
+                }
+                None => cell.beats_present.store(0, Ordering::Relaxed),
+            }
+            cell.session_epoch
+                .store(u64::from(context.session_epoch()), Ordering::Relaxed);
+            cell.transport_revision.store(
+                context.transport_revision().map_or(0, u64::from),
+                Ordering::Relaxed,
+            );
+            cell.frontier_source
+                .store(frontier.source(), Ordering::Relaxed);
+            cell.frontier_output
+                .store(i64::from(frontier.output()), Ordering::Relaxed);
+            cell.sample_rate
+                .store(context.sample_rate().get(), Ordering::Relaxed);
+        });
+    }
+
+    fn write(&self, fields: impl FnOnce(&Self)) {
+        self.version.fetch_add(1, Ordering::AcqRel);
+        fields(self);
+        self.version.fetch_add(1, Ordering::Release);
+    }
+}
+
+struct RawSnapshot {
+    output_start: i64,
+    output_end: i64,
+    sample_rate: u32,
+    beat_start: u64,
+    beat_end: u64,
+    beats_present: bool,
+    session_epoch: u64,
+    transport_revision: u64,
+    frontier_source: u64,
+    frontier_output: i64,
+}
+
+impl RawSnapshot {
+    fn build(self) -> Option<RenderSnapshot> {
+        let sample_rate = NonZeroU32::new(self.sample_rate)?;
+        let session_beats = if self.beats_present {
+            Some(
+                SessionBeat::new(f64::from_bits(self.beat_start)).ok()?
+                    ..SessionBeat::new(f64::from_bits(self.beat_end)).ok()?,
+            )
+        } else {
+            None
+        };
+        let transport_revision =
+            NonZeroU64::new(self.transport_revision).map(TransportRevision::from_raw);
+        let context = RenderContext::new(
+            SessionFrame::new(self.output_start)..SessionFrame::new(self.output_end),
+            sample_rate,
+            session_beats,
+            SessionEpoch::new(self.session_epoch),
+            transport_revision,
+        )?;
+        let frontier = PresentationFrontier::builder()
+            .source(self.frontier_source)
+            .output(SessionFrame::new(self.frontier_output))
+            .build();
+        Some(RenderSnapshot { context, frontier })
+    }
+}
+
+/// Callback-side writer for one resident [`crate::Warp`] render context.
+///
+/// Publication is allocation-free and lock-free. A Warp has exactly one
+/// publisher; the type is deliberately not cloneable to preserve that invariant.
+#[derive(Debug, Default)]
+pub struct RenderPublisher(Arc<RenderCell>);
+
+impl RenderPublisher {
+    delegate::delegate! {
+        to self.0 {
+            /// Withdraws the current context at a session-axis discontinuity.
+            pub fn clear(&self);
+            /// Publishes the exact callback context and its current presentation base.
+            pub fn publish(&self, context: &RenderContext, frontier: PresentationFrontier);
+        }
+    }
+
+    /// Returns the read side paired with this publisher.
+    #[must_use]
+    pub fn reader(&self) -> RenderReader {
+        RenderReader(Arc::clone(&self.0))
+    }
+}
+
+/// Worker-side reader for one resident [`crate::Warp`] render context.
+#[derive(Clone, Debug)]
+pub struct RenderReader(Arc<RenderCell>);
+
+impl RenderReader {
+    #[cfg(feature = "render")]
+    pub(crate) fn is_current(&self, snapshot: &RenderSnapshot) -> bool {
+        self.load().is_some_and(|current| {
+            current.context.session_epoch() == snapshot.context.session_epoch()
+        })
+    }
+
+    /// Loads one coherent immutable snapshot, or `None` before publication or after clear.
+    #[must_use]
+    pub fn load(&self) -> Option<RenderSnapshot> {
+        self.0.load()
+    }
+}
+
+/// One immutable callback context paired with its exact presentation base.
+#[derive(Clone, Debug, PartialEq, fieldwork::Fieldwork)]
+#[fieldwork(get)]
+#[non_exhaustive]
+pub struct RenderSnapshot {
+    context: RenderContext,
+    #[field(get, copy)]
+    frontier: PresentationFrontier,
+}
+
+impl RenderSnapshot {
+    #[cfg(feature = "render")]
+    pub(crate) fn advance(
+        self,
+        previous: Option<&Self>,
+        source: u64,
+        output_frames: usize,
+    ) -> Option<Self> {
+        let previous = previous
+            .filter(|previous| previous.context.session_epoch() == self.context.session_epoch());
+        let minimum_source = previous
+            .map_or_else(
+                || self.frontier.source(),
+                |previous| previous.frontier.source(),
+            )
+            .max(self.frontier.source());
+        if source < minimum_source {
+            return None;
+        }
+        let output = previous
+            .map_or_else(
+                || self.frontier.output(),
+                |previous| previous.frontier.output(),
+            )
+            .max(self.frontier.output());
+        let output = i64::from(output).checked_add(i64::try_from(output_frames).ok()?)?;
+        let frontier = PresentationFrontier::builder()
+            .source(source)
+            .output(SessionFrame::new(output))
+            .build();
+        Some(Self {
+            context: self.context,
+            frontier,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU32;
+
+    use kithara_test_utils::kithara;
+
+    use super::RenderPublisher;
+    use crate::{
+        PresentationFrontier, RenderContext, SessionBeat, SessionEpoch, SessionFrame,
+        TransportRevision,
+    };
+
+    fn context(epoch: u64, start: i64) -> RenderContext {
+        RenderContext::new(
+            SessionFrame::new(start)..SessionFrame::new(start + 128),
+            NonZeroU32::new(48_000).expect("fixture sample rate is non-zero"),
+            Some(
+                SessionBeat::new(1.0).expect("fixture beat is finite")
+                    ..SessionBeat::new(1.01).expect("fixture beat is finite"),
+            ),
+            SessionEpoch::new(epoch),
+            Some(TransportRevision::first()),
+        )
+        .expect("fixture context is valid")
+    }
+
+    fn frontier(source: u64, output: i64) -> PresentationFrontier {
+        PresentationFrontier::builder()
+            .source(source)
+            .output(SessionFrame::new(output))
+            .build()
+    }
+
+    #[kithara::test]
+    fn publication_is_one_coherent_snapshot() {
+        let publisher = RenderPublisher::default();
+        let reader = publisher.reader();
+        let expected_context = context(3, 1_000);
+        let expected_frontier = frontier(8_000, 1_128);
+
+        publisher.publish(&expected_context, expected_frontier);
+
+        let actual = reader.load().expect("published snapshot is readable");
+        assert_eq!(actual.context(), &expected_context);
+        assert_eq!(actual.frontier(), expected_frontier);
+    }
+
+    #[kithara::test]
+    fn clear_withdraws_the_previous_epoch() {
+        let publisher = RenderPublisher::default();
+        let reader = publisher.reader();
+        publisher.publish(&context(3, 1_000), frontier(8_000, 1_128));
+
+        publisher.clear();
+
+        assert!(reader.load().is_none());
+    }
+}

--- a/crates/kithara-warp/src/temporal/mod.rs
+++ b/crates/kithara-warp/src/temporal/mod.rs
@@ -1,6 +1,8 @@
+mod context;
 mod controls;
 mod region;
 
+pub use context::RenderContext;
 pub use controls::StretchControls;
 #[cfg(all(
     not(target_arch = "wasm32"),

--- a/crates/kithara-warp/src/temporal/mod.rs
+++ b/crates/kithara-warp/src/temporal/mod.rs
@@ -1,5 +1,6 @@
 mod context;
 mod controls;
+mod live;
 mod region;
 
 pub use context::RenderContext;
@@ -9,4 +10,5 @@ pub use controls::StretchControls;
     any(feature = "stretch-signalsmith", feature = "stretch-bungee")
 ))]
 pub use kithara_stretch::StretchKind;
+pub use live::{RenderPublisher, RenderReader, RenderSnapshot};
 pub use region::{ActiveRegion, GridSegment, RegionPlan, RegionPlanError};

--- a/crates/kithara-warp/src/warp/actuator.rs
+++ b/crates/kithara-warp/src/warp/actuator.rs
@@ -8,7 +8,7 @@ use {
 use super::WarpConfig;
 #[cfg(feature = "render")]
 use super::WarpRenderer;
-use crate::StretchControls;
+use crate::{RenderPublisher, RenderReader, StretchControls};
 
 /// Resident warp actuator around one decoded-audio source.
 ///
@@ -21,6 +21,8 @@ use crate::StretchControls;
 pub struct Warp<S> {
     #[field(get, deref = false)]
     stretch: Arc<StretchControls>,
+    publisher: Option<RenderPublisher>,
+    reader: RenderReader,
     #[field(get, get_mut)]
     source: S,
 }
@@ -29,10 +31,20 @@ impl<S> Warp<S> {
     /// Wraps `source` with the configured live temporal controls.
     #[must_use]
     pub fn new(source: S, config: &WarpConfig) -> Self {
+        let publisher = RenderPublisher::default();
+        let reader = publisher.reader();
         Self {
             source,
             stretch: Arc::clone(config.stretch()),
+            publisher: Some(publisher),
+            reader,
         }
+    }
+
+    /// Takes the sole callback-side publisher paired with this resident Warp.
+    #[must_use]
+    pub fn take_publisher(&mut self) -> Option<RenderPublisher> {
+        self.publisher.take()
     }
 
     /// Creates the worker-side renderer paired with this Warp facade.
@@ -42,7 +54,7 @@ impl<S> Warp<S> {
     where
         P: HasPool<f32>,
     {
-        WarpRenderer::new(Arc::clone(&self.stretch), spec, pools)
+        WarpRenderer::new(Arc::clone(&self.stretch), self.reader.clone(), spec, pools)
     }
 }
 

--- a/crates/kithara-warp/src/warp/actuator.rs
+++ b/crates/kithara-warp/src/warp/actuator.rs
@@ -8,7 +8,9 @@ use {
 use super::WarpConfig;
 #[cfg(feature = "render")]
 use super::WarpRenderer;
-use crate::{RenderPublisher, RenderReader, StretchControls};
+#[cfg(feature = "render")]
+use crate::RenderReader;
+use crate::{RenderPublisher, StretchControls};
 
 /// Resident warp actuator around one decoded-audio source.
 ///
@@ -22,6 +24,7 @@ pub struct Warp<S> {
     #[field(get, deref = false)]
     stretch: Arc<StretchControls>,
     publisher: Option<RenderPublisher>,
+    #[cfg(feature = "render")]
     reader: RenderReader,
     #[field(get, get_mut)]
     source: S,
@@ -32,11 +35,13 @@ impl<S> Warp<S> {
     #[must_use]
     pub fn new(source: S, config: &WarpConfig) -> Self {
         let publisher = RenderPublisher::default();
+        #[cfg(feature = "render")]
         let reader = publisher.reader();
         Self {
             source,
             stretch: Arc::clone(config.stretch()),
             publisher: Some(publisher),
+            #[cfg(feature = "render")]
             reader,
         }
     }

--- a/crates/kithara-warp/src/warp/render/identity.rs
+++ b/crates/kithara-warp/src/warp/render/identity.rs
@@ -3,6 +3,7 @@ use std::{marker::PhantomData, num::NonZeroU32};
 use kithara_bufpool::{HasPool, PoolRegion};
 use kithara_platform::sync::Arc;
 use kithara_signal::{AudioChunk, AudioSpec};
+use kithara_test_macros as kithara;
 
 use crate::{RenderReader, RenderSnapshot, StretchControls};
 
@@ -20,6 +21,23 @@ impl<S> WarpRenderer<S>
 where
     S: HasPool<f32>,
 {
+    #[kithara::probe(
+        session_epoch = u64::from(committed.context().session_epoch()),
+        transport_revision = committed.context().transport_revision().map_or(0, u64::from),
+        output_start,
+        output_end = i64::from(committed.frontier().output()),
+        source_start,
+        source_end = committed.frontier().source()
+    )]
+    fn render_committed(
+        &mut self,
+        committed: RenderSnapshot,
+        source_start: u64,
+        output_start: i64,
+    ) {
+        self.committed = Some(committed);
+    }
+
     pub(crate) fn new(
         _controls: Arc<StretchControls>,
         context: RenderReader,
@@ -60,10 +78,14 @@ where
         if let Some(snapshot) = snapshot
             && self.context.is_current(&snapshot)
             && let Some((source, _)) = self.rendered_source_end
-            && let Some(committed) =
-                snapshot.advance(self.committed.as_ref(), source, chunk.frames())
         {
-            self.committed = Some(committed);
+            let source_start = snapshot.frontier().source();
+            let output_start = i64::from(snapshot.frontier().output());
+            if let Some(committed) =
+                snapshot.advance(self.committed.as_ref(), source, chunk.frames())
+            {
+                self.render_committed(committed, source_start, output_start);
+            }
         }
         Some(chunk)
     }

--- a/crates/kithara-warp/src/warp/render/identity.rs
+++ b/crates/kithara-warp/src/warp/render/identity.rs
@@ -4,12 +4,14 @@ use kithara_bufpool::{HasPool, PoolRegion};
 use kithara_platform::sync::Arc;
 use kithara_signal::{AudioChunk, AudioSpec};
 
-use crate::StretchControls;
+use crate::{RenderReader, RenderSnapshot, StretchControls};
 
 /// Identity renderer for targets without elastic DSP.
 /// It preserves decoded samples exactly and keeps playback-rate capability disabled.
 #[non_exhaustive]
 pub struct WarpRenderer<S> {
+    context: RenderReader,
+    committed: Option<RenderSnapshot>,
     rendered_source_end: Option<(u64, NonZeroU32)>,
     schema: PhantomData<fn() -> S>,
 }
@@ -20,10 +22,13 @@ where
 {
     pub(crate) fn new(
         _controls: Arc<StretchControls>,
+        context: RenderReader,
         _spec: AudioSpec,
         _pools: PoolRegion<S>,
     ) -> Self {
         Self {
+            context,
+            committed: None,
             rendered_source_end: None,
             schema: PhantomData,
         }
@@ -44,6 +49,7 @@ where
 
     #[doc(hidden)]
     pub fn render(&mut self, chunk: AudioChunk) -> Option<AudioChunk> {
+        let snapshot = self.context.load();
         self.rendered_source_end = Some((
             chunk
                 .meta
@@ -51,7 +57,22 @@ where
                 .saturating_add(u64::from(chunk.meta.frames)),
             chunk.meta.spec.sample_rate,
         ));
+        if let Some(snapshot) = snapshot
+            && self.context.is_current(&snapshot)
+            && let Some((source, _)) = self.rendered_source_end
+            && let Some(committed) =
+                snapshot.advance(self.committed.as_ref(), source, chunk.frames())
+        {
+            self.committed = Some(committed);
+        }
         Some(chunk)
+    }
+
+    /// Last context and frontier committed by a successful worker render.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn render_snapshot(&self) -> Option<&RenderSnapshot> {
+        self.committed.as_ref()
     }
 
     #[doc(hidden)]
@@ -61,6 +82,7 @@ where
 
     #[doc(hidden)]
     pub const fn reset(&mut self) {
+        self.committed = None;
         self.rendered_source_end = None;
     }
 
@@ -90,7 +112,12 @@ mod tests {
         meta.frame_offset = 41;
         let input = AudioChunk::new(meta, sample_buffer(&pools, &[0.25, -0.5]));
         let input_ptr = input.samples.as_ptr();
-        let mut renderer = WarpRenderer::new(StretchControls::new(1.5), spec, pools);
+        let mut renderer = WarpRenderer::new(
+            StretchControls::new(1.5),
+            crate::RenderPublisher::default().reader(),
+            spec,
+            pools,
+        );
 
         assert_eq!(renderer.rendered_source_end(), None);
         let output = renderer.render(input).expect("identity output");

--- a/crates/kithara-warp/src/warp/render/region_tests.rs
+++ b/crates/kithara-warp/src/warp/render/region_tests.rs
@@ -7,7 +7,7 @@ use kithara_test_utils::kithara;
 
 use super::WarpRenderer as GenericWarpRenderer;
 use crate::{
-    GridSegment, RegionPlan, RegionPlanError, StretchControls,
+    GridSegment, RegionPlan, RegionPlanError, RenderPublisher, StretchControls,
     test_pools::{Pools, TestPools, pools, sample_buffer},
 };
 
@@ -104,7 +104,12 @@ fn render(backend: StretchKind, speed: f32, plan: Option<RegionPlan>, source: &[
     controls.set_keylock(true);
     controls.set_backend(backend);
     controls.set_region_plan(plan.map(Arc::new));
-    let mut fx = WarpRenderer::new(controls, spec(), pools.clone());
+    let mut fx = WarpRenderer::new(
+        controls,
+        RenderPublisher::default().reader(),
+        spec(),
+        pools.clone(),
+    );
     let mut out = Vec::new();
     let mut offset = 0_u64;
     for data in source.chunks(4096 * CH) {

--- a/crates/kithara-warp/src/warp/render/renderer.rs
+++ b/crates/kithara-warp/src/warp/render/renderer.rs
@@ -5,7 +5,7 @@ use kithara_platform::{sync::Arc, time::Duration};
 use kithara_signal::{AudioChunkInfo, AudioSpec};
 use kithara_stretch::{ElasticEngine, ElasticError, StretchKind};
 
-use crate::{ActiveRegion, RegionPlan, StretchControls};
+use crate::{ActiveRegion, RegionPlan, RenderReader, RenderSnapshot, StretchControls};
 
 #[cfg(test)]
 mod tests;
@@ -14,6 +14,8 @@ mod tests;
 /// Unity speed without a region plan is a byte-identical passthrough.
 #[non_exhaustive]
 pub struct WarpRenderer<S> {
+    pub(super) context: RenderReader,
+    pub(super) committed: Option<RenderSnapshot>,
     pub(super) controls: Arc<StretchControls>,
     pub(super) engine: Option<Box<dyn ElasticEngine>>,
     /// Engine displaced by a checked render failure. The scheduler shell
@@ -78,6 +80,7 @@ where
     /// Build the slot at the source `spec`, driven by the shared `controls`.
     pub(crate) fn new(
         controls: Arc<StretchControls>,
+        context: RenderReader,
         spec: AudioSpec,
         pools: PoolRegion<S>,
     ) -> Self {
@@ -85,6 +88,8 @@ where
         let plan = controls.region_plan();
         let target = Self::prepare_target(current_kind, spec, &pools, None, None);
         Self {
+            context,
+            committed: None,
             engine: target.engine,
             retired_engine: None,
             current_kind,
@@ -248,6 +253,28 @@ where
             admitted.saturating_sub(held_source_frames),
             meta.spec.sample_rate,
         ));
+    }
+
+    pub(super) fn commit_render(&mut self, snapshot: Option<RenderSnapshot>, output_frames: usize) {
+        let Some(snapshot) = snapshot else {
+            return;
+        };
+        if !self.context.is_current(&snapshot) {
+            return;
+        }
+        let Some((source, _)) = self.rendered_source_end else {
+            return;
+        };
+        if let Some(committed) = snapshot.advance(self.committed.as_ref(), source, output_frames) {
+            self.committed = Some(committed);
+        }
+    }
+
+    /// Last context and frontier committed by a successful worker render.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn render_snapshot(&self) -> Option<&RenderSnapshot> {
+        self.committed.as_ref()
     }
 
     /// Exact decoded-source boundary represented by the latest emitted samples.

--- a/crates/kithara-warp/src/warp/render/renderer.rs
+++ b/crates/kithara-warp/src/warp/render/renderer.rs
@@ -4,6 +4,7 @@ use kithara_bufpool::{HasPool, PoolRegion, SampleBuffer};
 use kithara_platform::{sync::Arc, time::Duration};
 use kithara_signal::{AudioChunkInfo, AudioSpec};
 use kithara_stretch::{ElasticEngine, ElasticError, StretchKind};
+use kithara_test_macros as kithara;
 
 use crate::{ActiveRegion, RegionPlan, RenderReader, RenderSnapshot, StretchControls};
 
@@ -265,9 +266,28 @@ where
         let Some((source, _)) = self.rendered_source_end else {
             return;
         };
+        let source_start = snapshot.frontier().source();
+        let output_start = i64::from(snapshot.frontier().output());
         if let Some(committed) = snapshot.advance(self.committed.as_ref(), source, output_frames) {
-            self.committed = Some(committed);
+            self.render_committed(committed, source_start, output_start);
         }
+    }
+
+    #[kithara::probe(
+        session_epoch = u64::from(committed.context().session_epoch()),
+        transport_revision = committed.context().transport_revision().map_or(0, u64::from),
+        output_start,
+        output_end = i64::from(committed.frontier().output()),
+        source_start,
+        source_end = committed.frontier().source()
+    )]
+    fn render_committed(
+        &mut self,
+        committed: RenderSnapshot,
+        source_start: u64,
+        output_start: i64,
+    ) {
+        self.committed = Some(committed);
     }
 
     /// Last context and frontier committed by a successful worker render.

--- a/crates/kithara-warp/src/warp/render/renderer/tests.rs
+++ b/crates/kithara-warp/src/warp/render/renderer/tests.rs
@@ -2,10 +2,14 @@ use std::num::NonZero;
 
 use kithara_platform::{sync::Arc, time::Duration};
 use kithara_signal::{AudioChunk, AudioChunkInfo, AudioSpec};
+use kithara_test_utils::kithara;
 use realfft::RealFftPlanner;
 
 use super::{StretchControls, WarpRenderer as GenericWarpRenderer};
-use crate::test_pools::{Pools, TestPools, pools, sample_buffer};
+use crate::{
+    PresentationFrontier, RenderContext, RenderPublisher, SessionEpoch, SessionFrame,
+    test_pools::{Pools, TestPools, pools, sample_buffer},
+};
 
 type WarpRenderer = GenericWarpRenderer<TestPools>;
 
@@ -92,7 +96,12 @@ fn spec() -> AudioSpec {
 }
 
 fn renderer(controls: Arc<StretchControls>) -> WarpRenderer {
-    WarpRenderer::new(controls, spec(), pools())
+    WarpRenderer::new(
+        controls,
+        RenderPublisher::default().reader(),
+        spec(),
+        pools(),
+    )
 }
 
 fn render_serviced(fx: &mut WarpRenderer, input: AudioChunk) -> Option<AudioChunk> {
@@ -107,4 +116,43 @@ fn flush_serviced(fx: &mut WarpRenderer) -> Option<AudioChunk> {
     let output = fx.flush();
     fx.prepare(spec());
     output
+}
+
+#[kithara::test]
+fn render_commits_the_context_captured_for_the_operation() {
+    let pools = pools();
+    let publisher = RenderPublisher::default();
+    let mut renderer = WarpRenderer::new(
+        StretchControls::new(1.0),
+        publisher.reader(),
+        spec(),
+        pools.clone(),
+    );
+    let context = RenderContext::new(
+        SessionFrame::new(1_000)..SessionFrame::new(1_001),
+        spec().sample_rate,
+        None,
+        SessionEpoch::new(1),
+        None,
+    )
+    .expect("fixture context is valid");
+    publisher.publish(
+        &context,
+        PresentationFrontier::builder()
+            .source(41)
+            .output(SessionFrame::new(1_000))
+            .build(),
+    );
+    let mut input = chunk(&pools, &[0.25, -0.5]);
+    input.meta.frame_offset = 41;
+
+    let output = render_serviced(&mut renderer, input).expect("unity render succeeds");
+    let snapshot = renderer
+        .render_snapshot()
+        .expect("successful render commits a snapshot");
+
+    assert_eq!(output.frames(), 1);
+    assert_eq!(snapshot.context(), &context);
+    assert_eq!(snapshot.frontier().source(), 42);
+    assert_eq!(snapshot.frontier().output(), SessionFrame::new(1_001));
 }

--- a/crates/kithara-warp/src/warp/render/renderer/tests/target.rs
+++ b/crates/kithara-warp/src/warp/render/renderer/tests/target.rs
@@ -10,7 +10,7 @@ use kithara_test_utils::kithara;
 use super::{
     Consts, chunk, dominant_bin, expected_bin, flush_serviced, render_serviced, renderer, sine,
 };
-use super::{StretchControls, WarpRenderer, spec};
+use super::{RenderPublisher, StretchControls, WarpRenderer, spec};
 use crate::test_pools::pools_with_budget as test_pools;
 
 /// Swapping the backend mid-stream keeps the stream flowing and pitch-locked.
@@ -74,7 +74,12 @@ fn target_rebuild_reuses_one_target_pool_budget(#[case] backend: StretchKind) {
             let controls = StretchControls::new(0.5);
             controls.set_keylock(true);
             controls.set_backend(backend);
-            let target = WarpRenderer::new(controls, target_spec, pools.clone());
+            let target = WarpRenderer::new(
+                controls,
+                RenderPublisher::default().reader(),
+                target_spec,
+                pools.clone(),
+            );
             assert!(target.engine.is_some());
             pools.stats().allocated_bytes
         })
@@ -86,7 +91,12 @@ fn target_rebuild_reuses_one_target_pool_budget(#[case] backend: StretchKind) {
     let controls = StretchControls::new(0.5);
     controls.set_keylock(true);
     controls.set_backend(backend);
-    let mut fx = WarpRenderer::new(controls, initial, pools.clone());
+    let mut fx = WarpRenderer::new(
+        controls,
+        RenderPublisher::default().reader(),
+        initial,
+        pools.clone(),
+    );
     assert!(fx.engine.is_some());
     assert!(fx.pending_source.is_some());
     assert!(fx.scratch.is_some());
@@ -110,7 +120,12 @@ fn failed_target_rebuild_is_not_retried_without_a_new_revision(#[case] backend: 
     let controls = StretchControls::new(0.5);
     controls.set_keylock(true);
     controls.set_backend(backend);
-    let mut fx = WarpRenderer::new(controls, spec(), pools.clone());
+    let mut fx = WarpRenderer::new(
+        controls,
+        RenderPublisher::default().reader(),
+        spec(),
+        pools.clone(),
+    );
     assert!(fx.engine.is_none());
 
     fx.rebuild_pending = true;

--- a/crates/kithara-warp/src/warp/render/renderer/tests/timeline.rs
+++ b/crates/kithara-warp/src/warp/render/renderer/tests/timeline.rs
@@ -8,7 +8,7 @@ use super::{
     Consts, StretchControls, WarpRenderer, chunk, f64_of, flush_serviced, render_serviced,
     renderer, sine, spec,
 };
-use crate::{GridSegment, RegionPlan};
+use crate::{GridSegment, RegionPlan, RenderPublisher};
 
 fn finish_unity_transition(
     renderer: &mut WarpRenderer,
@@ -357,7 +357,12 @@ fn live_unity_transition_drains_active_backend_tail(#[case] backend: StretchKind
     let live_controls = StretchControls::new(0.5);
     live_controls.set_keylock(true);
     live_controls.set_backend(backend);
-    let mut live = WarpRenderer::new(Arc::clone(&live_controls), spec(), pools.clone());
+    let mut live = WarpRenderer::new(
+        Arc::clone(&live_controls),
+        RenderPublisher::default().reader(),
+        spec(),
+        pools.clone(),
+    );
     let live_active = render_serviced(&mut live, chunk(&pools, &source[..split]))
         .expect("non-unity span emits samples");
     assert_eq!(live_active.frames(), reference_active.frames());
@@ -475,7 +480,12 @@ fn negative_rounding_debt_adds_no_frame_at_unity_transition(#[case] backend: Str
         ])
         .expect("fixture regions are contiguous"),
     )));
-    let mut fx = WarpRenderer::new(Arc::clone(&controls), spec(), pools.clone());
+    let mut fx = WarpRenderer::new(
+        Arc::clone(&controls),
+        RenderPublisher::default().reader(),
+        spec(),
+        pools.clone(),
+    );
     let first = render_serviced(&mut fx, chunk(&pools, &source[..usize::from(Consts::CH)]))
         .expect("the first span rounds to two frames");
     assert_eq!(first.frames(), 2);

--- a/crates/kithara-warp/src/warp/render/renderer_lifecycle.rs
+++ b/crates/kithara-warp/src/warp/render/renderer_lifecycle.rs
@@ -317,6 +317,7 @@ where
 
     #[doc(hidden)]
     pub fn flush(&mut self) -> Option<AudioChunk> {
+        let snapshot = self.context.load();
         if let Some(scratch) = self.scratch.as_mut() {
             scratch.clear();
         } else {
@@ -345,11 +346,16 @@ where
         } else {
             self.held_source_frames()
         };
-        self.emit(None, held_source_frames)
+        let output = self.emit(None, held_source_frames);
+        if let Some(output) = output.as_ref() {
+            self.commit_render(snapshot, output.frames());
+        }
+        output
     }
 
     #[doc(hidden)]
     pub fn render(&mut self, chunk: AudioChunk) -> Option<AudioChunk> {
+        let snapshot = self.context.load();
         if chunk.spec() != self.spec {
             warn!(
                 expected = %self.spec,
@@ -366,15 +372,21 @@ where
         }
 
         let speed = self.controls.speed();
-        if self.unity_passthrough(speed) {
-            return self.process_unity(chunk);
+        let output = if self.unity_passthrough(speed) {
+            self.process_unity(chunk)
+        } else {
+            self.process_active(chunk, speed)
+        };
+        if let Some(output) = output.as_ref() {
+            self.commit_render(snapshot, output.frames());
         }
-        self.process_active(chunk, speed)
+        output
     }
 
     #[doc(hidden)]
     pub fn reset(&mut self) {
         self.reset_pending = true;
         self.clear_render_state();
+        self.committed = None;
     }
 }

--- a/tests/src/audio_mock.rs
+++ b/tests/src/audio_mock.rs
@@ -173,6 +173,7 @@ impl AudioRead for TestPcmReader {
         Ok(ReadOutcome::Frames {
             count,
             position: new_position,
+            source_span: None,
         })
     }
 
@@ -217,6 +218,7 @@ impl AudioRead for TestPcmReader {
         Ok(ReadOutcome::Frames {
             count,
             position: new_position,
+            source_span: None,
         })
     }
 
@@ -460,6 +462,7 @@ impl AudioRead for MisreportedDurationReader {
         Ok(ReadOutcome::Frames {
             count: NonZeroUsize::new(frames).expect("BUG: frames > 0"),
             position: self.position(),
+            source_span: None,
         })
     }
 
@@ -486,6 +489,7 @@ impl AudioRead for MisreportedDurationReader {
         Ok(ReadOutcome::Frames {
             count: NonZeroUsize::new(frames).expect("BUG: frames > 0"),
             position: self.position(),
+            source_span: None,
         })
     }
 

--- a/tests/tests/kithara_hls/abr_mode_switch.rs
+++ b/tests/tests/kithara_hls/abr_mode_switch.rs
@@ -361,7 +361,9 @@ fn read_phase_until<S: StreamType>(
 
     while stats.samples < target_samples || !settled() {
         match audio.read(&mut buf) {
-            Ok(ReadOutcome::Frames { count, position }) => {
+            Ok(ReadOutcome::Frames {
+                count, position, ..
+            }) => {
                 if stats.samples >= target_samples {
                     paced_backoff(position.saturating_sub(consumed));
                 }

--- a/tests/tests/kithara_hls/abr_switch_playback.rs
+++ b/tests/tests/kithara_hls/abr_switch_playback.rs
@@ -264,7 +264,9 @@ async fn packaged_abr_switch_keeps_player_continuity(temp_dir: TestTempDir) {
     while Instant::now() < deadline {
         let _ = progress_audio.preload();
         let read: usize = match progress_audio.read(&mut buf) {
-            Ok(ReadOutcome::Frames { count, position }) => {
+            Ok(ReadOutcome::Frames {
+                count, position, ..
+            }) => {
                 if !switch_seen {
                     let pace = position.saturating_sub(consumed);
                     spawn_blocking(move || paced_backoff(pace))
@@ -993,7 +995,9 @@ fn read_manual_cross_codec_phase(
         }
 
         match audio.read(&mut buf) {
-            Ok(ReadOutcome::Frames { count, position }) => {
+            Ok(ReadOutcome::Frames {
+                count, position, ..
+            }) => {
                 let count = u64::try_from(count.get())
                     .unwrap_or_else(|error| panic!("read count does not fit u64: {error}"));
                 if manual_applied {

--- a/tests/tests/kithara_play/gapless_offline_e2e.rs
+++ b/tests/tests/kithara_play/gapless_offline_e2e.rs
@@ -1142,6 +1142,7 @@ impl SyntheticPcmReader {
             |count| ReadOutcome::Frames {
                 count,
                 position: self.position(),
+                source_span: None,
             },
         )
     }

--- a/tests/tests/kithara_play/player_resource_internal.rs
+++ b/tests/tests/kithara_play/player_resource_internal.rs
@@ -132,6 +132,7 @@ impl ChunkReader {
         ReadOutcome::Frames {
             count: std::num::NonZeroUsize::new(frames).expect("chunk is non-empty"),
             position: self.position(),
+            source_span: None,
         }
     }
 }
@@ -232,6 +233,7 @@ impl AudioRead for PositionReader {
         Ok(ReadOutcome::Frames {
             count: std::num::NonZeroUsize::new(avail).unwrap(),
             position: self.position(),
+            source_span: None,
         })
     }
 
@@ -256,6 +258,7 @@ impl AudioRead for PositionReader {
         Ok(ReadOutcome::Frames {
             count: std::num::NonZeroUsize::new(avail).unwrap(),
             position: self.position(),
+            source_span: None,
         })
     }
 

--- a/tests/tests/phase_continuity/common.rs
+++ b/tests/tests/phase_continuity/common.rs
@@ -164,7 +164,9 @@ where
     let mut retries = 0usize;
     loop {
         match audio.read(buf) {
-            Ok(ReadOutcome::Frames { count, position }) => return Some((count.get(), position)),
+            Ok(ReadOutcome::Frames {
+                count, position, ..
+            }) => return Some((count.get(), position)),
             Ok(ReadOutcome::Pending { .. }) => {
                 retries += 1;
                 assert!(


### PR DESCRIPTION
## Summary
This extracts the transport-observability slice from #232 without changing rate control, scheduling, buffering, or DSP policy. Host now owns one immutable musical `RenderContext` for each rendered block, Player carries the exact decoded source frontier through the callback boundary, and resident Warp publishes the committed render frontier. Production USDT probes observe the command and application boundaries needed by the later rate-response fix.

For reviewers, this PR establishes measurement and ownership only: it does not attempt to improve tempo response or introduce the remaining Warp machinery.

## Behavior / scope
- contract or behavior: Host is the sole per-block transport publisher; Player and Warp receive the same immutable context and exact source/output spans
- contract or behavior: the render publisher has one writer, readers are read-only, seek clears the resident Warp frontier, and unknown source spans invalidate rather than preserve stale progress
- contract or behavior: USDT probes fire on real callback publication and successful Warp render commit with session revision, transport revision, and exact source/output boundaries
- affected area: decoded Audio read outcomes, Player callback/worker propagation, Host session transport, and Warp temporal observation
- excluded: rate policy, smoothing, Q64/ring admission, scheduler cadence, DSP/backend behavior, latency budgets, and UI

## Validation
- `just fmt`
- `just fmt check`
- `git diff --check`
- `just check`
- scoped Clippy with warnings denied for the affected crates
- focused Host, Player, Warp, and Audio contract tests
- probe-enabled and no-default-feature compilation
- pre-commit `lint-fast` hooks — all three commits passed
- exact-head fork CI: [`33671770289`](https://github.com/gerasim13/kithara/actions/runs/33671770289) at `72904b75d09b357503d96fde9f976a14d64b7076` — 20 jobs passed
- request-only UI workflow: intentionally not run
- same-runner nextest A/B against base `9c3d4ea2`: simulated-clock `131.957s -> 150.515s` (+18 tests), real-clock `542.451s -> 562.140s` (+18 tests); RTSan fast `0.375s -> 0.316s`, file `2.960s -> 3.771s`, HLS `11.769s -> 12.026s`. Compilation is excluded. The base workflow unrelated `linux-secrets` lane failed, while all compared test lanes passed.

## Surface impact
- Public API: changed: adds immutable render-context/frontier observation contracts in `kithara-warp` and exact source spans in decoded read outcomes
- Platform/runtime: changed: native Host session blocks propagate transport through Player into resident Warp; standalone Players remain context-free
- Perf-sensitive paths: changed: callback and Warp render paths publish preallocated snapshots and probes without allocation, locking, blocking, or success-path logging

## Risks / follow-ups
- This PR provides the production measurement boundary but intentionally does not fix tempo-response latency; that remains in the final Warp response slice after the intervening regressions are isolated.
- The one-run nextest timing comparison is evidence, not a stable benchmark. The additional contract tests account for a different test count, so runtime-path performance must be judged by the later dedicated response acceptance.
- The upstream `kithara/gitlab-verification` status is still pending; exact-head fork CI is green.