### PR TITLE
refactor(app): keep beat clock under controller ownership

### DIFF
--- a/.config/arch/baseline.toml
+++ b/.config/arch/baseline.toml
@@ -209,7 +209,6 @@ schema_version = 1
 "crates/kithara-stream/src/source.rs::SourceSeekAnchor" = 1
 
 [shared_state]
-"crates/kithara-app/src/state.rs" = 1
 "crates/kithara-ffi/src/native/bridge/event_bridge.rs" = 1
 "crates/kithara-ffi/src/native/bridge/item_bridge.rs" = 1
 "crates/kithara-queue/src/queue/state.rs" = 1

--- a/crates/kithara-app/src/state.rs
+++ b/crates/kithara-app/src/state.rs
@@ -224,7 +224,7 @@ fn unready_ranges(analysis: &TrackAnalysis) -> Arc<[[f32; 2]]> {
 #[derive(fieldwork::Fieldwork)]
 #[fieldwork(opt_in, get)]
 pub struct StateController {
-    beat_clock: Arc<Mutex<BeatClockState>>,
+    beat_clock: Mutex<BeatClockState>,
     #[field(get, deref = false)]
     queue: AppQueueControl,
     state: Arc<Mutex<UiState>>,
@@ -264,7 +264,7 @@ impl StateController {
             state,
             timestretch,
             cancel,
-            beat_clock: Arc::new(Mutex::new(BeatClockState::default())),
+            beat_clock: Mutex::new(BeatClockState::default()),
         }
     }
 


### PR DESCRIPTION
## Summary

`StateController` is the sole owner and consumer of the app beat clock, but the field carried an extra `Arc` as if it were shared independently. This removes that redundant shared owner and the corresponding architecture debt entry while preserving the existing lock and event flow.

## Behavior / scope

- contract or behavior: beat-clock state remains serialized by its mutex and is still read only through `StateController`;
- affected area: internal `kithara-app` beat publication state and one resolved `shared_state` baseline entry.

## Validation

- `just lint arch --check shared_state --path crates/kithara-app/src/state.rs`;
- `just fmt check`;
- `git diff --check`;
- pre-commit `just lint fast`;
- exact-head fork CI: [run 33807802604, attempt 3](https://github.com/gerasim13/kithara/actions/runs/33807802604) passed at `33d0c13228ac3bdd9d337787583874b21aa5bdd5`;
- not run: behavioral test suite; this slice changes internal ownership only and adds no behavior.

## Surface impact

- Public API: none;
- Platform/runtime: internal native app state ownership only;
- Perf-sensitive paths: none.

## Risks / follow-ups

- none.
