### PR TITLE
fix(ffi): preserve stretch backend wire payload

### DIFF
--- a/.config/just/test.just
+++ b/.config/just/test.just
@@ -19,8 +19,8 @@ all:
 # why they do not go through `just test run`. `just platform wasm` keeps the
 # artifacts (check, build, size-check); the tests belong here.
 #
-# Both suites run the wasm Host unit tests. SUITE `all` also runs the integration
-# browser suite; `webcodecs` adds only kithara-decode's browser target.
+# Both suites run the wasm Host tests and FFI wire contract. SUITE `all` also
+# runs the integration browser suite; `webcodecs` adds kithara-decode's target.
 
 # Run the Rust tests that need a browser (SUITE: all | webcodecs).
 [positional-arguments]
@@ -71,6 +71,13 @@ wasm BROWSER="chrome" SUITE="all":
       -Z build-std-features=optimize_for_size \
       -p kithara-host --lib --no-default-features \
       --features backend-web-audio,wasm-bindgen,symphonia,webcodecs,resample-rubato,client-reqwest,tls-rustls
+    WASM_BINDGEN_TEST_TIMEOUT=300 WASM_BINDGEN_USE_BROWSER=1 \
+      cargo "+$toolchain" test --profile test-release \
+      --target wasm32-unknown-unknown \
+      -Z build-std=std,panic_abort,core,alloc \
+      -Z build-std-features=optimize_for_size \
+      -p kithara-ffi --test web-observer --no-default-features \
+      --features wasm
     if [[ "$suite" == "all" ]]; then
       # The integration browser tests live in `suite_heavy`. Building the whole
       # crate for wasm compiles every native suite too, and those reach for

--- a/.config/xtask.toml
+++ b/.config/xtask.toml
@@ -2399,7 +2399,7 @@ hard_invariant = true
 
 [[quality.assessment.deep_stages]]
 name = "wasm-tests"
-command = ["just", "platform", "wasm", "test"]
+command = ["just", "test", "wasm"]
 tools = ["wasm-tests"]
 hard_invariant = true
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4899,6 +4899,7 @@ dependencies = [
  "uuid",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-bindgen-test",
  "web-sys",
 ]
 

--- a/crates/kithara-ffi/Cargo.toml
+++ b/crates/kithara-ffi/Cargo.toml
@@ -16,6 +16,11 @@ name = "uniffi-bindgen"
 path = "src/uniffi_bindgen.rs"
 required-features = ["uniffi-bindgen-cli"]
 
+[[test]]
+name = "web-observer"
+path = "src/web/observer/tests.rs"
+required-features = ["wasm"]
+
 # Native-only deps for the UniFFI surface (`src/{cipher,config,item,…}.rs`).
 # Moved to `[target.'cfg(not(target_arch = "wasm32"))'.dependencies]` so
 # wasm32 builds don't pull `uniffi` (Future + Send incompatible with wasm)
