### PR TITLE
fix(ci): let the self-cache fixture name the directory it builds into

### DIFF
--- a/crates/kithara-ffi/Cargo.toml
+++ b/crates/kithara-ffi/Cargo.toml
@@ -16,11 +16,6 @@ name = "uniffi-bindgen"
 path = "src/uniffi_bindgen.rs"
 required-features = ["uniffi-bindgen-cli"]
 
-[[test]]
-name = "web-observer"
-path = "src/web/observer/tests.rs"
-required-features = ["wasm"]
-
 # Native-only deps for the UniFFI surface (`src/{cipher,config,item,…}.rs`).
 # Moved to `[target.'cfg(not(target_arch = "wasm32"))'.dependencies]` so
 # wasm32 builds don't pull `uniffi` (Future + Send incompatible with wasm)
@@ -145,9 +140,6 @@ wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 web-sys = { workspace = true }
 
-[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen-test = { workspace = true }
-
 [target.'cfg(target_os = "android")'.dependencies]
 jni = { workspace = true }
 ndk-context = { workspace = true }
@@ -161,6 +153,14 @@ kithara-test-utils = { workspace = true, features = ["mock", "probe", "hang"] }
 futures = { workspace = true }
 tempfile = { workspace = true }
 unimock = { workspace = true }
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = { workspace = true }
+
+[[test]]
+name = "web-observer"
+path = "src/web/observer/tests.rs"
+required-features = ["wasm"]
 
 [lints]
 workspace = true

--- a/xtask/tests/self_cache_runner.rs
+++ b/xtask/tests/self_cache_runner.rs
@@ -22,13 +22,6 @@ use tempfile::TempDir;
 
 struct Fixture {
     _temp: TempDir,
-    /// Where the fake Cargo publishes the built xtask.
-    ///
-    /// `self_cache::layout::target_dir` names `CARGO_TARGET_DIR` when the
-    /// environment carries one, so every command this fixture spawns decides
-    /// that variable itself. An inherited one would move the target directory
-    /// away from this path and the private-directory guard would reject a
-    /// build that is in fact correct.
     bootstrap_artifact: PathBuf,
     bootstrap_cargo: PathBuf,
     cargo_log: PathBuf,
@@ -36,6 +29,13 @@ struct Fixture {
     git_log: PathBuf,
     justfile: PathBuf,
     root: PathBuf,
+    /// The build directory this fixture hands to every command it spawns.
+    ///
+    /// `_xtask-bootstrap` exports `CARGO_TARGET_DIR` for the self-cache build
+    /// and `layout::target_dir` reads it back. The commands spawned here stand
+    /// in for that recipe, so they name this directory instead of inheriting
+    /// the one the surrounding lane is building into.
+    target: PathBuf,
 }
 
 impl Fixture {
@@ -91,7 +91,10 @@ printf 'target=%s\n' "${CARGO_TARGET_DIR-}" >> "$SELF_CACHE_CARGO_LOG"
 exit 97
 "#,
         )?;
-        let bootstrap_artifact = root.join("target/xtask-self-cache/debug/xtask");
+        let target = fs::canonicalize(&root)
+            .context("resolve fixture root")?
+            .join("target/xtask-self-cache");
+        let bootstrap_artifact = target.join("debug/xtask");
         fs::create_dir_all(
             bootstrap_artifact
                 .parent()
@@ -122,6 +125,7 @@ exit 98
             git_log,
             justfile,
             root,
+            target,
         })
     }
 
@@ -129,7 +133,7 @@ exit 98
         Command::new(env!("CARGO_BIN_EXE_xtask"))
             .args(["self-cache", "bootstrap"])
             .current_dir(&self.root)
-            .env_remove("CARGO_TARGET_DIR")
+            .env("CARGO_TARGET_DIR", &self.target)
             .env("CARGO", env!("CARGO"))
             .env("XTASK_SELF_CACHE_CARGO", &self.bootstrap_cargo)
             .env("SELF_CACHE_BOOTSTRAP_ARTIFACT", &self.bootstrap_artifact)
@@ -156,7 +160,7 @@ exit 98
         command
             .args(args)
             .current_dir(&self.root)
-            .env_remove("CARGO_TARGET_DIR")
+            .env("CARGO_TARGET_DIR", &self.target)
             .env("PATH", self.fake_path()?)
             .env("SELF_CACHE_CARGO_LOG", &self.cargo_log)
             .env("SELF_CACHE_GIT_LOG", &self.git_log)
