### PR TITLE
fix(ci): persist nightly quality report

### DIFF
--- a/.config/xtask.toml
+++ b/.config/xtask.toml
@@ -1743,7 +1743,7 @@ os = "linux"
 fetch_depth = 1
 tools = ["cargo", "just"]
 program = "just"
-artifact = { name = "quality-report", path = "target/quality-report.md" }
+artifact = { name = "quality-report", path = "target/consolidated-quality-report.md" }
 steps = [
   { args = [
     "ci",

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -38,6 +38,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
           RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
           REPOSITORY: ${{ github.repository }}
@@ -70,11 +71,11 @@ jobs:
           # report`) and archive it, so this collector carries the numbers
           # rather than re-deriving them. A run that selected no quality lane
           # leaves no such artifact, and that is a normal state, not a failure.
-          if gh run download "$RUN_ID" --repo "$REPOSITORY" --name quality-report --dir quality \
-              && [[ -f quality/quality-report.md ]]; then
+          if gh run download "$RUN_ID" --repo "$REPOSITORY" --name quality-report-${RUN_ID}-${RUN_ATTEMPT} --dir quality \
+              && [[ -f quality/consolidated-quality-report.md ]]; then
             {
               echo
-              cat quality/quality-report.md
+              cat quality/consolidated-quality-report.md
             } >> target/dispatch-report.md
           fi
 

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -118,3 +118,6 @@ jobs:
       timeout-minutes: ${{ matrix.timeout }}
       fetch-depth: ${{ matrix.depth }}
       download: ${{ join(matrix.needs, ' ') }}
+      artifact-name: ${{ matrix.artifact.name || '' }}
+      artifact-path: ${{ matrix.artifact.path || '' }}
+      artifact-when: ${{ matrix.artifact.when || 'always' }}

--- a/crates/kithara-devtools/src/ci_report.rs
+++ b/crates/kithara-devtools/src/ci_report.rs
@@ -35,7 +35,12 @@ pub struct CiReportArgs {
 }
 
 pub(crate) fn run(args: &CiReportArgs, ctx: &Ctx) -> Result<()> {
-    print!("{}", render(&args.artifacts, &ctx.config.ci_report)?);
+    let report = render(&args.artifacts, &ctx.config.ci_report)?;
+    let target = ctx.root.join("target");
+    fs::create_dir_all(&target).with_context(|| format!("create {}", target.display()))?;
+    let output = target.join("consolidated-quality-report.md");
+    fs::write(&output, &report).with_context(|| format!("write {}", output.display()))?;
+    print!("{report}");
     Ok(())
 }
 
@@ -115,7 +120,11 @@ fn health(artifacts: &Path) -> Result<String> {
     let summary = text
         .split_once(Consts::STAGE_DETAILS)
         .map_or(text.as_str(), |(before, _)| before);
-    Ok(format!("{}\n", summary.trim_end()))
+    let (title, body) = summary.split_once('\n').unwrap_or((summary, ""));
+    if !title.starts_with("# ") || !title.ends_with(" health report") {
+        anyhow::bail!("{} has an unexpected title {title:?}", report.display());
+    }
+    Ok(format!("\n## Workspace health\n\n{}\n", body.trim()))
 }
 
 fn coverage_risk(artifacts: &Path, rows: usize) -> Result<String> {
@@ -216,12 +225,17 @@ fn named(path: &Path, name: &str) -> bool {
     path.file_name().is_some_and(|found| found == name)
 }
 
-/// Whether the artifact this file came from is the one named. The similarity
-/// report sits under a revision directory the workflow never states, so its
-/// own file name and its parent are both the wrong things to match on.
+/// Whether the artifact this file came from is the one named. Downloads keep
+/// the run id and attempt suffix added by the uploader.
 fn under(path: &Path, name: &str) -> bool {
-    path.components()
-        .any(|component| component.as_os_str() == name)
+    path.components().any(|component| {
+        component.as_os_str().to_str().is_some_and(|found| {
+            found == name
+                || found
+                    .strip_prefix(name)
+                    .is_some_and(|suffix| suffix.starts_with('-'))
+        })
+    })
 }
 
 fn parent_named(path: &Path, name: &str) -> bool {
@@ -260,12 +274,32 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
+    use crate::common::project::ProjectConfig;
 
     fn write(path: &Path, contents: &str) {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent).expect("create artifact directory");
         }
         fs::write(path, contents).expect("write artifact");
+    }
+
+    #[test]
+    fn run_writes_the_consolidated_report_with_numeric_crap_metrics() {
+        let temp = tempdir().expect("tempdir");
+        let artifacts = temp.path().join("artifacts");
+        write(
+            &artifacts.join("coverage-risk/cargo-crap/report.md"),
+            "## 3 function(s) exceed CRAP threshold 30\n\n| | CRAP | CC | Cov % | Function | Location |\n|---|---:|---:|---:|---|---|\n| high | 35.48 | 28 | 78.79 | prepare_planned_variant_reader | prepare.rs:22 |\n",
+        );
+        let ctx = Ctx::new(temp.path().to_path_buf(), ProjectConfig::default());
+
+        run(&CiReportArgs { artifacts }, &ctx).expect("write consolidated report");
+
+        let report = fs::read_to_string(temp.path().join("target/consolidated-quality-report.md"))
+            .expect("read consolidated report");
+        assert!(report.contains("## Coverage risk (CRAP)"), "{report}");
+        assert!(report.contains("| | CRAP | CC | Cov % |"), "{report}");
+        assert!(report.contains("| high | 35.48 | 28 | 78.79 |"), "{report}");
     }
 
     #[test]
@@ -286,12 +320,26 @@ mod tests {
         let temp = tempdir().expect("tempdir");
         write(
             &temp.path().join("health-report/health-report.md"),
-            "# health report\n\n## Summary\n\n| 1 | orphans | FAIL |\n\n## Stage details\n\nlog tail\n",
+            "# musicbox health report\n\n## Summary\n\n| 1 | orphans | FAIL |\n\n## Stage details\n\nlog tail\n",
         );
 
         let report = health(temp.path()).expect("health section");
 
+        assert!(report.contains("## Workspace health"));
         assert!(report.contains("| 1 | orphans | FAIL |"));
+    }
+
+    #[test]
+    fn health_section_rejects_an_unexpected_title() {
+        let temp = tempdir().expect("tempdir");
+        write(
+            &temp.path().join("health-report/health-report.md"),
+            "# unrelated report\n",
+        );
+
+        let error = health(temp.path()).expect_err("unexpected title");
+
+        assert!(error.to_string().contains("unexpected title"), "{error:#}");
     }
 
     #[test]
@@ -432,7 +480,7 @@ mod tests {
     fn duplication_section_reads_the_report_under_its_revision() {
         let temp = tempdir().expect("tempdir");
         write(
-            &temp.path().join("similarity-report/abc1234/report.md"),
+            &temp.path().join("similarity-report-42-1/abc1234/report.md"),
             "# duplication\n\n| pair | score |\n",
         );
 

--- a/xtask/src/ci/lane/select.rs
+++ b/xtask/src/ci/lane/select.rs
@@ -62,6 +62,7 @@ pub(crate) struct Dependent {
     pub(crate) timeout: u32,
     pub(crate) depth: u32,
     pub(crate) needs: Vec<String>,
+    pub(crate) artifact: Option<CiLaneArtifact>,
 }
 
 #[derive(Debug, Serialize)]
@@ -171,6 +172,7 @@ pub(crate) fn render(
             timeout: lane.timeout_minutes,
             depth: lane.fetch_depth,
             needs: lane.needs.clone(),
+            artifact: lane.artifact.clone(),
         })
         .collect();
 
@@ -228,6 +230,7 @@ pub(crate) fn run(args: &LanesArgs, ctx: &Ctx) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::ArtifactWhen;
 
     fn lane(role: &str, kinds: &[&str], needs: &[&str]) -> CiLaneConfig {
         CiLaneConfig {
@@ -280,8 +283,17 @@ mod tests {
     // Asking for one lane must bring what reads its artifact, and nothing else.
     #[test]
     fn selecting_one_lane_brings_only_its_own_dependents() {
+        let mut catalog = catalog();
+        let dependent = catalog
+            .get_mut("deep-stress-report")
+            .expect("the dependent lane is in the catalog");
+        dependent.artifact = Some(CiLaneArtifact {
+            name: "quality-report".to_owned(),
+            path: "target/consolidated-quality-report.md".to_owned(),
+            when: ArtifactWhen::Failure,
+        });
         let selection = render(
-            &catalog(),
+            &catalog,
             &args("deep", PipelineKind::Nightly, &["deep-stress"]),
         )
         .expect("the stress lane renders");
@@ -297,6 +309,10 @@ mod tests {
             .collect();
         assert_eq!(names, ["deep-stress"]);
         assert_eq!(dependent, ["deep-stress-report"]);
+        assert_eq!(
+            field(&selection, Some(Field::Dependent)).expect("the dependent field renders"),
+            r#"[{"lane":"deep-stress-report","timeout":30,"depth":0,"needs":["deep-stress"],"artifact":{"name":"quality-report","path":"target/consolidated-quality-report.md","when":"failure"}}]"#
+        );
     }
 
     #[test]

--- a/xtask/tests/github_workflows.rs
+++ b/xtask/tests/github_workflows.rs
@@ -1597,11 +1597,20 @@ fn the_dispatch_collector_is_read_only_and_does_not_mirror_the_source_verdict() 
     );
 
     let collect = named_step(job, "Collect the source run jobs");
+    let env = mapping_field(collect, "env")
+        .as_mapping()
+        .expect("the collector has an environment");
+    assert_eq!(
+        mapping_field(env, "RUN_ATTEMPT").as_str(),
+        Some("${{ github.event.workflow_run.run_attempt }}")
+    );
     let script = mapping_field(collect, "run")
         .as_str()
         .expect("dispatch collector is a script");
     for contract in [
         "gh api \"repos/$REPOSITORY/actions/runs/$RUN_ID/jobs\"",
+        "--name quality-report-${RUN_ID}-${RUN_ATTEMPT}",
+        "quality/consolidated-quality-report.md",
         "target/dispatch-report.md",
         "$GITHUB_STEP_SUMMARY",
     ] {
@@ -1829,6 +1838,14 @@ fn the_lane_executor_runs_a_named_lane_and_nothing_else() {
         Some("${{ inputs.lane }}"),
         "the executor's job carries the lane's name"
     );
+    let upload = named_step(job, "Upload the lane's report");
+    let upload_inputs = mapping_field(upload, "with")
+        .as_mapping()
+        .expect("the lane upload has inputs");
+    assert_eq!(
+        mapping_field(upload_inputs, "name").as_str(),
+        Some("${{ inputs.artifact-name }}-${{ github.run_id }}-${{ github.run_attempt }}")
+    );
 }
 
 // The other half of the same tree. Each calling job has to be named, because
@@ -1986,4 +2003,19 @@ fn the_role_runner_reads_its_matrix_from_the_catalog() {
         BTreeSet::from(["select".to_owned(), "run".to_owned()]),
         "a dependent lane runs after the matrix it reads"
     );
+    let dependent = workflow_job(jobs, "dependent");
+    let with = mapping_field(dependent, "with")
+        .as_mapping()
+        .expect("the dependent lane call passes inputs");
+    for (name, value) in [
+        ("artifact-name", "${{ matrix.artifact.name || '' }}"),
+        ("artifact-path", "${{ matrix.artifact.path || '' }}"),
+        ("artifact-when", "${{ matrix.artifact.when || 'always' }}"),
+    ] {
+        assert_eq!(
+            mapping_field(with, name).as_str(),
+            Some(value),
+            "the dependent lane loses `{name}`"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
The nightly quality producers already ran, but their consolidated Markdown was only printed and its artifact configuration was dropped for the dependent lane. This change persists and uploads one report per run attempt, keeps the existing raw artifacts, and lets the Dispatch collector embed the matching report. The document now carries repository assessment, workspace health, numeric CRAP, architecture complexity, and similarity evidence from the producer artifacts.

## Behavior / scope
- contract or behavior: dependent CI lanes retain their artifact configuration; `quality-report` writes and uploads `target/consolidated-quality-report.md` as `quality-report-<run_id>-<run_attempt>`; the Dispatch collector downloads that exact artifact.
- affected area: GitHub Actions quality scheduling and `kithara-devtools` CI report assembly.

## Validation
- `cargo test -p kithara-devtools ci_report::tests` (18 passed)
- `cargo test -p xtask ci::lane::select::tests` (11 passed)
- `cargo test -p xtask --test github_workflows` (23 passed)
- `cargo test -p xtask --test lane_config` (6 passed)
- `cargo check -p kithara-devtools -p xtask --tests`
- `just fmt check`
- pre-commit `lint-fast`
- `just ci lanes --role quality --kind nightly`
- `just ci report --artifacts target/ci-artifacts/33718992148` (real archived run; all five sections rendered, including 993 functions above CRAP 30)
- exact-head [Dispatch run 33764772942](https://github.com/gerasim13/kithara/actions/runs/33764772942): the dependent `quality-report` job passed after three producer failures; downloaded artifact `quality-report-33764772942-1` contains all five sections, including 991 functions above CRAP 30, architecture index 12.61364, and 5286 similarity candidates
- `just test` (4135 passed, 4 failed outside the changed CI/reporting paths: one render-budget test and three queue hard-timeout tests)

## Surface impact
- Public API: none
- Platform/runtime: tooling surface only
- Perf-sensitive paths: none

## Risks / follow-ups
- Verify the Dispatch collector and unattended schedule on the next nightly after merge. GitHub executes `workflow_run` workflows from the default branch, so the branch version of `report.yml` cannot be exercised before merge.
