### PR TITLE
feat(play,warp): add opt-in pooled render staging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,9 @@ Every fact below has one owner. Link to the owner; do not restate it.
 - Use repo harnesses for acceptance and formatting: `just test` and `just fmt`.
   Raw `cargo test`, `cargo nextest`, or direct formatter commands are scoped
   probes only, not final validation claims.
+- Production types and functions must not gain fields, methods, or behavior
+  solely for tests. Attach USDT probes only to real operations; never add a
+  no-op function just to expose a probe point.
 - Do not preserve backward compatibility.
 
 ## Command Routing

--- a/crates/kithara-app/src/deck.rs
+++ b/crates/kithara-app/src/deck.rs
@@ -8,6 +8,7 @@ use kithara::{
         effects::eq::generate_log_spaced_bands,
     },
     queue::QueueConfig,
+    warp::WarpConfig,
 };
 
 use crate::{
@@ -104,7 +105,11 @@ impl Deck {
                 .crossfade_duration(config.crossfade_seconds)
                 .eq_layout(generate_log_spaced_bands(config.eq_bands))
                 .sample_rate(host.requested_sample_rate())
-                .timestretch(Arc::clone(&timestretch))
+                .warp(
+                    WarpConfig::builder()
+                        .stretch(Arc::clone(&timestretch))
+                        .build(),
+                )
                 .worker(config.worker.clone())
                 .build(),
         );
@@ -327,7 +332,11 @@ mod tests {
             PlayerConfig::builder()
                 .cancel(cancel.clone())
                 .sample_rate(host.requested_sample_rate())
-                .timestretch(Arc::clone(&timestretch))
+                .warp(
+                    WarpConfig::builder()
+                        .stretch(Arc::clone(&timestretch))
+                        .build(),
+                )
                 .worker(worker.clone())
                 .build(),
         );

--- a/crates/kithara-audio/src/audio/build.rs
+++ b/crates/kithara-audio/src/audio/build.rs
@@ -201,6 +201,7 @@ where
     #[kithara::measure(label = "audio.prepare")]
     pub async fn prepare<B, S>(
         config: AudioConfig<T, B>,
+        audio_buffer_chunks: usize,
         wake: Arc<dyn WorkerWake>,
         pools: PoolRegion<S>,
     ) -> Result<PreparedAudio<Self, impl crate::AudioSource<Chunk = AudioChunk>>, DecodeError>
@@ -212,7 +213,7 @@ where
             hint,
             host_sample_rate: config_host_sr,
             media_info: user_media_info,
-            audio_buffer_chunks,
+            audio_buffer_chunks: _,
             observer,
             decoder,
             preload_chunks,

--- a/crates/kithara-audio/src/pipeline/config/audio.rs
+++ b/crates/kithara-audio/src/pipeline/config/audio.rs
@@ -11,6 +11,12 @@ use crate::{pipeline::config::AudioDecoderConfig, traits::AudioObserver};
 struct Consts;
 
 impl Consts {
+    /// Output ring depth. wasm needs a deeper ring because its worker is
+    /// scheduled coarsely.
+    #[cfg(not(target_arch = "wasm32"))]
+    const AUDIO_BUFFER_CHUNKS: usize = 10;
+    #[cfg(target_arch = "wasm32")]
+    const AUDIO_BUFFER_CHUNKS: usize = 32;
     /// Chunks buffered before preload readiness is signalled.
     const PRELOAD_CHUNKS: usize = 3;
 }
@@ -81,10 +87,10 @@ pub struct AudioConfig<T: StreamType, B = NoResamplerBackend> {
     #[builder(default)]
     #[field(get)]
     pub(crate) block_on_underrun: bool,
-    /// Explicit output-ring depth in producer chunks. `None` lets the playback
-    /// composition root preserve its frame horizon after Warp partitioning.
+    /// Output-ring depth in producer chunks.
+    #[builder(default = Consts::AUDIO_BUFFER_CHUNKS)]
     #[field(get, copy)]
-    pub(crate) audio_buffer_chunks: Option<usize>,
+    pub(crate) audio_buffer_chunks: usize,
 }
 
 impl<T, B> AudioConfig<T, B>

--- a/crates/kithara-audio/src/pipeline/config/audio.rs
+++ b/crates/kithara-audio/src/pipeline/config/audio.rs
@@ -11,12 +11,6 @@ use crate::{pipeline::config::AudioDecoderConfig, traits::AudioObserver};
 struct Consts;
 
 impl Consts {
-    /// PCM ring depth, ~100 ms per chunk. wasm needs a deeper ring because
-    /// its worker is scheduled coarsely.
-    #[cfg(not(target_arch = "wasm32"))]
-    const PCM_BUFFER_CHUNKS: usize = 10;
-    #[cfg(target_arch = "wasm32")]
-    const PCM_BUFFER_CHUNKS: usize = 32;
     /// Chunks buffered before preload readiness is signalled.
     const PRELOAD_CHUNKS: usize = 3;
 }
@@ -87,11 +81,10 @@ pub struct AudioConfig<T: StreamType, B = NoResamplerBackend> {
     #[builder(default)]
     #[field(get)]
     pub(crate) block_on_underrun: bool,
-    /// PCM buffer size in chunks (~100ms per chunk = 10 chunks ≈ 1s).
-    /// Default: 10 on native, 32 on wasm32.
-    #[builder(default = Consts::PCM_BUFFER_CHUNKS)]
-    #[field(get)]
-    pub(crate) audio_buffer_chunks: usize,
+    /// Explicit output-ring depth in producer chunks. `None` lets the playback
+    /// composition root preserve its frame horizon after Warp partitioning.
+    #[field(get, copy)]
+    pub(crate) audio_buffer_chunks: Option<usize>,
 }
 
 impl<T, B> AudioConfig<T, B>

--- a/crates/kithara-audio/src/pipeline/config/tests.rs
+++ b/crates/kithara-audio/src/pipeline/config/tests.rs
@@ -39,6 +39,17 @@ mod native {
     }
 
     #[kithara::test]
+    fn audio_config_keeps_the_native_ring_and_preload_defaults() {
+        let config = AudioConfig::<kithara_file::File<TestPools>, NoResamplerBackend>::for_stream(
+            file_config(),
+        )
+        .build();
+
+        assert_eq!(config.audio_buffer_chunks(), 10);
+        assert_eq!(config.preload_chunks().get(), 3);
+    }
+
+    #[kithara::test]
     fn audio_config_observer_is_optional_and_configurable() {
         let default = AudioConfig::<kithara_file::File<TestPools>, NoResamplerBackend>::for_stream(
             file_config(),

--- a/crates/kithara-audio/src/producer/lane.rs
+++ b/crates/kithara-audio/src/producer/lane.rs
@@ -48,20 +48,11 @@ impl ProducerPort {
 
     delegate::delegate! {
         to self.outlet {
-            /// Forward a parked item after the consumer frees ring capacity.
+            /// Report whether one item can enter the final playback ring directly.
             #[must_use]
-            pub fn flush(&mut self) -> bool;
-            /// Push one produced item into the final playback ring.
-            #[call(try_push)]
-            #[expr($.is_ok())]
-            #[must_use]
-            pub fn try_push(&mut self, item: Fetch<AudioChunk>) -> bool;
-            /// Report whether one item is parked in the overflow slot.
-            #[must_use]
-            pub const fn has_pending(&self) -> bool;
-            /// Remove the item parked in the overflow slot.
-            #[must_use]
-            pub const fn take_pending(&mut self) -> Option<Fetch<AudioChunk>>;
+            pub fn can_push_direct(&self) -> bool;
+            /// Push one produced item directly into the final playback ring.
+            pub fn push_direct(&mut self, item: Fetch<AudioChunk>);
             /// Deliver deferred wake signals outside the checked producer core.
             #[call(flush_wake_signals)]
             pub fn flush_wake(&self);

--- a/crates/kithara-audio/src/runtime/ports.rs
+++ b/crates/kithara-audio/src/runtime/ports.rs
@@ -55,6 +55,27 @@ impl<T> Outlet<T> {
         self.push_or_park(item)
     }
 
+    /// Whether one item can enter the ring without occupying overflow.
+    pub(crate) fn can_push_direct(&self) -> bool {
+        self.overflow.is_none() && !self.producer.is_full()
+    }
+
+    /// Push directly into the ring without using overflow.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the single producer did not reserve ring capacity first.
+    pub(crate) fn push_direct(&mut self, item: T) {
+        assert!(
+            self.overflow.is_none(),
+            "direct ring admission requires an empty overflow slot"
+        );
+        match self.try_push_ring(item) {
+            Ok(()) => {}
+            Err(_) => panic!("direct ring admission requires reserved capacity"),
+        }
+    }
+
     /// Flush any deferred work owned by the wake signal.
     pub(crate) fn flush_wake_signals(&self) {
         if let Some(wake) = &self.wake {
@@ -93,6 +114,16 @@ impl<T> Outlet<T> {
             self.overflow.is_none(),
             "push_or_park called with non-empty overflow"
         );
+        match self.try_push_ring(item) {
+            Ok(()) => true,
+            Err(item) => {
+                self.overflow = Some(item);
+                false
+            }
+        }
+    }
+
+    fn try_push_ring(&mut self, item: T) -> Result<(), T> {
         let was_empty = self.producer.is_empty();
         match self.producer.try_push(item) {
             Ok(()) => {
@@ -100,12 +131,9 @@ impl<T> Outlet<T> {
                 if was_empty {
                     self.notify_data_available();
                 }
-                true
+                Ok(())
             }
-            Err(item) => {
-                self.overflow = Some(item);
-                false
-            }
+            Err(item) => Err(item),
         }
     }
 
@@ -132,14 +160,8 @@ impl<T> Outlet<T> {
         to self.overflow {
             /// Whether an item is currently parked in the overflow slot.
             #[call(is_some)]
+            #[cfg(test)]
             pub(crate) const fn has_pending(&self) -> bool;
-            /// Discard the parked overflow item, returning it to the caller.
-            ///
-            /// Useful when a producer needs to invalidate previously enqueued data
-            /// (e.g. on a seek epoch change) without waiting for the consumer to
-            /// drain the ring.
-            #[call(take)]
-            pub(crate) const fn take_pending(&mut self) -> Option<T>;
         }
     }
 }
@@ -270,14 +292,15 @@ mod tests {
     }
 
     #[kithara::test]
-    fn take_pending_clears_overflow() {
-        let (mut out, _inl) = connect::<i32>(1, None);
+    fn direct_push_never_occupies_overflow() {
+        let (mut out, mut inl) = connect::<i32>(1, None);
 
-        assert_eq!(out.try_push(1), Ok(()));
-        assert_eq!(out.try_push(2), Ok(()));
-        assert_eq!(out.take_pending(), Some(2));
+        assert!(out.can_push_direct());
+        out.push_direct(1);
+        assert!(!out.can_push_direct());
         assert!(!out.has_pending());
-        assert_eq!(out.take_pending(), None);
+        assert_eq!(inl.try_pop(), Some(1));
+        assert!(out.can_push_direct());
     }
 
     #[kithara::test]

--- a/crates/kithara-audio/src/runtime/ports.rs
+++ b/crates/kithara-audio/src/runtime/ports.rs
@@ -83,15 +83,6 @@ impl<T> Outlet<T> {
         }
     }
 
-    /// Whether both the ring buffer and the overflow slot are full.
-    ///
-    /// When `true`, the next [`try_push`](Self::try_push) is guaranteed to
-    /// return `Err`.
-    #[cfg(test)]
-    pub(crate) fn is_full(&self) -> bool {
-        self.overflow.is_some() && self.producer.is_full()
-    }
-
     fn notify(&self) {
         if let Some(wake) = &self.wake {
             wake.wake();
@@ -155,15 +146,6 @@ impl<T> Outlet<T> {
         let _ = self.push_or_park(item);
         Ok(())
     }
-
-    delegate::delegate! {
-        to self.overflow {
-            /// Whether an item is currently parked in the overflow slot.
-            #[call(is_some)]
-            #[cfg(test)]
-            pub(crate) const fn has_pending(&self) -> bool;
-        }
-    }
 }
 
 /// The input port of a node.
@@ -174,9 +156,6 @@ pub(crate) struct Inlet<T> {
 impl<T> Inlet<T> {
     delegate::delegate! {
         to self.consumer {
-            /// Check if the inlet is empty.
-            #[cfg(test)]
-            pub(crate) fn is_empty(&self) -> bool;
             /// Pop an item from the inlet. Returns `None` if empty.
             pub(crate) fn try_pop(&mut self) -> Option<T>;
         }
@@ -237,25 +216,20 @@ mod tests {
     #[kithara::test]
     fn connect_push_pop() {
         let (mut out, mut inl) = connect::<i32>(2, None);
-        assert!(inl.is_empty());
-        assert!(!out.is_full());
+        assert_eq!(inl.try_pop(), None);
 
         assert_eq!(out.try_push(1), Ok(()));
         assert_eq!(out.try_push(2), Ok(()));
         assert_eq!(out.try_push(3), Ok(()));
-        assert!(out.has_pending());
         assert_eq!(out.try_push(4), Err(4));
-        assert!(out.is_full());
 
         assert_eq!(inl.try_pop(), Some(1));
         assert_eq!(inl.try_pop(), Some(2));
         assert_eq!(inl.try_pop(), None);
 
         assert!(out.flush());
-        assert!(!out.has_pending());
         assert_eq!(inl.try_pop(), Some(3));
         assert_eq!(inl.try_pop(), None);
-        assert!(inl.is_empty());
     }
 
     #[kithara::test]
@@ -264,11 +238,9 @@ mod tests {
 
         assert_eq!(out.try_push(1), Ok(()));
         assert_eq!(out.try_push(2), Ok(()));
-        assert!(out.has_pending());
 
         assert_eq!(inl.try_pop(), Some(1));
         assert_eq!(out.try_push(3), Ok(()));
-        assert!(out.has_pending());
 
         assert_eq!(inl.try_pop(), Some(2));
         assert!(out.flush());
@@ -281,14 +253,13 @@ mod tests {
 
         assert_eq!(out.try_push(1), Ok(()));
         assert_eq!(out.try_push(2), Ok(()));
-        assert!(out.has_pending());
 
         assert!(!out.flush());
-        assert!(out.has_pending());
 
         assert_eq!(inl.try_pop(), Some(1));
         assert!(out.flush());
-        assert!(!out.has_pending());
+        assert_eq!(inl.try_pop(), Some(2));
+        assert_eq!(inl.try_pop(), None);
     }
 
     #[kithara::test]
@@ -298,8 +269,8 @@ mod tests {
         assert!(out.can_push_direct());
         out.push_direct(1);
         assert!(!out.can_push_direct());
-        assert!(!out.has_pending());
         assert_eq!(inl.try_pop(), Some(1));
+        assert_eq!(inl.try_pop(), None);
         assert!(out.can_push_direct());
     }
 

--- a/crates/kithara-bufpool/CONTEXT.md
+++ b/crates/kithara-bufpool/CONTEXT.md
@@ -79,5 +79,9 @@ collect, or pre-warm contract.
 empty guard from the same core. Long-lived storage can therefore publish one
 generation and continue without retaining the schema facade.
 
+`BufferRing<B>` is an owning FIFO view over one already-sized buffer. It never
+grows or shifts retained values; failed pushes and pops leave both sides
+unchanged, and `into_inner` returns the original pool guard to its owner.
+
 `stats()` reports the shared region budget. `pool_stats::<K>()` reports reuse for
 one registered generic slot; built-in hot-path keys compile out counter updates.

--- a/crates/kithara-bufpool/README.md
+++ b/crates/kithara-bufpool/README.md
@@ -75,6 +75,8 @@ fn build() -> Result<(), PoolError> {
 
 <tr><td><code>ByteBuffer</code> / <code>SampleBuffer</code></td><td>Checked RAII guards returned to their typed pool on drop</td></tr>
 
+<tr><td><code>BufferRing&lt;B&gt;</code></td><td>FIFO view over fixed pooled storage; pops and pushes move indices without shifting retained samples</td></tr>
+
 <tr><td><code>VecKey</code> / <code>StringKey</code></td><td>Safe registered storage shapes for crate-owned aliases</td></tr>
 
 <tr><td><code>PooledVec</code> / <code>PooledString</code></td><td>Checked guards for registered vector and UTF-8 storage</td></tr>

--- a/crates/kithara-bufpool/src/lib.rs
+++ b/crates/kithara-bufpool/src/lib.rs
@@ -11,6 +11,7 @@ mod error;
 mod key;
 mod pool;
 mod region;
+mod ring;
 mod schema;
 #[cfg(feature = "test-utils")]
 pub mod testing;
@@ -22,4 +23,5 @@ pub use error::PoolError;
 pub use key::{PoolAlias, PoolKey, PoolKeyWithLen, StringKey, VecKey};
 pub use pool::PoolStats;
 pub use region::{PoolRegion, RegionStats};
+pub use ring::BufferRing;
 pub use schema::HasPool;

--- a/crates/kithara-bufpool/src/ring.rs
+++ b/crates/kithara-bufpool/src/ring.rs
@@ -1,0 +1,144 @@
+use std::ops::{Deref, DerefMut};
+
+/// FIFO view over an owning pooled buffer.
+///
+/// The backing slice is fixed while the ring is live. Reading and writing only
+/// move indices; retained elements are never shifted.
+#[non_exhaustive]
+pub struct BufferRing<B> {
+    buffer: B,
+    head: usize,
+    len: usize,
+}
+
+impl<B> BufferRing<B> {
+    /// Wrap a buffer whose readable values occupy its prefix.
+    ///
+    /// # Errors
+    ///
+    /// Returns the unchanged owner when `len` exceeds the backing slice.
+    pub fn from_prefix<T>(buffer: B, len: usize) -> Result<Self, B>
+    where
+        B: Deref<Target = [T]> + DerefMut,
+    {
+        if len > buffer.len() {
+            return Err(buffer);
+        }
+        Ok(Self {
+            buffer,
+            head: 0,
+            len,
+        })
+    }
+
+    /// Number of readable elements.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Fixed number of elements in the backing slice.
+    #[must_use]
+    pub fn capacity<T>(&self) -> usize
+    where
+        B: Deref<Target = [T]>,
+    {
+        self.buffer.len()
+    }
+
+    /// Whether no readable elements remain.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Copy and consume the next elements without shifting the retained tail.
+    /// Returns `false` without changing either side when output exceeds the
+    /// readable length.
+    pub fn try_pop_into<T>(&mut self, output: &mut [T]) -> bool
+    where
+        T: Copy,
+        B: Deref<Target = [T]> + DerefMut,
+    {
+        if output.len() > self.len {
+            return false;
+        }
+        if output.is_empty() {
+            return true;
+        }
+        let output_len = output.len();
+        let first = output_len.min(self.buffer.len() - self.head);
+        output[..first].copy_from_slice(&self.buffer[self.head..self.head + first]);
+        output[first..].copy_from_slice(&self.buffer[..output_len - first]);
+        self.head = (self.head + output_len) % self.buffer.len();
+        self.len -= output_len;
+        if self.len == 0 {
+            self.head = 0;
+        }
+        true
+    }
+
+    /// Copy elements into the free tail without shifting readable values.
+    /// Returns `false` without changing the ring when input exceeds free space.
+    pub fn try_push<T>(&mut self, input: &[T]) -> bool
+    where
+        T: Copy,
+        B: Deref<Target = [T]> + DerefMut,
+    {
+        let capacity = self.buffer.len();
+        if input.len() > capacity - self.len {
+            return false;
+        }
+        if input.is_empty() {
+            return true;
+        }
+        let tail = (self.head + self.len) % capacity;
+        let first = input.len().min(capacity - tail);
+        self.buffer[tail..tail + first].copy_from_slice(&input[..first]);
+        self.buffer[..input.len() - first].copy_from_slice(&input[first..]);
+        self.len += input.len();
+        true
+    }
+
+    /// Return the owning pooled buffer.
+    #[must_use]
+    pub fn into_inner(self) -> B {
+        self.buffer
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use kithara_test_utils::kithara;
+
+    use super::BufferRing;
+
+    #[kithara::test]
+    fn wraps_without_shifting_retained_values() {
+        let Err(rejected) = BufferRing::from_prefix(vec![9], 2) else {
+            panic!("an oversized prefix must return its owner");
+        };
+        assert_eq!(rejected, [9]);
+        let mut empty = BufferRing::from_prefix(Vec::<i32>::new(), 0)
+            .unwrap_or_else(|_| panic!("an empty prefix fits empty storage"));
+        assert!(empty.try_pop_into(&mut []));
+        assert!(empty.try_push(&[]));
+
+        let mut ring = BufferRing::from_prefix(vec![1, 2, 3, 0], 3)
+            .unwrap_or_else(|_| panic!("test prefix fits the backing buffer"));
+        let mut oversized = [9; 4];
+        assert!(!ring.try_pop_into(&mut oversized));
+        assert_eq!(oversized, [9; 4]);
+        let mut first = [0; 2];
+        assert!(ring.try_pop_into(&mut first));
+        assert_eq!(first, [1, 2]);
+        assert!(!ring.try_push(&[6, 7, 8, 9]));
+        assert!(ring.try_push(&[4, 5]));
+
+        let mut rest = [0; 3];
+        assert!(ring.try_pop_into(&mut rest));
+        assert_eq!(rest, [3, 4, 5]);
+        assert!(ring.is_empty());
+        assert_eq!(ring.into_inner(), [5, 2, 3, 4]);
+    }
+}

--- a/crates/kithara-host/src/session/offline.rs
+++ b/crates/kithara-host/src/session/offline.rs
@@ -37,7 +37,7 @@ enum OfflineMsg<S> {
 }
 
 struct OfflineSessionTask<S> {
-    cmd_rx: mpsc::Receiver<OfflineMsg<S>>,
+    cmd_rx: Option<mpsc::Receiver<OfflineMsg<S>>>,
     max_block_frames: NonZeroU32,
     pools: PoolRegion<S>,
     position: u64,
@@ -75,6 +75,7 @@ where
     fn tick_host(&mut self, message: HostCmdMsg<S>) -> TickResult {
         let HostCmdMsg { cmd, reply_tx } = message;
         if matches!(&cmd, HostCmd::Shutdown) {
+            drop(self.cmd_rx.take());
             self.state.take();
             if reply_tx.send(HostReply::Ok).is_err() {
                 warn!("offline Host shutdown reply receiver dropped");
@@ -168,7 +169,10 @@ where
     }
 
     fn tick(&mut self) -> TickResult {
-        match self.cmd_rx.try_recv() {
+        let Some(cmd_rx) = self.cmd_rx.as_ref() else {
+            return TickResult::Done;
+        };
+        match cmd_rx.try_recv() {
             Ok(message) => self.tick_message(message),
             Err(mpsc::TryRecvError::Disconnected) => TickResult::Done,
             Err(mpsc::TryRecvError::Empty) => {
@@ -231,7 +235,7 @@ where
                 ctx.start_stream(config).map_err(|error| error.to_string())
             };
             OfflineSessionTask {
-                cmd_rx,
+                cmd_rx: Some(cmd_rx),
                 max_block_frames,
                 pools,
                 position: 0,

--- a/crates/kithara-platform/src/flash/sync/mpsc.rs
+++ b/crates/kithara-platform/src/flash/sync/mpsc.rs
@@ -41,10 +41,12 @@ impl<T> Sender<T> {
     ///
     /// Returns [`SendError`] if the receiver has been dropped.
     pub fn send(&self, value: T) -> Result<(), SendError<T>> {
+        let mut queue = self.0.queue.lock();
         if !self.0.receiver_alive.load(Ordering::Acquire) {
             return Err(SendError(value));
         }
-        self.0.queue.lock().push_back(value);
+        queue.push_back(value);
+        drop(queue);
         // WHY: A receiver registers its condvar waiter UNDER the queue lock and releases the lock only as it parks, so this notify (which we
         // issue after releasing the lock above) can never land before the waiter is registered - no lost wakeup.
         self.0.cv.notify_one();
@@ -143,6 +145,31 @@ impl<T> Receiver<T> {
 
 impl<T> Drop for Receiver<T> {
     fn drop(&mut self) {
+        let mut queue = self.0.queue.lock();
         self.0.receiver_alive.store(false, Ordering::Release);
+        let queued = std::mem::take(&mut *queue);
+        drop(queue);
+        drop(queued);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use kithara_test_utils::kithara;
+
+    use super::{TryRecvError, channel};
+
+    #[kithara::test]
+    fn dropping_receiver_drops_queued_messages() {
+        let (outer_tx, outer_rx) = channel();
+        let (reply_tx, reply_rx) = channel::<()>();
+
+        assert!(outer_tx.send(reply_tx).is_ok());
+        drop(outer_rx);
+
+        assert!(matches!(
+            reply_rx.try_recv(),
+            Err(TryRecvError::Disconnected)
+        ));
     }
 }

--- a/crates/kithara-play/src/player/config.rs
+++ b/crates/kithara-play/src/player/config.rs
@@ -5,7 +5,7 @@ use kithara_abr::AbrController;
 use kithara_decode::GaplessMode;
 use kithara_events::EventBus;
 use kithara_platform::{CancelToken, sync::Arc};
-use kithara_warp::{BeatGridId, StretchControls};
+use kithara_warp::{BeatGridId, WarpConfig};
 
 use crate::{
     PlayWorker,
@@ -28,10 +28,9 @@ pub struct PlayerConfig<S> {
     /// Stable synchronization-group identity owned by this player.
     #[builder(default = allocate_grid_id())]
     pub(crate) grid_id: BeatGridId,
-    /// Per-deck time-stretch control handle, shared with the UI and the
-    /// worker Warp chain (see `kithara_warp::StretchControls`).
-    #[builder(default = StretchControls::new(1.0))]
-    pub(crate) timestretch: Arc<StretchControls>,
+    /// Per-deck Warp resources and live temporal controls.
+    #[builder(default = WarpConfig::builder().build())]
+    pub(crate) warp: WarpConfig,
     /// Explicit shared playback worker. Its pools and cancellation lifetime
     /// are configured once in [`crate::PlayWorkerConfig`].
     pub(crate) worker: PlayWorker<S>,
@@ -80,7 +79,7 @@ impl<S> Clone for PlayerConfig<S> {
     fn clone(&self) -> Self {
         Self {
             grid_id: self.grid_id,
-            timestretch: Arc::clone(&self.timestretch),
+            warp: self.warp.clone(),
             worker: self.worker.clone(),
             gapless_mode: self.gapless_mode,
             block_on_underrun: self.block_on_underrun,
@@ -102,6 +101,7 @@ impl<S> Clone for PlayerConfig<S> {
 impl<S> fmt::Debug for PlayerConfig<S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("PlayerConfig")
+            .field("warp", &self.warp)
             .field("gapless_mode", &self.gapless_mode)
             .field("eq_layout", &self.eq_layout)
             .field("auto_advance_enabled", &self.auto_advance_enabled)

--- a/crates/kithara-play/src/player/core.rs
+++ b/crates/kithara-play/src/player/core.rs
@@ -5,7 +5,7 @@ use delegate::delegate;
 use kithara_bufpool::{HasPool, PoolRegion};
 use kithara_decode::GaplessMode;
 use kithara_platform::sync::{Arc, Mutex};
-use kithara_warp::StretchControls;
+use kithara_warp::WarpConfig;
 use tracing::debug;
 
 use self::lifecycle::{CloseAdmission, PlayerLifecycle};
@@ -32,7 +32,7 @@ pub(crate) struct PlayerCore<S> {
     /// Constructed once and kept address-stable for the player's lifetime.
     pub(crate) engine_load: Arc<EngineLoad>,
 
-    pub(crate) timestretch: Arc<StretchControls>,
+    pub(crate) warp: WarpConfig,
     /// Undelivered resources unregister before the worker owner drops.
     pub(crate) items: ItemQueue,
     /// Host lifecycle explicitly detaches the engine session lane before the
@@ -238,7 +238,7 @@ mod tests {
     use kithara_events::{Envelope, Event};
     use kithara_platform::{CancelToken, time::Duration};
     use kithara_test_utils::kithara;
-    use kithara_warp::StretchControls;
+    use kithara_warp::{StretchControls, WarpConfig};
 
     use super::*;
     use crate::{
@@ -528,7 +528,11 @@ mod tests {
             .eq_layout(generate_log_spaced_bands(5))
             .gapless_mode(GaplessMode::MediaOnly)
             .max_slots(2)
-            .timestretch(StretchControls::new(1.0))
+            .warp(
+                WarpConfig::builder()
+                    .stretch(StretchControls::new(1.0))
+                    .build(),
+            )
             .build();
         let player = PlayerImpl::new(config);
         assert!((player.crossfade_duration() - 2.0).abs() < f32::EPSILON);
@@ -575,7 +579,7 @@ mod tests {
         assert!((player.default_rate() - 1.0).abs() < f32::EPSILON);
         player.set_default_rate(0.75);
         assert!((player.default_rate() - 0.75).abs() < f32::EPSILON);
-        assert!((player.core.timestretch.speed() - 0.75).abs() < f32::EPSILON);
+        assert!((player.core.warp.stretch().speed() - 0.75).abs() < f32::EPSILON);
         assert_eq!(player.rate(), 0.0);
     }
 
@@ -622,7 +626,7 @@ mod tests {
         let player = player();
         player.set_rate(2.0);
         assert!((player.rate() - 0.0).abs() < f32::EPSILON);
-        assert!((player.core.timestretch.speed() - 2.0).abs() < f32::EPSILON);
+        assert!((player.core.warp.stretch().speed() - 2.0).abs() < f32::EPSILON);
     }
 
     #[kithara::test]
@@ -634,11 +638,11 @@ mod tests {
                 .session(testing::test_session())
                 .build(),
         );
-        let ptr_before = Arc::as_ptr(&player.core.timestretch);
+        let ptr_before = Arc::as_ptr(player.core.warp.stretch());
         player.play();
         player.pause();
         player.play();
-        let ptr_after = Arc::as_ptr(&player.core.timestretch);
+        let ptr_after = Arc::as_ptr(player.core.warp.stretch());
         assert_eq!(
             ptr_before, ptr_after,
             "timestretch controls must stay address-stable across transitions"

--- a/crates/kithara-play/src/player/core/player.rs
+++ b/crates/kithara-play/src/player/core/player.rs
@@ -78,14 +78,14 @@ impl<S> PlayerImpl<S> {
         }
 
         // Seed the single speed source with the configured default rate.
-        config.timestretch.set_speed(config.default_rate);
+        config.warp.stretch().set_speed(config.default_rate);
         let params = PlayerParams::from(&config);
         let core = PlayerCore {
             engine,
             worker: config.worker,
             engine_load: Arc::new(EngineLoad::default()),
             params,
-            timestretch: config.timestretch,
+            warp: config.warp,
             gapless_mode: config.gapless_mode,
             block_on_underrun: config.block_on_underrun,
             status: Mutex::default(),

--- a/crates/kithara-play/src/player/flow/control.rs
+++ b/crates/kithara-play/src/player/flow/control.rs
@@ -67,7 +67,7 @@ impl<S> PlayerRuntime<S> {
     /// not a resume. The new value takes effect on the next `play()`.
     pub fn set_default_rate(&self, rate: f32) {
         let target = self.core.params.set_default_rate(rate);
-        self.core.timestretch.set_speed(target);
+        self.core.warp.stretch().set_speed(target);
         if self.phase_kind() == PlayerPhaseKind::Playing {
             self.set_rate(target);
         }
@@ -114,8 +114,8 @@ impl<S> PlayerRuntime<S> {
     /// Set the requested rate target, clamped to
     /// [`kithara_warp::StretchControls::MIN_SPEED`].
     pub fn set_rate(&self, rate: f32) {
-        self.core.timestretch.set_speed(rate);
-        let target = self.core.timestretch.speed();
+        self.core.warp.stretch().set_speed(rate);
+        let target = self.core.warp.stretch().speed();
         let _ = self.send_to_slot(PlayerCmd::SetPlaybackRate(target));
     }
 

--- a/crates/kithara-play/src/player/flow/prepare.rs
+++ b/crates/kithara-play/src/player/flow/prepare.rs
@@ -28,7 +28,7 @@ where
             .cancel
             .or_else(|| self.player.core.engine.cancel_token())
             .map(|parent| parent.child());
-        let stretch = Arc::clone(&self.player.core.timestretch);
+        let warp = self.player.core.warp.clone();
         let host_sample_rate = NonZeroU32::new(self.player.core.engine.master_sample_rate())
             .or_else(|| NonZeroU32::new(self.player.core.engine.configured_sample_rate()));
         let decoder = AudioDecoderConfig::builder()
@@ -44,7 +44,7 @@ where
             block_on_underrun: self.player.core.block_on_underrun,
             host_sample_rate,
             decoder,
-            stretch,
+            warp,
             engine_load: Some(Arc::clone(&self.player.core.engine_load)),
             ..config
         }

--- a/crates/kithara-play/src/player/flow/transport.rs
+++ b/crates/kithara-play/src/player/flow/transport.rs
@@ -77,7 +77,7 @@ where
     /// Start playback from the configured default-rate target.
     pub fn play(&self) {
         let rate = self.default_rate().max(Self::MIN_PLAYBACK_RATE);
-        self.core.timestretch.set_speed(rate);
+        self.core.warp.stretch().set_speed(rate);
 
         if let Err(e) = self.ensure_engine_started() {
             warn!(?e, "failed to start engine");
@@ -215,7 +215,7 @@ where
         }
 
         if autoplay {
-            self.core.timestretch.set_speed(self.default_rate());
+            self.core.warp.stretch().set_speed(self.default_rate());
         }
 
         self.ensure_engine_started()?;

--- a/crates/kithara-play/src/resource/build.rs
+++ b/crates/kithara-play/src/resource/build.rs
@@ -37,6 +37,9 @@ where
         observer: Option<Box<dyn AudioObserver>>,
     ) -> AudioConfig<kithara_file::File<S>, B> {
         let pools = worker.pools().clone();
+        let audio_buffer_chunks = self
+            .audio_buffer_chunks
+            .map(|chunks| chunks.max(self.preload_chunks).get());
         let (file_src, derived_hint) = match self.src {
             ResourceSrc::Url(ref url) => {
                 (FileSrc::Remote(url.clone()), derive_remote_file_hint(url))
@@ -70,6 +73,7 @@ where
             .maybe_cancel(self.cancel.clone())
             .build();
         AudioConfig::<kithara_file::File<S>, B>::for_stream(file_config)
+            .maybe_audio_buffer_chunks(audio_buffer_chunks)
             .maybe_cancel(self.cancel.clone())
             .maybe_hint(extension)
             .maybe_host_sample_rate(self.host_sample_rate)
@@ -88,6 +92,9 @@ where
         observer: Option<Box<dyn AudioObserver>>,
     ) -> Result<AudioConfig<kithara_hls::Hls<S>, B>, DecodeError> {
         let pools = worker.pools().clone();
+        let audio_buffer_chunks = self
+            .audio_buffer_chunks
+            .map(|chunks| chunks.max(self.preload_chunks).get());
         let url = match self.src {
             ResourceSrc::Url(ref url) => url.clone(),
             ResourceSrc::Path(_) => {
@@ -112,6 +119,7 @@ where
             .build();
         Ok(
             AudioConfig::<kithara_hls::Hls<S>, B>::for_stream(hls_config)
+                .maybe_audio_buffer_chunks(audio_buffer_chunks)
                 .maybe_cancel(self.cancel.clone())
                 .maybe_hint(self.hint)
                 .maybe_host_sample_rate(self.host_sample_rate)

--- a/crates/kithara-play/src/resource/config.rs
+++ b/crates/kithara-play/src/resource/config.rs
@@ -45,8 +45,8 @@ where
     /// Number of chunks to buffer before signaling preload readiness.
     #[builder(default = DEFAULT_PRELOAD_CHUNKS)]
     pub(crate) preload_chunks: NonZeroUsize,
-    /// Optional output-ring depth. Player preparation otherwise preserves the
-    /// platform frame horizon from the configured Warp quantum.
+    /// Optional output-ring depth in producer chunks.
+    /// When omitted, the audio pipeline keeps its platform default.
     pub(crate) audio_buffer_chunks: Option<NonZeroUsize>,
     /// Unified event bus for streaming, decode, and audio events.
     #[builder(name = events)]

--- a/crates/kithara-play/src/resource/config.rs
+++ b/crates/kithara-play/src/resource/config.rs
@@ -10,7 +10,7 @@ use kithara_hls::{KeyOptions, SizeProbeMethod};
 use kithara_net::Headers;
 use kithara_platform::{CancelToken, sync::Arc};
 use kithara_stream::dl::Downloader;
-use kithara_warp::StretchControls;
+use kithara_warp::WarpConfig;
 use url::Url;
 
 use super::{ResourceSrc, resampler::PlaybackResamplerBackend};
@@ -45,6 +45,9 @@ where
     /// Number of chunks to buffer before signaling preload readiness.
     #[builder(default = DEFAULT_PRELOAD_CHUNKS)]
     pub(crate) preload_chunks: NonZeroUsize,
+    /// Optional output-ring depth. Player preparation otherwise preserves the
+    /// platform frame horizon from the configured Warp quantum.
+    pub(crate) audio_buffer_chunks: Option<NonZeroUsize>,
     /// Unified event bus for streaming, decode, and audio events.
     #[builder(name = events)]
     pub(crate) bus: Option<EventBus>,
@@ -69,9 +72,9 @@ where
     pub(crate) host_sample_rate: Option<NonZeroU32>,
     /// Max bytes the downloader may be ahead of the reader before it pauses.
     pub(crate) look_ahead_bytes: Option<u64>,
-    /// Live time-stretch controls shared with the resident Warp chain.
-    #[builder(default = StretchControls::new(1.0))]
-    pub(crate) stretch: Arc<StretchControls>,
+    /// Resident Warp resources and live temporal controls.
+    #[builder(default = WarpConfig::builder().build())]
+    pub(crate) warp: WarpConfig,
     /// Explicit playback worker. Player preparation fills this field; direct
     /// Resource callers must configure it themselves.
     pub(crate) worker: Option<PlayWorker<S>>,
@@ -116,6 +119,7 @@ where
             decoder: self.decoder.clone(),
             keys: self.keys.clone(),
             preload_chunks: self.preload_chunks,
+            audio_buffer_chunks: self.audio_buffer_chunks,
             bus: self.bus.clone(),
             cancel: self.cancel.clone(),
             discriminator: self.discriminator.clone(),
@@ -126,7 +130,7 @@ where
             hls_base_url: self.hls_base_url.clone(),
             host_sample_rate: self.host_sample_rate,
             look_ahead_bytes: self.look_ahead_bytes,
-            stretch: Arc::clone(&self.stretch),
+            warp: self.warp.clone(),
             worker: self.worker.clone(),
             consumer_wake_mode: self.consumer_wake_mode,
             block_on_underrun: self.block_on_underrun,
@@ -373,7 +377,7 @@ mod tests {
     #[kithara::test]
     fn config_stretch_defaults_to_unity() {
         let config = test_config("https://example.com/song.mp3").unwrap();
-        assert!((config.stretch.speed() - 1.0).abs() < f32::EPSILON);
+        assert!((config.warp.stretch().speed() - 1.0).abs() < f32::EPSILON);
     }
 
     #[kithara::test]

--- a/crates/kithara-play/src/resource/reader.rs
+++ b/crates/kithara-play/src/resource/reader.rs
@@ -10,9 +10,7 @@ use kithara_events::EventBus;
 use kithara_platform::{CancelToken, sync::Arc, time::Duration};
 use kithara_signal::AudioSpec;
 use kithara_stream::{Stream, StreamType};
-use kithara_warp::{
-    PresentationFrontier, RenderContext, RenderPublisher, StretchControls, WarpConfig,
-};
+use kithara_warp::{PresentationFrontier, RenderContext, RenderPublisher, StretchControls};
 use tracing::warn;
 
 use super::{ResourceConfig, SourceType};
@@ -181,7 +179,7 @@ impl Resource {
         let worker = config.worker.clone().ok_or(DecodeError::InvalidData {
             detail: "ResourceConfig requires an explicit PlayWorker",
         })?;
-        let stretch = Arc::clone(&config.stretch);
+        let warp = config.warp.clone();
         let engine_load = config.engine_load.clone();
         // Capture the per-track cancel before `build_*_config` consumes `config`
         // (it is cloned by identity into both the inner stream and the Audio).
@@ -191,7 +189,7 @@ impl Resource {
                 let audio_config = config.build_file_config(&worker, observer);
                 let track = TrackConfig::for_audio(audio_config)
                     .maybe_engine_load(engine_load)
-                    .warp(WarpConfig::builder().stretch(Arc::clone(&stretch)).build())
+                    .warp(warp.clone())
                     .build();
                 Self::from_stream_audio(track, src, &worker).await?
             }
@@ -199,7 +197,7 @@ impl Resource {
                 let audio_config = config.build_hls_config(&worker, observer)?;
                 let track = TrackConfig::for_audio(audio_config)
                     .maybe_engine_load(engine_load)
-                    .warp(WarpConfig::builder().stretch(Arc::clone(&stretch)).build())
+                    .warp(warp)
                     .build();
                 Self::from_stream_audio(track, src, &worker).await?
             }
@@ -409,7 +407,7 @@ mod tests {
     use kithara_platform::{CancelToken, sync::Arc};
     use kithara_signal::AudioSpec;
     use kithara_test_utils::kithara;
-    use kithara_warp::{SessionEpoch, SessionFrame, Warp};
+    use kithara_warp::{SessionEpoch, SessionFrame, Warp, WarpConfig};
     use ringbuf::traits::{Consumer, Producer};
 
     use super::*;

--- a/crates/kithara-play/src/worker/core.rs
+++ b/crates/kithara-play/src/worker/core.rs
@@ -105,16 +105,23 @@ where
         B: Default + ResamplerBackend,
         C: Into<TrackConfig<T, B>>,
     {
+        let config = config.into();
+        let audio_buffer_chunks = config.resolved_audio_buffer_chunks();
         let TrackConfig {
             audio,
             effects,
             engine_load,
             warp,
-        } = config.into();
+        } = config;
         let task_cancel = audio.cancel().cloned();
         let wake = Wake::new(self.0.dispatcher.wake_handle());
-        let prepared =
-            Audio::<Stream<T>>::prepare(audio, Arc::new(wake), self.pools().clone()).await?;
+        let prepared = Audio::<Stream<T>>::prepare(
+            audio,
+            audio_buffer_chunks,
+            Arc::new(wake),
+            self.pools().clone(),
+        )
+        .await?;
         let drain = EffectDrain::new(effects.len(), self.pools())?;
         let prepared = prepared.map(|audio, source| {
             let spec = audio.spec();
@@ -125,6 +132,7 @@ where
                 effects,
                 drain,
                 spec,
+                self.pools().clone(),
             );
             (warp, source)
         });

--- a/crates/kithara-play/src/worker/core.rs
+++ b/crates/kithara-play/src/worker/core.rs
@@ -106,7 +106,7 @@ where
         C: Into<TrackConfig<T, B>>,
     {
         let config = config.into();
-        let audio_buffer_chunks = config.resolved_audio_buffer_chunks();
+        let audio_buffer_chunks = config.audio().audio_buffer_chunks();
         let TrackConfig {
             audio,
             effects,

--- a/crates/kithara-play/src/worker/node.rs
+++ b/crates/kithara-play/src/worker/node.rs
@@ -35,9 +35,6 @@ pub(crate) struct DecoderNode<S> {
     seek_obs: Arc<dyn SeekObserve>,
     runtime: DecoderRuntime,
     engine_load: Option<Arc<EngineLoad>>,
-    /// Chunk displaced by a seek inside the checked tick. The scheduler shell
-    /// reclaims it in `recycle` before the next tick.
-    retired_chunk: Option<AudioChunk>,
     port: ProducerPort,
     source: S,
     preload_chunks: usize,
@@ -60,7 +57,7 @@ impl<S> DecoderNode<S> {
         }
 
         self.runtime.chunks_sent += 1;
-        if self.runtime.chunks_sent >= self.preload_chunks && !self.port.has_pending() {
+        if self.runtime.chunks_sent >= self.preload_chunks {
             self.complete_preload();
         }
     }
@@ -140,14 +137,6 @@ where
             return;
         }
 
-        if let Some(Fetch::Data { data, .. }) = self.port.take_pending() {
-            if self.retired_chunk.is_some() {
-                mem::forget(data);
-                debug_assert!(false, "scheduler skipped the required post-tick recycle");
-            } else {
-                self.retired_chunk = Some(data);
-            }
-        }
         self.preload_gate.rearm();
         self.runtime = DecoderRuntime {
             seek_epoch: current,
@@ -167,7 +156,6 @@ where
             seek_obs,
             engine_load,
             source: lane.source,
-            retired_chunk: None,
             port: lane.port,
             playhead: lane.playhead,
             emit: lane.emit,
@@ -190,9 +178,6 @@ where
     }
 
     fn recycle(&mut self) {
-        if let Some(chunk) = self.retired_chunk.take() {
-            self.source.retire_chunk(chunk);
-        }
         self.port.recycle();
         let _ = self.source.prepare_deferred();
         self.source.finish_deferred();
@@ -204,7 +189,7 @@ where
     fn tick(&mut self) -> TickResult {
         self.sync_seek_epoch();
 
-        if !self.port.flush() {
+        if !self.port.can_push_direct() {
             return TickResult::Backpressured;
         }
 
@@ -228,20 +213,14 @@ where
                     ),
                     _ => (None, None),
                 };
-                if self.port.try_push(fetch) {
-                    if let Some((source_end, epoch)) = source_end {
-                        self.source.commit_source_end(source_end, epoch);
-                    }
-                    if let Some(frontier) = decoded_frontier {
-                        self.playhead.set_decoded_frontier(frontier);
-                    }
-                    self.mark_preload_progress();
-                } else {
-                    debug_assert!(
-                        false,
-                        "producer output rejected - overflow invariant violated"
-                    );
+                self.port.push_direct(fetch);
+                if let Some((source_end, epoch)) = source_end {
+                    self.source.commit_source_end(source_end, epoch);
                 }
+                if let Some(frontier) = decoded_frontier {
+                    self.playhead.set_decoded_frontier(frontier);
+                }
+                self.mark_preload_progress();
                 TickResult::Progress
             }
 
@@ -260,35 +239,20 @@ where
             TrackStep::Eof => {
                 let epoch = self.source.decode_epoch();
                 let marker = Fetch::eof(epoch);
-                if self.port.try_push(marker) {
-                    self.complete_preload();
-                    self.emit
-                        .enqueue(AudioEvent::EndOfStream { seek_epoch: epoch }.into());
-                    self.runtime.eof_sent = true;
-                    TickResult::Progress
-                } else {
-                    debug_assert!(false, "EOF marker rejected - overflow invariant violated");
-                    TickResult::Waiting
-                }
+                self.port.push_direct(marker);
+                self.complete_preload();
+                self.emit
+                    .enqueue(AudioEvent::EndOfStream { seek_epoch: epoch }.into());
+                self.runtime.eof_sent = true;
+                TickResult::Progress
             }
 
             TrackStep::Failed => {
                 let epoch = self.source.decode_epoch();
                 let marker = Fetch::failure(epoch);
-                if self.port.try_push(marker) {
-                    self.complete_preload();
-                    if self.port.has_pending() {
-                        TickResult::Progress
-                    } else {
-                        TickResult::Done
-                    }
-                } else {
-                    debug_assert!(
-                        false,
-                        "Failed marker rejected - overflow invariant violated"
-                    );
-                    TickResult::Waiting
-                }
+                self.port.push_direct(marker);
+                self.complete_preload();
+                TickResult::Done
             }
         };
         self.maybe_emit_worker_telemetry(Instant::now());

--- a/crates/kithara-play/src/worker/node.rs
+++ b/crates/kithara-play/src/worker/node.rs
@@ -1,5 +1,3 @@
-use std::mem;
-
 use kithara_audio::{
     AudioSource, Fetch, PreloadGate, PreparedAudioLane, ProducerPort, TrackStep, WaitingReason,
 };

--- a/crates/kithara-play/src/worker/node/scheduler_tests.rs
+++ b/crates/kithara-play/src/worker/node/scheduler_tests.rs
@@ -140,7 +140,6 @@ where
         emit: Arc::new(DeferredBus::<Event>::new(EventBus::new(8), 8)),
         playhead: Arc::new(PlayheadState::new()) as Arc<dyn PlayheadWrite>,
         preload_gate: Arc::clone(&preload_gate),
-        retired_chunk: None,
         runtime: DecoderRuntime {
             seek_epoch,
             ..Default::default()

--- a/crates/kithara-play/src/worker/node/tests.rs
+++ b/crates/kithara-play/src/worker/node/tests.rs
@@ -182,8 +182,8 @@ fn decoder_node_does_not_republish_exhausted_warp_source_eof() {
     let spec = AudioSpec::new(2, NonZeroU32::new(44_100).expect("test sample rate"));
     let config = kithara_warp::WarpConfig::builder().build();
     let warp = kithara_warp::Warp::new((), &config);
-    let renderer = warp.renderer(spec, pools);
-    let source = WarpSource::new(source, renderer, effects, drain, spec);
+    let renderer = warp.renderer(spec, pools.clone());
+    let source = WarpSource::new(source, renderer, effects, drain, spec, pools);
     let (port, mut pop) = ProducerPort::probe(1);
     let bus = EventBus::new(8);
     let mut events = bus.subscribe();

--- a/crates/kithara-play/src/worker/node/tests.rs
+++ b/crates/kithara-play/src/worker/node/tests.rs
@@ -125,9 +125,7 @@ fn decoder_node_eof_under_backpressure() {
     let gate = Arc::new(PreloadGate::default());
     let (mut port, mut pop) = ProducerPort::probe(1);
 
-    assert!(port.try_push(Fetch::data(empty_chunk(&pools), 0)));
-    assert!(port.try_push(Fetch::data(empty_chunk(&pools), 0)));
-    assert!(port.has_pending());
+    port.push_direct(Fetch::data(empty_chunk(&pools), 0));
 
     let source = Unimock::new((
         AudioSourceMock::step_track.stub(|each| {
@@ -151,14 +149,10 @@ fn decoder_node_eof_under_backpressure() {
     assert_eq!(node.tick(), TickResult::Backpressured);
     assert!(!node.runtime.eof_sent);
 
-    let _ = node.port.take_pending();
+    assert!(pop().is_some(), "the queued data must drain first");
 
     assert_eq!(node.tick(), TickResult::Progress);
     assert!(node.runtime.eof_sent);
-    assert!(node.port.has_pending());
-
-    assert!(pop().is_some(), "the queued data must drain first");
-    assert!(node.port.flush(), "the EOF marker must leave overflow");
     assert!(matches!(pop(), Some(Fetch::NaturalEof { .. })));
     assert_eq!(node.tick(), TickResult::Backpressured);
 
@@ -407,9 +401,8 @@ fn eof_marker_and_deferred_event_keep_the_decode_epoch() {
 #[kithara::test]
 fn decoded_frontier_advances_only_after_final_port_admission() {
     let pools = pools();
-    let (mut port, _pop) = ProducerPort::probe(1);
-    assert!(port.try_push(Fetch::data(empty_chunk(&pools), 0)));
-    assert!(port.try_push(Fetch::data(empty_chunk(&pools), 0)));
+    let (mut port, mut pop) = ProducerPort::probe(1);
+    port.push_direct(Fetch::data(empty_chunk(&pools), 0));
     let end = Duration::from_millis(750);
     let mut chunk = empty_chunk(&pools);
     chunk.meta.end_timestamp = end;
@@ -430,7 +423,7 @@ fn decoded_frontier_advances_only_after_final_port_admission() {
     assert_eq!(node.tick(), TickResult::Backpressured);
     assert_eq!(playhead.decoded_frontier(), Duration::ZERO);
 
-    let _ = node.port.take_pending();
+    assert!(pop().is_some());
     assert_eq!(node.tick(), TickResult::Progress);
     assert_eq!(playhead.decoded_frontier(), end);
 }
@@ -438,9 +431,8 @@ fn decoded_frontier_advances_only_after_final_port_admission() {
 #[kithara::test]
 fn source_end_commits_only_after_final_port_admission() {
     let pools = pools();
-    let (mut port, _pop) = ProducerPort::probe(1);
-    assert!(port.try_push(Fetch::data(empty_chunk(&pools), 0)));
-    assert!(port.try_push(Fetch::data(empty_chunk(&pools), 0)));
+    let (mut port, mut pop) = ProducerPort::probe(1);
+    port.push_direct(Fetch::data(empty_chunk(&pools), 0));
     let source_end = SourceEnd::new(
         12_345,
         NonZeroU32::new(44_100).expect("test sample rate is non-zero"),
@@ -462,7 +454,7 @@ fn source_end_commits_only_after_final_port_admission() {
     assert_eq!(node.tick(), TickResult::Backpressured);
     assert!(commits.lock().is_empty());
 
-    let _ = node.port.take_pending();
+    assert!(pop().is_some());
     assert_eq!(node.tick(), TickResult::Progress);
     assert_eq!(commits.lock().as_slice(), &[(source_end, 7)]);
 }
@@ -473,16 +465,13 @@ fn decoder_node_preload_gate_waits_for_ring() {
     let gate = Arc::new(PreloadGate::default());
     let (mut port, mut pop) = ProducerPort::probe(1);
 
-    assert!(port.try_push(Fetch::data(empty_chunk(&pools), 0)));
+    port.push_direct(Fetch::data(empty_chunk(&pools), 0));
 
-    let source = Unimock::new((
+    let source = Unimock::new(
         AudioSourceMock::step_track
             .next_call(matching!())
             .returns(TrackStep::Produced(Fetch::data(empty_chunk(&pools), 0))),
-        AudioSourceMock::step_track
-            .next_call(matching!())
-            .returns(TrackStep::Blocked(WaitingReason::Waiting)),
-    ));
+    );
 
     let mut node = test_node(
         source,
@@ -491,18 +480,15 @@ fn decoder_node_preload_gate_waits_for_ring() {
         Arc::new(SeekState::new()) as Arc<dyn SeekObserve>,
     );
 
+    assert_eq!(node.tick(), TickResult::Backpressured);
+    assert_eq!(node.runtime.chunks_sent, 0);
+    assert!(!node.runtime.preloaded);
+    assert!(!gate.is_ready());
+
+    assert!(pop().is_some());
+
     assert_eq!(node.tick(), TickResult::Progress);
     assert_eq!(node.runtime.chunks_sent, 1);
-    assert!(!node.runtime.preloaded);
-    assert!(!gate.is_ready());
-
-    assert_eq!(node.tick(), TickResult::Backpressured);
-    assert!(!node.runtime.preloaded);
-    assert!(!gate.is_ready());
-
-    let _ = pop();
-
-    assert_eq!(node.tick(), TickResult::Waiting);
     assert!(node.runtime.preloaded);
     assert!(gate.is_ready());
 }
@@ -532,7 +518,7 @@ fn decoder_node_live_upstream_demand_does_not_tick_hang_wait() {
 fn decoder_node_seek_rearms_preload_gate() {
     let pools = pools();
     let gate = Arc::new(PreloadGate::default());
-    let (port, mut pop) = ProducerPort::probe(2);
+    let (port, mut pop) = ProducerPort::probe(1);
 
     let seek_state = Arc::new(SeekState::new());
     let source = Unimock::new((
@@ -560,11 +546,20 @@ fn decoder_node_seek_rearms_preload_gate() {
 
     let epoch = SeekControl::begin(&*seek_state, Duration::from_secs(1));
 
-    assert_eq!(node.tick(), TickResult::Progress);
+    assert_eq!(node.tick(), TickResult::Backpressured);
     assert!(!node.runtime.preloaded, "seek resets the preload runtime");
     assert!(!gate.is_ready(), "sync_seek_epoch closes the gate");
 
-    let _ = pop();
+    assert!(
+        pop().is_some(),
+        "consumer discards the stale pre-seek chunk"
+    );
+
+    assert_eq!(node.tick(), TickResult::Progress);
+    assert!(
+        !node.runtime.preloaded,
+        "source first applies the seek epoch"
+    );
 
     assert_eq!(node.tick(), TickResult::Progress);
     assert!(node.runtime.preloaded);

--- a/crates/kithara-play/src/worker/node/tests.rs
+++ b/crates/kithara-play/src/worker/node/tests.rs
@@ -1,7 +1,4 @@
-use std::{
-    num::NonZeroU32,
-    sync::atomic::{AtomicUsize, Ordering},
-};
+use std::num::NonZeroU32;
 
 use kithara_audio::{
     AudioSource, Fetch, PreloadGate, ProducerPort, SourceEnd, TrackStep, WaitingReason,
@@ -40,7 +37,6 @@ fn test_node<S>(
     DecoderNode {
         seek_obs,
         source,
-        retired_chunk: None,
         port,
         preload_gate,
         playhead: Arc::new(PlayheadState::new()) as Arc<dyn PlayheadWrite>,
@@ -53,13 +49,6 @@ fn test_node<S>(
 
 struct PersistentEofSource {
     seek: Arc<SeekState>,
-}
-
-struct RetiringSource {
-    pools: Pools,
-    seek: Arc<SeekState>,
-    retired: Arc<AtomicUsize>,
-    chunks_left: usize,
 }
 
 struct CommitSource {
@@ -84,26 +73,6 @@ impl AudioSource for CommitSource {
         self.chunk.take().map_or(TrackStep::Eof, |chunk| {
             TrackStep::Produced(Fetch::rendered(chunk, 7, self.source_end))
         })
-    }
-}
-
-impl AudioSource for RetiringSource {
-    type Chunk = AudioChunk;
-
-    fn retire_chunk(&self, _chunk: AudioChunk) {
-        self.retired.fetch_add(1, Ordering::Relaxed);
-    }
-
-    fn seek_observe(&self) -> Arc<dyn SeekObserve> {
-        Arc::clone(&self.seek) as Arc<dyn SeekObserve>
-    }
-
-    fn step_track(&mut self) -> TrackStep<AudioChunk> {
-        if self.chunks_left == 0 {
-            return TrackStep::Eof;
-        }
-        self.chunks_left -= 1;
-        TrackStep::Produced(Fetch::data(empty_chunk(&self.pools), 0))
     }
 }
 
@@ -232,7 +201,6 @@ fn decoder_node_records_engine_load_on_produced() {
 
     let mut node = DecoderNode {
         source,
-        retired_chunk: None,
         port,
         seek_obs: Arc::new(SeekState::new()) as Arc<dyn SeekObserve>,
         preload_gate: Arc::new(PreloadGate::default()),
@@ -268,7 +236,6 @@ fn worker_telemetry_throttles_immediate_repeats() {
 
     let mut node = DecoderNode {
         source,
-        retired_chunk: None,
         port,
         seek_obs: Arc::clone(&seek) as Arc<dyn SeekObserve>,
         preload_gate: gate,
@@ -304,11 +271,7 @@ fn worker_telemetry_throttles_immediate_repeats() {
 
 #[kithara::test]
 fn decoder_node_distinguishes_failed_from_eof_on_the_wire() {
-    fn drain_marker(
-        port: &mut ProducerPort,
-        pop: &mut impl FnMut() -> Option<Fetch<AudioChunk>>,
-    ) -> Fetch<AudioChunk> {
-        let _ = port.flush();
+    fn drain_marker(pop: &mut impl FnMut() -> Option<Fetch<AudioChunk>>) -> Fetch<AudioChunk> {
         pop().expect("producer pushed a terminal marker")
     }
 
@@ -330,7 +293,7 @@ fn decoder_node_distinguishes_failed_from_eof_on_the_wire() {
         Arc::new(SeekState::new()) as Arc<dyn SeekObserve>,
     );
     assert_eq!(eof_node.tick(), TickResult::Progress);
-    let eof_marker = drain_marker(&mut eof_node.port, &mut eof_pop);
+    let eof_marker = drain_marker(&mut eof_pop);
 
     let (failed_port, mut failed_pop) = ProducerPort::probe(1);
     let failed_source = Unimock::new((
@@ -348,7 +311,7 @@ fn decoder_node_distinguishes_failed_from_eof_on_the_wire() {
         Arc::new(SeekState::new()) as Arc<dyn SeekObserve>,
     );
     let _ = failed_node.tick();
-    let failed_marker = drain_marker(&mut failed_node.port, &mut failed_pop);
+    let failed_marker = drain_marker(&mut failed_pop);
 
     assert!(matches!(eof_marker, Fetch::NaturalEof { .. }));
     assert!(matches!(failed_marker, Fetch::Failure { .. }));
@@ -380,7 +343,6 @@ fn eof_marker_and_deferred_event_keep_the_decode_epoch() {
     let live_epoch = seek_state.begin(Duration::from_secs(1));
     assert_eq!(live_epoch, 1, "seek overtakes the deferred EOF flush");
 
-    let _ = node.port.flush();
     let marker = pop().expect("producer pushed an EOF marker");
     assert!(matches!(&marker, Fetch::NaturalEof { .. }));
     assert_eq!(
@@ -568,35 +530,4 @@ fn decoder_node_seek_rearms_preload_gate() {
         gate.is_ready_for_epoch(epoch),
         "post-seek refill must open the new seek epoch"
     );
-}
-
-#[kithara::test]
-fn decoder_node_retires_displaced_seek_chunk_from_recycle_shell() {
-    let pools = pools();
-    let (port, _pop) = ProducerPort::probe(1);
-    let seek = Arc::new(SeekState::new());
-    let retired = Arc::new(AtomicUsize::new(0));
-    let source = RetiringSource {
-        pools: pools.clone(),
-        seek: Arc::clone(&seek),
-        retired: Arc::clone(&retired),
-        chunks_left: 2,
-    };
-    let mut node = test_node(
-        source,
-        port,
-        Arc::new(PreloadGate::default()),
-        Arc::clone(&seek) as Arc<dyn SeekObserve>,
-    );
-
-    assert_eq!(node.tick(), TickResult::Progress);
-    assert_eq!(node.tick(), TickResult::Progress);
-    assert!(node.port.has_pending(), "second chunk must occupy overflow");
-
-    SeekControl::begin(&*seek, Duration::from_secs(1));
-    let _ = node.tick();
-    assert_eq!(retired.load(Ordering::Relaxed), 0);
-
-    node.recycle();
-    assert_eq!(retired.load(Ordering::Relaxed), 1);
 }

--- a/crates/kithara-play/src/worker/source.rs
+++ b/crates/kithara-play/src/worker/source.rs
@@ -1,7 +1,7 @@
 use kithara_audio::{AudioSource, Fetch, SourceDiscontinuity, SourceEnd, TrackStep};
-use kithara_bufpool::HasPool;
+use kithara_bufpool::{BufferRing, HasPool, PoolRegion, SampleBuffer};
 use kithara_platform::sync::Arc;
-use kithara_signal::{AudioChunk, AudioSpec};
+use kithara_signal::{AudioChunk, AudioChunkInfo, AudioSpec};
 use kithara_stream::SeekObserve;
 
 use crate::effects::{
@@ -29,6 +29,12 @@ impl DrainState {
     }
 }
 
+struct PendingInput {
+    chunk: AudioChunk,
+    consumed_frames: usize,
+    epoch: u64,
+}
+
 /// The sole producer-side Warp/effect stage before the play output ring.
 pub(crate) struct WarpSource<T, S> {
     source: T,
@@ -40,6 +46,15 @@ pub(crate) struct WarpSource<T, S> {
     spec: AudioSpec,
     drain_state: DrainState,
     reset_epoch: Option<u64>,
+    pools: PoolRegion<S>,
+    pending_input: Option<PendingInput>,
+    staging: Option<BufferRing<SampleBuffer>>,
+    staged_meta: Option<AudioChunkInfo>,
+    staged_epoch: Option<u64>,
+    prepared_frames: Option<usize>,
+    render_input: Option<SampleBuffer>,
+    retired_input: Option<AudioChunk>,
+    quantum_failed: bool,
 }
 
 impl<T, S> WarpSource<T, S>
@@ -53,6 +68,7 @@ where
         effects: Vec<Box<dyn AudioEffect>>,
         drain: EffectDrain,
         spec: AudioSpec,
+        pools: PoolRegion<S>,
     ) -> Self {
         let discontinuity = source.discontinuity();
         let seek = source.seek_observe();
@@ -66,9 +82,199 @@ where
             spec,
             drain_state: DrainState::Open,
             reset_epoch: None,
+            pools,
+            pending_input: None,
+            staging: None,
+            staged_meta: None,
+            staged_epoch: None,
+            prepared_frames: None,
+            render_input: None,
+            retired_input: None,
+            quantum_failed: false,
         }
     }
 
+    fn retire_pending_input(&mut self) {
+        let Some(pending) = self.pending_input.take() else {
+            return;
+        };
+        debug_assert!(self.retired_input.is_none());
+        self.retired_input = Some(pending.chunk);
+    }
+
+    fn clear_staging(&mut self) {
+        let Some(staging) = self.staging.take() else {
+            self.staged_meta = None;
+            self.staged_epoch = None;
+            self.prepared_frames = None;
+            return;
+        };
+        let buffer = staging.into_inner();
+        self.staging = BufferRing::from_prefix(buffer, 0).ok();
+        self.staged_meta = None;
+        self.staged_epoch = None;
+        self.prepared_frames = None;
+    }
+
+    fn discard_staged_input(&mut self) {
+        self.retire_pending_input();
+        self.clear_staging();
+        self.quantum_failed = false;
+    }
+
+    fn prepare_staging(&mut self) {
+        if self.quantum_failed {
+            return;
+        }
+        if self.warp.render_quantum_frames().is_none() || self.prepared_frames.is_some() {
+            return;
+        }
+        let Some((meta, remaining)) = self.pending_input.as_ref().and_then(|pending| {
+            let remaining = pending
+                .chunk
+                .frames()
+                .checked_sub(pending.consumed_frames)?;
+            Some((
+                Self::span_meta(pending.chunk.meta, pending.consumed_frames, remaining)?,
+                remaining,
+            ))
+        }) else {
+            return;
+        };
+        let Some(frames) = self.warp.prepare_quantum(meta, remaining) else {
+            self.quantum_failed = true;
+            return;
+        };
+        let frames = frames.get();
+        let Some(required) = frames.checked_mul(usize::from(self.spec.channels.max(1))) else {
+            self.quantum_failed = true;
+            return;
+        };
+
+        let needs_staging = self
+            .staging
+            .as_ref()
+            .is_none_or(|staging| staging.capacity() != required);
+        if needs_staging {
+            let mut buffer = self
+                .staging
+                .take()
+                .map_or_else(|| self.pools.get::<f32>(), BufferRing::into_inner);
+            if buffer.ensure_len(required).is_err() {
+                self.quantum_failed = true;
+                return;
+            }
+            buffer.truncate(required);
+            let Ok(staging) = BufferRing::from_prefix(buffer, 0) else {
+                self.quantum_failed = true;
+                return;
+            };
+            self.staging = Some(staging);
+        }
+
+        let mut input = self
+            .render_input
+            .take()
+            .unwrap_or_else(|| self.pools.get::<f32>());
+        if input.ensure_len(required).is_err() {
+            self.render_input = Some(input);
+            self.quantum_failed = true;
+            return;
+        }
+        self.render_input = Some(input);
+        self.prepared_frames = Some(frames);
+    }
+
+    fn span_meta(original: AudioChunkInfo, offset: usize, frames: usize) -> Option<AudioChunkInfo> {
+        let offset = u64::try_from(offset).ok()?;
+        let frames = u32::try_from(frames).ok()?;
+        let mut meta = original;
+        meta.frame_offset = original.frame_offset.checked_add(offset)?;
+        meta.timestamp = original
+            .timestamp
+            .checked_add(original.spec.duration_for(offset).ok()?)?;
+        meta.frames = frames;
+        meta.end_timestamp = meta
+            .timestamp
+            .checked_add(original.spec.duration_for(u64::from(frames)).ok()?)?;
+        meta.source_byte_offset = None;
+        meta.source_bytes = 0;
+        Some(meta)
+    }
+
+    fn staged_frames(&self) -> usize {
+        let channels = usize::from(self.spec.channels.max(1));
+        self.staging.as_ref().map_or(0, BufferRing::len) / channels
+    }
+
+    fn stage_pending(&mut self) -> bool {
+        let channels = usize::from(self.spec.channels.max(1));
+        let Some(capacity) = self.staging.as_ref().map(BufferRing::capacity) else {
+            return false;
+        };
+        let staged = self.staging.as_ref().map_or(0, BufferRing::len);
+        let staged_frames = staged / channels;
+        let Some(pending) = self.pending_input.as_mut() else {
+            return false;
+        };
+        if pending.chunk.spec() != self.spec || pending.epoch != self.seek.epoch() {
+            self.quantum_failed = true;
+            return false;
+        }
+
+        let pending_frame = u64::try_from(pending.consumed_frames)
+            .ok()
+            .and_then(|consumed| pending.chunk.meta.frame_offset.checked_add(consumed));
+        let expected_frame = self.staged_meta.and_then(|meta| {
+            meta.frame_offset
+                .checked_add(u64::try_from(staged_frames).ok()?)
+        });
+        if staged > 0
+            && (self.staged_epoch != Some(pending.epoch) || expected_frame != pending_frame)
+        {
+            self.quantum_failed = true;
+            return false;
+        }
+
+        let remaining_frames = pending
+            .chunk
+            .frames()
+            .saturating_sub(pending.consumed_frames);
+        let free_frames = capacity.saturating_sub(staged) / channels;
+        let frames = remaining_frames.min(free_frames);
+        let source_start = pending.consumed_frames.saturating_mul(channels);
+        let samples = frames.saturating_mul(channels);
+        let source_end = source_start.saturating_add(samples);
+        let Some(source) = pending.chunk.samples.get(source_start..source_end) else {
+            self.quantum_failed = true;
+            return false;
+        };
+        if staged == 0 {
+            self.staged_meta = Self::span_meta(pending.chunk.meta, pending.consumed_frames, 0);
+            self.staged_epoch = Some(pending.epoch);
+        }
+        if !self
+            .staging
+            .as_mut()
+            .is_some_and(|staging| staging.try_push(source))
+        {
+            self.quantum_failed = true;
+            return false;
+        }
+        pending.consumed_frames = pending.consumed_frames.saturating_add(frames);
+        let consumed = pending.consumed_frames == pending.chunk.frames();
+        if consumed {
+            self.retire_pending_input();
+        }
+        consumed
+    }
+}
+
+impl<T, S> WarpSource<T, S>
+where
+    T: AudioSource<Chunk = AudioChunk>,
+    S: HasPool<f32>,
+{
     fn sync_discontinuity(&mut self) {
         let next = self.source.discontinuity();
         let revision_changed = next.as_ref().map(SourceDiscontinuity::revision)
@@ -84,6 +290,7 @@ where
         if !revision_changed {
             return;
         }
+        self.discard_staged_input();
         if already_reset {
             self.reset_epoch = None;
         } else {
@@ -101,6 +308,7 @@ where
     fn prepare_renderers(&mut self, spec: AudioSpec) {
         self.spec = spec;
         self.warp.prepare(spec);
+        self.prepare_staging();
         for effect in &mut self.effects {
             effect.service_deferred(spec);
         }
@@ -115,6 +323,24 @@ where
             return false;
         }
         let epoch = self.seek.epoch();
+        self.reset_renderers();
+        self.drain.reset();
+        self.drain_state = DrainState::Open;
+        self.reset_epoch = Some(epoch);
+        true
+    }
+
+    fn cancel_stale_input(&mut self) -> bool {
+        let stale = self.pending_input.as_ref().is_some_and(|pending| {
+            self.seek.epoch() != pending.epoch || self.source.decode_epoch() != pending.epoch
+        }) || self
+            .staged_epoch
+            .is_some_and(|epoch| self.seek.epoch() != epoch || self.source.decode_epoch() != epoch);
+        if !stale {
+            return false;
+        }
+        let epoch = self.seek.epoch();
+        self.discard_staged_input();
         self.reset_renderers();
         self.drain.reset();
         self.drain_state = DrainState::Open;
@@ -147,6 +373,101 @@ where
         let chunk = chunk?;
         let output = apply_effects(&mut self.effects, chunk)?;
         Some(self.fetch(output, epoch))
+    }
+
+    fn render_quantum(&mut self, chunk: AudioChunk, epoch: u64) -> Option<Fetch<AudioChunk>> {
+        let chunk = self.warp.render_quantum(chunk);
+        if self.warp.transition_pending() {
+            self.drain_state = DrainState::LiveWarp(epoch);
+        }
+        let chunk = chunk?;
+        let output = apply_effects(&mut self.effects, chunk)?;
+        Some(self.fetch(output, epoch))
+    }
+
+    fn render_staged(&mut self, frames: usize) -> TrackStep<AudioChunk> {
+        if self.quantum_failed || frames == 0 {
+            return TrackStep::Failed;
+        }
+        let channels = usize::from(self.spec.channels.max(1));
+        let Some(samples) = frames.checked_mul(channels) else {
+            self.quantum_failed = true;
+            return TrackStep::Failed;
+        };
+        let Some(meta) = self
+            .staged_meta
+            .and_then(|meta| Self::span_meta(meta, 0, frames))
+        else {
+            self.quantum_failed = true;
+            return TrackStep::Failed;
+        };
+        let Some(epoch) = self.staged_epoch else {
+            self.quantum_failed = true;
+            return TrackStep::Failed;
+        };
+        let Some(mut input) = self.render_input.take() else {
+            return TrackStep::StateChanged;
+        };
+        if input.len() < samples {
+            self.render_input = Some(input);
+            self.quantum_failed = true;
+            return TrackStep::Failed;
+        }
+        input.truncate(samples);
+        if !self
+            .staging
+            .as_mut()
+            .is_some_and(|staging| staging.try_pop_into(&mut input))
+        {
+            self.render_input = Some(input);
+            self.quantum_failed = true;
+            return TrackStep::Failed;
+        }
+        if self.staging.as_ref().is_none_or(BufferRing::is_empty) {
+            self.staged_meta = None;
+            self.staged_epoch = None;
+        }
+        self.prepared_frames = None;
+        self.render_quantum(AudioChunk::new(meta, input), epoch)
+            .map_or(TrackStep::StateChanged, TrackStep::Produced)
+    }
+
+    fn render_full_quantum(&mut self) -> Option<TrackStep<AudioChunk>> {
+        let frames = self.prepared_frames?;
+        (self.staged_frames() == frames).then(|| self.render_staged(frames))
+    }
+
+    fn render_whole_pending(&mut self) -> Option<TrackStep<AudioChunk>> {
+        let prepared = self.prepared_frames?;
+        let pending = self.pending_input.as_ref()?;
+        if pending.consumed_frames != 0 || pending.chunk.frames() != prepared {
+            return None;
+        }
+        let pending = self.pending_input.take()?;
+        self.prepared_frames = None;
+        Some(
+            self.render_quantum(pending.chunk, pending.epoch)
+                .map_or(TrackStep::StateChanged, TrackStep::Produced),
+        )
+    }
+
+    fn step_direct(&mut self) -> TrackStep<AudioChunk> {
+        match self.source.step_track() {
+            TrackStep::Produced(Fetch::Data { data, epoch, .. }) => self
+                .render(data, epoch)
+                .map_or(TrackStep::StateChanged, TrackStep::Produced),
+            TrackStep::Produced(fetch) => TrackStep::Produced(fetch),
+            TrackStep::Eof => {
+                self.begin_drain(self.source.decode_epoch());
+                TrackStep::StateChanged
+            }
+            TrackStep::StateChanged => {
+                self.sync_discontinuity();
+                TrackStep::StateChanged
+            }
+            TrackStep::Blocked(reason) => TrackStep::Blocked(reason),
+            TrackStep::Failed => TrackStep::Failed,
+        }
     }
 
     fn drain_step(&mut self) -> Option<TrackStep<AudioChunk>> {
@@ -217,8 +538,14 @@ where
 
     fn step_track(&mut self) -> TrackStep<AudioChunk> {
         self.sync_discontinuity();
+        if self.cancel_stale_input() {
+            return TrackStep::StateChanged;
+        }
         if self.cancel_stale_drain() {
             return TrackStep::StateChanged;
+        }
+        if self.quantum_failed {
+            return TrackStep::Failed;
         }
 
         if matches!(self.drain_state, DrainState::Exhausted(_)) {
@@ -227,18 +554,55 @@ where
         if let Some(step) = self.drain_step() {
             return step;
         }
+        if self.warp.render_quantum_frames().is_none() {
+            return self.step_direct();
+        }
+        if let Some(step) = self.render_whole_pending() {
+            return step;
+        }
+        if let Some(step) = self.render_full_quantum() {
+            return step;
+        }
+        if self.pending_input.is_some() {
+            if self.prepared_frames.is_none() {
+                return TrackStep::StateChanged;
+            }
+            self.stage_pending();
+            return self
+                .render_full_quantum()
+                .unwrap_or(TrackStep::StateChanged);
+        }
         if !self.warp.accepts_input() {
             return TrackStep::Failed;
         }
 
         match self.source.step_track() {
-            TrackStep::Produced(Fetch::Data { data, epoch, .. }) => self
-                .render(data, epoch)
-                .map_or(TrackStep::StateChanged, TrackStep::Produced),
+            TrackStep::Produced(Fetch::Data { data, epoch, .. }) => {
+                self.pending_input = Some(PendingInput {
+                    chunk: data,
+                    consumed_frames: 0,
+                    epoch,
+                });
+                TrackStep::StateChanged
+            }
             TrackStep::Produced(fetch) => TrackStep::Produced(fetch),
             TrackStep::Eof => {
                 self.begin_drain(self.source.decode_epoch());
-                TrackStep::StateChanged
+                let frames = self.staged_frames();
+                if frames == 0 {
+                    TrackStep::StateChanged
+                } else {
+                    let Some(meta) = self.staged_meta else {
+                        self.quantum_failed = true;
+                        return TrackStep::Failed;
+                    };
+                    let Some(frames) = self.warp.prepare_terminal_quantum(meta, frames) else {
+                        self.quantum_failed = true;
+                        return TrackStep::Failed;
+                    };
+                    self.prepared_frames = Some(frames.get());
+                    self.render_staged(frames.get())
+                }
             }
             TrackStep::StateChanged => {
                 self.sync_discontinuity();
@@ -250,6 +614,9 @@ where
     }
 
     fn prepare_deferred(&mut self) -> Option<AudioSpec> {
+        if let Some(chunk) = self.retired_input.take() {
+            self.source.retire_chunk(chunk);
+        }
         let spec = self.source.prepare_deferred();
         self.sync_discontinuity();
         self.prepare_renderers(spec.unwrap_or(self.spec));
@@ -259,7 +626,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::VecDeque, num::NonZeroU32};
+    use std::{
+        collections::VecDeque,
+        num::{NonZeroU32, NonZeroUsize},
+    };
 
     use kithara_audio::{Fetch, TrackStep, WaitingReason};
     use kithara_bufpool::PoolRegion;
@@ -292,12 +662,29 @@ mod tests {
     where
         T: AudioSource<Chunk = AudioChunk>,
     {
-        let config = kithara_warp::WarpConfig::builder().build();
+        source_stage_with_quantum(pools, source, effects, spec, 128)
+    }
+
+    fn source_stage_with_quantum<T>(
+        pools: &PoolRegion<TestPools>,
+        source: T,
+        effects: Vec<Box<dyn AudioEffect>>,
+        spec: AudioSpec,
+        quantum_frames: usize,
+    ) -> WarpSource<T, TestPools>
+    where
+        T: AudioSource<Chunk = AudioChunk>,
+    {
+        let config = kithara_warp::WarpConfig::builder()
+            .render_quantum_frames(
+                NonZeroUsize::new(quantum_frames).expect("test quantum is non-zero"),
+            )
+            .build();
         let warp = kithara_warp::Warp::new((), &config);
         let renderer = warp.renderer(spec, pools.clone());
         let drain = EffectDrain::new(effects.len(), pools)
             .unwrap_or_else(|error| panic!("test effect drain: {error}"));
-        WarpSource::new(source, renderer, effects, drain, spec)
+        WarpSource::new(source, renderer, effects, drain, spec, pools.clone())
     }
 
     struct RawSource {
@@ -308,6 +695,10 @@ mod tests {
 
     impl AudioSource for RawSource {
         type Chunk = AudioChunk;
+
+        fn decode_epoch(&self) -> u64 {
+            self.seek.epoch()
+        }
 
         fn seek_observe(&self) -> Arc<dyn SeekObserve> {
             Arc::clone(&self.seek) as Arc<dyn SeekObserve>
@@ -324,7 +715,7 @@ mod tests {
                     .saturating_add(u64::from(chunk.meta.frames)),
                 Ordering::Release,
             );
-            TrackStep::Produced(Fetch::data(chunk, 0))
+            TrackStep::Produced(Fetch::data(chunk, self.seek.epoch()))
         }
     }
 
@@ -619,6 +1010,56 @@ mod tests {
         )
     }
 
+    #[kithara::test(native)]
+    #[case::q16(16)]
+    #[case::q32(32)]
+    fn source_chunks_are_partitioned_without_losing_terminal_input(#[case] quantum_frames: usize) {
+        let spec = AudioSpec::new(2, NonZeroU32::new(48_000).expect("test sample rate"));
+        let pools = pools();
+        let input_frames = [20_usize, 20, 10];
+        let chunks = [
+            chunk_with_frames(&pools, spec, 0, 20, 0.25),
+            chunk_with_frames(&pools, spec, 20, 20, -0.5),
+            chunk_with_frames(&pools, spec, 40, 10, 0.75),
+        ];
+        let expected_samples = chunks
+            .iter()
+            .flat_map(|chunk| chunk.samples.iter().copied())
+            .collect::<Vec<_>>();
+        let source = RawSource {
+            chunks: VecDeque::from(chunks),
+            head: Arc::new(AtomicU64::new(0)),
+            seek: Arc::new(SeekState::new()),
+        };
+        let mut source =
+            source_stage_with_quantum(&pools, source, Vec::new(), spec, quantum_frames);
+        let mut output_frames = Vec::new();
+        let mut output_samples = Vec::new();
+
+        for _ in 0..32 {
+            match source.step_track() {
+                TrackStep::Produced(Fetch::Data { data, .. }) => {
+                    output_frames.push(data.frames());
+                    output_samples.extend_from_slice(&data.samples);
+                }
+                TrackStep::StateChanged => {}
+                TrackStep::Eof => break,
+                _ => panic!("staged source must only produce, progress, or finish"),
+            }
+            flush_deferred(&mut source);
+        }
+
+        let expected_frames = input_frames
+            .into_iter()
+            .flat_map(|frames| {
+                std::iter::repeat_n(quantum_frames, frames / quantum_frames)
+                    .chain(std::iter::once(frames % quantum_frames).filter(|frames| *frames > 0))
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(output_frames, expected_frames);
+        assert_eq!(output_samples, expected_samples);
+    }
+
     #[kithara::test]
     fn buffered_frame_changing_effect_tracks_live_and_flush_frontiers() {
         let spec = AudioSpec::new(2, NonZeroU32::new(44_100).expect("test sample rate"));
@@ -641,6 +1082,11 @@ mod tests {
             128,
             "one worker pass advances exactly one source transition"
         );
+        flush_deferred(&mut source);
+        assert!(matches!(source.step_track(), TrackStep::StateChanged));
+        flush_deferred(&mut source);
+        assert!(matches!(source.step_track(), TrackStep::StateChanged));
+        flush_deferred(&mut source);
 
         let TrackStep::Produced(Fetch::Data {
             data, source_end, ..
@@ -763,6 +1209,8 @@ mod tests {
         let effects = Vec::new();
         let mut source = source_stage(&pools, source, effects, initial);
 
+        assert!(matches!(source.step_track(), TrackStep::StateChanged));
+        flush_deferred(&mut source);
         let TrackStep::Produced(Fetch::Data { data, .. }) = source.step_track() else {
             panic!("initial unity span must pass through");
         };
@@ -770,6 +1218,8 @@ mod tests {
         assert_eq!(&data.samples[..], &first_samples);
 
         *discontinuity.lock() = SourceDiscontinuity::new(8, changed);
+        flush_deferred(&mut source);
+        assert!(matches!(source.step_track(), TrackStep::StateChanged));
         flush_deferred(&mut source);
         let TrackStep::Produced(Fetch::Data { data, .. }) = source.step_track() else {
             panic!("post-discontinuity unity span must pass through");
@@ -788,8 +1238,8 @@ mod tests {
         #[case] backend: StretchKind,
     ) {
         const ACTIVE_FRAMES: u32 = 4096;
-        const UNITY_FRAMES: u32 = 1024;
-        const SENTINEL_FRAMES: u32 = 512;
+        const UNITY_FRAMES: u32 = 4096;
+        const SENTINEL_FRAMES: u32 = 4096;
 
         let spec = AudioSpec::new(2, NonZeroU32::new(44_100).expect("test sample rate"));
         let pools = pools();
@@ -825,14 +1275,21 @@ mod tests {
         let controls = StretchControls::new(0.5);
         controls.set_keylock(true);
         controls.set_backend(backend);
+        let render_quantum_frames = usize::try_from(ACTIVE_FRAMES)
+            .expect("test quantum fits usize")
+            .saturating_mul(2)
+            .saturating_add(1);
         let config = kithara_warp::WarpConfig::builder()
             .stretch(Arc::clone(&controls))
+            .render_quantum_frames(
+                NonZeroUsize::new(render_quantum_frames).expect("test quantum is non-zero"),
+            )
             .build();
         let renderer = kithara_warp::Warp::new((), &config).renderer(spec, pools.clone());
         let effects = Vec::new();
         let drain = EffectDrain::new(effects.len(), &pools)
             .unwrap_or_else(|error| panic!("test effect drain: {error}"));
-        let mut source = WarpSource::new(raw, renderer, effects, drain, spec);
+        let mut source = WarpSource::new(raw, renderer, effects, drain, spec, pools.clone());
 
         assert!(matches!(
             source.step_track(),
@@ -840,8 +1297,15 @@ mod tests {
         ));
         assert_eq!(head.load(Ordering::Acquire), first_active_end);
         flush_deferred(&mut source);
+        let TrackStep::Produced(_) = source.step_track() else {
+            panic!("the first active quantum must render");
+        };
+        flush_deferred(&mut source);
 
         controls.set_speed(1.0);
+        assert!(matches!(source.step_track(), TrackStep::StateChanged));
+        assert_eq!(head.load(Ordering::Acquire), first_unity_end);
+        flush_deferred(&mut source);
         let TrackStep::Produced(_) = source.step_track() else {
             panic!("active-to-unity transition must emit its first tail quantum");
         };
@@ -883,8 +1347,15 @@ mod tests {
             TrackStep::Produced(_) | TrackStep::StateChanged
         ));
         assert_eq!(head.load(Ordering::Acquire), second_active_end);
+        flush_deferred(&mut source);
+        let TrackStep::Produced(_) = source.step_track() else {
+            panic!("the second active quantum must render");
+        };
 
         controls.set_speed(1.0);
+        flush_deferred(&mut source);
+        assert!(matches!(source.step_track(), TrackStep::StateChanged));
+        assert_eq!(head.load(Ordering::Acquire), second_unity_end);
         flush_deferred(&mut source);
         let TrackStep::Produced(_) = source.step_track() else {
             panic!("the second transition must emit its first tail quantum");
@@ -901,6 +1372,8 @@ mod tests {
         assert_eq!(head.load(Ordering::Acquire), second_unity_end);
         assert!(!source.warp.transition_pending());
 
+        flush_deferred(&mut source);
+        assert!(matches!(source.step_track(), TrackStep::StateChanged));
         flush_deferred(&mut source);
         let TrackStep::Produced(Fetch::Data { data, .. }) = source.step_track() else {
             panic!("playback must resume with the post-seek source chunk");
@@ -936,7 +1409,7 @@ mod tests {
         let effects = Vec::new();
         let drain = EffectDrain::new(effects.len(), &target_pools)
             .unwrap_or_else(|error| panic!("test effect drain: {error}"));
-        let mut source = WarpSource::new(raw, renderer, effects, drain, spec);
+        let mut source = WarpSource::new(raw, renderer, effects, drain, spec, target_pools.clone());
 
         for _ in 0..3 {
             flush_deferred(&mut source);

--- a/crates/kithara-play/src/worker/source.rs
+++ b/crates/kithara-play/src/worker/source.rs
@@ -126,7 +126,7 @@ where
         if self.quantum_failed {
             return;
         }
-        if self.warp.render_quantum_frames().is_none() || self.prepared_frames.is_some() {
+        if !self.warp.requires_staging() || self.prepared_frames.is_some() {
             return;
         }
         let Some((meta, remaining)) = self.pending_input.as_ref().and_then(|pending| {
@@ -554,7 +554,7 @@ where
         if let Some(step) = self.drain_step() {
             return step;
         }
-        if self.warp.render_quantum_frames().is_none() {
+        if !self.warp.requires_staging() {
             return self.step_direct();
         }
         if let Some(step) = self.render_whole_pending() {
@@ -1088,14 +1088,20 @@ mod tests {
             "one worker pass advances exactly one source transition"
         );
         flush_deferred(&mut source);
-        assert!(matches!(source.step_track(), TrackStep::StateChanged));
-        flush_deferred(&mut source);
-        assert!(matches!(source.step_track(), TrackStep::StateChanged));
-        flush_deferred(&mut source);
-
-        let TrackStep::Produced(Fetch::Data {
+        let mut produced = None;
+        for _ in 0..3 {
+            match source.step_track() {
+                TrackStep::Produced(fetch) => {
+                    produced = Some(fetch);
+                    break;
+                }
+                TrackStep::StateChanged => flush_deferred(&mut source),
+                _ => panic!("the second raw chunk must release the first buffered span"),
+            }
+        }
+        let Some(Fetch::Data {
             data, source_end, ..
-        }) = source.step_track()
+        }) = produced
         else {
             panic!("the second raw chunk must release the first buffered span");
         };
@@ -1292,24 +1298,33 @@ mod tests {
             .unwrap_or_else(|error| panic!("test effect drain: {error}"));
         let mut source = WarpSource::new(raw, renderer, effects, drain, spec, pools.clone());
 
+        let initial = source.step_track();
         assert!(matches!(
-            source.step_track(),
+            &initial,
             TrackStep::Produced(_) | TrackStep::StateChanged
         ));
         assert_eq!(head.load(Ordering::Acquire), first_active_end);
         flush_deferred(&mut source);
-        let TrackStep::Produced(_) = source.step_track() else {
-            panic!("the first active quantum must render");
-        };
-        flush_deferred(&mut source);
+        if matches!(&initial, TrackStep::StateChanged) {
+            let TrackStep::Produced(_) = source.step_track() else {
+                panic!("the first active quantum must render");
+            };
+            flush_deferred(&mut source);
+        }
 
         controls.set_speed(1.0);
-        assert!(matches!(source.step_track(), TrackStep::StateChanged));
+        let transition = source.step_track();
+        assert!(matches!(
+            &transition,
+            TrackStep::Produced(_) | TrackStep::StateChanged
+        ));
         assert_eq!(head.load(Ordering::Acquire), first_unity_end);
         flush_deferred(&mut source);
-        let TrackStep::Produced(_) = source.step_track() else {
-            panic!("active-to-unity transition must emit its first tail quantum");
-        };
+        if matches!(&transition, TrackStep::StateChanged) {
+            let TrackStep::Produced(_) = source.step_track() else {
+                panic!("active-to-unity transition must emit its first tail quantum");
+            };
+        }
         assert_eq!(head.load(Ordering::Acquire), first_unity_end);
         assert!(source.warp.transition_pending());
 
@@ -1343,24 +1358,33 @@ mod tests {
 
         controls.set_speed(0.5);
         flush_deferred(&mut source);
+        let second_active = source.step_track();
         assert!(matches!(
-            source.step_track(),
+            &second_active,
             TrackStep::Produced(_) | TrackStep::StateChanged
         ));
         assert_eq!(head.load(Ordering::Acquire), second_active_end);
         flush_deferred(&mut source);
-        let TrackStep::Produced(_) = source.step_track() else {
-            panic!("the second active quantum must render");
-        };
+        if matches!(&second_active, TrackStep::StateChanged) {
+            let TrackStep::Produced(_) = source.step_track() else {
+                panic!("the second active quantum must render");
+            };
+        }
 
         controls.set_speed(1.0);
         flush_deferred(&mut source);
-        assert!(matches!(source.step_track(), TrackStep::StateChanged));
+        let second_transition = source.step_track();
+        assert!(matches!(
+            &second_transition,
+            TrackStep::Produced(_) | TrackStep::StateChanged
+        ));
         assert_eq!(head.load(Ordering::Acquire), second_unity_end);
         flush_deferred(&mut source);
-        let TrackStep::Produced(_) = source.step_track() else {
-            panic!("the second transition must emit its first tail quantum");
-        };
+        if matches!(&second_transition, TrackStep::StateChanged) {
+            let TrackStep::Produced(_) = source.step_track() else {
+                panic!("the second transition must emit its first tail quantum");
+            };
+        }
         assert_eq!(head.load(Ordering::Acquire), second_unity_end);
         assert!(source.warp.transition_pending());
         flush_deferred(&mut source);
@@ -1374,10 +1398,20 @@ mod tests {
         assert!(!source.warp.transition_pending());
 
         flush_deferred(&mut source);
-        assert!(matches!(source.step_track(), TrackStep::StateChanged));
-        flush_deferred(&mut source);
-        let TrackStep::Produced(Fetch::Data { data, .. }) = source.step_track() else {
-            panic!("playback must resume with the post-seek source chunk");
+        let resumed = source.step_track();
+        let resumed = match resumed {
+            TrackStep::Produced(fetch) => fetch,
+            TrackStep::StateChanged => {
+                flush_deferred(&mut source);
+                let TrackStep::Produced(fetch) = source.step_track() else {
+                    panic!("playback must resume with the post-seek source chunk");
+                };
+                fetch
+            }
+            _ => panic!("playback must resume with the post-seek source chunk"),
+        };
+        let Fetch::Data { data, .. } = resumed else {
+            panic!("playback must resume with post-seek audio data");
         };
         assert_eq!(head.load(Ordering::Acquire), sentinel_end);
         assert_eq!(data.samples.as_ptr(), sentinel_ptr);

--- a/crates/kithara-play/src/worker/source.rs
+++ b/crates/kithara-play/src/worker/source.rs
@@ -578,6 +578,16 @@ where
 
         match self.source.step_track() {
             TrackStep::Produced(Fetch::Data { data, epoch, .. }) => {
+                if data.spec() == self.spec
+                    && self
+                        .warp
+                        .prepare_quantum(data.meta, data.frames())
+                        .is_some_and(|frames| frames.get() == data.frames())
+                {
+                    return self
+                        .render_quantum(data, epoch)
+                        .map_or(TrackStep::StateChanged, TrackStep::Produced);
+                }
                 self.pending_input = Some(PendingInput {
                     chunk: data,
                     consumed_frames: 0,
@@ -1013,7 +1023,9 @@ mod tests {
     #[kithara::test(native)]
     #[case::q16(16)]
     #[case::q32(32)]
-    fn source_chunks_are_partitioned_without_losing_terminal_input(#[case] quantum_frames: usize) {
+    fn unity_source_chunks_bypass_staging_without_losing_terminal_input(
+        #[case] quantum_frames: usize,
+    ) {
         let spec = AudioSpec::new(2, NonZeroU32::new(48_000).expect("test sample rate"));
         let pools = pools();
         let input_frames = [20_usize, 20, 10];
@@ -1049,14 +1061,7 @@ mod tests {
             flush_deferred(&mut source);
         }
 
-        let expected_frames = input_frames
-            .into_iter()
-            .flat_map(|frames| {
-                std::iter::repeat_n(quantum_frames, frames / quantum_frames)
-                    .chain(std::iter::once(frames % quantum_frames).filter(|frames| *frames > 0))
-            })
-            .collect::<Vec<_>>();
-        assert_eq!(output_frames, expected_frames);
+        assert_eq!(output_frames, input_frames);
         assert_eq!(output_samples, expected_samples);
     }
 
@@ -1209,8 +1214,6 @@ mod tests {
         let effects = Vec::new();
         let mut source = source_stage(&pools, source, effects, initial);
 
-        assert!(matches!(source.step_track(), TrackStep::StateChanged));
-        flush_deferred(&mut source);
         let TrackStep::Produced(Fetch::Data { data, .. }) = source.step_track() else {
             panic!("initial unity span must pass through");
         };
@@ -1218,8 +1221,6 @@ mod tests {
         assert_eq!(&data.samples[..], &first_samples);
 
         *discontinuity.lock() = SourceDiscontinuity::new(8, changed);
-        flush_deferred(&mut source);
-        assert!(matches!(source.step_track(), TrackStep::StateChanged));
         flush_deferred(&mut source);
         let TrackStep::Produced(Fetch::Data { data, .. }) = source.step_track() else {
             panic!("post-discontinuity unity span must pass through");

--- a/crates/kithara-play/src/worker/track.rs
+++ b/crates/kithara-play/src/worker/track.rs
@@ -1,5 +1,3 @@
-use std::num::NonZeroUsize;
-
 use bon::Builder;
 use kithara_audio::{AudioConfig, ResamplerBackend};
 use kithara_platform::sync::Arc;
@@ -8,34 +6,6 @@ use kithara_warp::WarpConfig;
 
 use super::EngineLoad;
 use crate::effects::AudioEffect;
-
-struct Consts;
-
-impl Consts {
-    const NATIVE_AUDIO_BUFFER_FRAMES: usize = 5_120;
-    const NATIVE_AUDIO_BUFFER_CHUNKS: usize = 10;
-    const WASM_AUDIO_BUFFER_CHUNKS: usize = 32;
-}
-
-fn resolve_audio_buffer_chunks(
-    configured_chunks: Option<usize>,
-    render_quantum_frames: NonZeroUsize,
-) -> usize {
-    configured_chunks.unwrap_or_else(|| default_audio_buffer_chunks(render_quantum_frames))
-}
-
-fn default_audio_buffer_chunks(render_quantum_frames: NonZeroUsize) -> usize {
-    if cfg!(target_arch = "wasm32") {
-        Consts::WASM_AUDIO_BUFFER_CHUNKS
-    } else if cfg!(any(
-        feature = "stretch-signalsmith",
-        feature = "stretch-bungee"
-    )) {
-        Consts::NATIVE_AUDIO_BUFFER_FRAMES.div_ceil(render_quantum_frames.get())
-    } else {
-        Consts::NATIVE_AUDIO_BUFFER_CHUNKS
-    }
-}
 
 /// Play-owned configuration for one resident Warp/audio producer lane.
 #[derive(Builder, fieldwork::Fieldwork)]
@@ -64,19 +34,6 @@ where
     pub(crate) warp: WarpConfig,
 }
 
-impl<T, B> TrackConfig<T, B>
-where
-    T: StreamType,
-    B: ResamplerBackend,
-{
-    pub(crate) fn resolved_audio_buffer_chunks(&self) -> usize {
-        resolve_audio_buffer_chunks(
-            self.audio.audio_buffer_chunks(),
-            self.warp.render_quantum_frames(),
-        )
-    }
-}
-
 impl<T, B> From<AudioConfig<T, B>> for TrackConfig<T, B>
 where
     T: StreamType,
@@ -84,32 +41,5 @@ where
 {
     fn from(audio: AudioConfig<T, B>) -> Self {
         Self::for_audio(audio).build()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::num::NonZeroUsize;
-
-    use kithara_test_utils::kithara;
-
-    use super::resolve_audio_buffer_chunks;
-
-    #[kithara::test(native)]
-    #[case::legacy_horizon(None, 512, 10)]
-    #[case::partitioned_horizon(None, 32, 160)]
-    #[case::explicit_override(Some(2), 32, 2)]
-    fn audio_buffer_horizon_is_resolved_in_frames(
-        #[case] configured_chunks: Option<usize>,
-        #[case] quantum_frames: usize,
-        #[case] expected_chunks: usize,
-    ) {
-        let quantum_frames =
-            NonZeroUsize::new(quantum_frames).expect("fixture quantum is non-zero");
-
-        assert_eq!(
-            resolve_audio_buffer_chunks(configured_chunks, quantum_frames),
-            expected_chunks
-        );
     }
 }

--- a/crates/kithara-play/src/worker/track.rs
+++ b/crates/kithara-play/src/worker/track.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroUsize;
+
 use bon::Builder;
 use kithara_audio::{AudioConfig, ResamplerBackend};
 use kithara_platform::sync::Arc;
@@ -6,6 +8,34 @@ use kithara_warp::WarpConfig;
 
 use super::EngineLoad;
 use crate::effects::AudioEffect;
+
+struct Consts;
+
+impl Consts {
+    const NATIVE_AUDIO_BUFFER_FRAMES: usize = 5_120;
+    const NATIVE_AUDIO_BUFFER_CHUNKS: usize = 10;
+    const WASM_AUDIO_BUFFER_CHUNKS: usize = 32;
+}
+
+fn resolve_audio_buffer_chunks(
+    configured_chunks: Option<usize>,
+    render_quantum_frames: NonZeroUsize,
+) -> usize {
+    configured_chunks.unwrap_or_else(|| default_audio_buffer_chunks(render_quantum_frames))
+}
+
+fn default_audio_buffer_chunks(render_quantum_frames: NonZeroUsize) -> usize {
+    if cfg!(target_arch = "wasm32") {
+        Consts::WASM_AUDIO_BUFFER_CHUNKS
+    } else if cfg!(any(
+        feature = "stretch-signalsmith",
+        feature = "stretch-bungee"
+    )) {
+        Consts::NATIVE_AUDIO_BUFFER_FRAMES.div_ceil(render_quantum_frames.get())
+    } else {
+        Consts::NATIVE_AUDIO_BUFFER_CHUNKS
+    }
+}
 
 /// Play-owned configuration for one resident Warp/audio producer lane.
 #[derive(Builder, fieldwork::Fieldwork)]
@@ -34,6 +64,19 @@ where
     pub(crate) warp: WarpConfig,
 }
 
+impl<T, B> TrackConfig<T, B>
+where
+    T: StreamType,
+    B: ResamplerBackend,
+{
+    pub(crate) fn resolved_audio_buffer_chunks(&self) -> usize {
+        resolve_audio_buffer_chunks(
+            self.audio.audio_buffer_chunks(),
+            self.warp.render_quantum_frames(),
+        )
+    }
+}
+
 impl<T, B> From<AudioConfig<T, B>> for TrackConfig<T, B>
 where
     T: StreamType,
@@ -41,5 +84,32 @@ where
 {
     fn from(audio: AudioConfig<T, B>) -> Self {
         Self::for_audio(audio).build()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroUsize;
+
+    use kithara_test_utils::kithara;
+
+    use super::resolve_audio_buffer_chunks;
+
+    #[kithara::test(native)]
+    #[case::legacy_horizon(None, 512, 10)]
+    #[case::partitioned_horizon(None, 32, 160)]
+    #[case::explicit_override(Some(2), 32, 2)]
+    fn audio_buffer_horizon_is_resolved_in_frames(
+        #[case] configured_chunks: Option<usize>,
+        #[case] quantum_frames: usize,
+        #[case] expected_chunks: usize,
+    ) {
+        let quantum_frames =
+            NonZeroUsize::new(quantum_frames).expect("fixture quantum is non-zero");
+
+        assert_eq!(
+            resolve_audio_buffer_chunks(configured_chunks, quantum_frames),
+            expected_chunks
+        );
     }
 }

--- a/crates/kithara-warp/src/warp/actuator.rs
+++ b/crates/kithara-warp/src/warp/actuator.rs
@@ -21,8 +21,7 @@ use crate::{RenderPublisher, StretchControls};
 #[fieldwork(opt_in, get)]
 #[non_exhaustive]
 pub struct Warp<S> {
-    #[field(get, deref = false)]
-    stretch: Arc<StretchControls>,
+    config: WarpConfig,
     publisher: Option<RenderPublisher>,
     #[cfg(feature = "render")]
     reader: RenderReader,
@@ -39,11 +38,17 @@ impl<S> Warp<S> {
         let reader = publisher.reader();
         Self {
             source,
-            stretch: Arc::clone(config.stretch()),
+            config: config.clone(),
             publisher: Some(publisher),
             #[cfg(feature = "render")]
             reader,
         }
+    }
+
+    /// Live temporal controls shared with the resident Warp lane.
+    #[must_use]
+    pub fn stretch(&self) -> &Arc<StretchControls> {
+        self.config.stretch()
     }
 
     /// Takes the sole callback-side publisher paired with this resident Warp.
@@ -59,7 +64,7 @@ impl<S> Warp<S> {
     where
         P: HasPool<f32>,
     {
-        WarpRenderer::new(Arc::clone(&self.stretch), self.reader.clone(), spec, pools)
+        WarpRenderer::new(&self.config, self.reader.clone(), spec, pools)
     }
 }
 

--- a/crates/kithara-warp/src/warp/config.rs
+++ b/crates/kithara-warp/src/warp/config.rs
@@ -1,7 +1,14 @@
+use std::num::NonZeroUsize;
+
 use bon::Builder;
 use kithara_platform::sync::Arc;
 
 use crate::StretchControls;
+
+const DEFAULT_RENDER_QUANTUM_FRAMES: NonZeroUsize = match NonZeroUsize::new(32) {
+    Some(frames) => frames,
+    None => unreachable!(),
+};
 
 /// Fixed resources used to construct one resident [`super::Warp`].
 #[derive(Clone, Debug, Builder, fieldwork::Fieldwork)]
@@ -13,4 +20,32 @@ pub struct WarpConfig {
     #[builder(default = StretchControls::new(1.0))]
     #[field(get, deref = false)]
     stretch: Arc<StretchControls>,
+    /// Maximum output frames planned before live temporal controls are sampled again.
+    #[builder(default = DEFAULT_RENDER_QUANTUM_FRAMES)]
+    #[field(get, copy)]
+    render_quantum_frames: NonZeroUsize,
+}
+
+#[cfg(test)]
+mod tests {
+    use kithara_test_utils::kithara;
+
+    use super::*;
+
+    #[kithara::test]
+    #[case::default(None, 32)]
+    #[case::configured(Some(64), 64)]
+    fn render_quantum_is_configurable_in_frames(
+        #[case] configured: Option<usize>,
+        #[case] expected: usize,
+    ) {
+        let config = WarpConfig::builder()
+            .maybe_render_quantum_frames(
+                configured
+                    .map(|frames| NonZeroUsize::new(frames).expect("fixture quantum is non-zero")),
+            )
+            .build();
+
+        assert_eq!(config.render_quantum_frames().get(), expected);
+    }
 }

--- a/crates/kithara-warp/src/warp/config.rs
+++ b/crates/kithara-warp/src/warp/config.rs
@@ -5,11 +5,6 @@ use kithara_platform::sync::Arc;
 
 use crate::StretchControls;
 
-const DEFAULT_RENDER_QUANTUM_FRAMES: NonZeroUsize = match NonZeroUsize::new(32) {
-    Some(frames) => frames,
-    None => unreachable!(),
-};
-
 /// Fixed resources used to construct one resident [`super::Warp`].
 #[derive(Clone, Debug, Builder, fieldwork::Fieldwork)]
 #[builder(state_mod(vis = "pub"))]
@@ -20,10 +15,10 @@ pub struct WarpConfig {
     #[builder(default = StretchControls::new(1.0))]
     #[field(get, deref = false)]
     stretch: Arc<StretchControls>,
-    /// Maximum output frames planned before live temporal controls are sampled again.
-    #[builder(default = DEFAULT_RENDER_QUANTUM_FRAMES)]
+    /// Optional output-frame cap between samples of live temporal controls.
+    /// Without a cap, Warp consumes the complete source span accepted by its backend.
     #[field(get, copy)]
-    render_quantum_frames: NonZeroUsize,
+    render_quantum_frames: Option<NonZeroUsize>,
 }
 
 #[cfg(test)]
@@ -33,11 +28,11 @@ mod tests {
     use super::*;
 
     #[kithara::test]
-    #[case::default(None, 32)]
-    #[case::configured(Some(64), 64)]
+    #[case::default(None, None)]
+    #[case::configured(Some(64), Some(64))]
     fn render_quantum_is_configurable_in_frames(
         #[case] configured: Option<usize>,
-        #[case] expected: usize,
+        #[case] expected: Option<usize>,
     ) {
         let config = WarpConfig::builder()
             .maybe_render_quantum_frames(
@@ -46,6 +41,9 @@ mod tests {
             )
             .build();
 
-        assert_eq!(config.render_quantum_frames().get(), expected);
+        assert_eq!(
+            config.render_quantum_frames().map(NonZeroUsize::get),
+            expected
+        );
     }
 }

--- a/crates/kithara-warp/src/warp/render/identity.rs
+++ b/crates/kithara-warp/src/warp/render/identity.rs
@@ -83,8 +83,8 @@ where
     }
 
     #[doc(hidden)]
-    pub const fn render_quantum_frames(&self) -> Option<std::num::NonZeroUsize> {
-        None
+    pub const fn requires_staging(&self) -> bool {
+        false
     }
 
     #[doc(hidden)]

--- a/crates/kithara-warp/src/warp/render/identity.rs
+++ b/crates/kithara-warp/src/warp/render/identity.rs
@@ -1,11 +1,10 @@
 use std::{marker::PhantomData, num::NonZeroU32};
 
 use kithara_bufpool::{HasPool, PoolRegion};
-use kithara_platform::sync::Arc;
-use kithara_signal::{AudioChunk, AudioSpec};
+use kithara_signal::{AudioChunk, AudioChunkInfo, AudioSpec, FrameCount};
 use kithara_test_macros as kithara;
 
-use crate::{RenderReader, RenderSnapshot, StretchControls};
+use crate::{RenderReader, RenderSnapshot, WarpConfig};
 
 /// Identity renderer for targets without elastic DSP.
 /// It preserves decoded samples exactly and keeps playback-rate capability disabled.
@@ -13,6 +12,7 @@ use crate::{RenderReader, RenderSnapshot, StretchControls};
 pub struct WarpRenderer<S> {
     context: RenderReader,
     committed: Option<RenderSnapshot>,
+    prepared: Option<usize>,
     rendered_source_end: Option<(u64, NonZeroU32)>,
     schema: PhantomData<fn() -> S>,
 }
@@ -39,7 +39,7 @@ where
     }
 
     pub(crate) fn new(
-        _controls: Arc<StretchControls>,
+        _config: &WarpConfig,
         context: RenderReader,
         _spec: AudioSpec,
         _pools: PoolRegion<S>,
@@ -47,6 +47,7 @@ where
         Self {
             context,
             committed: None,
+            prepared: None,
             rendered_source_end: None,
             schema: PhantomData,
         }
@@ -55,6 +56,35 @@ where
     #[doc(hidden)]
     pub const fn accepts_input(&self) -> bool {
         true
+    }
+
+    #[doc(hidden)]
+    pub fn prepare_quantum(
+        &mut self,
+        _meta: AudioChunkInfo,
+        remaining: usize,
+    ) -> Option<FrameCount> {
+        self.prepared = (remaining > 0).then_some(remaining);
+        self.prepared.map(FrameCount::new)
+    }
+
+    #[doc(hidden)]
+    pub fn prepare_terminal_quantum(
+        &mut self,
+        _meta: AudioChunkInfo,
+        frames: usize,
+    ) -> Option<FrameCount> {
+        let prepared = self.prepared.take()?;
+        if frames == 0 || frames > prepared {
+            return None;
+        }
+        self.prepared = Some(frames);
+        Some(FrameCount::new(frames))
+    }
+
+    #[doc(hidden)]
+    pub const fn render_quantum_frames(&self) -> Option<std::num::NonZeroUsize> {
+        None
     }
 
     #[doc(hidden)]
@@ -67,6 +97,17 @@ where
 
     #[doc(hidden)]
     pub fn render(&mut self, chunk: AudioChunk) -> Option<AudioChunk> {
+        self.prepared = None;
+        self.render_prepared(chunk)
+    }
+
+    #[doc(hidden)]
+    pub fn render_quantum(&mut self, chunk: AudioChunk) -> Option<AudioChunk> {
+        let frames = self.prepared.take()?;
+        (chunk.frames() == frames).then(|| self.render_prepared(chunk))?
+    }
+
+    fn render_prepared(&mut self, chunk: AudioChunk) -> Option<AudioChunk> {
         let snapshot = self.context.load();
         self.rendered_source_end = Some((
             chunk
@@ -105,6 +146,7 @@ where
     #[doc(hidden)]
     pub const fn reset(&mut self) {
         self.committed = None;
+        self.prepared = None;
         self.rendered_source_end = None;
     }
 
@@ -134,8 +176,11 @@ mod tests {
         meta.frame_offset = 41;
         let input = AudioChunk::new(meta, sample_buffer(&pools, &[0.25, -0.5]));
         let input_ptr = input.samples.as_ptr();
+        let config = WarpConfig::builder()
+            .stretch(StretchControls::new(1.5))
+            .build();
         let mut renderer = WarpRenderer::new(
-            StretchControls::new(1.5),
+            &config,
             crate::RenderPublisher::default().reader(),
             spec,
             pools,

--- a/crates/kithara-warp/src/warp/render/identity.rs
+++ b/crates/kithara-warp/src/warp/render/identity.rs
@@ -53,12 +53,13 @@ where
         }
     }
 
-    #[doc(hidden)]
+    /// Whether the renderer can accept another source chunk.
+    #[must_use]
     pub const fn accepts_input(&self) -> bool {
         true
     }
 
-    #[doc(hidden)]
+    /// Select the next source span that fits the output quantum.
     pub fn prepare_quantum(
         &mut self,
         _meta: AudioChunkInfo,
@@ -68,7 +69,7 @@ where
         self.prepared.map(FrameCount::new)
     }
 
-    #[doc(hidden)]
+    /// Shrink a prepared source span at true EOF.
     pub fn prepare_terminal_quantum(
         &mut self,
         _meta: AudioChunkInfo,
@@ -82,26 +83,27 @@ where
         Some(FrameCount::new(frames))
     }
 
-    #[doc(hidden)]
+    /// Whether rendering needs worker-owned staging buffers.
+    #[must_use]
     pub const fn requires_staging(&self) -> bool {
         false
     }
 
-    #[doc(hidden)]
+    /// Drain one buffered output chunk after source EOF or a transition.
     pub const fn flush(&mut self) -> Option<AudioChunk> {
         None
     }
 
-    #[doc(hidden)]
+    /// Prepare deferred renderer state for the current source format.
     pub const fn prepare(&mut self, _spec: AudioSpec) {}
 
-    #[doc(hidden)]
+    /// Render one complete decoded source chunk.
     pub fn render(&mut self, chunk: AudioChunk) -> Option<AudioChunk> {
         self.prepared = None;
         self.render_prepared(chunk)
     }
 
-    #[doc(hidden)]
+    /// Render the source span selected by [`Self::prepare_quantum`].
     pub fn render_quantum(&mut self, chunk: AudioChunk) -> Option<AudioChunk> {
         let frames = self.prepared.take()?;
         (chunk.frames() == frames).then(|| self.render_prepared(chunk))?
@@ -131,26 +133,21 @@ where
         Some(chunk)
     }
 
-    /// Last context and frontier committed by a successful worker render.
-    #[doc(hidden)]
+    /// Exact decoded-source boundary represented by the latest emitted samples.
     #[must_use]
-    pub fn render_snapshot(&self) -> Option<&RenderSnapshot> {
-        self.committed.as_ref()
-    }
-
-    #[doc(hidden)]
     pub const fn rendered_source_end(&self) -> Option<(u64, NonZeroU32)> {
         self.rendered_source_end
     }
 
-    #[doc(hidden)]
+    /// Discard renderer state after a source discontinuity.
     pub const fn reset(&mut self) {
         self.committed = None;
         self.prepared = None;
         self.rendered_source_end = None;
     }
 
-    #[doc(hidden)]
+    /// Whether a live transition still owns buffered samples.
+    #[must_use]
     pub const fn transition_pending(&self) -> bool {
         false
     }

--- a/crates/kithara-warp/src/warp/render/region_tests.rs
+++ b/crates/kithara-warp/src/warp/render/region_tests.rs
@@ -5,13 +5,10 @@ use kithara_signal::{AudioChunk, AudioChunkInfo, AudioSpec};
 use kithara_stretch::StretchKind;
 use kithara_test_utils::kithara;
 
-use super::WarpRenderer as GenericWarpRenderer;
 use crate::{
-    GridSegment, RegionPlan, RegionPlanError, RenderPublisher, StretchControls,
-    test_pools::{Pools, TestPools, pools, sample_buffer},
+    GridSegment, RegionPlan, RegionPlanError, StretchControls, Warp, WarpConfig,
+    test_pools::{Pools, pools, sample_buffer},
 };
-
-type WarpRenderer = GenericWarpRenderer<TestPools>;
 
 const SR: u32 = 44_100;
 const CH: usize = 2;
@@ -104,12 +101,8 @@ fn render(backend: StretchKind, speed: f32, plan: Option<RegionPlan>, source: &[
     controls.set_keylock(true);
     controls.set_backend(backend);
     controls.set_region_plan(plan.map(Arc::new));
-    let mut fx = WarpRenderer::new(
-        controls,
-        RenderPublisher::default().reader(),
-        spec(),
-        pools.clone(),
-    );
+    let config = WarpConfig::builder().stretch(controls).build();
+    let mut fx = Warp::new((), &config).renderer(spec(), pools.clone());
     let mut out = Vec::new();
     let mut offset = 0_u64;
     for data in source.chunks(4096 * CH) {

--- a/crates/kithara-warp/src/warp/render/renderer.rs
+++ b/crates/kithara-warp/src/warp/render/renderer.rs
@@ -131,7 +131,6 @@ where
     }
 
     /// Select the next source span that fits the configured output quantum.
-    #[doc(hidden)]
     pub fn prepare_quantum(
         &mut self,
         meta: AudioChunkInfo,
@@ -153,7 +152,6 @@ where
     }
 
     /// Shrink a prepared source span at true EOF without sampling controls again.
-    #[doc(hidden)]
     pub fn prepare_terminal_quantum(
         &mut self,
         _meta: AudioChunkInfo,
@@ -169,7 +167,6 @@ where
     }
 
     /// Whether this target has elastic DSP and needs worker staging.
-    #[doc(hidden)]
     #[must_use]
     pub const fn requires_staging(&self) -> bool {
         true
@@ -271,14 +268,12 @@ where
     }
 
     /// Whether a live active-to-unity transition still owns queued samples.
-    #[doc(hidden)]
     #[must_use]
     pub const fn transition_pending(&self) -> bool {
         self.pending_unity_meta.is_some()
     }
 
     /// Whether the renderer can accept another source chunk without dropping it.
-    #[doc(hidden)]
     #[must_use]
     pub fn accepts_input(&self) -> bool {
         !self.transition_pending()
@@ -351,15 +346,7 @@ where
         self.committed = Some(committed);
     }
 
-    /// Last context and frontier committed by a successful worker render.
-    #[doc(hidden)]
-    #[must_use]
-    pub fn render_snapshot(&self) -> Option<&RenderSnapshot> {
-        self.committed.as_ref()
-    }
-
     /// Exact decoded-source boundary represented by the latest emitted samples.
-    #[doc(hidden)]
     #[must_use]
     pub const fn rendered_source_end(&self) -> Option<(u64, NonZeroU32)> {
         self.rendered_source_end

--- a/crates/kithara-warp/src/warp/render/renderer.rs
+++ b/crates/kithara-warp/src/warp/render/renderer.rs
@@ -1,15 +1,22 @@
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, NonZeroUsize};
 
 use kithara_bufpool::{HasPool, PoolRegion, SampleBuffer};
 use kithara_platform::{sync::Arc, time::Duration};
-use kithara_signal::{AudioChunkInfo, AudioSpec};
+use kithara_signal::{AudioChunkInfo, AudioSpec, FrameCount};
 use kithara_stretch::{ElasticEngine, ElasticError, StretchKind};
 use kithara_test_macros as kithara;
+use tracing::warn;
 
-use crate::{ActiveRegion, RegionPlan, RenderReader, RenderSnapshot, StretchControls};
+use crate::{ActiveRegion, RegionPlan, RenderReader, RenderSnapshot, StretchControls, WarpConfig};
 
 #[cfg(test)]
 mod tests;
+
+#[derive(Clone, Copy)]
+pub(super) struct PreparedQuantum {
+    pub(super) frames: usize,
+    pub(super) speed: f32,
+}
 
 /// Source-timeline exact-span time-stretch driven by shared live controls.
 /// Unity speed without a region plan is a byte-identical passthrough.
@@ -33,6 +40,10 @@ pub struct WarpRenderer<S> {
     pub(super) region: Option<ActiveRegion>,
     pub(super) pools: PoolRegion<S>,
     pub(super) spec: AudioSpec,
+    /// Maximum output frames between samples of live temporal controls.
+    pub(super) render_quantum_frames: NonZeroUsize,
+    /// Source span and live speed selected by the scheduler for the next render.
+    pub(super) prepared_quantum: Option<PreparedQuantum>,
     /// Engine kind currently prepared by the scheduler shell.
     pub(super) current_kind: StretchKind,
     /// Interleaved output scratch prepared by the scheduler shell. A produced
@@ -80,11 +91,12 @@ where
 
     /// Build the slot at the source `spec`, driven by the shared `controls`.
     pub(crate) fn new(
-        controls: Arc<StretchControls>,
+        config: &WarpConfig,
         context: RenderReader,
         spec: AudioSpec,
         pools: PoolRegion<S>,
     ) -> Self {
+        let controls = Arc::clone(config.stretch());
         let current_kind = controls.backend();
         let plan = controls.region_plan();
         let target = Self::prepare_target(current_kind, spec, &pools, None, None);
@@ -97,6 +109,8 @@ where
             controls,
             pools,
             spec,
+            render_quantum_frames: config.render_quantum_frames(),
+            prepared_quantum: None,
             applied_pitch: f64::NAN,
             active: false,
             output_remainder: 0.0,
@@ -114,6 +128,51 @@ where
             plan,
             region: None,
         }
+    }
+
+    /// Select the next source span that fits the configured output quantum.
+    #[doc(hidden)]
+    pub fn prepare_quantum(
+        &mut self,
+        meta: AudioChunkInfo,
+        remaining: usize,
+    ) -> Option<FrameCount> {
+        self.sync_plan();
+        let speed = self.controls.speed();
+        match self.source_frames_for_quantum(meta, remaining, speed) {
+            Ok(frames) => {
+                self.prepared_quantum = Some(PreparedQuantum { frames, speed });
+                Some(FrameCount::new(frames))
+            }
+            Err(error) => {
+                self.prepared_quantum = None;
+                warn!(%error, "time-stretch source quantum sizing failed");
+                None
+            }
+        }
+    }
+
+    /// Shrink a prepared source span at true EOF without sampling controls again.
+    #[doc(hidden)]
+    pub fn prepare_terminal_quantum(
+        &mut self,
+        _meta: AudioChunkInfo,
+        frames: usize,
+    ) -> Option<FrameCount> {
+        let mut prepared = self.prepared_quantum.take()?;
+        if frames == 0 || frames > prepared.frames {
+            return None;
+        }
+        prepared.frames = frames;
+        self.prepared_quantum = Some(prepared);
+        Some(FrameCount::new(frames))
+    }
+
+    /// Output quantum when this target has elastic DSP and needs worker staging.
+    #[doc(hidden)]
+    #[must_use]
+    pub const fn render_quantum_frames(&self) -> Option<NonZeroUsize> {
+        Some(self.render_quantum_frames)
     }
 
     /// Push `pitch` to the backend when it moved beyond `RATIO_EPS`.
@@ -153,6 +212,7 @@ where
         self.output_start_meta = None;
         self.applied_pitch = f64::NAN;
         self.output_remainder = 0.0;
+        self.prepared_quantum = None;
         self.rendered_source_end = None;
         self.source_frames_admitted = 0;
         self.active = false;
@@ -193,6 +253,7 @@ where
         if !same {
             self.plan = want;
             self.region = None;
+            self.prepared_quantum = None;
         }
     }
 

--- a/crates/kithara-warp/src/warp/render/renderer.rs
+++ b/crates/kithara-warp/src/warp/render/renderer.rs
@@ -41,7 +41,7 @@ pub struct WarpRenderer<S> {
     pub(super) pools: PoolRegion<S>,
     pub(super) spec: AudioSpec,
     /// Maximum output frames between samples of live temporal controls.
-    pub(super) render_quantum_frames: NonZeroUsize,
+    pub(super) render_quantum_frames: Option<NonZeroUsize>,
     /// Source span and live speed selected by the scheduler for the next render.
     pub(super) prepared_quantum: Option<PreparedQuantum>,
     /// Engine kind currently prepared by the scheduler shell.
@@ -168,11 +168,11 @@ where
         Some(FrameCount::new(frames))
     }
 
-    /// Output quantum when this target has elastic DSP and needs worker staging.
+    /// Whether this target has elastic DSP and needs worker staging.
     #[doc(hidden)]
     #[must_use]
-    pub const fn render_quantum_frames(&self) -> Option<NonZeroUsize> {
-        Some(self.render_quantum_frames)
+    pub const fn requires_staging(&self) -> bool {
+        true
     }
 
     /// Push `pitch` to the backend when it moved beyond `RATIO_EPS`.

--- a/crates/kithara-warp/src/warp/render/renderer/tests.rs
+++ b/crates/kithara-warp/src/warp/render/renderer/tests.rs
@@ -143,7 +143,8 @@ fn render_commits_the_context_captured_for_the_operation() {
 
     let output = render_serviced(&mut renderer, input).expect("unity render succeeds");
     let snapshot = renderer
-        .render_snapshot()
+        .committed
+        .as_ref()
         .expect("successful render commits a snapshot");
 
     assert_eq!(output.frames(), 1);

--- a/crates/kithara-warp/src/warp/render/renderer/tests.rs
+++ b/crates/kithara-warp/src/warp/render/renderer/tests.rs
@@ -7,7 +7,7 @@ use realfft::RealFftPlanner;
 
 use super::{StretchControls, WarpRenderer as GenericWarpRenderer};
 use crate::{
-    PresentationFrontier, RenderContext, RenderPublisher, SessionEpoch, SessionFrame,
+    PresentationFrontier, RenderContext, SessionEpoch, SessionFrame, Warp, WarpConfig,
     test_pools::{Pools, TestPools, pools, sample_buffer},
 };
 
@@ -96,12 +96,8 @@ fn spec() -> AudioSpec {
 }
 
 fn renderer(controls: Arc<StretchControls>) -> WarpRenderer {
-    WarpRenderer::new(
-        controls,
-        RenderPublisher::default().reader(),
-        spec(),
-        pools(),
-    )
+    let config = WarpConfig::builder().stretch(controls).build();
+    Warp::new((), &config).renderer(spec(), pools())
 }
 
 fn render_serviced(fx: &mut WarpRenderer, input: AudioChunk) -> Option<AudioChunk> {
@@ -121,13 +117,12 @@ fn flush_serviced(fx: &mut WarpRenderer) -> Option<AudioChunk> {
 #[kithara::test]
 fn render_commits_the_context_captured_for_the_operation() {
     let pools = pools();
-    let publisher = RenderPublisher::default();
-    let mut renderer = WarpRenderer::new(
-        StretchControls::new(1.0),
-        publisher.reader(),
-        spec(),
-        pools.clone(),
-    );
+    let config = WarpConfig::builder()
+        .stretch(StretchControls::new(1.0))
+        .build();
+    let mut warp = Warp::new((), &config);
+    let publisher = warp.take_publisher().expect("test Warp owns its publisher");
+    let mut renderer = warp.renderer(spec(), pools.clone());
     let context = RenderContext::new(
         SessionFrame::new(1_000)..SessionFrame::new(1_001),
         spec().sample_rate,

--- a/crates/kithara-warp/src/warp/render/renderer/tests/playback.rs
+++ b/crates/kithara-warp/src/warp/render/renderer/tests/playback.rs
@@ -21,7 +21,7 @@ use crate::{Warp, WarpConfig, test_pools::pools};
 )]
 #[cfg_attr(
     feature = "stretch-signalsmith",
-    case::signalsmith_unity(StretchKind::Signalsmith, 1.0, 32)
+    case::signalsmith_unity(StretchKind::Signalsmith, 1.0, 128)
 )]
 #[cfg_attr(
     feature = "stretch-signalsmith",
@@ -33,7 +33,7 @@ use crate::{Warp, WarpConfig, test_pools::pools};
 )]
 #[cfg_attr(
     feature = "stretch-bungee",
-    case::bungee_unity(StretchKind::Bungee, 1.0, 32)
+    case::bungee_unity(StretchKind::Bungee, 1.0, 128)
 )]
 #[cfg_attr(
     feature = "stretch-bungee",

--- a/crates/kithara-warp/src/warp/render/renderer/tests/playback.rs
+++ b/crates/kithara-warp/src/warp/render/renderer/tests/playback.rs
@@ -1,10 +1,10 @@
 use std::{
     collections::HashSet,
-    num::{NonZero, NonZeroU32},
+    num::{NonZero, NonZeroU32, NonZeroUsize},
 };
 
 use kithara_platform::{sync::Arc, time::Duration};
-use kithara_signal::AudioSpec;
+use kithara_signal::{AudioChunkInfo, AudioSpec};
 use kithara_stretch::StretchKind;
 use kithara_test_utils::kithara;
 
@@ -12,6 +12,53 @@ use super::{
     Consts, StretchControls, WarpRenderer, chunk, dominant_bin, expected_bin, flush_serviced,
     render_serviced, renderer, sine, spec,
 };
+use crate::{Warp, WarpConfig, test_pools::pools};
+
+#[kithara::test]
+#[cfg_attr(
+    feature = "stretch-signalsmith",
+    case::signalsmith_slow(StretchKind::Signalsmith, 0.5, 15)
+)]
+#[cfg_attr(
+    feature = "stretch-signalsmith",
+    case::signalsmith_unity(StretchKind::Signalsmith, 1.0, 32)
+)]
+#[cfg_attr(
+    feature = "stretch-signalsmith",
+    case::signalsmith_fast(StretchKind::Signalsmith, 2.0, 63)
+)]
+#[cfg_attr(
+    feature = "stretch-bungee",
+    case::bungee_slow(StretchKind::Bungee, 0.5, 15)
+)]
+#[cfg_attr(
+    feature = "stretch-bungee",
+    case::bungee_unity(StretchKind::Bungee, 1.0, 32)
+)]
+#[cfg_attr(
+    feature = "stretch-bungee",
+    case::bungee_fast(StretchKind::Bungee, 2.0, 63)
+)]
+fn source_span_is_planned_from_the_output_quantum(
+    #[case] backend: StretchKind,
+    #[case] speed: f32,
+    #[case] expected_source_frames: usize,
+) {
+    let controls = StretchControls::new(speed);
+    controls.set_backend(backend);
+    let config = WarpConfig::builder()
+        .stretch(controls)
+        .render_quantum_frames(NonZeroUsize::new(32).expect("test quantum is non-zero"))
+        .build();
+    let mut renderer = Warp::new((), &config).renderer(spec(), pools());
+    renderer.prepare(spec());
+
+    let frames = renderer
+        .prepare_quantum(AudioChunkInfo::default(), 128)
+        .expect("test source span is plannable");
+
+    assert_eq!(frames.get(), expected_source_frames);
+}
 
 fn keylocked(kind: StretchKind, speed: f32) -> WarpRenderer {
     let controls = StretchControls::new(speed);

--- a/crates/kithara-warp/src/warp/render/renderer/tests/target.rs
+++ b/crates/kithara-warp/src/warp/render/renderer/tests/target.rs
@@ -10,7 +10,7 @@ use kithara_test_utils::kithara;
 use super::{
     Consts, chunk, dominant_bin, expected_bin, flush_serviced, render_serviced, renderer, sine,
 };
-use super::{RenderPublisher, StretchControls, WarpRenderer, spec};
+use super::{StretchControls, WarpConfig, spec};
 use crate::test_pools::pools_with_budget as test_pools;
 
 /// Swapping the backend mid-stream keeps the stream flowing and pitch-locked.
@@ -74,12 +74,8 @@ fn target_rebuild_reuses_one_target_pool_budget(#[case] backend: StretchKind) {
             let controls = StretchControls::new(0.5);
             controls.set_keylock(true);
             controls.set_backend(backend);
-            let target = WarpRenderer::new(
-                controls,
-                RenderPublisher::default().reader(),
-                target_spec,
-                pools.clone(),
-            );
+            let config = WarpConfig::builder().stretch(controls).build();
+            let target = crate::Warp::new((), &config).renderer(target_spec, pools.clone());
             assert!(target.engine.is_some());
             pools.stats().allocated_bytes
         })
@@ -91,12 +87,8 @@ fn target_rebuild_reuses_one_target_pool_budget(#[case] backend: StretchKind) {
     let controls = StretchControls::new(0.5);
     controls.set_keylock(true);
     controls.set_backend(backend);
-    let mut fx = WarpRenderer::new(
-        controls,
-        RenderPublisher::default().reader(),
-        initial,
-        pools.clone(),
-    );
+    let config = WarpConfig::builder().stretch(controls).build();
+    let mut fx = crate::Warp::new((), &config).renderer(initial, pools.clone());
     assert!(fx.engine.is_some());
     assert!(fx.pending_source.is_some());
     assert!(fx.scratch.is_some());
@@ -120,12 +112,8 @@ fn failed_target_rebuild_is_not_retried_without_a_new_revision(#[case] backend: 
     let controls = StretchControls::new(0.5);
     controls.set_keylock(true);
     controls.set_backend(backend);
-    let mut fx = WarpRenderer::new(
-        controls,
-        RenderPublisher::default().reader(),
-        spec(),
-        pools.clone(),
-    );
+    let config = WarpConfig::builder().stretch(controls).build();
+    let mut fx = crate::Warp::new((), &config).renderer(spec(), pools.clone());
     assert!(fx.engine.is_none());
 
     fx.rebuild_pending = true;

--- a/crates/kithara-warp/src/warp/render/renderer/tests/timeline.rs
+++ b/crates/kithara-warp/src/warp/render/renderer/tests/timeline.rs
@@ -8,7 +8,7 @@ use super::{
     Consts, StretchControls, WarpRenderer, chunk, f64_of, flush_serviced, render_serviced,
     renderer, sine, spec,
 };
-use crate::{GridSegment, RegionPlan, RenderPublisher};
+use crate::{GridSegment, RegionPlan, Warp, WarpConfig};
 
 fn finish_unity_transition(
     renderer: &mut WarpRenderer,
@@ -357,12 +357,10 @@ fn live_unity_transition_drains_active_backend_tail(#[case] backend: StretchKind
     let live_controls = StretchControls::new(0.5);
     live_controls.set_keylock(true);
     live_controls.set_backend(backend);
-    let mut live = WarpRenderer::new(
-        Arc::clone(&live_controls),
-        RenderPublisher::default().reader(),
-        spec(),
-        pools.clone(),
-    );
+    let live_config = WarpConfig::builder()
+        .stretch(Arc::clone(&live_controls))
+        .build();
+    let mut live = Warp::new((), &live_config).renderer(spec(), pools.clone());
     let live_active = render_serviced(&mut live, chunk(&pools, &source[..split]))
         .expect("non-unity span emits samples");
     assert_eq!(live_active.frames(), reference_active.frames());
@@ -480,12 +478,8 @@ fn negative_rounding_debt_adds_no_frame_at_unity_transition(#[case] backend: Str
         ])
         .expect("fixture regions are contiguous"),
     )));
-    let mut fx = WarpRenderer::new(
-        Arc::clone(&controls),
-        RenderPublisher::default().reader(),
-        spec(),
-        pools.clone(),
-    );
+    let config = WarpConfig::builder().stretch(Arc::clone(&controls)).build();
+    let mut fx = Warp::new((), &config).renderer(spec(), pools.clone());
     let first = render_serviced(&mut fx, chunk(&pools, &source[..usize::from(Consts::CH)]))
         .expect("the first span rounds to two frames");
     assert_eq!(first.frames(), 2);

--- a/crates/kithara-warp/src/warp/render/renderer_lifecycle.rs
+++ b/crates/kithara-warp/src/warp/render/renderer_lifecycle.rs
@@ -304,12 +304,12 @@ where
         self.emit(Some(samples), held_source_frames)
     }
 
-    #[doc(hidden)]
+    /// Prepare deferred renderer state for the current source format.
     pub fn prepare(&mut self, spec: AudioSpec) {
         self.service_target(spec);
     }
 
-    #[doc(hidden)]
+    /// Drain one buffered output chunk after source EOF or a transition.
     pub fn flush(&mut self) -> Option<AudioChunk> {
         let snapshot = self.context.load();
         if let Some(scratch) = self.scratch.as_mut() {
@@ -347,7 +347,7 @@ where
         output
     }
 
-    #[doc(hidden)]
+    /// Render one complete decoded source chunk.
     pub fn render(&mut self, chunk: AudioChunk) -> Option<AudioChunk> {
         let snapshot = self.context.load();
         self.prepared_quantum = None;
@@ -355,7 +355,6 @@ where
     }
 
     /// Render the source span selected by [`Self::prepare_quantum`].
-    #[doc(hidden)]
     pub fn render_quantum(&mut self, chunk: AudioChunk) -> Option<AudioChunk> {
         let prepared = self.prepared_quantum.take()?;
         if chunk.frames() != prepared.frames {
@@ -397,7 +396,7 @@ where
         output
     }
 
-    #[doc(hidden)]
+    /// Discard renderer state after a source discontinuity.
     pub fn reset(&mut self) {
         self.reset_pending = true;
         self.clear_render_state();

--- a/crates/kithara-warp/src/warp/render/renderer_lifecycle.rs
+++ b/crates/kithara-warp/src/warp/render/renderer_lifecycle.rs
@@ -350,6 +350,27 @@ where
     #[doc(hidden)]
     pub fn render(&mut self, chunk: AudioChunk) -> Option<AudioChunk> {
         let snapshot = self.context.load();
+        self.prepared_quantum = None;
+        self.render_at(chunk, self.controls.speed(), snapshot)
+    }
+
+    /// Render the source span selected by [`Self::prepare_quantum`].
+    #[doc(hidden)]
+    pub fn render_quantum(&mut self, chunk: AudioChunk) -> Option<AudioChunk> {
+        let prepared = self.prepared_quantum.take()?;
+        if chunk.frames() != prepared.frames {
+            return None;
+        }
+        let snapshot = self.context.load();
+        self.render_at(chunk, prepared.speed, snapshot)
+    }
+
+    fn render_at(
+        &mut self,
+        chunk: AudioChunk,
+        speed: f32,
+        snapshot: Option<crate::RenderSnapshot>,
+    ) -> Option<AudioChunk> {
         if chunk.spec() != self.spec {
             warn!(
                 expected = %self.spec,
@@ -365,7 +386,6 @@ where
             return None;
         }
 
-        let speed = self.controls.speed();
         let output = if self.unity_passthrough(speed) {
             self.process_unity(chunk)
         } else {

--- a/crates/kithara-warp/src/warp/render/renderer_render.rs
+++ b/crates/kithara-warp/src/warp/render/renderer_render.rs
@@ -9,6 +9,61 @@ impl<S> WarpRenderer<S>
 where
     S: HasPool<f32>,
 {
+    pub(super) fn source_frames_for_quantum(
+        &mut self,
+        meta: AudioChunkInfo,
+        remaining: usize,
+        speed: f32,
+    ) -> Result<usize, ElasticError> {
+        if remaining == 0 {
+            return Err(ElasticError::EmptySource);
+        }
+        if !self.active
+            && !self.transition_pending()
+            && self.pending_frames(usize::from(self.spec.channels.max(1))) == 0
+            && self.unity_passthrough(speed)
+        {
+            return Ok(remaining.min(self.render_quantum_frames.get()));
+        }
+
+        let channels = usize::from(self.spec.channels.max(1));
+        let region = self.region_for(meta.frame_offset);
+        let region_frames = usize::try_from(
+            region
+                .end()
+                .checked_sub(meta.frame_offset)
+                .ok_or(ElasticError::SampleCountOverflow)?
+                .min(u64::try_from(remaining).map_err(|_| ElasticError::SampleCountOverflow)?),
+        )
+        .map_err(|_| ElasticError::SampleCountOverflow)?;
+        if region_frames == 0 {
+            return Err(ElasticError::StationarySourceSpan);
+        }
+        let stretch = (1.0 / f64::from(speed)) * region.correction();
+        let capabilities = self
+            .engine
+            .as_ref()
+            .map(|engine| engine.capabilities())
+            .ok_or(ElasticError::EnginePreparation("engine is unavailable"))?;
+        let output_limit = capabilities
+            .max_output_frames()
+            .min(self.render_quantum_frames.get());
+        let source_limit =
+            Self::source_block_limit(stretch, capabilities.max_source_frames(), output_limit)?;
+        let pending_frames = self.pending_frames(channels);
+        let available =
+            source_limit
+                .checked_sub(pending_frames)
+                .ok_or(ElasticError::SourceFrameLimit {
+                    frames: pending_frames,
+                    limit: source_limit,
+                })?;
+        if available == 0 {
+            return Err(ElasticError::InvalidRate(stretch.recip()));
+        }
+        Ok(region_frames.min(available))
+    }
+
     pub(super) fn source_block_limit(
         stretch: f64,
         max_source_frames: usize,

--- a/crates/kithara-warp/src/warp/render/renderer_render.rs
+++ b/crates/kithara-warp/src/warp/render/renderer_render.rs
@@ -45,9 +45,10 @@ where
             .as_ref()
             .map(|engine| engine.capabilities())
             .ok_or(ElasticError::EnginePreparation("engine is unavailable"))?;
-        let output_limit = capabilities
-            .max_output_frames()
-            .min(self.render_quantum_frames.get());
+        let output_limit = self.render_quantum_frames.map_or_else(
+            || capabilities.max_output_frames(),
+            |frames| capabilities.max_output_frames().min(frames.get()),
+        );
         let source_limit =
             Self::source_block_limit(stretch, capabilities.max_source_frames(), output_limit)?;
         let pending_frames = self.pending_frames(channels);

--- a/crates/kithara-warp/src/warp/render/renderer_render.rs
+++ b/crates/kithara-warp/src/warp/render/renderer_render.rs
@@ -23,7 +23,7 @@ where
             && self.pending_frames(usize::from(self.spec.channels.max(1))) == 0
             && self.unity_passthrough(speed)
         {
-            return Ok(remaining.min(self.render_quantum_frames.get()));
+            return Ok(remaining);
         }
 
         let channels = usize::from(self.spec.channels.max(1));

--- a/docs/guides/test-harness.md
+++ b/docs/guides/test-harness.md
@@ -61,5 +61,9 @@ validation scope.
 - Test logs and generated data stay at a reasonable size.
 - `src/` is production code, not a fixture warehouse. Large fixtures, local
   servers, generated content, and multi-step scenarios belong in `tests/`;
-  small unit tests and tiny helpers under `#[cfg(test)]` stay next to the code.
+  small unit-test modules may stay next to the code under `#[cfg(test)]`.
+- Keep test helpers inside test modules. Do not add test-only fields, methods,
+  functions, or branches to production types and implementations.
+- Observe internal state through real behavior, events, or USDT probes attached
+  to real operations. Do not add no-op functions solely as probe points.
 - Any public API change comes with tests that capture the contract.

--- a/tests/src/offline/harness.rs
+++ b/tests/src/offline/harness.rs
@@ -4,16 +4,13 @@ use kithara::{
     decode::GaplessMode,
     events::{Event, EventReceiver, PlayerEvent},
     host::{HostConfig, HostOwned},
-    platform::{
-        sync::{Arc, Mutex},
-        tokio::sync::broadcast::error::TryRecvError,
-    },
+    platform::{sync::Mutex, tokio::sync::broadcast::error::TryRecvError},
     play::{
         PlayWorker, PlayWorkerConfig, PlayerConfig, PlayerImpl,
         effects::eq::EqBandConfig,
         player::{Player, PlayerControl, PlayerControlSource},
     },
-    warp::StretchControls,
+    warp::WarpConfig,
 };
 
 use super::{OfflineHostHarness, host::offline_pools};
@@ -41,7 +38,7 @@ pub struct OfflinePlayerOptions {
     /// panic instead of inserted silence.
     #[builder(default)]
     block_on_underrun: bool,
-    timestretch: Option<Arc<StretchControls>>,
+    warp: Option<WarpConfig>,
 }
 
 impl OfflinePlayerHarness {
@@ -64,7 +61,7 @@ impl OfflinePlayerHarness {
             .sample_rate(sample_rate)
             .worker(worker.clone())
             .maybe_eq_layout(options.eq_layout)
-            .maybe_timestretch(options.timestretch)
+            .maybe_warp(options.warp)
             .build();
 
         let player = PlayerImpl::new(player_config);

--- a/tests/tests/kithara_audio/no_sync_passthrough.rs
+++ b/tests/tests/kithara_audio/no_sync_passthrough.rs
@@ -477,7 +477,7 @@ async fn render_queue_passthrough(source: &[u8], stretch: Option<(StretchKind, f
     let harness = OfflinePlayerHarness::with_sample_rate(
         OfflinePlayerOptions::builder()
             .crossfade_duration(0.0)
-            .timestretch(Arc::clone(&stretch))
+            .warp(WarpConfig::builder().stretch(Arc::clone(&stretch)).build())
             .build(),
         SAMPLE_RATE,
     );

--- a/tests/tests/kithara_play/no_sync_real_media.rs
+++ b/tests/tests/kithara_play/no_sync_real_media.rs
@@ -24,7 +24,7 @@ use kithara::{
         PlayWorker, PlayWorkerConfig, PlayerConfig, PlayerImpl, Resource, ResourceConfig,
         ResourceSrc, SeekOutcome, SelectTransition,
     },
-    warp::{StretchControls, StretchKind},
+    warp::{StretchControls, StretchKind, WarpConfig},
 };
 use kithara_integration_tests::{
     HlsFixtureBuilder, TestServerHelper, TestTempDir, audio_artifact::write_audio_artifact,
@@ -893,7 +893,7 @@ async fn prepare_deck(
                 NonZeroU32::new(case.host_rate).expect("host sample rate must be non-zero"),
             )
             .crossfade_duration(0.0)
-            .timestretch(Arc::clone(&controls))
+            .warp(WarpConfig::builder().stretch(Arc::clone(&controls)).build())
             .build(),
     );
     let events = player.subscribe();

--- a/tests/tests/kithara_play/quality_switch_continuity/desktop.rs
+++ b/tests/tests/kithara_play/quality_switch_continuity/desktop.rs
@@ -7,7 +7,7 @@ use kithara::{
     events::{ResamplerKind, TrackId},
     platform::sync::Arc,
     play::{PlaybackResamplerBackend, ResourceSrc},
-    warp::StretchControls,
+    warp::{StretchControls, WarpConfig},
 };
 use kithara_integration_tests::{
     TestServerHelper,
@@ -169,7 +169,11 @@ async fn prepare_desktop_player(master_url: &url::Url, label: &str) -> DesktopPr
     timestretch.set_backend(StretchKind::Signalsmith);
     let harness = OfflinePlayerHarness::with_sample_rate(
         OfflinePlayerOptions::builder()
-            .timestretch(Arc::clone(&timestretch))
+            .warp(
+                WarpConfig::builder()
+                    .stretch(Arc::clone(&timestretch))
+                    .build(),
+            )
             .build(),
         HOST_SAMPLE_RATE,
     );

--- a/tests/tests/kithara_queue/advance_boundary_provenance.rs
+++ b/tests/tests/kithara_queue/advance_boundary_provenance.rs
@@ -11,10 +11,11 @@ use kithara::{
         tokio::sync::broadcast::error::TryRecvError,
     },
     play::{
-        Resource, ResourceConfig, ResourceSrc, StretchControls,
-        effects::eq::generate_log_spaced_bands, player::PlayerControl,
+        Resource, ResourceConfig, ResourceSrc, effects::eq::generate_log_spaced_bands,
+        player::PlayerControl,
     },
     queue::{Queue, QueueConfig, QueueControl, Transition, test_utils::QueueProbe},
+    warp::{StretchControls, WarpConfig},
 };
 use kithara_integration_tests::{
     HlsFixtureBuilder, TestServerHelper, TestTempDir,
@@ -992,7 +993,11 @@ fn crossfade_eq_stretch_player_config(timestretch: &Arc<StretchControls>) -> Off
     OfflinePlayerOptions::builder()
         .crossfade_duration(CROSSFADE_SECS)
         .eq_layout(generate_log_spaced_bands(10))
-        .timestretch(Arc::clone(timestretch))
+        .warp(
+            WarpConfig::builder()
+                .stretch(Arc::clone(timestretch))
+                .build(),
+        )
         .build()
 }
 


### PR DESCRIPTION
## Summary
Add pool-backed staging for elastic Warp rendering without changing production buffering by default. Warp partitioning is now an explicit configuration: the default consumes the source span accepted by the backend, while latency tests or hosts may set a smaller output-frame cap. Player admits completed rendered chunks directly, and the audio pipeline keeps its established platform ring depth and preload defaults.

## Behavior / scope
- contract or behavior: `WarpConfig::render_quantum_frames` is an optional output-frame cap; `None` is the default. Decoder chunks remain codec-defined, `ChunkCursor` adapts them to callback reads, and Warp quantum does not determine producer-ring depth.
- affected area: pool-backed `BufferRing`, Warp render staging, Player worker admission, and audio/play configuration propagation.

## Validation
- `just lint fast`
- `just platform wasm check`
- `just test run -E 'package(kithara-audio) | package(kithara-play) | package(kithara-warp)'` (505 passed)
- not run as acceptance locally: full `just test`; exact-head non-UI CI owns the complete matrix and same-runner execution-time comparison.

## Surface impact
- Public API: changed: `WarpConfig` exposes an optional render-quantum cap and pool-backed `BufferRing` remains the staging contract.
- Platform/runtime: changed: explicitly configured elastic Warp lanes may partition output; production defaults remain 10 audio chunks on native, 32 on wasm, and 3 preload chunks. Backendless/identity playback remains direct passthrough.
- Perf-sensitive paths: changed: elastic source staging and Player worker admission.

## Risks / follow-ups
- CI must verify that opt-in staging does not regress the full test matrix or same-runner execution time.
- Later PR #232 slices still own producer pacing, deferred reader delivery, ABR rebuild correctness, and final latest-wins rate-response acceptance.
