### PR TITLE
fix(ci): say what the build-directory reset actually does

### DIFF
--- a/.gitlab/ci/common.yml
+++ b/.gitlab/ci/common.yml
@@ -1,12 +1,49 @@
+# Cargo never collects a target directory: a lockfile, toolchain or source
+# change leaves the previous artifacts behind, and this one passes a gigabyte
+# per checkout. Reset it when the inputs that decide its contents change.
+#
+# `xtask` charges this directory and the Linux slot caches against the host
+# budget and evicts from both, but it cannot evict a target directory whose
+# lease a running job holds — the state a refused job finds. This runs before
+# the lane takes that lease, which is the room it can still free.
+#
+# The stamp is what the directory is filled from, not the commit that happened
+# to be checked out: `xtask`'s own sources, the workspace crate it links, the
+# lockfile and toolchain that decide what it compiles against, and the
+# configuration it parses. Keying on the commit instead threw a good build
+# directory away on every push and spent a minute of every pipeline recompiling
+# `proc-macro2` and `serde` to get the same bytes.
+#
+# The path is the checkout's own. Since #277 the Linux bootstrap builds into a
+# slot directory shared across checkouts, and that one is left alone on purpose:
+# resetting it whenever the next job's inputs differ from the last one's is the
+# rebuild-per-checkout that sharing was introduced to end.
+#
+# Not applied to Windows, whose shell is not this one; that lane has no runner
+# today.
+.unix-job:
+  before_script:
+    - |
+      stamp=target/xtask-self-cache/.inputs
+      inputs=$(git ls-files -s xtask crates/kithara-devtools .config Cargo.toml Cargo.lock rust-toolchain.toml | git hash-object --stdin)
+      if [ "$(cat "$stamp" 2>/dev/null)" != "$inputs" ]; then
+        rm -rf target/xtask-self-cache
+        mkdir -p target/xtask-self-cache
+        printf '%s' "$inputs" > "$stamp"
+      fi
+
 .macos-job:
+  extends: .unix-job
   tags:
     - kithara-macos
 
 .linux-job:
+  extends: .unix-job
   tags:
     - kithara-linux
 
 .android-job:
+  extends: .unix-job
   tags:
     - kithara-android
 
@@ -18,6 +55,7 @@
     - kithara-windows
 
 .release-job:
+  extends: .unix-job
   tags:
     - kithara-release
 

--- a/.gitlab/ci/common.yml
+++ b/.gitlab/ci/common.yml
@@ -1,40 +1,12 @@
-# Keeping the build directory across jobs also keeps the cached `xtask` binary,
-# which is built from one commit and would then be used by the next. When the
-# two disagree it fails while parsing its own configuration, and the staleness
-# check runs that same stale binary to find out — so it cannot report the
-# problem. Stamp the cache and drop it when the stamp no longer matches.
-#
-# The stamp is what the binary is made of, not the commit that happened to be
-# checked out: its own sources, the workspace crate it links, the lockfile and
-# toolchain that decide what it compiles against, and the configuration it
-# parses — which is the half that produced the failure above. Keying on the
-# commit instead threw a good binary away on every push and spent a minute of
-# every pipeline recompiling `proc-macro2` and `serde` to get the same bytes.
-# Not applied to Windows, whose shell is not this one; that lane has no runner
-# today.
-.unix-job:
-  before_script:
-    - |
-      stamp=target/xtask-self-cache/.inputs
-      inputs=$(git ls-files -s xtask crates/kithara-devtools .config Cargo.toml Cargo.lock rust-toolchain.toml | git hash-object --stdin)
-      if [ "$(cat "$stamp" 2>/dev/null)" != "$inputs" ]; then
-        rm -rf target/xtask-self-cache
-        mkdir -p target/xtask-self-cache
-        printf '%s' "$inputs" > "$stamp"
-      fi
-
 .macos-job:
-  extends: .unix-job
   tags:
     - kithara-macos
 
 .linux-job:
-  extends: .unix-job
   tags:
     - kithara-linux
 
 .android-job:
-  extends: .unix-job
   tags:
     - kithara-android
 
@@ -46,7 +18,6 @@
     - kithara-windows
 
 .release-job:
-  extends: .unix-job
   tags:
     - kithara-release
 

--- a/docs/guides/agent-hooks.md
+++ b/docs/guides/agent-hooks.md
@@ -108,8 +108,8 @@ just tooling xtask <args> -> _xtask-ready -> current: cached run
 The ignored `xtask/.xtask-cache` locator contains one absolute path to an
 immutable generation below the concrete worktree Git directory. A warm command
 reads that locator and starts the binary directly; it does not start Cargo or
-Git. Cargo is used only for a cold bootstrap or stale refresh, with its private
-target retained at `target/xtask-self-cache`.
+Git. Cargo is used only for a cold bootstrap or stale refresh, in the build
+directory `_xtask-bootstrap` names through `CARGO_TARGET_DIR`.
 
 The Just recipes only resolve the locator, ensure a current generation, and
 execute it. Rust owns freshness, single-flight locking, publication, leases,