@@ -139,6 +144,9 @@ uuid = { workspace = true }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 web-sys = { workspace = true }
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = { workspace = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 jni = { workspace = true }

--- a/crates/kithara-ffi/src/web/observer/decode.rs
+++ b/crates/kithara-ffi/src/web/observer/decode.rs
@@ -99,7 +99,7 @@ pub(crate) fn decode(data: &JsValue) -> Option<FfiPlayerEvent> {
             on: get_bool(data, "on")?,
         },
         "DjStretchBackendChanged" => FfiPlayerEvent::DjStretchBackendChanged {
-            kind: decode_stretch_backend_kind(get_str(data, "kind")),
+            kind: decode_stretch_backend_kind(get_str(data, "backend")),
         },
         "AssetCommitted" => FfiPlayerEvent::AssetCommitted {
             asset_root: get_str(data, "asset_root").unwrap_or_default(),

--- a/crates/kithara-ffi/src/web/observer/encode.rs
+++ b/crates/kithara-ffi/src/web/observer/encode.rs
@@ -156,7 +156,7 @@ pub(crate) fn encode(event: &FfiPlayerEvent) -> JsValue {
         }
         FfiPlayerEvent::DjStretchBackendChanged { kind } => {
             set_str(&obj, KIND, "DjStretchBackendChanged");
-            set_str(&obj, "kind", stretch_backend_kind_str(*kind));
+            set_str(&obj, "backend", stretch_backend_kind_str(*kind));
         }
         FfiPlayerEvent::AssetCommitted {
             asset_root,

--- a/crates/kithara-ffi/src/web/observer/tests.rs
+++ b/crates/kithara-ffi/src/web/observer/tests.rs
@@ -1,0 +1,121 @@
+#![cfg(target_arch = "wasm32")]
+
+use js_sys::Reflect;
+use kithara::events::TrackId;
+use wasm_bindgen::JsValue;
+use wasm_bindgen_test::wasm_bindgen_test;
+
+#[path = "decode.rs"]
+mod decode;
+#[path = "decode_item.rs"]
+mod decode_item;
+#[path = "encode.rs"]
+mod encode;
+#[path = "encode_item.rs"]
+mod encode_item;
+#[path = "marshal.rs"]
+mod marshal;
+
+mod types {
+    pub(crate) use kithara_ffi::types::*;
+}
+
+use types::{FfiItemEvent, FfiKeySource, FfiPlayerEvent, FfiStretchBackendKind, FfiTrackStatus};
+
+const MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
+const MAX_SAFE_INTEGER_F64: f64 = 9_007_199_254_740_991.0;
+
+fn keys(value: &JsValue) -> Vec<String> {
+    let mut keys = Reflect::own_keys(value)
+        .expect("wire keys")
+        .iter()
+        .map(|key| key.as_string().expect("string key"))
+        .collect::<Vec<_>>();
+    keys.sort_unstable();
+    keys
+}
+
+#[wasm_bindgen_test]
+fn stretch_backend_event_preserves_kind_and_backend() {
+    let encoded = encode::encode(&FfiPlayerEvent::DjStretchBackendChanged {
+        kind: FfiStretchBackendKind::Bungee,
+    });
+
+    let kind = Reflect::get(&encoded, &JsValue::from_str("kind"))
+        .expect("event kind")
+        .as_string();
+    let backend = Reflect::get(&encoded, &JsValue::from_str("backend"))
+        .expect("backend payload")
+        .as_string();
+
+    assert_eq!(kind.as_deref(), Some("DjStretchBackendChanged"));
+    assert_eq!(backend.as_deref(), Some("Bungee"));
+    assert!(matches!(
+        decode::decode(&encoded),
+        Some(FfiPlayerEvent::DjStretchBackendChanged {
+            kind: FfiStretchBackendKind::Bungee
+        })
+    ));
+}
+
+#[wasm_bindgen_test]
+fn track_status_schema_preserves_max_safe_item_id() {
+    let encoded = encode::encode(&FfiPlayerEvent::TrackStatusChanged {
+        item_id: TrackId(MAX_SAFE_INTEGER),
+        status: FfiTrackStatus::Loaded,
+    });
+
+    assert_eq!(keys(&encoded), ["item_id", "kind", "status"]);
+    assert_eq!(
+        marshal::get_str(&encoded, "kind").as_deref(),
+        Some("TrackStatusChanged")
+    );
+    assert_eq!(
+        marshal::get_f64(&encoded, "item_id"),
+        Some(MAX_SAFE_INTEGER_F64)
+    );
+    assert_eq!(marshal::get_f64(&encoded, "status"), Some(3.0));
+    assert!(!Reflect::has(&encoded, &JsValue::from_str("reason")).expect("reason presence"));
+    assert!(matches!(
+        decode::decode(&encoded),
+        Some(FfiPlayerEvent::TrackStatusChanged {
+            item_id: TrackId(MAX_SAFE_INTEGER),
+            status: FfiTrackStatus::Loaded
+        })
+    ));
+}
+
+#[wasm_bindgen_test]
+fn drm_key_schema_omits_absent_optional_fields() {
+    let encoded = encode_item::encode_item_event(&FfiItemEvent::DrmKeyAcquired {
+        key_host: None,
+        source: FfiKeySource::DiskCache,
+        bytes: MAX_SAFE_INTEGER,
+        latency_ms: None,
+    });
+
+    assert_eq!(keys(&encoded), ["bytes", "kind", "source"]);
+    assert_eq!(
+        marshal::get_str(&encoded, "kind").as_deref(),
+        Some("DrmKeyAcquired")
+    );
+    assert_eq!(
+        marshal::get_str(&encoded, "source").as_deref(),
+        Some("DiskCache")
+    );
+    assert_eq!(
+        marshal::get_f64(&encoded, "bytes"),
+        Some(MAX_SAFE_INTEGER_F64)
+    );
+    assert!(!Reflect::has(&encoded, &JsValue::from_str("key_host")).expect("key host presence"));
+    assert!(!Reflect::has(&encoded, &JsValue::from_str("latency_ms")).expect("latency presence"));
+    assert!(matches!(
+        decode_item::decode_item_event(&encoded),
+        Some(FfiItemEvent::DrmKeyAcquired {
+            key_host: None,
+            source: FfiKeySource::DiskCache,
+            bytes: MAX_SAFE_INTEGER,
+            latency_ms: None
+        })
+    ));
+}


### PR DESCRIPTION
## Summary

The browser event encoder wrote both the event discriminant and the stretch backend payload to `kind`, so `DjStretchBackendChanged(Bungee)` reached JavaScript with `kind = "Bungee"` and could no longer be decoded as an event. This keeps the discriminant in `kind`, moves the payload to `backend`, and adds the existing FFI browser contract to the canonical wasm test route.

## Behavior / scope

- contract or behavior: the stretch event now round-trips as `kind = "DjStretchBackendChanged"` and `backend = "Bungee"`;
- contract or behavior: focused browser tests pin player-event keys and numeric codes, omitted optional item fields, string enums, and JavaScript's maximum safe integer;
- affected area: `kithara-ffi` web observer encoding/decoding and the canonical wasm/deep-quality test route.

## Validation

- regression red on the old encoder: JavaScript received `kind = "Bungee"` instead of `DjStretchBackendChanged`;
- `just test wasm chrome webcodecs` — passed in Chrome: 3 encode, 54 host, 3 FFI wire-contract, and 3 WebCodecs tests;
- `just arch orphans --package kithara-ffi --deny` — no orphans;
- `just --dry-run test wasm chrome webcodecs`;
- `just fmt check`;
- `git diff --check`;
- pre-commit `just lint fast`;
- exact-head fork CI [run 33859416703, attempt 2](https://github.com/gerasim13/kithara/actions/runs/33859416703/attempts/2) — passed at `b38211d83a2a0272e87a2e55b3a7780ba4bcce2a`.

## Surface impact

- Public API: none;
- Platform/runtime: changed browser/wasm event wire output for the previously undecodable stretch-backend event;
- Perf-sensitive paths: none.

## Risks / follow-ups

- The broader FFI codec remains unchanged; CRAP alone is not used to justify a wire-format migration.
- Attempt 1 hit a recurrent real-clock teardown watchdog after the unchanged HLS test completed its contract; that test passed on retry, and its teardown fix is tracked separately in PR #281.
