### PR TITLE
chore(style): make the CONTEXT.md size budget a hard deny

### DIFF
--- a/.config/style/thresholds.toml
+++ b/.config/style/thresholds.toml
@@ -79,8 +79,8 @@ deny = 4000
 
 [[doc_size.limits]]
 globs = ["**/CONTEXT.md"]
-warn = 24000
-deny = 48000
+warn = 20000
+deny = 24000
 
 [[doc_size.limits]]
 globs = ["docs/guides/**/*.md"]


### PR DESCRIPTION
## Why

A warn never fails. `Baseline::diff` (`crates/kithara-devtools/src/common/baseline.rs`) pushes a violation into `new_violations` only when its severity is `Deny`, and only `new_violations` or `regressions` make `has_failures()` true. The `**/CONTEXT.md` budget was `warn = 24000` / `deny = 48000`, so a crate contract could grow to 48 KB with nothing but a printed line to show for it — and 48 KB is roughly twice the size at which a contract stops fitting an agent's reading budget.

## What

`**/CONTEXT.md` is now `warn = 20000` / `deny = 24000`: 24 KB is the ceiling and it denies, 20 KB is the early signal.

## Effect on `main`

`just lint style --check doc_size` on this branch:

```
summary: 0 deny, 6 warn, 0 regression(s), 0 new across 1 check(s).
```

Six contracts stand in the warn band (`kithara-play` 21324, `kithara-audio` 21018, `kithara-platform` 20994, `kithara-hls` 20967, `kithara-devtools` 20965, `kithara-assets` 20925). None of them deny, and `.config/style/baseline.toml` gains no entry.

## Validation

- `just lint style --check doc_size` — 0 deny, 6 warn
- `just lint fast` via the commit hook — passed