### PR TITLE
fix(stretch,warp): configure backends and stream exact terminal drain

### DIFF
--- a/crates/kithara-stretch/CONTEXT.md
+++ b/crates/kithara-stretch/CONTEXT.md
@@ -23,8 +23,8 @@ expanded dependency, so the manifest records this single scanner exception.
   compiled-in backend, which is also `Default`.
 - `ElasticConfig<S>` is the single fallible `#[non_exhaustive]` `bon` root config. It owns the
   `StretchKind` selection, sample rate, channel count, maximum source/output frame spans and the
-  practical playback-rate envelope, plus the injected pool region; the selector is not a second
-  factory argument.
+  practical playback-rate envelope, backend preparation geometry, and the injected pool region;
+  the selector is not a second factory argument.
 - `build_engine(config)` dispatches the config-owned selector to `Box<dyn ElasticEngine>`.
 - Every backend must implement priming; callers may still render a fresh unprimed stream. Nothing
   above an adapter names a concrete DSP library.

--- a/crates/kithara-stretch/CONTEXT.md
+++ b/crates/kithara-stretch/CONTEXT.md
@@ -25,6 +25,9 @@ expanded dependency, so the manifest records this single scanner exception.
   `StretchKind` selection, sample rate, channel count, maximum source/output frame spans and the
   practical playback-rate envelope, backend preparation geometry, and the injected pool region;
   the selector is not a second factory argument.
+- Backend geometry defaults preserve each native engine's quality preset: Signalsmith derives its
+  block and interval from the sample rate, and Bungee uses zero synthesis-hop adjustment. Supplying
+  one custom Signalsmith dimension requires supplying both.
 - `build_engine(config)` dispatches the config-owned selector to `Box<dyn ElasticEngine>`.
 - Every backend must implement priming; callers may still render a fresh unprimed stream. Nothing
   above an adapter names a concrete DSP library.

--- a/crates/kithara-stretch/CONTEXT.md
+++ b/crates/kithara-stretch/CONTEXT.md
@@ -64,9 +64,10 @@ reserved before the checked render call, and an engine that needs planar scratch
 the `PoolRegion<S>` supplied in `ElasticConfig<S>`; no engine owns a default or global pool. Bungee keeps
 that channel-major scratch in `kithara_signal::PlanarBuffer` instead of a backend-local buffer type.
 
-`flush(out)` writes the next buffered-tail portion into caller-owned storage sized from
-`terminal_chunk_frames` and returns its frame count together with whether that portion completed
-the drain. EOF repeats the call until completion; a completed drain stays empty until new input.
+`flush(out)` writes the next buffered-tail portion into non-empty caller-owned storage containing
+only complete interleaved frames and returns its frame count together with whether that portion
+completed the drain. The caller normally supplies one render quantum and repeats the call until
+completion; a completed drain stays empty until new input.
 An active drain reports completion on its final non-empty portion, so the caller can publish the
 released source frontier with those samples. This streaming contract lets a
 rate-dependent tail span several fixed-size chunks without loss. At a steady rate `r`, the complete
@@ -93,6 +94,10 @@ expose `kithara_signal::AudioSpec`; native adapters use it only to shape canonic
   first advances finite requests to the exact source end, clips output by native request timestamps,
   then clears the four-grain pipeline with invalid requests. `flush` therefore returns real terminal
   audio across one or more chunks instead of dropping roughly one latency of the track.
+- Once one exact rate has rendered for a complete output-latency window, Bungee bounds EOF with the
+  integer `ElasticRequest` ratio and the common settled-tail formula. Before that point its real
+  history-dependent native timestamps remain authoritative. Repeated floating-point native hops
+  therefore cannot add a frame to a settled tail or replace a transitional tail with a formula.
 - Bungee preparation fails when the injected region budget cannot cover its planar scratch or
   native stretcher construction fails; the audio adapter warns once and marks the engine unavailable.
 - Bungee priming drains old resident state, stages history, lookahead and warm source in the
@@ -105,9 +110,8 @@ expose `kithara_signal::AudioSpec`; native adapters use it only to shape canonic
   rebuilding it; its Rust-side input/output storage remains the buffers reserved from the injected
   pool at prepare.
 - Bungee reports its unity latency only after its pipeline is warm, and runtime latency moves with
-  the rate. Preparation measures the unity reference on the resident, shape-sized core, resets that
-  same core in place, and separately declares a safe fixed terminal chunk from the native maximum
-  input-grain span; no probe engine or extra pool allocation is retained. An unprimed stream converts
+  the rate. Preparation measures the unity reference on the resident, shape-sized core and resets
+  that same core in place; no probe engine or extra pool allocation is retained. An unprimed stream converts
   the larger native processing center into the measured source/output latency split while its cold
   pipeline fills. Once output starts, rate changes slew that center toward the new mapping with grain
   positions clamped to the configured rate envelope. Positions therefore remain strictly monotone,

--- a/crates/kithara-stretch/src/backends/bungee/drain.rs
+++ b/crates/kithara-stretch/src/backends/bungee/drain.rs
@@ -198,8 +198,12 @@ impl StreamCore {
                 ));
             }
         }
-        Err(ElasticError::EnginePreparation(
-            "Bungee terminal output exceeded its fixed grain bound",
-        ))
+        if drained > 0 {
+            Ok(ElasticDrain::new(drained, false))
+        } else {
+            Err(ElasticError::EnginePreparation(
+                "Bungee terminal output exceeded its fixed grain bound",
+            ))
+        }
     }
 }

