### PR TITLE
fix(ci): read flattened similarity artifact

### DIFF
--- a/crates/kithara-devtools/src/ci_report.rs
+++ b/crates/kithara-devtools/src/ci_report.rs
@@ -92,13 +92,20 @@ fn assessment(artifacts: &Path) -> Result<String> {
 }
 
 fn duplication(artifacts: &Path, rows: usize) -> Result<String> {
-    let Some(report) = find(artifacts, &|path| {
+    let (report, flattened) = if let Some(report) = find(artifacts, &|path| {
         named(path, Consts::SIMILARITY_REPORT) && under(path, Consts::SIMILARITY_ARTIFACT)
-    })?
-    else {
-        return Ok(missing("Duplication", "similarity-report"));
+    })? {
+        (report, false)
+    } else {
+        let Some(report) = find(artifacts, &|path| named(path, Consts::SIMILARITY_REPORT))? else {
+            return Ok(missing("Duplication", "similarity-report"));
+        };
+        (report, true)
     };
     let text = read(&report)?;
+    if flattened && !text.starts_with("# Behavioral similarity") {
+        return Ok(missing("Duplication", "similarity-report"));
+    }
     let mut out = String::from("\n## Duplication\n\n");
     for line in text.lines().take(rows) {
         out.push_str(line);
@@ -487,6 +494,19 @@ mod tests {
         let report = duplication(temp.path(), 10).expect("duplication section");
 
         assert!(report.contains("| pair | score |"), "{report}");
+    }
+
+    #[test]
+    fn duplication_section_reads_a_flattened_single_artifact() {
+        let temp = tempdir().expect("tempdir");
+        write(
+            &temp.path().join("abc1234/report.md"),
+            "# Behavioral similarity\n\n- Candidates: 42\n",
+        );
+
+        let report = duplication(temp.path(), 10).expect("duplication section");
+
+        assert!(report.contains("Candidates: 42"), "{report}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

When `actions/download-artifact` downloads exactly one artifact, it removes the artifact directory and places `report.md` directly under the requested path. The consolidated quality report therefore missed the Duplication section even though the similarity artifact existed. This change recognizes that flattened layout by its canonical report heading while keeping CRAP and other `report.md` files excluded.

## Behavior / scope

- contract or behavior: `just ci report --artifacts <dir>` reads both the normal `similarity-report-*` directory layout and the flattened single-artifact layout;
- affected area: CI quality-report consolidation in `kithara-devtools`.

## Validation

- `cargo test -p kithara-devtools ci_report::tests` — 19 passed;
- `cargo check -p kithara-devtools --tests`;
- `cargo clippy -p kithara-devtools -- -D warnings`;
- `just fmt check`;
- `git diff --check`;
- pre-commit `just lint fast`;
- [exact-head Dispatch 33780503669](https://github.com/gerasim13/kithara/actions/runs/33780503669) — success; the generated quality report contains `## Duplication` and `Candidates: 5299` for `ef970d701110`;
- [Dispatch report 33781179442](https://github.com/gerasim13/kithara/actions/runs/33781179442) — success; the collected report preserves the same Duplication metrics;
- [scheduled nightly 33840772050](https://github.com/gerasim13/kithara/actions/runs/33840772050) on fork main `4997f705d481` — the quality-report job passed and uploaded `quality-report-33840772050-1`; its consolidated Markdown contains all five sections, including CRAP with 992 functions above threshold 30 and worst score 16256; the overall run later failed in separate health/stress lanes;
- not run: full workspace tests; the shared test lane was occupied by another worktree, and the targeted suite covers this parser contract.

## Surface impact

- Public API: none;
- Platform/runtime: CI tooling surface only;
- Perf-sensitive paths: none.

## Risks / follow-ups

- The flattened fallback intentionally fails closed if the similarity report changes its canonical `# Behavioral similarity` heading.
- The upstream GitHub context remains stale at `PENDING`, although exact-head GitLab pipeline 2134532 completed successfully.