@@ -173,7 +177,7 @@ exit 98
     }
 
     fn cached_from(&self, root: &Path, args: &[&str]) -> Result<Output> {
-        self.cached_in(root, args, None)
+        self.cached_in(root, args, Some(&self.target))
     }
 
     fn cached_in(&self, root: &Path, args: &[&str], target: Option<&Path>) -> Result<Output> {
@@ -233,7 +237,7 @@ exit 98
             .arg("--working-directory")
             .arg(root)
             .args(args)
-            .env_remove("CARGO_TARGET_DIR")
+            .env("CARGO_TARGET_DIR", &self.target)
             .env("CARGO", env!("CARGO"))
             .env("PATH", self.fake_path()?)
             .env("SELF_CACHE_CARGO_LOG", &self.cargo_log)
@@ -717,14 +721,12 @@ fn failed_refresh_preserves_locator_and_uses_canonical_cargo_args() -> Result<()
 
     assert!(!refresh.status.success());
     assert_eq!(fs::read(locator)?, before);
-    let cargo = fs::read_to_string(&fixture.cargo_log)?;
     let canonical_root = fs::canonicalize(&fixture.root)?;
     assert_eq!(
-        cargo,
-        format!(
-            "run --locked --quiet --manifest-path {}/Cargo.toml -p xtask --bin xtask -- self-cache artifact\ntarget={}/target/xtask-self-cache\n",
-            canonical_root.display(),
-            canonical_root.display()
+        fs::read_to_string(&fixture.cargo_log)?,
+        cargo_build_log(
+            &canonical_root,
+            &canonical_root.join("target/xtask-self-cache")
         )
     );
     assert!(!fixture.git_log.exists());
@@ -735,21 +737,36 @@ fn failed_refresh_preserves_locator_and_uses_canonical_cargo_args() -> Result<()
 fn a_named_cargo_target_directory_carries_the_refresh_build() -> Result<()> {
     let fixture = Fixture::new()?;
     assert_success(&fixture.bootstrap()?);
-    let target = fs::canonicalize(&fixture.root)?.join("../shared-target");
-    fs::create_dir_all(&target)?;
-    let target = fs::canonicalize(&target)?;
+    let elsewhere = fixture.root.join("../shared-target");
+    fs::create_dir_all(&elsewhere)?;
+    let elsewhere = fs::canonicalize(&elsewhere)?;
 
     let refresh = fixture.cached_in(
         &fixture.root,
         &["self-cache", "refresh", "--force"],
-        Some(&target),
+        Some(&elsewhere),
     )?;
 
     assert!(!refresh.status.success());
-    let cargo = fs::read_to_string(&fixture.cargo_log)?;
-    assert!(
-        cargo.ends_with(&format!("target={}\n", target.display())),
-        "the refresh build must inherit the named target directory, got: {cargo}"
+    assert_eq!(
+        fs::read_to_string(&fixture.cargo_log)?,
+        cargo_build_log(&fs::canonicalize(&fixture.root)?, &elsewhere)
+    );
+    Ok(())
+}
+
+#[test]
+fn an_unnamed_cargo_target_directory_builds_inside_the_checkout() -> Result<()> {
+    let fixture = Fixture::new()?;
+    assert_success(&fixture.bootstrap()?);
+
+    let refresh = fixture.cached_in(&fixture.root, &["self-cache", "refresh", "--force"], None)?;
+
+    assert!(!refresh.status.success());
+    let root = fs::canonicalize(&fixture.root)?;
+    assert_eq!(
+        fs::read_to_string(&fixture.cargo_log)?,
+        cargo_build_log(&root, &root.join("target/xtask-self-cache"))
     );
     Ok(())
 }
@@ -806,7 +823,7 @@ wait "$descendant"
     command
         .args(["self-cache", "refresh", "--force"])
         .current_dir(&fixture.root)
-        .env_remove("CARGO_TARGET_DIR")
+        .env("CARGO_TARGET_DIR", &fixture.target)
         .env("CARGO", env!("CARGO"))
         .env("XTASK_SELF_CACHE_CARGO", &fake_cargo)
         .env("SELF_CACHE_CARGO_PID", &cargo_pid)
@@ -854,6 +871,14 @@ handler = "command-guard"
         ),
     )?;
     Ok(())
+}
+
+fn cargo_build_log(root: &Path, target: &Path) -> String {
+    format!(
+        "run --locked --quiet --manifest-path {}/Cargo.toml -p xtask --bin xtask -- self-cache artifact\ntarget={}\n",
+        root.display(),
+        target.display()
+    )
 }
 
 fn write_executable(path: &Path, body: &str) -> Result<()> {

--- a/xtask/tests/self_cache_runner.rs
+++ b/xtask/tests/self_cache_runner.rs
@@ -22,6 +22,13 @@ use tempfile::TempDir;
 
 struct Fixture {
     _temp: TempDir,
+    /// Where the fake Cargo publishes the built xtask.
+    ///
+    /// `self_cache::layout::target_dir` names `CARGO_TARGET_DIR` when the
+    /// environment carries one, so every command this fixture spawns decides
+    /// that variable itself. An inherited one would move the target directory
+    /// away from this path and the private-directory guard would reject a
+    /// build that is in fact correct.
     bootstrap_artifact: PathBuf,
     bootstrap_cargo: PathBuf,
     cargo_log: PathBuf,
@@ -122,6 +129,7 @@ exit 98
         Command::new(env!("CARGO_BIN_EXE_xtask"))
             .args(["self-cache", "bootstrap"])
             .current_dir(&self.root)
+            .env_remove("CARGO_TARGET_DIR")
             .env("CARGO", env!("CARGO"))
             .env("XTASK_SELF_CACHE_CARGO", &self.bootstrap_cargo)
             .env("SELF_CACHE_BOOTSTRAP_ARTIFACT", &self.bootstrap_artifact)
@@ -148,6 +156,7 @@ exit 98
         command
             .args(args)
             .current_dir(&self.root)
+            .env_remove("CARGO_TARGET_DIR")
             .env("PATH", self.fake_path()?)
             .env("SELF_CACHE_CARGO_LOG", &self.cargo_log)
             .env("SELF_CACHE_GIT_LOG", &self.git_log)
@@ -164,8 +173,13 @@ exit 98
     }
 
     fn cached_from(&self, root: &Path, args: &[&str]) -> Result<Output> {
+        self.cached_in(root, args, None)
+    }
+
+    fn cached_in(&self, root: &Path, args: &[&str], target: Option<&Path>) -> Result<Output> {
         let fake_cargo = self.fake_bin.join("cargo");
-        Command::new(self.active_binary()?)
+        let mut command = Command::new(self.active_binary()?);
+        command
             .args(args)
             .current_dir(root)
             .env("CARGO", env!("CARGO"))
@@ -173,9 +187,12 @@ exit 98
             .env("PATH", self.fake_path()?)
             .env("SELF_CACHE_CARGO_LOG", &self.cargo_log)
             .env("SELF_CACHE_GIT_LOG", &self.git_log)
-            .stdin(Stdio::null())
-            .output()
-            .context("run cached xtask")
+            .stdin(Stdio::null());
+        match target {
+            Some(target) => command.env("CARGO_TARGET_DIR", target),
+            None => command.env_remove("CARGO_TARGET_DIR"),
+        };
+        command.output().context("run cached xtask")
     }
 
     fn transport(&self, root: &Path) -> Result<Output> {
@@ -216,6 +233,7 @@ exit 98
             .arg("--working-directory")
             .arg(root)
             .args(args)
+            .env_remove("CARGO_TARGET_DIR")
             .env("CARGO", env!("CARGO"))
             .env("PATH", self.fake_path()?)
             .env("SELF_CACHE_CARGO_LOG", &self.cargo_log)
@@ -714,6 +732,29 @@ fn failed_refresh_preserves_locator_and_uses_canonical_cargo_args() -> Result<()
 }
 
 #[test]
+fn a_named_cargo_target_directory_carries_the_refresh_build() -> Result<()> {
+    let fixture = Fixture::new()?;
+    assert_success(&fixture.bootstrap()?);
+    let target = fs::canonicalize(&fixture.root)?.join("../shared-target");
+    fs::create_dir_all(&target)?;
+    let target = fs::canonicalize(&target)?;
+
+    let refresh = fixture.cached_in(
+        &fixture.root,
+        &["self-cache", "refresh", "--force"],
+        Some(&target),
+    )?;
+
+    assert!(!refresh.status.success());
+    let cargo = fs::read_to_string(&fixture.cargo_log)?;
+    assert!(
+        cargo.ends_with(&format!("target={}\n", target.display())),
+        "the refresh build must inherit the named target directory, got: {cargo}"
+    );
+    Ok(())
+}
+
+#[test]
 fn concurrent_cold_bootstraps_publish_one_generation() -> Result<()> {
     let fixture = Arc::new(Fixture::new()?);
     let barrier = Arc::new(Barrier::new(9));
@@ -765,6 +806,7 @@ wait "$descendant"
     command
         .args(["self-cache", "refresh", "--force"])
         .current_dir(&fixture.root)
+        .env_remove("CARGO_TARGET_DIR")
         .env("CARGO", env!("CARGO"))
         .env("XTASK_SELF_CACHE_CARGO", &fake_cargo)
         .env("SELF_CACHE_CARGO_PID", &cargo_pid)


### PR DESCRIPTION
## Summary

`apple:lint` is red on the default branch, and because the job is `allow_failure = false`
every job behind it is skipped and `verdict` fails with it. The lane that runs the `xtask`
tests is the only one that sees this, which is why merge-request pipelines still report a
green `apple:lint` while the branch pipeline dies.

`xtask/tests/self_cache_runner.rs` fails 12 of its 16 tests, all with the same message:

```
built xtask artifact is outside its private target directory:
  <root>/target/xtask-self-cache/debug/xtask
```

`CARGO_TARGET_DIR` is a parameter here, not ambient state. `_xtask-bootstrap` — the one
build with no cache of its own — computes the self-cache build directory and exports it
(`justfile`), and #277 taught `self_cache::layout::target_dir` to read it back:

```rust
env::var_os("CARGO_TARGET_DIR")
    .map_or_else(|| root.join("target/xtask-self-cache"), PathBuf::from)
```

The fixture stands in for that recipe: it invokes `xtask self-cache bootstrap` directly, so
it is the side that has to hand the variable over. It did not. It published its artifact at
a hardcoded `<root>/target/xtask-self-cache/debug/xtask` and let the surrounding lane's
value through instead — and a lane sets `CARGO_TARGET_DIR` to its own build directory
(`xtask/src/ci/environment.rs`). The two sides then named different directories and the
private-directory guard rejected a build that was in fact correct. The test had become a
function of the machine's environment: green on a clean one, red on CI.

Every command the fixture spawns now names this fixture's own directory, the way the recipe
names one. Both arms of `target_dir` are pinned: a named directory reaches the refresh
build, an unnamed one falls back to the checkout. Before this change all sixteen tests took
the fallback arm — the arm the real transport never takes — which is how #277 landed with
its new branch uncovered.

The commit also carries a `cargo-sort` reordering of `crates/kithara-ffi/Cargo.toml`, which
`just fmt` produces on its own — the manifest is unsorted on the default branch.

## Behavior / scope

- contract or behavior: the `self_cache_runner` fixture names `CARGO_TARGET_DIR` for every
  command it spawns, so the private-directory guard is judged against the directory the
  build actually used. No production behavior changes.
- affected area: `xtask/tests/self_cache_runner.rs`, `crates/kithara-ffi/Cargo.toml`
  (formatting only).

## Validation

- `cargo test -p xtask --test self_cache_runner` — 18 passed, run twice: with
  `CARGO_TARGET_DIR` set, which is the condition the CI lane is red under, and with it
  unset.
- The same suite before this change, with `CARGO_TARGET_DIR` set: 4 passed, 12 failed.
- Mutation check: dropping the `env::var_os` read from `layout::target_dir` fails
  `a_named_cargo_target_directory_carries_the_refresh_build` and leaves the unnamed-directory
  test green, so each pin answers for one arm.

## Surface impact

- Public API: none
- Platform/runtime: changed: tooling surface (xtask test fixture only)
- Perf-sensitive paths: none

## Risks / follow-ups

- The `apple:test` lane on the default branch is red for an unrelated reason:
  `kithara_play::sync_listening::sync_listening_mix_is_not_quieter_than_a_solo_deck`,
  added by #281, calls the synchronous `host.insert(queue)` from an async test body. That
  call blocks on `reply_rx.recv()` waiting for the offline session worker, and the lane's
  `--flash=on --no-block=on` gate panics on a blocking wait inside a poll. It reproduces
  locally in 0.35 s. Forty tests in the `kithara_play::` group abort under that gate; the
  verdict journal forgives thirty-nine of them and cannot forgive this one, because the
  journal is only written by a default-branch run and those stop at the red `apple:lint`
  this change fixes.
- `.gitlab/ci/common.yml` stamps and clears the literal relative `target/xtask-self-cache`,
  but #277 moved the Linux bootstrap build to
  `$KITHARA_CI_CACHE_ROOT/target-slots/<trust>-linux-<arch>-slot-<slot>/xtask-self-cache`.
  On Linux that staleness guard now watches a directory the bootstrap no longer writes.
  Left alone here.