--- a/crates/kithara-stretch/src/backends/bungee/elastic.rs
+++ b/crates/kithara-stretch/src/backends/bungee/elastic.rs
@@ -13,12 +13,74 @@ use crate::{
 pub(crate) struct BungeeElastic {
     capabilities: ElasticCapabilities,
     core: StreamCore,
+    last_request: Option<ElasticRequest>,
     pitch: f64,
+    rate_age_frames: usize,
     tail_armed: bool,
+    tail_remaining: Option<usize>,
 }
 
 impl BungeeElastic {
     const LATENCY_PROBE_BLOCKS: usize = 4;
+
+    fn frame_count(frames: usize) -> Result<u128, ElasticError> {
+        frames.to_u128().ok_or(ElasticError::SampleCountOverflow)
+    }
+
+    fn exact_tail_frames(&self, request: ElasticRequest) -> Result<usize, ElasticError> {
+        let latency = self.capabilities.latency();
+        let source = Self::frame_count(request.source_frames())?;
+        let output = Self::frame_count(request.output_frames())?;
+        let source_tail = Self::frame_count(latency.source_frames())?
+            .checked_mul(output)
+            .map(|frames| frames.div_ceil(source))
+            .ok_or(ElasticError::SampleCountOverflow)?;
+        let total = source_tail
+            .checked_add(Self::frame_count(latency.output_frames())?)
+            .ok_or(ElasticError::SampleCountOverflow)?;
+        usize::try_from(total).map_err(|_| ElasticError::SampleCountOverflow)
+    }
+
+    fn record_request(&mut self, request: ElasticRequest) -> Result<(), ElasticError> {
+        let latency_frames = self.capabilities.latency().output_frames();
+        let same_rate = self.last_request.map(|previous| {
+            Ok::<_, ElasticError>(
+                Self::frame_count(previous.source_frames())?
+                    * Self::frame_count(request.output_frames())?
+                    == Self::frame_count(request.source_frames())?
+                        * Self::frame_count(previous.output_frames())?,
+            )
+        });
+        self.rate_age_frames = if same_rate.transpose()?.unwrap_or(false) {
+            self.rate_age_frames
+                .saturating_add(request.output_frames())
+                .min(latency_frames)
+        } else {
+            request.output_frames().min(latency_frames)
+        };
+        self.last_request = Some(request);
+        self.tail_remaining = None;
+        Ok(())
+    }
+
+    fn prepare_exact_tail(&mut self) -> Result<(), ElasticError> {
+        if self.tail_remaining.is_some()
+            || self.rate_age_frames != self.capabilities.latency().output_frames()
+        {
+            return Ok(());
+        }
+        let request = self.last_request.ok_or(ElasticError::EnginePreparation(
+            "Bungee exact tail has no source request",
+        ))?;
+        self.tail_remaining = Some(self.exact_tail_frames(request)?);
+        Ok(())
+    }
+
+    fn reset_rate(&mut self) {
+        self.last_request = None;
+        self.rate_age_frames = 0;
+        self.tail_remaining = None;
+    }
 
     fn latency<S>(
         core: &mut StreamCore,
@@ -91,13 +153,15 @@ impl ElasticEngine for BungeeElastic {
             .checked_add(retained)
             .ok_or(ElasticError::SampleCountOverflow)?;
         core.prepare_input_capacity(input_capacity)?;
-        let terminal_chunk_frames = core.max_input_frames();
-        let capabilities = ElasticCapabilities::new(config.shape(), latency, terminal_chunk_frames);
+        let capabilities = ElasticCapabilities::new(config.shape(), latency);
         Ok(Self {
             core,
             capabilities,
+            last_request: None,
             pitch: 1.0,
+            rate_age_frames: 0,
             tail_armed: false,
+            tail_remaining: None,
         })
     }
 
@@ -121,6 +185,7 @@ impl ElasticEngine for BungeeElastic {
             discarded_output.len(),
         )?;
         self.tail_armed = false;
+        self.reset_rate();
         self.core.prime(
             source_history,
             source_lookahead,
@@ -129,6 +194,7 @@ impl ElasticEngine for BungeeElastic {
             self.pitch,
             discarded_output,
         )?;
+        self.record_request(request)?;
         self.tail_armed = true;
         Ok(())
     }
@@ -143,6 +209,7 @@ impl ElasticEngine for BungeeElastic {
             .validate(request, source.len(), output.len())?;
         self.core
             .render(Some(source), request, self.pitch, Some(output))?;
+        self.record_request(request)?;
         self.tail_armed = true;
         Ok(())
     }
@@ -157,22 +224,46 @@ impl ElasticEngine for BungeeElastic {
         if !self.tail_armed {
             return Ok(ElasticDrain::new(0, true));
         }
-        let tail_frames = self.capabilities.terminal_chunk_frames();
-        let expected = self.capabilities.samples(tail_frames)?;
-        if output.len() != expected {
-            return Err(ElasticError::OutputSampleCount {
-                actual: output.len(),
-                expected,
-            });
+        self.prepare_exact_tail()?;
+        let capacity = self.capabilities.output_capacity(output.len())?;
+        let capacity = self
+            .tail_remaining
+            .map_or(capacity, |remaining| capacity.min(remaining));
+        let mut chunk = self.core.terminal_tail(output, capacity)?;
+        if let Some(remaining) = self.tail_remaining {
+            let remaining =
+                remaining
+                    .checked_sub(chunk.frames())
+                    .ok_or(ElasticError::EnginePreparation(
+                        "Bungee terminal output exceeded its exact span",
+                    ))?;
+            if chunk.complete() && remaining > 0 {
+                self.tail_armed = false;
+                self.reset_rate();
+                return Err(ElasticError::EnginePreparation(
+                    "Bungee terminal output ended before its exact span",
+                ));
+            }
+            if remaining == 0 {
+                if !chunk.complete() {
+                    self.core.discard()?;
+                }
+                chunk = ElasticDrain::new(chunk.frames(), true);
+            } else {
+                self.tail_remaining = Some(remaining);
+            }
         }
-        let chunk = self.core.terminal_tail(output, tail_frames)?;
         self.tail_armed = !chunk.complete();
+        if chunk.complete() {
+            self.reset_rate();
+        }
         Ok(chunk)
     }
 
     fn reset(&mut self) -> Result<(), ElasticError> {
         self.core.discard()?;
         self.tail_armed = false;
+        self.reset_rate();
         Ok(())
     }
 }

--- a/crates/kithara-stretch/src/backends/bungee/elastic.rs
+++ b/crates/kithara-stretch/src/backends/bungee/elastic.rs
@@ -21,8 +21,6 @@ pub(crate) struct BungeeElastic {
 }
 
 impl BungeeElastic {
-    const LATENCY_PROBE_BLOCKS: usize = 4;
-
     fn frame_count(frames: usize) -> Result<u128, ElasticError> {
         frames.to_u128().ok_or(ElasticError::SampleCountOverflow)
     }
@@ -91,7 +89,7 @@ impl BungeeElastic {
     {
         let probe_frames = config.max_source_frames().min(config.max_output_frames());
         let request = ElasticRequest::new(probe_frames, probe_frames)?;
-        for _ in 0..Self::LATENCY_PROBE_BLOCKS {
+        for _ in 0..StreamCore::PIPELINE_GRAINS {
             core.probe_silence(request)?;
         }
         let source_frames = core.source_latency_frames()?;

--- a/crates/kithara-stretch/src/backends/bungee/ffi.rs
+++ b/crates/kithara-stretch/src/backends/bungee/ffi.rs
@@ -2,7 +2,7 @@ use std::{cell::Cell, marker::PhantomData, ptr::NonNull, slice};
 
 use bungee_sys::{BungeeStretcher, InputChunk, OutputChunk, Request, SampleRates, stretcher};
 
-use crate::ElasticError;
+use crate::{BungeeConfig, ElasticError};
 
 #[derive(Clone, Copy)]
 pub(super) struct AnalysisInput<'a> {
@@ -39,11 +39,13 @@ pub(super) enum NativeFault {
 unsafe impl Send for NativeStretcher {}
 
 impl NativeStretcher {
-    // New controls cross three grains; -3 keeps that transition inside the live-response SLA.
-    const LOG2_SYNTHESIS_HOP_ADJUST: i32 = -3;
     const OUTPUT_ENDPOINT_COUNT: usize = 2;
 
-    pub(super) fn new(sample_rate: u32, channels: usize) -> Result<Self, ElasticError> {
+    pub(super) fn new(
+        sample_rate: u32,
+        channels: usize,
+        config: BungeeConfig,
+    ) -> Result<Self, ElasticError> {
         let input = i32::try_from(sample_rate)
             .map_err(|_| ElasticError::EnginePreparation("Bungee sample rate is out of range"))?;
         let channels = i32::try_from(channels)
@@ -54,7 +56,7 @@ impl NativeStretcher {
                 output: input,
             },
             channels,
-            Self::LOG2_SYNTHESIS_HOP_ADJUST,
+            config.log2_synthesis_hop_adjust(),
         );
         Ok(Self {
             inner: NonNull::new(inner).ok_or(ElasticError::EnginePreparation(

--- a/crates/kithara-stretch/src/backends/bungee/ffi.rs
+++ b/crates/kithara-stretch/src/backends/bungee/ffi.rs
@@ -39,6 +39,8 @@ pub(super) enum NativeFault {
 unsafe impl Send for NativeStretcher {}
 
 impl NativeStretcher {
+    // New controls cross three grains; -3 keeps that transition inside the live-response SLA.
+    const LOG2_SYNTHESIS_HOP_ADJUST: i32 = -3;
     const OUTPUT_ENDPOINT_COUNT: usize = 2;
 
     pub(super) fn new(sample_rate: u32, channels: usize) -> Result<Self, ElasticError> {
@@ -52,7 +54,7 @@ impl NativeStretcher {
                 output: input,
             },
             channels,
-            0,
+            Self::LOG2_SYNTHESIS_HOP_ADJUST,
         );
         Ok(Self {
             inner: NonNull::new(inner).ok_or(ElasticError::EnginePreparation(

--- a/crates/kithara-stretch/src/backends/bungee/stream.rs
+++ b/crates/kithara-stretch/src/backends/bungee/stream.rs
@@ -39,7 +39,11 @@ impl StreamCore {
     where
         S: HasPool<f32>,
     {
-        let native = NativeStretcher::new(config.sample_rate(), config.channels())?;
+        let native = NativeStretcher::new(
+            config.sample_rate(),
+            config.channels(),
+            *config.backends().bungee(),
+        )?;
         let max_input_frames = native.max_input_frames()?;
         let source_latency_frames = max_input_frames / 2;
         Ok(Self {

--- a/crates/kithara-stretch/src/backends/bungee/stream.rs
+++ b/crates/kithara-stretch/src/backends/bungee/stream.rs
@@ -109,7 +109,6 @@ mod tests {
     impl Fixture {
         const CHANNELS: usize = 2;
         const CONTEXT_FRAMES: usize = 8192;
-        const LATENCY_PROBE_BLOCKS: usize = 4;
         const SAMPLE_RATE: u32 = 48_000;
     }
 
@@ -204,7 +203,7 @@ mod tests {
             StreamCore::new(&config, Fixture::CONTEXT_FRAMES).expect("the fixture core prepares");
         let probe = ElasticRequest::new(Fixture::CONTEXT_FRAMES, Fixture::CONTEXT_FRAMES)
             .expect("the latency probe request is valid");
-        for _ in 0..Fixture::LATENCY_PROBE_BLOCKS {
+        for _ in 0..StreamCore::PIPELINE_GRAINS {
             core.probe_silence(probe)
                 .expect("the latency probe renders");
         }

--- a/crates/kithara-stretch/src/backends/signalsmith.rs
+++ b/crates/kithara-stretch/src/backends/signalsmith.rs
@@ -10,18 +10,26 @@ use crate::{
     ElasticRequest, SignalsmithConfig, elastic::PitchScale,
 };
 
-fn engine(channels: u32, config: SignalsmithConfig) -> (Stretch, ElasticLatency) {
-    let inner = Stretch::new(
-        channels,
-        config.block_frames().get(),
-        config.interval_frames().get(),
-    );
+fn engine(
+    sample_rate: u32,
+    channels: u32,
+    config: SignalsmithConfig,
+) -> Result<(Stretch, ElasticLatency), ElasticError> {
+    let inner = match (config.block_frames(), config.interval_frames()) {
+        (Some(block), Some(interval)) => Stretch::new(channels, block.get(), interval.get()),
+        (None, None) => Stretch::preset_default(channels, sample_rate),
+        _ => {
+            return Err(ElasticError::EnginePreparation(
+                "Signalsmith block and interval must be configured together",
+            ));
+        }
+    };
     let native_input_latency = inner.input_latency();
     let native_output_latency = inner.output_latency();
-    (
+    Ok((
         inner,
         ElasticLatency::new(native_input_latency, native_output_latency),
-    )
+    ))
 }
 
 #[derive(Clone, Copy)]
@@ -165,7 +173,11 @@ impl ElasticEngine for SignalsmithElastic {
     {
         let channels = u32::try_from(config.channels())
             .map_err(|_| ElasticError::ChannelCountOutOfRange(config.channels()))?;
-        let (mut inner, latency) = engine(channels, *config.backends().signalsmith());
+        let (mut inner, latency) = engine(
+            config.sample_rate(),
+            channels,
+            *config.backends().signalsmith(),
+        )?;
         inner.set_transpose_factor(1.0, None);
         let capabilities = ElasticCapabilities::new(config.shape(), latency);
         let prime_window_samples = capabilities.samples(latency.source_frames())?;

--- a/crates/kithara-stretch/src/backends/signalsmith.rs
+++ b/crates/kithara-stretch/src/backends/signalsmith.rs
@@ -10,8 +10,11 @@ use crate::{
     ElasticRequest, elastic::PitchScale,
 };
 
-fn engine(sample_rate: u32, channels: u32) -> (Stretch, ElasticLatency) {
-    let inner = Stretch::preset_default(channels, sample_rate);
+fn engine(channels: u32) -> (Stretch, ElasticLatency) {
+    const BLOCK_FRAMES: usize = 416;
+    const INTERVAL_FRAMES: usize = 64;
+
+    let inner = Stretch::new(channels, BLOCK_FRAMES, INTERVAL_FRAMES);
     let native_input_latency = inner.input_latency();
     let native_output_latency = inner.output_latency();
     (
@@ -23,8 +26,18 @@ fn engine(sample_rate: u32, channels: u32) -> (Stretch, ElasticLatency) {
 #[derive(Clone, Copy)]
 enum TerminalState {
     Idle,
-    Armed { rate: f64 },
-    Flush,
+    Armed {
+        request: ElasticRequest,
+    },
+    Padding {
+        request: ElasticRequest,
+        source_cursor: usize,
+        output_cursor: usize,
+        output_frames: usize,
+    },
+    Native {
+        cursor: usize,
+    },
 }
 
 /// Exact-span Signalsmith engine, prepared for fixed maximum source and output
@@ -34,6 +47,105 @@ pub(crate) struct SignalsmithElastic {
     capabilities: ElasticCapabilities,
     prime_input: SampleBuffer,
     terminal: TerminalState,
+}
+
+impl SignalsmithElastic {
+    fn terminal_output_frames(&self, request: ElasticRequest) -> Result<usize, ElasticError> {
+        self.capabilities
+            .latency()
+            .source_frames()
+            .checked_mul(request.output_frames())
+            .map(|frames| frames.div_ceil(request.source_frames()))
+            .ok_or(ElasticError::SampleCountOverflow)
+    }
+
+    fn terminal_source_boundary(
+        &self,
+        request: ElasticRequest,
+        output_cursor: usize,
+    ) -> Result<usize, ElasticError> {
+        output_cursor
+            .checked_mul(request.source_frames())
+            .and_then(|frames| frames.checked_add(request.output_frames() / 2))
+            .map(|frames| frames / request.output_frames())
+            .map(|frames| frames.min(self.capabilities.latency().source_frames()))
+            .ok_or(ElasticError::SampleCountOverflow)
+    }
+
+    fn flush_padding(
+        &mut self,
+        output: &mut [f32],
+        capacity: usize,
+        request: ElasticRequest,
+        source_cursor: usize,
+        output_cursor: usize,
+        output_frames: usize,
+    ) -> Result<ElasticDrain, ElasticError> {
+        let next_output = output_cursor
+            .checked_add(capacity)
+            .map(|end| end.min(output_frames))
+            .ok_or(ElasticError::SampleCountOverflow)?;
+        let next_source = self.terminal_source_boundary(request, next_output)?;
+        let source_frames = next_source
+            .checked_sub(source_cursor)
+            .ok_or(ElasticError::SampleCountOverflow)?;
+        let rendered_frames = next_output
+            .checked_sub(output_cursor)
+            .ok_or(ElasticError::SampleCountOverflow)?;
+        let source_samples = self.capabilities.samples(source_frames)?;
+        let rendered_samples = self.capabilities.samples(rendered_frames)?;
+        self.prime_input[..source_samples].fill(0.0);
+        self.inner.process(
+            &self.prime_input[..source_samples],
+            &mut output[..rendered_samples],
+        );
+
+        if next_output == output_frames {
+            let native_frames = self.capabilities.latency().output_frames();
+            let native_samples = self.capabilities.samples(native_frames)?;
+            self.inner.flush(&mut self.prime_input[..native_samples]);
+            self.terminal = TerminalState::Native { cursor: 0 };
+            let remaining = capacity - rendered_frames;
+            if remaining > 0 {
+                let native = self.flush_native(&mut output[rendered_samples..], remaining, 0)?;
+                let frames = rendered_frames
+                    .checked_add(native.frames())
+                    .ok_or(ElasticError::SampleCountOverflow)?;
+                return Ok(ElasticDrain::new(frames, native.complete()));
+            }
+        } else {
+            self.terminal = TerminalState::Padding {
+                request,
+                source_cursor: next_source,
+                output_cursor: next_output,
+                output_frames,
+            };
+        }
+        Ok(ElasticDrain::new(rendered_frames, false))
+    }
+
+    fn flush_native(
+        &mut self,
+        output: &mut [f32],
+        capacity: usize,
+        cursor: usize,
+    ) -> Result<ElasticDrain, ElasticError> {
+        let total = self.capabilities.latency().output_frames();
+        let frames = total.saturating_sub(cursor).min(capacity);
+        let next = cursor
+            .checked_add(frames)
+            .ok_or(ElasticError::SampleCountOverflow)?;
+        let start = self.capabilities.samples(cursor)?;
+        let end = self.capabilities.samples(next)?;
+        output[..end - start].copy_from_slice(&self.prime_input[start..end]);
+        let complete = next == total;
+        self.terminal = if complete {
+            TerminalState::Idle
+        } else {
+            TerminalState::Native { cursor: next }
+        };
+        Ok(ElasticDrain::new(frames, complete))
+    }
 }
 
 impl fmt::Debug for SignalsmithElastic {
@@ -52,24 +164,17 @@ impl ElasticEngine for SignalsmithElastic {
     {
         let channels = u32::try_from(config.channels())
             .map_err(|_| ElasticError::ChannelCountOutOfRange(config.channels()))?;
-        let (mut inner, latency) = engine(config.sample_rate(), channels);
+        let (mut inner, latency) = engine(channels);
         inner.set_transpose_factor(1.0, None);
-        let minimum_rate = config.rate_envelope().min_source_frames_per_output();
-        let terminal_process_frames = latency
-            .source_frames()
-            .to_f64()
-            .map(|frames| (frames / minimum_rate).ceil())
-            .and_then(|frames| frames.to_usize())
-            .ok_or(ElasticError::SampleCountOverflow)?;
-        let terminal_chunk_frames = terminal_process_frames.max(latency.output_frames());
-        let capabilities = ElasticCapabilities::new(config.shape(), latency, terminal_chunk_frames);
+        let capabilities = ElasticCapabilities::new(config.shape(), latency);
         let prime_window_samples = capabilities.samples(latency.source_frames())?;
         let prime_samples = prime_window_samples
             .checked_add(prime_window_samples)
             .ok_or(ElasticError::SampleCountOverflow)?;
+        let native_tail_samples = capabilities.samples(latency.output_frames())?;
         let mut prime_input = config.pools().get::<f32>();
         prime_input
-            .ensure_len(prime_samples)
+            .ensure_len(prime_samples.max(native_tail_samples))
             .map_err(|_| ElasticError::PoolCapacity)?;
         Ok(Self {
             inner,
@@ -109,9 +214,7 @@ impl ElasticEngine for SignalsmithElastic {
         self.inner
             .seek(&self.prime_input[..input_end], playback_rate);
         self.inner.process(source, discarded_output);
-        self.terminal = TerminalState::Armed {
-            rate: playback_rate,
-        };
+        self.terminal = TerminalState::Armed { request };
         Ok(())
     }
 
@@ -123,11 +226,10 @@ impl ElasticEngine for SignalsmithElastic {
     ) -> Result<(), ElasticError> {
         self.capabilities
             .validate(request, source.len(), output.len())?;
-        let rate = request.source_frames_per_output()?;
         kithara::measure_block!("signalsmith::Stretch::process", {
             self.inner.process(source, output);
         });
-        self.terminal = TerminalState::Armed { rate };
+        self.terminal = TerminalState::Armed { request };
         Ok(())
     }
 
@@ -145,39 +247,30 @@ impl ElasticEngine for SignalsmithElastic {
         if matches!(self.terminal, TerminalState::Idle) {
             return Ok(ElasticDrain::new(0, true));
         }
-        let chunk_frames = self.capabilities.terminal_chunk_frames();
-        let expected = self.capabilities.samples(chunk_frames)?;
-        if output.len() != expected {
-            return Err(ElasticError::OutputSampleCount {
-                actual: output.len(),
-                expected,
-            });
-        }
+        let capacity = self.capabilities.output_capacity(output.len())?;
         match self.terminal {
-            TerminalState::Armed { rate } => {
-                let source_frames = self.capabilities.latency().source_frames();
-                let output_frames = source_frames
-                    .to_f64()
-                    .map(|frames| (frames / rate).ceil())
-                    .and_then(|frames| frames.to_usize())
-                    .ok_or(ElasticError::SampleCountOverflow)?;
-                let source_samples = self.capabilities.samples(source_frames)?;
-                let output_samples = self.capabilities.samples(output_frames)?;
-                self.prime_input[..source_samples].fill(0.0);
-                self.inner.process(
-                    &self.prime_input[..source_samples],
-                    &mut output[..output_samples],
-                );
-                self.terminal = TerminalState::Flush;
-                Ok(ElasticDrain::new(output_frames, false))
-            }
-            TerminalState::Flush => {
-                let output_frames = self.capabilities.latency().output_frames();
-                let output_samples = self.capabilities.samples(output_frames)?;
-                self.inner.flush(&mut output[..output_samples]);
-                self.terminal = TerminalState::Idle;
-                Ok(ElasticDrain::new(output_frames, true))
-            }
+            TerminalState::Armed { request } => self.flush_padding(
+                output,
+                capacity,
+                request,
+                0,
+                0,
+                self.terminal_output_frames(request)?,
+            ),
+            TerminalState::Padding {
+                request,
+                source_cursor,
+                output_cursor,
+                output_frames,
+            } => self.flush_padding(
+                output,
+                capacity,
+                request,
+                source_cursor,
+                output_cursor,
+                output_frames,
+            ),
+            TerminalState::Native { cursor } => self.flush_native(output, capacity, cursor),
             TerminalState::Idle => Ok(ElasticDrain::new(0, true)),
         }
     }

--- a/crates/kithara-stretch/src/backends/signalsmith.rs
+++ b/crates/kithara-stretch/src/backends/signalsmith.rs
@@ -7,14 +7,15 @@ use signalsmith_stretch::Stretch;
 
 use crate::{
     ElasticCapabilities, ElasticConfig, ElasticDrain, ElasticEngine, ElasticError, ElasticLatency,
-    ElasticRequest, elastic::PitchScale,
+    ElasticRequest, SignalsmithConfig, elastic::PitchScale,
 };
 
-fn engine(channels: u32) -> (Stretch, ElasticLatency) {
-    const BLOCK_FRAMES: usize = 416;
-    const INTERVAL_FRAMES: usize = 64;
-
-    let inner = Stretch::new(channels, BLOCK_FRAMES, INTERVAL_FRAMES);
+fn engine(channels: u32, config: SignalsmithConfig) -> (Stretch, ElasticLatency) {
+    let inner = Stretch::new(
+        channels,
+        config.block_frames().get(),
+        config.interval_frames().get(),
+    );
     let native_input_latency = inner.input_latency();
     let native_output_latency = inner.output_latency();
     (
@@ -164,7 +165,7 @@ impl ElasticEngine for SignalsmithElastic {
     {
         let channels = u32::try_from(config.channels())
             .map_err(|_| ElasticError::ChannelCountOutOfRange(config.channels()))?;
-        let (mut inner, latency) = engine(channels);
+        let (mut inner, latency) = engine(channels, *config.backends().signalsmith());
         inner.set_transpose_factor(1.0, None);
         let capabilities = ElasticCapabilities::new(config.shape(), latency);
         let prime_window_samples = capabilities.samples(latency.source_frames())?;

--- a/crates/kithara-stretch/src/elastic/capabilities.rs
+++ b/crates/kithara-stretch/src/elastic/capabilities.rs
@@ -13,22 +13,11 @@ pub struct ElasticCapabilities {
     latency: ElasticLatency,
     #[field(skip)]
     shape: ElasticShape,
-    /// Fixed caller-owned storage span for one terminal-drain chunk.
-    #[field(get, copy)]
-    terminal_chunk_frames: usize,
 }
 
 impl ElasticCapabilities {
-    pub(crate) fn new(
-        shape: ElasticShape,
-        latency: ElasticLatency,
-        terminal_chunk_frames: usize,
-    ) -> Self {
-        Self {
-            latency,
-            shape,
-            terminal_chunk_frames,
-        }
+    pub(crate) fn new(shape: ElasticShape, latency: ElasticLatency) -> Self {
+        Self { latency, shape }
     }
 
     /// Interleaved sample count of a frame span at the prepared channel count.
@@ -36,6 +25,22 @@ impl ElasticCapabilities {
         frames
             .checked_mul(self.channels())
             .ok_or(ElasticError::SampleCountOverflow)
+    }
+
+    /// Validate caller-owned interleaved storage and return its frame capacity.
+    pub(crate) fn output_capacity(self, output_samples: usize) -> Result<usize, ElasticError> {
+        if output_samples == 0 {
+            return Err(ElasticError::EmptyOutput);
+        }
+        let channels = self.channels();
+        if !output_samples.is_multiple_of(channels) {
+            let expected = self.samples(output_samples.div_ceil(channels))?;
+            return Err(ElasticError::OutputSampleCount {
+                actual: output_samples,
+                expected,
+            });
+        }
+        Ok(output_samples / channels)
     }
 
     /// Every engine accepts the same requests: inside the prepared block
@@ -175,7 +180,7 @@ mod tests {
             .max_output_frames(64)
             .build()
             .expect("valid elastic config");
-        let capabilities = ElasticCapabilities::new(config.shape(), ElasticLatency::new(1, 1), 64);
+        let capabilities = ElasticCapabilities::new(config.shape(), ElasticLatency::new(1, 1));
         let request = ElasticRequest::new(32, 1).expect("non-empty request");
 
         let result = capabilities.validate(request, 64, 2);

--- a/crates/kithara-stretch/src/elastic/config.rs
+++ b/crates/kithara-stretch/src/elastic/config.rs
@@ -1,6 +1,6 @@
-use std::ops::RangeInclusive;
+use std::{num::NonZeroUsize, ops::RangeInclusive};
 
-use bon::bon;
+use bon::{Builder, bon};
 use kithara_bufpool::PoolRegion;
 use num_traits::ToPrimitive;
 
@@ -11,10 +11,81 @@ struct Consts;
 
 impl Consts {
     const CONTINUITY_TOLERANCE: f64 = 1.0e-6;
+    const DEFAULT_SIGNALSMITH_BLOCK_FRAMES: NonZeroUsize = match NonZeroUsize::new(224) {
+        Some(frames) => frames,
+        None => unreachable!(),
+    };
+    const DEFAULT_SIGNALSMITH_INTERVAL_FRAMES: NonZeroUsize = match NonZeroUsize::new(32) {
+        Some(frames) => frames,
+        None => unreachable!(),
+    };
     const MAX_CORRECTION_PER_BLOCK: f64 = 1.0;
     const MAX_PHASE_ERROR: f64 = 1.0;
     const MAX_SOURCE_FRAMES_PER_OUTPUT: f64 = 4.0;
     const MIN_SOURCE_FRAMES_PER_OUTPUT: f64 = 0.05;
+}
+
+/// Signalsmith preparation geometry.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Builder, fieldwork::Fieldwork)]
+#[builder(state_mod(vis = "pub"))]
+#[fieldwork(get, copy)]
+#[non_exhaustive]
+pub struct SignalsmithConfig {
+    /// Analysis block size in source frames.
+    #[builder(default = Consts::DEFAULT_SIGNALSMITH_BLOCK_FRAMES)]
+    block_frames: NonZeroUsize,
+    /// Analysis interval in source frames.
+    #[builder(default = Consts::DEFAULT_SIGNALSMITH_INTERVAL_FRAMES)]
+    interval_frames: NonZeroUsize,
+}
+
+impl SignalsmithConfig {
+    fn validate(self) -> Result<Self, ElasticError> {
+        if self.interval_frames > self.block_frames {
+            return Err(ElasticError::EnginePreparation(
+                "Signalsmith interval exceeds its analysis block",
+            ));
+        }
+        Ok(self)
+    }
+}
+
+impl Default for SignalsmithConfig {
+    fn default() -> Self {
+        Self {
+            block_frames: Consts::DEFAULT_SIGNALSMITH_BLOCK_FRAMES,
+            interval_frames: Consts::DEFAULT_SIGNALSMITH_INTERVAL_FRAMES,
+        }
+    }
+}
+
+/// Bungee native synthesis geometry.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Builder, fieldwork::Fieldwork)]
+#[builder(state_mod(vis = "pub"))]
+#[fieldwork(get, copy)]
+#[non_exhaustive]
+pub struct BungeeConfig {
+    /// Base-two synthesis-hop adjustment passed to the native stretcher.
+    #[builder(default = -4)]
+    log2_synthesis_hop_adjust: i32,
+}
+
+impl Default for BungeeConfig {
+    fn default() -> Self {
+        Self::builder().build()
+    }
+}
+
+/// Per-backend preparation parameters carried by the common elastic facade.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Builder, fieldwork::Fieldwork)]
+#[builder(state_mod(vis = "pub"))]
+#[fieldwork(get, copy)]
+#[non_exhaustive]
+pub struct ElasticBackendConfig {
+    #[builder(default)]
+    bungee: BungeeConfig,
+    #[builder(default)]
+    signalsmith: SignalsmithConfig,
 }
 
 /// Numeric continuity policy for exact-span planning.
@@ -72,6 +143,8 @@ pub struct ElasticConfig<S> {
     #[field(get)]
     pools: PoolRegion<S>,
     #[field(get(copy), vis = "pub(crate)")]
+    backends: ElasticBackendConfig,
+    #[field(get(copy), vis = "pub(crate)")]
     shape: ElasticShape,
 }
 
@@ -90,6 +163,7 @@ impl<S> ElasticConfig<S> {
     )]
     fn new(
         #[builder(default)] backend: StretchKind,
+        #[builder(default)] backends: ElasticBackendConfig,
         pools: PoolRegion<S>,
         sample_rate: u32,
         channels: usize,
@@ -101,6 +175,7 @@ impl<S> ElasticConfig<S> {
         )]
         rate_envelope: RangeInclusive<f64>,
     ) -> Result<Self, ElasticError> {
+        backends.signalsmith.validate()?;
         if sample_rate == 0 {
             return Err(ElasticError::InvalidSampleRate);
         }
@@ -125,6 +200,7 @@ impl<S> ElasticConfig<S> {
         Ok(Self {
             backend,
             pools,
+            backends,
             shape,
         })
     }
@@ -324,6 +400,68 @@ mod tests {
         assert_eq!(config.backend(), StretchKind::default());
         assert_eq!(envelope.min_source_frames_per_output(), 0.05);
         assert_eq!(envelope.max_source_frames_per_output(), 4.0);
+    }
+
+    #[kithara::test]
+    fn backend_geometry_has_one_configured_default_owner() {
+        let backends = ElasticBackendConfig::builder().build();
+
+        assert_eq!(backends.signalsmith().block_frames().get(), 224);
+        assert_eq!(backends.signalsmith().interval_frames().get(), 32);
+        assert_eq!(backends.bungee().log2_synthesis_hop_adjust(), -4);
+    }
+
+    #[kithara::test]
+    fn elastic_config_carries_backend_geometry() {
+        let signalsmith = SignalsmithConfig::builder()
+            .block_frames(NonZeroUsize::new(512).expect("fixture block is non-zero"))
+            .interval_frames(NonZeroUsize::new(16).expect("fixture interval is non-zero"))
+            .build();
+        let bungee = BungeeConfig::builder()
+            .log2_synthesis_hop_adjust(-2)
+            .build();
+        let backends = ElasticBackendConfig::builder()
+            .signalsmith(signalsmith)
+            .bungee(bungee)
+            .build();
+        let config = ElasticConfig::builder()
+            .backends(backends)
+            .pools(pools())
+            .sample_rate(48_000)
+            .channels(2)
+            .max_source_frames(960)
+            .max_output_frames(480)
+            .build()
+            .expect("fixture backend geometry is valid");
+
+        assert_eq!(config.backends(), backends);
+    }
+
+    #[kithara::test]
+    fn signalsmith_geometry_rejects_an_interval_larger_than_its_block() {
+        let signalsmith = SignalsmithConfig::builder()
+            .block_frames(NonZeroUsize::new(16).expect("fixture block is non-zero"))
+            .interval_frames(NonZeroUsize::new(32).expect("fixture interval is non-zero"))
+            .build();
+        let backends = ElasticBackendConfig::builder()
+            .signalsmith(signalsmith)
+            .build();
+
+        let result = ElasticConfig::builder()
+            .backends(backends)
+            .pools(pools())
+            .sample_rate(48_000)
+            .channels(2)
+            .max_source_frames(960)
+            .max_output_frames(480)
+            .build();
+
+        assert!(matches!(
+            result,
+            Err(ElasticError::EnginePreparation(
+                "Signalsmith interval exceeds its analysis block"
+            ))
+        ));
     }
 
     #[kithara::test]

--- a/crates/kithara-stretch/src/elastic/config.rs
+++ b/crates/kithara-stretch/src/elastic/config.rs
@@ -11,14 +11,6 @@ struct Consts;
 
 impl Consts {
     const CONTINUITY_TOLERANCE: f64 = 1.0e-6;
-    const DEFAULT_SIGNALSMITH_BLOCK_FRAMES: NonZeroUsize = match NonZeroUsize::new(224) {
-        Some(frames) => frames,
-        None => unreachable!(),
-    };
-    const DEFAULT_SIGNALSMITH_INTERVAL_FRAMES: NonZeroUsize = match NonZeroUsize::new(32) {
-        Some(frames) => frames,
-        None => unreachable!(),
-    };
     const MAX_CORRECTION_PER_BLOCK: f64 = 1.0;
     const MAX_PHASE_ERROR: f64 = 1.0;
     const MAX_SOURCE_FRAMES_PER_OUTPUT: f64 = 4.0;
@@ -26,35 +18,27 @@ impl Consts {
 }
 
 /// Signalsmith preparation geometry.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Builder, fieldwork::Fieldwork)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Builder, fieldwork::Fieldwork)]
 #[builder(state_mod(vis = "pub"))]
 #[fieldwork(get, copy)]
 #[non_exhaustive]
 pub struct SignalsmithConfig {
-    /// Analysis block size in source frames.
-    #[builder(default = Consts::DEFAULT_SIGNALSMITH_BLOCK_FRAMES)]
-    block_frames: NonZeroUsize,
-    /// Analysis interval in source frames.
-    #[builder(default = Consts::DEFAULT_SIGNALSMITH_INTERVAL_FRAMES)]
-    interval_frames: NonZeroUsize,
+    /// Custom analysis block size in source frames; absent selects the native preset.
+    block_frames: Option<NonZeroUsize>,
+    /// Custom analysis interval in source frames; absent selects the native preset.
+    interval_frames: Option<NonZeroUsize>,
 }
 
 impl SignalsmithConfig {
     fn validate(self) -> Result<Self, ElasticError> {
-        if self.interval_frames > self.block_frames {
-            return Err(ElasticError::EnginePreparation(
-                "Signalsmith interval exceeds its analysis block",
-            ));
-        }
-        Ok(self)
-    }
-}
-
-impl Default for SignalsmithConfig {
-    fn default() -> Self {
-        Self {
-            block_frames: Consts::DEFAULT_SIGNALSMITH_BLOCK_FRAMES,
-            interval_frames: Consts::DEFAULT_SIGNALSMITH_INTERVAL_FRAMES,
+        match (self.block_frames, self.interval_frames) {
+            (Some(block), Some(interval)) if interval > block => Err(
+                ElasticError::EnginePreparation("Signalsmith interval exceeds its analysis block"),
+            ),
+            (Some(_), None) | (None, Some(_)) => Err(ElasticError::EnginePreparation(
+                "Signalsmith block and interval must be configured together",
+            )),
+            _ => Ok(self),
         }
     }
 }
@@ -66,7 +50,7 @@ impl Default for SignalsmithConfig {
 #[non_exhaustive]
 pub struct BungeeConfig {
     /// Base-two synthesis-hop adjustment passed to the native stretcher.
-    #[builder(default = -4)]
+    #[builder(default)]
     log2_synthesis_hop_adjust: i32,
 }
 
@@ -406,9 +390,9 @@ mod tests {
     fn backend_geometry_has_one_configured_default_owner() {
         let backends = ElasticBackendConfig::builder().build();
 
-        assert_eq!(backends.signalsmith().block_frames().get(), 224);
-        assert_eq!(backends.signalsmith().interval_frames().get(), 32);
-        assert_eq!(backends.bungee().log2_synthesis_hop_adjust(), -4);
+        assert_eq!(backends.signalsmith().block_frames(), None);
+        assert_eq!(backends.signalsmith().interval_frames(), None);
+        assert_eq!(backends.bungee().log2_synthesis_hop_adjust(), 0);
     }
 
     #[kithara::test]
@@ -460,6 +444,37 @@ mod tests {
             result,
             Err(ElasticError::EnginePreparation(
                 "Signalsmith interval exceeds its analysis block"
+            ))
+        ));
+    }
+
+    #[kithara::test]
+    #[case::block_only(true)]
+    #[case::interval_only(false)]
+    fn signalsmith_custom_geometry_requires_both_values(#[case] block_only: bool) {
+        let frames = NonZeroUsize::new(32).expect("fixture geometry is non-zero");
+        let signalsmith = if block_only {
+            SignalsmithConfig::builder().block_frames(frames).build()
+        } else {
+            SignalsmithConfig::builder().interval_frames(frames).build()
+        };
+        let result = ElasticConfig::builder()
+            .backends(
+                ElasticBackendConfig::builder()
+                    .signalsmith(signalsmith)
+                    .build(),
+            )
+            .pools(pools())
+            .sample_rate(48_000)
+            .channels(2)
+            .max_source_frames(960)
+            .max_output_frames(480)
+            .build();
+
+        assert!(matches!(
+            result,
+            Err(ElasticError::EnginePreparation(
+                "Signalsmith block and interval must be configured together"
             ))
         ));
     }

--- a/crates/kithara-stretch/src/elastic/config.rs
+++ b/crates/kithara-stretch/src/elastic/config.rs
@@ -2,7 +2,7 @@ use std::ops::RangeInclusive;
 
 use bon::bon;
 use kithara_bufpool::PoolRegion;
-use num_traits::{Float, ToPrimitive};
+use num_traits::ToPrimitive;
 
 use super::{ElasticError, ElasticRateEnvelope};
 use crate::StretchKind;
@@ -13,8 +13,6 @@ impl Consts {
     const CONTINUITY_TOLERANCE: f64 = 1.0e-6;
     const MAX_CORRECTION_PER_BLOCK: f64 = 1.0;
     const MAX_PHASE_ERROR: f64 = 1.0;
-    /// i32-bounded numerators and denominators need fewer than 47 continued-fraction steps.
-    const RATE_FRACTION_DEPTH: u8 = 64;
     const MAX_SOURCE_FRAMES_PER_OUTPUT: f64 = 4.0;
     const MIN_SOURCE_FRAMES_PER_OUTPUT: f64 = 0.05;
 }
@@ -186,7 +184,7 @@ impl ElasticShape {
             .min(Consts::MAX_SOURCE_FRAMES_PER_OUTPUT)
             .min(max_source_frames_f64);
         let rate_envelope = ElasticRateEnvelope::try_from(min_rate..=max_rate)?;
-        if !has_representable_request(rate_envelope, max_source_frames, max_output_frames) {
+        if !rate_envelope.has_representable_request(max_source_frames, max_output_frames) {
             return Err(ElasticError::InvalidRateEnvelope {
                 max: max_rate,
                 min: min_rate,
@@ -201,106 +199,6 @@ impl ElasticShape {
             sample_rate,
         })
     }
-}
-
-fn has_representable_request(
-    envelope: ElasticRateEnvelope,
-    max_source_frames: usize,
-    max_output_frames: usize,
-) -> bool {
-    let accepted_minimum = envelope.min_source_frames_per_output().next_down();
-    let accepted_maximum = envelope.max_source_frames_per_output().next_up();
-    // Convert the accepted f64 edges into their exact division-rounding basins.
-    let Some(minimum) = binary_midpoint(accepted_minimum.next_down(), accepted_minimum) else {
-        return false;
-    };
-    let Some(maximum) = binary_midpoint(accepted_maximum, accepted_maximum.next_up()) else {
-        return false;
-    };
-    let Some((_, denominator)) = simplest_fraction(minimum, maximum, Consts::RATE_FRACTION_DEPTH)
-    else {
-        return false;
-    };
-    let Ok(max_output_frames) = u128::try_from(max_output_frames) else {
-        return false;
-    };
-    if denominator > max_output_frames {
-        return false;
-    }
-    let Some(scaled_minimum) = minimum.0.checked_mul(denominator) else {
-        return false;
-    };
-    let source_frames =
-        scaled_minimum / minimum.1 + u128::from(!scaled_minimum.is_multiple_of(minimum.1));
-    let Some(scaled_source) = source_frames.checked_mul(maximum.1) else {
-        return false;
-    };
-    let Some(scaled_maximum) = maximum.0.checked_mul(denominator) else {
-        return false;
-    };
-    let Ok(max_source_frames) = u128::try_from(max_source_frames) else {
-        return false;
-    };
-    source_frames > 0 && source_frames <= max_source_frames && scaled_source <= scaled_maximum
-}
-
-fn binary_midpoint(left: f64, right: f64) -> Option<(u128, u128)> {
-    let left = binary_fraction(left)?;
-    let right = binary_fraction(right)?;
-    let denominator = left.1.max(right.1);
-    let numerator = left
-        .0
-        .checked_mul(denominator / left.1)?
-        .checked_add(right.0.checked_mul(denominator / right.1)?)?;
-    Some((numerator, denominator.checked_mul(2)?))
-}
-
-fn binary_fraction(value: f64) -> Option<(u128, u128)> {
-    if !value.is_finite() || value <= 0.0 {
-        return None;
-    }
-    let (mantissa, exponent, sign) = value.integer_decode();
-    if sign <= 0 {
-        return None;
-    }
-    let mantissa = u128::from(mantissa);
-    if exponent >= 0 {
-        Some((mantissa.checked_shl(u32::try_from(exponent).ok()?)?, 1))
-    } else {
-        Some((
-            mantissa,
-            1_u128.checked_shl(u32::from(exponent.unsigned_abs()))?,
-        ))
-    }
-}
-
-fn simplest_fraction(
-    minimum: (u128, u128),
-    maximum: (u128, u128),
-    depth: u8,
-) -> Option<(u128, u128)> {
-    if depth == 0 {
-        return None;
-    }
-    let whole = minimum.0 / minimum.1;
-    let maximum_whole = maximum.0 / maximum.1;
-    if whole < maximum_whole {
-        return Some((whole.checked_add(1)?, 1));
-    }
-    let minimum_remainder = minimum.0 % minimum.1;
-    if minimum_remainder == 0 {
-        return Some((whole, 1));
-    }
-    let maximum_remainder = maximum.0 % maximum.1;
-    let (numerator, denominator) = simplest_fraction(
-        (maximum.1, maximum_remainder),
-        (minimum.1, minimum_remainder),
-        depth - 1,
-    )?;
-    Some((
-        whole.checked_mul(numerator)?.checked_add(denominator)?,
-        numerator,
-    ))
 }
 
 /// [`kithara_signal::AudioSpec`] represents channel counts with `u16`.

--- a/crates/kithara-stretch/src/elastic/engine.rs
+++ b/crates/kithara-stretch/src/elastic/engine.rs
@@ -20,18 +20,17 @@ pub trait ElasticEngine: Send + 'static {
 
     /// Writes the next portion of terminal buffered audio into caller-owned storage.
     ///
-    /// The caller supplies storage for
-    /// `capabilities().terminal_chunk_frames() * channels` samples and repeats
+    /// The caller chooses the non-empty whole-frame storage capacity and repeats
     /// until the returned [`ElasticDrain`] is complete. Every incomplete step
-    /// writes a non-empty contiguous tail portion; an active drain reports
-    /// completion together with its final non-empty portion. Fresh, reset and
-    /// already-completed engines return an empty completed step until
-    /// [`prime`](Self::prime) or [`process`](Self::process).
+    /// writes a non-empty contiguous tail portion no larger than that capacity;
+    /// an active drain reports completion together with its final non-empty
+    /// portion. Fresh, reset and already-completed engines return an empty
+    /// completed step until [`prime`](Self::prime) or [`process`](Self::process).
     ///
     /// # Errors
-    /// While a drain is active, returns [`ElasticError`] when `output` does not
-    /// match the engine's declared terminal span or when sizing that span
-    /// overflows. An inactive drain returns an empty completed step without
+    /// While a drain is active, returns [`ElasticError`] when `output` is empty,
+    /// does not contain a whole number of interleaved frames, or when sizing a
+    /// span overflows. An inactive drain returns an empty completed step without
     /// accessing `output`.
     fn flush(&mut self, output: &mut [f32]) -> Result<ElasticDrain, ElasticError>;
 

--- a/crates/kithara-stretch/src/elastic/mod.rs
+++ b/crates/kithara-stretch/src/elastic/mod.rs
@@ -2,7 +2,9 @@ mod capabilities;
 pub use capabilities::ElasticCapabilities;
 
 mod config;
-pub use config::{ElasticConfig, ElasticSpanConfig};
+pub use config::{
+    BungeeConfig, ElasticBackendConfig, ElasticConfig, ElasticSpanConfig, SignalsmithConfig,
+};
 
 mod drain;
 pub use drain::ElasticDrain;

--- a/crates/kithara-stretch/src/elastic/rate.rs
+++ b/crates/kithara-stretch/src/elastic/rate.rs
@@ -1,6 +1,11 @@
 use std::ops::RangeInclusive;
 
+use num_traits::Float;
+
 use super::{ElasticError, ElasticRequest};
+
+// i32-bounded numerators and denominators need fewer than 47 continued-fraction steps.
+const RATE_FRACTION_DEPTH: u8 = 64;
 
 /// Supported source-frame advance per output frame.
 ///
@@ -32,6 +37,108 @@ impl ElasticRateEnvelope {
             && source_frames_per_output >= self.min_source_frames_per_output.next_down()
             && source_frames_per_output <= self.max_source_frames_per_output.next_up()
     }
+
+    pub(crate) fn has_representable_request(
+        self,
+        max_source_frames: usize,
+        max_output_frames: usize,
+    ) -> bool {
+        let accepted_minimum = self.min_source_frames_per_output.next_down();
+        let accepted_maximum = self.max_source_frames_per_output.next_up();
+        let Some(minimum) = binary_midpoint(accepted_minimum.next_down(), accepted_minimum) else {
+            return false;
+        };
+        let Some(maximum) = binary_midpoint(accepted_maximum, accepted_maximum.next_up()) else {
+            return false;
+        };
+        largest_request_between(minimum, maximum, max_source_frames, max_output_frames)
+            .is_some_and(|request| self.contains(request))
+    }
+}
+
+fn largest_request_between(
+    minimum: (u128, u128),
+    maximum: (u128, u128),
+    max_source_frames: usize,
+    max_output_frames: usize,
+) -> Option<ElasticRequest> {
+    let (_, denominator) = simplest_fraction(minimum, maximum, RATE_FRACTION_DEPTH)?;
+    let max_output_frames = u128::try_from(max_output_frames).ok()?;
+    if denominator > max_output_frames {
+        return None;
+    }
+    let scaled_minimum = minimum.0.checked_mul(denominator)?;
+    let source_frames =
+        scaled_minimum / minimum.1 + u128::from(!scaled_minimum.is_multiple_of(minimum.1));
+    let scaled_source = source_frames.checked_mul(maximum.1)?;
+    let scaled_maximum = maximum.0.checked_mul(denominator)?;
+    let max_source_frames = u128::try_from(max_source_frames).ok()?;
+    if source_frames == 0 || source_frames > max_source_frames || scaled_source > scaled_maximum {
+        return None;
+    }
+    let scale = (max_source_frames / source_frames).min(max_output_frames / denominator);
+    let source_frames = usize::try_from(source_frames.checked_mul(scale)?).ok()?;
+    let output_frames = usize::try_from(denominator.checked_mul(scale)?).ok()?;
+    ElasticRequest::new(source_frames, output_frames).ok()
+}
+
+fn binary_midpoint(left: f64, right: f64) -> Option<(u128, u128)> {
+    let left = binary_fraction(left)?;
+    let right = binary_fraction(right)?;
+    let denominator = left.1.max(right.1);
+    let numerator = left
+        .0
+        .checked_mul(denominator / left.1)?
+        .checked_add(right.0.checked_mul(denominator / right.1)?)?;
+    Some((numerator, denominator.checked_mul(2)?))
+}
+
+fn binary_fraction(value: f64) -> Option<(u128, u128)> {
+    if !value.is_finite() || value <= 0.0 {
+        return None;
+    }
+    let (mantissa, exponent, sign) = value.integer_decode();
+    if sign <= 0 {
+        return None;
+    }
+    let mantissa = u128::from(mantissa);
+    if exponent >= 0 {
+        Some((mantissa.checked_shl(u32::try_from(exponent).ok()?)?, 1))
+    } else {
+        Some((
+            mantissa,
+            1_u128.checked_shl(u32::from(exponent.unsigned_abs()))?,
+        ))
+    }
+}
+
+fn simplest_fraction(
+    minimum: (u128, u128),
+    maximum: (u128, u128),
+    depth: u8,
+) -> Option<(u128, u128)> {
+    if depth == 0 {
+        return None;
+    }
+    let whole = minimum.0 / minimum.1;
+    let maximum_whole = maximum.0 / maximum.1;
+    if whole < maximum_whole {
+        return Some((whole.checked_add(1)?, 1));
+    }
+    let minimum_remainder = minimum.0 % minimum.1;
+    if minimum_remainder == 0 {
+        return Some((whole, 1));
+    }
+    let maximum_remainder = maximum.0 % maximum.1;
+    let (numerator, denominator) = simplest_fraction(
+        (maximum.1, maximum_remainder),
+        (minimum.1, minimum_remainder),
+        depth - 1,
+    )?;
+    Some((
+        whole.checked_mul(numerator)?.checked_add(denominator)?,
+        numerator,
+    ))
 }
 
 impl TryFrom<RangeInclusive<f64>> for ElasticRateEnvelope {

--- a/crates/kithara-stretch/src/lib.rs
+++ b/crates/kithara-stretch/src/lib.rs
@@ -15,9 +15,9 @@ mod backends;
 
 mod elastic;
 pub use elastic::{
-    ElasticCapabilities, ElasticConfig, ElasticCursor, ElasticDrain, ElasticEngine, ElasticError,
-    ElasticLatency, ElasticRateEnvelope, ElasticRequest, ElasticSpan, ElasticSpanConfig,
-    ElasticSpanPlan, ElasticSpanRequest,
+    BungeeConfig, ElasticBackendConfig, ElasticCapabilities, ElasticConfig, ElasticCursor,
+    ElasticDrain, ElasticEngine, ElasticError, ElasticLatency, ElasticRateEnvelope, ElasticRequest,
+    ElasticSpan, ElasticSpanConfig, ElasticSpanPlan, ElasticSpanRequest, SignalsmithConfig,
 };
 #[cfg(test)]
 pub(crate) use kithara_bufpool::testing as test_pools;

--- a/crates/kithara-stretch/tests/elastic.rs
+++ b/crates/kithara-stretch/tests/elastic.rs
@@ -21,11 +21,12 @@ const LANDMARK_FREQUENCIES: [f64; 12] = [
     8_625.0, 9_375.0,
 ];
 const SAMPLE_RATE: u32 = 48_000;
+const SHORT_MARKER_HZ: f64 = 15_000.0;
+const SHORT_MARKER_WINDOW_FRAMES: usize = 16;
 const TONE_HZ: f64 = 440.0;
 const TERMINAL_HIGH_HZ: f64 = 6_000.0;
 const TERMINAL_LOW_HZ: f64 = 1_500.0;
-const TERMINAL_MARKER_FRAMES: usize = 2_048;
-const TERMINAL_WINDOW_FRAMES: usize = 256;
+const TERMINAL_WINDOW_FRAMES: usize = 64;
 
 fn prepared_backend(
     backend: StretchKind,
@@ -73,10 +74,9 @@ fn interleaved_signal(frames: usize) -> Vec<f32> {
 }
 
 fn drain_terminal(engine: &mut dyn ElasticEngine) -> Vec<f32> {
-    const MAX_CHUNKS: usize = 32;
+    const MAX_CHUNKS: usize = 256;
 
-    let chunk_frames = engine.capabilities().terminal_chunk_frames();
-    let mut chunk = vec![0.0; chunk_frames * CHANNELS];
+    let mut chunk = vec![0.0; CONTROL_QUANTUM * CHANNELS];
     let mut drained = Vec::new();
     for _ in 0..MAX_CHUNKS {
         chunk.fill(0.0);
@@ -198,10 +198,6 @@ fn first_audible_frame(samples: &[f32], channels: usize) -> Option<usize> {
         .position(|frame| frame.iter().any(|sample| sample.abs() >= 1.0e-4))
 }
 
-fn terminal_marker_signal(frames: usize) -> Vec<f32> {
-    terminal_marker_signal_with_span(frames, TERMINAL_MARKER_FRAMES)
-}
-
 fn terminal_marker_signal_with_span(frames: usize, marker_span: usize) -> Vec<f32> {
     let marker_frames = frames.min(marker_span);
     let marker_start = frames - marker_frames;
@@ -230,6 +226,24 @@ fn terminal_marker_signal_with_span(frames: usize, marker_span: usize) -> Vec<f3
             [sample, sample * -0.5]
         })
         .collect()
+}
+
+fn short_marker_signal(frames: usize) -> Vec<f32> {
+    tone_signal(frames, 0, SHORT_MARKER_HZ)
+}
+
+fn short_marker_is_present(samples: &[f32]) -> bool {
+    const MINIMUM_MAGNITUDE: f64 = 0.05;
+    const STEP_FRAMES: usize = 4;
+
+    let frames = samples.len() / CHANNELS;
+    frames >= SHORT_MARKER_WINDOW_FRAMES
+        && (0..=frames - SHORT_MARKER_WINDOW_FRAMES)
+            .step_by(STEP_FRAMES)
+            .any(|start| {
+                tone_window_magnitude(samples, start, SHORT_MARKER_WINDOW_FRAMES, SHORT_MARKER_HZ)
+                    >= MINIMUM_MAGNITUDE
+            })
 }
 
 fn strongest_tone_window(samples: &[f32], frequency: f64) -> Option<(usize, f64)> {
@@ -347,6 +361,14 @@ fn indexed_landmark_oracle_rejects_reorder_omission_replay_and_partial_drop() {
         &expected,
     ));
     assert!(!landmarks_appear_once_in_order(&partial, &expected));
+
+    let short = short_marker_signal(CONTROL_QUANTUM);
+    assert!(short_marker_is_present(&short));
+    assert!(!short_marker_is_present(&vec![0.0; short.len()]));
+    assert!(!short_marker_is_present(&continuous_tone(
+        CONTROL_QUANTUM,
+        0
+    )));
 }
 
 fn terminal_markers_are_ordered(samples: &[f32]) -> bool {
@@ -430,6 +452,27 @@ fn rate_aware_latency_frames(capabilities: ElasticCapabilities, request: Elastic
         .and_then(|frames| frames.to_usize())
         .and_then(|frames| frames.checked_add(capabilities.latency().output_frames()))
         .expect("the rate-aware latency fits in usize")
+}
+
+fn rate_aware_terminal_source_frames(
+    capabilities: ElasticCapabilities,
+    request: ElasticRequest,
+) -> usize {
+    let rate = request
+        .source_frames()
+        .to_f64()
+        .zip(request.output_frames().to_f64())
+        .map(|(source, output)| source / output)
+        .expect("the request spans fit in f64");
+    capabilities
+        .latency()
+        .source_frames()
+        .checked_add(source_frames_at(
+            rate,
+            capabilities.latency().output_frames(),
+            true,
+        ))
+        .expect("the terminal source span fits in usize")
 }
 
 fn edge_requests(capabilities: ElasticCapabilities) -> [ElasticRequest; 3] {
@@ -673,9 +716,10 @@ mod facade {
             ElasticRequest::new(FRAMES, FRAMES / 2).expect("double-speed request"),
         ] {
             let mut engine = prepared_backend(backend, FRAMES, FRAMES);
-            let source = terminal_marker_signal(request.source_frames());
-            let mut output = vec![0.0; request.output_frames() * CHANNELS];
             let capabilities = engine.capabilities();
+            let marker_frames = rate_aware_terminal_source_frames(capabilities, request);
+            let source = terminal_marker_signal_with_span(request.source_frames(), marker_frames);
+            let mut output = vec![0.0; request.output_frames() * CHANNELS];
             engine
                 .process(request, &source, &mut output)
                 .expect("the source block renders");
@@ -720,14 +764,101 @@ mod facade {
     #[kithara::test]
     #[cfg_attr(
         feature = "stretch-signalsmith",
+        case::signalsmith_minimum(StretchKind::Signalsmith, 0.05)
+    )]
+    #[cfg_attr(
+        feature = "stretch-signalsmith",
+        case::signalsmith_unity(StretchKind::Signalsmith, 1.0)
+    )]
+    #[cfg_attr(
+        feature = "stretch-signalsmith",
+        case::signalsmith_maximum(StretchKind::Signalsmith, 4.0)
+    )]
+    #[cfg_attr(
+        feature = "stretch-bungee",
+        case::bungee_minimum(StretchKind::Bungee, 0.05)
+    )]
+    #[cfg_attr(
+        feature = "stretch-bungee",
+        case::bungee_unity(StretchKind::Bungee, 1.0)
+    )]
+    #[cfg_attr(
+        feature = "stretch-bungee",
+        case::bungee_maximum(StretchKind::Bungee, 4.0)
+    )]
+    fn terminal_flush_drains_through_caller_sized_quantums(
+        #[case] backend: StretchKind,
+        #[case] rate: f64,
+    ) {
+        const OUTPUT_FRAMES: usize = 8_000;
+        const MAX_SOURCE_FRAMES: usize = OUTPUT_FRAMES * 4;
+
+        let mut engine = prepared_backend(backend, MAX_SOURCE_FRAMES, OUTPUT_FRAMES);
+        let capabilities = engine.capabilities();
+        let source_frames = source_frames_at(rate, OUTPUT_FRAMES, false);
+        let request = ElasticRequest::new(source_frames, OUTPUT_FRAMES)
+            .expect("the exact-rate request is non-empty");
+        let marker_frames = rate_aware_terminal_source_frames(capabilities, request);
+        let source = terminal_marker_signal_with_span(source_frames, marker_frames);
+        let mut output = vec![0.0; OUTPUT_FRAMES * CHANNELS];
+        engine
+            .process(request, &source, &mut output)
+            .expect("the source block renders");
+
+        let latency = capabilities.latency();
+        let expected_frames = latency
+            .source_frames()
+            .to_f64()
+            .map(|frames| (frames / rate).ceil())
+            .and_then(|frames| frames.to_usize())
+            .and_then(|frames| frames.checked_add(latency.output_frames()))
+            .expect("the terminal span fits in usize");
+        let mut quantum = [0.0; CONTROL_QUANTUM * CHANNELS];
+        let mut terminal = Vec::with_capacity(expected_frames * CHANNELS);
+        let max_steps = expected_frames.div_ceil(CONTROL_QUANTUM);
+
+        for _ in 0..max_steps {
+            quantum.fill(0.0);
+            let step = engine
+                .flush(&mut quantum)
+                .expect("terminal flush accepts caller-sized storage");
+            assert!(step.frames() > 0, "an active drain step is non-empty");
+            assert!(
+                step.frames() <= CONTROL_QUANTUM,
+                "a terminal drain step must fit the caller quantum: backend={backend:?}, rate={rate}, frames={}",
+                step.frames()
+            );
+            terminal.extend_from_slice(&quantum[..step.frames() * CHANNELS]);
+            if step.complete() {
+                let completed = engine
+                    .flush(&mut quantum)
+                    .expect("a completed drain remains queryable");
+                assert_eq!(completed.frames(), 0);
+                assert!(completed.complete());
+                assert!(
+                    terminal_pattern_is_valid(&terminal, expected_frames),
+                    "Q64 drain must preserve the complete ordered terminal PCM: backend={backend:?}, rate={rate}, drained={}",
+                    terminal.len() / CHANNELS
+                );
+                return;
+            }
+        }
+
+        panic!(
+            "terminal drain must complete within its exact frame bound: backend={backend:?}, rate={rate}, expected={expected_frames}, drained={}",
+            terminal.len() / CHANNELS
+        );
+    }
+
+    #[kithara::test]
+    #[cfg_attr(
+        feature = "stretch-signalsmith",
         case::signalsmith(StretchKind::Signalsmith)
     )]
     #[cfg_attr(feature = "stretch-bungee", case::bungee(StretchKind::Bungee))]
     fn terminal_flush_reaches_each_new_rate_within_declared_latency(#[case] backend: StretchKind) {
         const OUTPUT_FRAMES: usize = 8192;
         const MAX_SOURCE_FRAMES: usize = OUTPUT_FRAMES * 2;
-        const SETTLED_LANDMARKS: [usize; 4] = [8, 9, 10, 11];
-
         for (initial_is_minimum, settled_is_minimum) in [(true, false), (false, true)] {
             let mut engine = prepared_backend_with_rate_envelope(
                 backend,
@@ -749,7 +880,7 @@ mod facade {
 
             let settled_output_frames = capabilities.latency().output_frames();
             let settled = edge_request(capabilities, settled_output_frames, settled_is_minimum);
-            let settled_source = landmark_signal(settled.source_frames(), &SETTLED_LANDMARKS);
+            let settled_source = short_marker_signal(settled.source_frames());
             let mut settled_output = vec![0.0; settled.output_frames() * CHANNELS];
             engine
                 .process(settled, &settled_source, &mut settled_output)
@@ -765,9 +896,8 @@ mod facade {
                 "terminal drain must reach the new rate in both directions: backend={backend:?}, initial={initial:?}, settled={settled:?}"
             );
             assert!(
-                landmarks_appear_once_in_order(&settled_and_terminal, &SETTLED_LANDMARKS,),
-                "exactly one latency window must apply the new mapping and reach every ordered landmark through the end of its source: backend={backend:?}, initial={initial:?}, settled={settled:?}, sequence={:?}",
-                dominant_landmark_sequence(&settled_and_terminal, &SETTLED_LANDMARKS,),
+                short_marker_is_present(&settled_and_terminal),
+                "exactly one latency window must apply the new mapping and reach the terminal source marker: backend={backend:?}, initial={initial:?}, settled={settled:?}",
             );
         }
     }
@@ -831,8 +961,6 @@ mod facade {
         const MAX_SOURCE_FRAMES: usize = OUTPUT_FRAMES * 2;
         const INITIAL_LANDMARKS: usize = 8;
         const LANDMARKS_PER_INITIAL_BLOCK: usize = 2;
-        const TOTAL_LANDMARKS: usize = INITIAL_LANDMARKS + 1;
-
         for initial_is_slow in [true, false] {
             let mut engine = prepared_backend(backend, MAX_SOURCE_FRAMES, OUTPUT_FRAMES);
             let capabilities = engine.capabilities();
@@ -868,20 +996,24 @@ mod facade {
             let transition =
                 ElasticRequest::new(transition_source_frames, transition_output_frames)
                     .expect("the short transition request is valid");
-            let transition_landmarks = (INITIAL_LANDMARKS..TOTAL_LANDMARKS).collect::<Vec<_>>();
-            let source = landmark_signal(transition.source_frames(), &transition_landmarks);
+            let source = short_marker_signal(transition.source_frames());
             let mut output = vec![0.0; transition.output_frames() * CHANNELS];
             engine
                 .process(transition, &source, &mut output)
                 .expect("the short adjacent-rate block renders");
-            rendered.extend_from_slice(&output);
-            rendered.extend_from_slice(&drain_terminal(engine.as_mut()));
+            let mut transition_and_terminal = output;
+            transition_and_terminal.extend_from_slice(&drain_terminal(engine.as_mut()));
+            rendered.extend_from_slice(&transition_and_terminal);
 
-            let expected = (0..TOTAL_LANDMARKS).collect::<Vec<_>>();
+            let expected = (0..INITIAL_LANDMARKS).collect::<Vec<_>>();
             assert!(
                 landmarks_appear_once_in_order(&rendered, &expected),
-                "transitional EOF must preserve every unique position landmark exactly once and in order: backend={backend:?}, initial={initial:?}, transition={transition:?}, sequence={:?}",
+                "transitional EOF must preserve every indexed source landmark exactly once and in order: backend={backend:?}, initial={initial:?}, transition={transition:?}, sequence={:?}",
                 dominant_landmark_sequence(&rendered, &expected),
+            );
+            assert!(
+                short_marker_is_present(&transition_and_terminal),
+                "transitional EOF must preserve the short terminal source marker: backend={backend:?}, initial={initial:?}, transition={transition:?}"
             );
         }
     }
@@ -892,7 +1024,7 @@ mod facade {
         case::signalsmith(StretchKind::Signalsmith)
     )]
     #[cfg_attr(feature = "stretch-bungee", case::bungee(StretchKind::Bungee))]
-    fn flush_rejects_wrong_storage_without_disarming_tail(#[case] backend: StretchKind) {
+    fn flush_rejects_partial_frame_storage_without_disarming_tail(#[case] backend: StretchKind) {
         const FRAMES: usize = 8192;
 
         let mut engine = prepared_backend(backend, FRAMES, FRAMES);
@@ -902,27 +1034,25 @@ mod facade {
         engine
             .process(request, &source, &mut output)
             .expect("the source block renders");
-        let tail_frames = engine.capabilities().terminal_chunk_frames();
-        let tail_samples = tail_frames * CHANNELS;
-        let mut short = vec![0.0; tail_samples - CHANNELS];
+        let mut partial_frame = vec![0.0; CONTROL_QUANTUM * CHANNELS - 1];
 
         let error = engine
-            .flush(&mut short)
-            .expect_err("an armed tail requires latency-sized storage");
+            .flush(&mut partial_frame)
+            .expect_err("an armed tail requires whole-frame storage");
 
         assert_eq!(
             error,
             ElasticError::OutputSampleCount {
-                actual: short.len(),
-                expected: tail_samples,
+                actual: partial_frame.len(),
+                expected: CONTROL_QUANTUM * CHANNELS,
             }
         );
-        let mut terminal = vec![0.0; tail_samples];
+        let mut terminal = vec![0.0; CONTROL_QUANTUM * CHANNELS];
         let drained = engine
             .flush(&mut terminal)
             .expect("the rejected call keeps the tail armed");
         assert!(drained.frames() > 0);
-        assert!(drained.frames() <= tail_frames);
+        assert!(drained.frames() <= CONTROL_QUANTUM);
     }
 
     #[kithara::test]
@@ -933,8 +1063,7 @@ mod facade {
     #[cfg_attr(feature = "stretch-bungee", case::bungee(StretchKind::Bungee))]
     fn fresh_engine_has_no_terminal_tail(#[case] backend: StretchKind) {
         let mut engine = prepared_backend(backend, 8192, 8192);
-        let terminal_samples = engine.capabilities().terminal_chunk_frames() * CHANNELS;
-        let mut terminal = vec![0.0; terminal_samples];
+        let mut terminal = vec![0.0; CONTROL_QUANTUM * CHANNELS];
 
         let step = engine.flush(&mut terminal).expect("fresh terminal drain");
 
@@ -959,8 +1088,7 @@ mod facade {
             .process(request, &source, &mut output)
             .expect("the source block renders");
         engine.reset().expect("the engine clears its history");
-        let terminal_samples = engine.capabilities().terminal_chunk_frames() * CHANNELS;
-        let mut terminal = vec![0.0; terminal_samples];
+        let mut terminal = vec![0.0; CONTROL_QUANTUM * CHANNELS];
 
         let step = engine.flush(&mut terminal).expect("reset terminal drain");
 
@@ -979,7 +1107,9 @@ mod facade {
         const SHORT_FRAMES: usize = 4096;
 
         let mut engine = prepared_backend(backend, LONG_FRAMES, LONG_FRAMES);
+        let mut fresh = prepared_backend(backend, LONG_FRAMES, LONG_FRAMES);
         let capabilities = engine.capabilities();
+        assert_eq!(fresh.capabilities(), capabilities);
         let source = interleaved_signal(LONG_FRAMES);
         let mut output = vec![0.0; LONG_FRAMES * CHANNELS];
         engine
@@ -992,22 +1122,19 @@ mod facade {
         assert!(output.iter().any(|sample| sample.abs() > f32::EPSILON));
 
         engine.reset().expect("the engine clears its history");
-        output[..SHORT_FRAMES * CHANNELS].fill(f32::NAN);
+        let request = ElasticRequest::new(SHORT_FRAMES, SHORT_FRAMES).expect("unity request");
+        let short_source = &source[..SHORT_FRAMES * CHANNELS];
+        let mut reset_output = vec![f32::NAN; SHORT_FRAMES * CHANNELS];
+        let mut fresh_output = vec![f32::NAN; SHORT_FRAMES * CHANNELS];
         engine
-            .process(
-                ElasticRequest::new(SHORT_FRAMES, SHORT_FRAMES).expect("unity request"),
-                &source[..SHORT_FRAMES * CHANNELS],
-                &mut output[..SHORT_FRAMES * CHANNELS],
-            )
+            .process(request, short_source, &mut reset_output)
             .expect("the request after reset is supported");
+        fresh
+            .process(request, short_source, &mut fresh_output)
+            .expect("the fresh reference request is supported");
 
         assert_eq!(engine.capabilities(), capabilities);
-        assert!(
-            output[..SHORT_FRAMES * CHANNELS]
-                .iter()
-                .all(|sample| sample.abs() <= f32::EPSILON),
-            "a reset engine must start from its own latency again"
-        );
+        assert_exact_samples(&reset_output, &fresh_output);
     }
 
     #[kithara::test]
@@ -1887,11 +2014,11 @@ mod priming {
 #[kithara::test]
 #[cfg_attr(
     feature = "stretch-signalsmith",
-    case::signalsmith(StretchKind::Signalsmith, 2_880, 2_880)
+    case::signalsmith(StretchKind::Signalsmith, 208, 208)
 )]
 #[cfg_attr(
     feature = "stretch-bungee",
-    case::bungee(StretchKind::Bungee, 2_048, 7_168)
+    case::bungee(StretchKind::Bungee, 256, 896)
 )]
 fn backend_declares_its_prepared_domain_and_latency(
     #[case] backend: StretchKind,

--- a/crates/kithara-stretch/tests/elastic.rs
+++ b/crates/kithara-stretch/tests/elastic.rs
@@ -4,12 +4,12 @@
 //! mandatory priming lifecycle.
 //! Every observable lifecycle and audio behavior is shared; backend-specific
 //! tests cover only private preparation and storage mechanics.
-use std::{f32::consts::TAU, ops::RangeInclusive};
+use std::{f32::consts::TAU, num::NonZeroUsize, ops::RangeInclusive};
 
 use kithara_bufpool::testing::{pools as default_pools, pools_with_budget as pools};
 use kithara_stretch::{
-    ElasticCapabilities, ElasticConfig, ElasticEngine, ElasticError, ElasticRequest,
-    ElasticSpanConfig, StretchKind, build_engine,
+    BungeeConfig, ElasticBackendConfig, ElasticCapabilities, ElasticConfig, ElasticEngine,
+    ElasticError, ElasticRequest, ElasticSpanConfig, SignalsmithConfig, StretchKind, build_engine,
 };
 use kithara_test_utils::kithara;
 use num_traits::ToPrimitive;
@@ -28,6 +28,20 @@ const TERMINAL_HIGH_HZ: f64 = 6_000.0;
 const TERMINAL_LOW_HZ: f64 = 1_500.0;
 const TERMINAL_WINDOW_FRAMES: usize = 64;
 
+fn conformance_backends() -> ElasticBackendConfig {
+    let signalsmith = SignalsmithConfig::builder()
+        .block_frames(NonZeroUsize::new(416).expect("fixture block is non-zero"))
+        .interval_frames(NonZeroUsize::new(64).expect("fixture interval is non-zero"))
+        .build();
+    let bungee = BungeeConfig::builder()
+        .log2_synthesis_hop_adjust(-3)
+        .build();
+    ElasticBackendConfig::builder()
+        .signalsmith(signalsmith)
+        .bungee(bungee)
+        .build()
+}
+
 fn prepared_backend(
     backend: StretchKind,
     max_source_frames: usize,
@@ -35,6 +49,7 @@ fn prepared_backend(
 ) -> Box<dyn ElasticEngine> {
     let config = ElasticConfig::builder()
         .backend(backend)
+        .backends(conformance_backends())
         .pools(default_pools())
         .sample_rate(SAMPLE_RATE)
         .channels(CHANNELS)
@@ -53,6 +68,7 @@ fn prepared_backend_with_rate_envelope(
 ) -> Box<dyn ElasticEngine> {
     let config = ElasticConfig::builder()
         .backend(backend)
+        .backends(conformance_backends())
         .pools(default_pools())
         .sample_rate(SAMPLE_RATE)
         .channels(CHANNELS)
@@ -1149,6 +1165,7 @@ mod facade {
 
         let config = ElasticConfig::builder()
             .backend(backend)
+            .backends(conformance_backends())
             .pools(default_pools())
             .sample_rate(SAMPLE_RATE)
             .channels(1)
@@ -2094,6 +2111,7 @@ fn unprimed_render_exposes_the_declared_total_latency(#[case] backend: StretchKi
 fn prepare_uses_the_injected_pool_region_budget(#[case] backend: StretchKind) {
     let config = ElasticConfig::builder()
         .backend(backend)
+        .backends(conformance_backends())
         .pools(pools(0))
         .sample_rate(SAMPLE_RATE)
         .channels(CHANNELS)
@@ -2120,6 +2138,7 @@ fn config_rejects_channels_outside_audio_spec_range(#[case] backend: StretchKind
 
     let result = ElasticConfig::builder()
         .backend(backend)
+        .backends(conformance_backends())
         .pools(default_pools())
         .sample_rate(SAMPLE_RATE)
         .channels(channels)
@@ -2140,6 +2159,7 @@ fn bungee_pool_usage_scales_with_the_prepared_source_limit() {
         let pools = pools(usize::MAX);
         let config = ElasticConfig::builder()
             .backend(StretchKind::Bungee)
+            .backends(conformance_backends())
             .pools(pools.clone())
             .sample_rate(SAMPLE_RATE)
             .channels(CHANNELS)

--- a/crates/kithara-warp/src/warp/render/renderer_lifecycle.rs
+++ b/crates/kithara-warp/src/warp/render/renderer_lifecycle.rs
@@ -156,17 +156,16 @@ where
         if !self.active {
             return Ok(true);
         }
-        let tail_frames = self
+        let frame_limit = self
             .engine
             .as_ref()
             .ok_or(ElasticError::EnginePreparation("engine is unavailable"))?
             .capabilities()
-            .terminal_chunk_frames();
-        let tail_samples = SampleCount::new(
-            tail_frames
-                .checked_mul(channels)
-                .ok_or(ElasticError::SampleCountOverflow)?,
-        );
+            .latency()
+            .output_frames();
+        let sample_limit = frame_limit
+            .checked_mul(channels)
+            .ok_or(ElasticError::SampleCountOverflow)?;
         let scratch = self
             .scratch
             .as_mut()
@@ -174,28 +173,23 @@ where
                 "output scratch is unavailable",
             ))?;
         let start = scratch.len();
-        let end = start
-            .checked_add(tail_samples.get())
-            .ok_or(ElasticError::SampleCountOverflow)?;
-        if end > scratch.capacity() {
-            return Err(ElasticError::OutputFrameLimit {
-                frames: end / channels,
-                limit: scratch.capacity() / channels,
-            });
+        if start >= sample_limit {
+            return Ok(false);
         }
         scratch
-            .ensure_len(end)
+            .ensure_len(sample_limit)
             .map_err(|_| ElasticError::PoolCapacity)?;
         let drain = self
             .engine
             .as_mut()
             .ok_or(ElasticError::EnginePreparation("engine is unavailable"))?
-            .flush(&mut scratch[start..end])?;
+            .flush(&mut scratch[start..sample_limit])?;
         let rendered_frames = FrameCount::new(drain.frames());
-        if rendered_frames.get() > tail_frames {
+        let available_frames = (sample_limit - start) / channels;
+        if rendered_frames.get() > available_frames {
             return Err(ElasticError::EngineOutputFrameCount {
                 actual: rendered_frames.get(),
-                expected: tail_frames,
+                expected: available_frames,
             });
         }
         let rendered_samples = rendered_frames

--- a/crates/kithara-warp/src/warp/render/renderer_target.rs
+++ b/crates/kithara-warp/src/warp/render/renderer_target.rs
@@ -80,7 +80,6 @@ where
         let capabilities = engine.capabilities();
         capabilities
             .max_output_frames()
-            .max(capabilities.terminal_chunk_frames().saturating_add(1))
             .checked_mul(usize::from(spec.channels.max(1)))
             .map(SampleCount::new)
             .ok_or(ElasticError::SampleCountOverflow)


### PR DESCRIPTION
## Summary
This extracts the final PR #232 stretch-backend responsibility onto current main, then fixes the backend-quality regression exposed by exact base/head CI. Backend geometry has one Bon-configured owner, explicit overrides remain available, native quality presets remain the product default, and terminal draining is a caller-sized streaming contract that preserves exact tails.

## Behavior / scope
- contract or behavior: `ElasticConfig` carries `ElasticBackendConfig`; Signalsmith defaults to its sample-rate-derived native preset and Bungee defaults to zero synthesis-hop adjustment
- contract or behavior: custom Signalsmith block/interval geometry must be supplied as a complete pair
- contract or behavior: `ElasticEngine::flush` accepts any non-empty whole-frame caller buffer and reports bounded progress through the final non-empty completed step
- contract or behavior: Bungee preparation and its unit coverage share the single `StreamCore::PIPELINE_GRAINS` invariant
- affected area: `kithara-stretch` backend construction/conformance and the existing Warp terminal-drain/EOF frontier
- extraction base: `1a093f7481f303c74a3ff7fa8cad2446b0ae0a21`
- pushed head: `79bba4a68`
- final-tree source: PR #232 at `9e8dc041709b2660b00bd1f6ec74527a086ac420`

### Final-tree certificate
- changed-path allowlist: `crates/kithara-stretch/CONTEXT.md`; `src/backends/bungee/{drain,elastic,ffi,stream}.rs`; `src/backends/signalsmith.rs`; `src/elastic/{capabilities,config,engine,mod,rate}.rs`; `src/lib.rs`; `tests/elastic.rs`; `crates/kithara-warp/src/warp/render/{renderer_lifecycle,renderer_target}.rs`
- included: caller-sized exact drain; exact rate/capability bounds; Signalsmith incremental terminal state; Bungee settled-tail progress; backend config ownership; backend construction from config; backend-parity conformance cases; Warp native-output-latency drain cadence
- corrected from the final #232 snapshot: `224/32/-4` product defaults were rejected by exact CI because they introduced keylock-quality and route-resume failures; configuration remains, but native quality defaults are restored
- superseded: instrumentation-only attributes are already owned by merged tooling commit `19ddff4b2`
- reassigned, not copied: public `largest_request_at` and its large-request `kind_tests` case remain owned by E6, where Warp planning first consumes them
- no Player, Audio, Q64/ring, scheduler, smoothing, producer-pacing, UI, or rate-response hunks are included
- history pointers `7a3bfc068`, `b509e4d12`, `f07fcb367`, `e551c4c43`, and `fb926cfbf` were used only for discovery, never as transfer units

### Product-parameter audit
- config owner: `ElasticBackendConfig` with `SignalsmithConfig` and `BungeeConfig`
- default owner: Signalsmith native sample-rate preset; Bungee native hop adjustment `0`
- explicit override: conformance tests inject `416/64/-3`; custom geometry is never hidden in backend-local constants
- fixed Bungee pipeline depth is owned once by `StreamCore::PIPELINE_GRAINS`; latency probing, draining, rendering, priming, and unit coverage consume that invariant rather than exposing a false tuning knob
- rejected regression: Bungee documents non-zero hop as a quality tradeoff; exact CI showed the former `-3/-4` defaults break the shipping audio contract

## Validation
- dual-backend stretch suite: 117 passed
- default-config invariants: 4 passed
- Warp live-keylock matrix: 2 passed
- original CI regression matrix (active no-SYNC plus route change, both backends): 4 passed
- `just fmt check`
- scoped Clippy for `kithara-stretch` and `kithara-warp`, both backends, all targets, `-D warnings`
- pre-commit gate: passed
- exact-base CI `33691215815`: green; real-clock 3909/3909 in 672.267s, simulated-clock 3966/3966 in 180.862s
- rejected head `729a87459`, CI `33693841299`: real-clock 4 failures in 653.869s; simulated-clock 2 failures in 219.038s
- previous exact-head non-UI CI `33696788008`: green; real-clock 3920/3920 in 600.017s, simulated-clock 3977/3977 in 124.520s; the first changed observable versus exact base is +11 tests in each lane, while execution time improves by 72.250s real and 56.342s simulated
- current head `79bba4a68`, exact-head CI `33721401298`: green; real-clock 3920/3920 in 612.306s, simulated-clock 3977/3977 in 155.749s; 2 simulated-clock tests were retried and passed

## Surface impact
- Public API: changed: backend geometry is configurable through `ElasticConfig`; optional Signalsmith geometry selects either the native preset or one complete custom pair; terminal output capacity is caller-owned
- Platform/runtime: changed: native Signalsmith and Bungee construction and terminal draining
- Perf-sensitive paths: changed: time-stretch backend setup and terminal drain only

## Risks / follow-ups
- E6 owns Warp quantum planning, `largest_request_at`, smoothing, and parameterized planner tests
- Q64 admission, Player cadence, latest-wins rate response, producer pacing, and UI remain outside this slice