--- a/xtask/tests/self_cache_runner.rs
+++ b/xtask/tests/self_cache_runner.rs
@@ -279,7 +279,10 @@ esac
             r#"#!/bin/sh
 set -eu
 printf '%s\n' "$*" >> "$SELF_CACHE_CARGO_LOG"
-exec "$SELF_CACHE_TEST_XTASK" self-cache bootstrap
+while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done
+[ "$#" -gt 0 ] || { printf 'fixture cargo received no run arguments\n' >&2; exit 2; }
+shift
+exec "$SELF_CACHE_TEST_XTASK" "$@"
 "#,
         )
     }


### PR DESCRIPTION
## Summary

`.unix-job` in `.gitlab/ci/common.yml` stamps the inputs of the `xtask` build and clears
`target/xtask-self-cache` when the stamp moves. Its comment said this drops a cached `xtask`
binary built from an earlier commit, one that "fails while parsing its own configuration"
while "the staleness check runs that same stale binary to find out".

That is not what the block can do. A published generation goes to `layout::cache_dir(root)`
— `<git dir>/xtask-cache/generation-*` — and the transport reaches it through the
`xtask/.xtask-cache` locator (`justfile`, `_xtask-cached`). Neither is under `target/`.
`target/xtask-self-cache` is Cargo's build directory for the bootstrap compile, and no
stale binary is read out of it. The configuration is read at run time
(`xtask/src/config.rs`, `read_to_string`) and is not compiled in — `xtask` has no `build.rs`
and no `include_str!` — so rebuilding cannot change how an existing binary parses it.

What the block does do is worth keeping, and the comment now says it. Cargo never collects
a target directory: a lockfile, toolchain or source change leaves the previous artifacts
behind, and this directory passes a gigabyte per checkout (973 MB and 1.3 GB in two local
ones). `xtask` charges it against the host budget — `persistent_target_dirs` for the
checkout-local directories, `cached_target_dirs` for the Linux slot caches — and evicts from
both, but `collect` skips any target directory whose lease a running job holds, which is
exactly the state a job refused for disk finds itself in. The `before_script` runs before the
lane takes that lease.

The comment also now says why the Linux path is left alone. Since #277 `_xtask-bootstrap`
computes its own build directory and on Linux CI that is
`$KITHARA_CI_CACHE_ROOT/target-slots/<trust>-linux-<arch>-slot-<slot>/xtask-self-cache`,
shared across checkouts, so the block's `rm -rf` and `mkdir -p` there apply to a
checkout-local directory the bootstrap no longer writes. Pointing the block at the shared
directory would reset it whenever the next job's inputs differ from the last one's — the
rebuild-per-checkout that sharing was introduced to end. It stays the checkout's own path,
deliberately rather than by accident.

Two smaller corrections travel with it. `docs/guides/agent-hooks.md` still said the private
target is "retained at `target/xtask-self-cache`", untrue since #277; it now names
`_xtask-bootstrap` as the side that decides. And the fixture's stand-in Cargo ran
`self-cache bootstrap` whatever the recipe asked for — real Cargo forwards what follows
`--`, so the stand-in does too, and a recipe asking for something else is no longer silently
answered with a bootstrap.

## Behavior / scope

- contract or behavior: none. The `before_script` is byte-for-byte what it was; only its
  comment changed. The fixture change affects one test helper.
- affected area: `.gitlab/ci/common.yml` (comment), `docs/guides/agent-hooks.md`,
  `xtask/tests/self_cache_runner.rs`.

## Validation

- `cargo test -p xtask` — all suites pass, including `gitlab_pipelines` (8) and
  `self_cache_runner` (16).
- `just fmt`.

## Surface impact

- Public API: none
- Platform/runtime: none
- Perf-sensitive paths: none

## Risks / follow-ups

- The wedge the old comment described is real and still open, and nothing in CI addresses it.
  It reproduces on a clean checkout with no CI involved: give the active generation a binary
  that answers `self-cache probe` but fails `self-cache status`, and `just tooling xtask
  --help` dies with that binary's error. `probe` reads only the binary's own path and never
  opens the project configuration, so a generation built before a schema change passes it,
  and `status` is the first command to read the new file. `XtaskCacheConfig` is
  `deny_unknown_fields` (`xtask/src/config.rs`), so a new key under `[ext.xtask.cache]`
  wedges every binary built before it. The remedy is manual: remove
  `<git dir>/xtask-cache`.
- Recovering automatically is a design decision this change does not take. Having the
  transport rebuild when `status` cannot answer collides with
  `public_status_errors_do_not_start_cargo`, which deliberately pins the opposite for a
  genuinely broken configuration: invalid TOML must fail fast rather than spend a build
  producing the same error. From the shell the two causes are indistinguishable. The other
  candidate — letting `[ext.xtask.cache]` tolerate unknown fields so an older binary can
  still report itself stale — trades the typo protection `deny_unknown_fields` gives that
  section.
