### PR TITLE
fix(ci): resolve lanes in a checkout of their own

### DIFF
--- a/xtask/src/ci/run.rs
+++ b/xtask/src/ci/run.rs
@@ -477,6 +477,7 @@ mod tests {
     use std::{collections::BTreeSet, env, fs, path::Path};
 
     use clap::{Parser, ValueEnum};
+    use tempfile::TempDir;
 
     #[cfg(unix)]
     use super::execute_lane;
@@ -491,17 +492,43 @@ mod tests {
         config::{CiLaneConfig, KitharaExt},
     };
 
+    /// The repository the lane declarations are read from, whatever checkout a
+    /// resolution then runs against.
+    fn repo() -> &'static Path {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("xtask has a workspace root")
+    }
+
+    /// The checkout a lane resolves against. Routing asks the filesystem
+    /// questions - `apple-ios-test` converts a result bundle only when a run
+    /// left one behind - so resolving against the repository would make the
+    /// answer depend on what an earlier build wrote into `target/`. An
+    /// executor keeps that directory between jobs on purpose, so there the
+    /// bundle is always present and the recorded answer never matched.
+    fn checkout() -> TempDir {
+        tempfile::tempdir().expect("create a resolution checkout")
+    }
+
+    /// The same checkout once a simulator run has left its result bundle, which
+    /// is the state the conversion step exists for.
+    fn checkout_after_a_simulator_run() -> TempDir {
+        let checkout = checkout();
+        fs::create_dir_all(checkout.path().join("target/xcresult/ios-test.xcresult"))
+            .expect("leave a result bundle behind");
+        checkout
+    }
+
     /// One lane resolved in one pipeline kind: the program and arguments of
     /// each step it asks for, or the reason it refuses the kind.
     fn resolve(
         name: &str,
         kind: PipelineKind,
     ) -> (Result<(), String>, Vec<(String, Vec<String>, String)>) {
-        let root = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .expect("xtask has a workspace root");
+        let checkout = checkout();
+        let root = checkout.path();
         let ci_config = fixture();
-        let ext = KitharaExt::load(root).expect("the project config parses");
+        let ext = KitharaExt::load(repo()).expect("the project config parses");
         let lane = Lane::parse(name, &ext.ci.lanes).expect("the lane is declared");
         let recording = Recording::default().with_reply(
             "xcodebuild",
@@ -601,6 +628,17 @@ mod tests {
         assert_eq!(label, "full lint gate");
     }
 
+    /// The conversion runs off what a simulator run leaves behind, so a
+    /// checkout without a result bundle asks `xcrun` for nothing. The snapshot
+    /// resolves the same lane in a checkout that has one.
+    #[test]
+    fn a_checkout_without_a_result_bundle_converts_nothing() {
+        let (outcome, steps) = resolve("apple-ios-test", PipelineKind::Main);
+
+        assert_eq!(outcome, Ok(()));
+        assert!(steps.iter().all(|(program, ..)| program != "xcrun"));
+    }
+
     /// Every command lane, resolved but not run, in every pipeline kind it
     /// accepts. The snapshot is taken from the code that owns the routing
     /// today; moving that routing into configuration has to reproduce it
@@ -608,11 +646,10 @@ mod tests {
     /// the one thing a routing change cannot be verified against.
     #[test]
     fn every_command_lane_resolves_to_its_recorded_commands() {
-        let root = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .expect("xtask has a workspace root");
         let ci_config = fixture();
-        let ext = KitharaExt::load(root).expect("the project config parses");
+        let ext = KitharaExt::load(repo()).expect("the project config parses");
+        let checkout = checkout_after_a_simulator_run();
+        let root = checkout.path();
         let mut report = String::new();
 
         for name in every_lane() {
@@ -630,7 +667,10 @@ mod tests {
                         &format!("Xcode {}", ci_config.pins.expected_xcode_version),
                     )
                     .with_reply("chromium", &version)
-                    .with_reply("chromedriver", &version);
+                    .with_reply("chromedriver", &version)
+                    // Enough for the conversion to resolve; what it makes of
+                    // real results is pinned where that conversion lives.
+                    .with_reply("xcrun", r#"{"testNodes":[]}"#);
                 let process = Process::recording(root, recording);
                 let outcome = command_lane(
                     &lane,

--- a/xtask/tests/fixtures/ci-lane-commands.txt
+++ b/xtask/tests/fixtures/ci-lane-commands.txt
@@ -184,6 +184,7 @@
   just platform apple test --skip-build
     KITHARA_LOCAL_DEV=1
     KITHARA_TEST_SERVER_URL=http://127.0.0.1:3444
+  xcrun xcresulttool get test-results tests --path <root>/target/xcresult/ios-test.xcresult --format json
 # apple-ios-test / platforms
   <require os> macos
   <require tools> cargo just sccache swift xcodebuild xcodegen
@@ -194,6 +195,7 @@
   just platform apple test --skip-build
     KITHARA_LOCAL_DEV=1
     KITHARA_TEST_SERVER_URL=http://127.0.0.1:3444
+  xcrun xcresulttool get test-results tests --path <root>/target/xcresult/ios-test.xcresult --format json
 # apple-ios-test / merge-request
   <require os> macos
   <require tools> cargo just sccache swift xcodebuild xcodegen
@@ -204,6 +206,7 @@
   just platform apple test --skip-build
     KITHARA_LOCAL_DEV=1
     KITHARA_TEST_SERVER_URL=http://127.0.0.1:3444
+  xcrun xcresulttool get test-results tests --path <root>/target/xcresult/ios-test.xcresult --format json
 # apple-ios-test / quarantine
   <require os> macos
   <require tools> cargo just sccache swift xcodebuild xcodegen
@@ -214,6 +217,7 @@
   just platform apple test --skip-build
     KITHARA_LOCAL_DEV=1
     KITHARA_TEST_SERVER_URL=http://127.0.0.1:3444
+  xcrun xcresulttool get test-results tests --path <root>/target/xcresult/ios-test.xcresult --format json
 # apple-ios-test / main
   <require os> macos
   <require tools> cargo just sccache swift xcodebuild xcodegen
@@ -224,6 +228,7 @@
   just platform apple test --skip-build
     KITHARA_LOCAL_DEV=1
     KITHARA_TEST_SERVER_URL=http://127.0.0.1:3444
+  xcrun xcresulttool get test-results tests --path <root>/target/xcresult/ios-test.xcresult --format json
 # apple-ios-test / nightly
   <require os> macos
   <require tools> cargo just sccache swift xcodebuild xcodegen
@@ -234,6 +239,7 @@
   just platform apple test --skip-build
     KITHARA_LOCAL_DEV=1
     KITHARA_TEST_SERVER_URL=http://127.0.0.1:3444
+  xcrun xcresulttool get test-results tests --path <root>/target/xcresult/ios-test.xcresult --format json
 # apple-ios-test / weekly
   <require os> macos
   <require tools> cargo just sccache swift xcodebuild xcodegen
@@ -244,6 +250,7 @@
   just platform apple test --skip-build
     KITHARA_LOCAL_DEV=1
     KITHARA_TEST_SERVER_URL=http://127.0.0.1:3444
+  xcrun xcresulttool get test-results tests --path <root>/target/xcresult/ios-test.xcresult --format json
 # apple-ios-test / release
   <require os> macos
   <require tools> cargo just sccache swift xcodebuild xcodegen
@@ -254,6 +261,7 @@
   just platform apple test --skip-build
     KITHARA_LOCAL_DEV=1
     KITHARA_TEST_SERVER_URL=http://127.0.0.1:3444
+  xcrun xcresulttool get test-results tests --path <root>/target/xcresult/ios-test.xcresult --format json
 # apple-lint / branch
   <require os> macos
   <require tools> cargo just sccache swift xcodebuild xcodegen


### PR DESCRIPTION
`apple:lint` has been red on the macOS executor on every commit since the simulator lane last ran there, while the same test passes on every ephemeral runner. The difference is not in the code — it is in what the checkout contains.

## What happens

`every_command_lane_resolves_to_its_recorded_commands` resolves every lane against the working checkout, and one lane asks the filesystem a question:

```rust
// xtask/src/ci/lane/apple.rs
let bundle = process.root().join("target/xcresult/ios-test.xcresult");
if bundle.exists() {
    xcresult::write_junit(...)?;
}
```

An executor keeps `target/` between jobs on purpose, so once `apple:ios-test` has run there the bundle is always present, `apple-ios-test` resolves through the conversion step, and the recorded answer — taken on a machine that never ran the simulator — can never match again. A runner that starts from a clean checkout never sees the bundle and never sees the failure, which is why this could not be caught before it landed.

The test also wrote into the checkout it was reading: resolving `apple-swift-test` creates `target/xcresult/`.

## What changes

Resolution gets a directory of its own instead of the checkout. Lane declarations still come from the repository; only the directory a lane resolves *against* moves.

The snapshot seeds that directory with the result bundle, so the conversion step is part of what it records rather than something the snapshot could only observe by accident, and `xcresulttool` gets a canned answer so the step resolves rather than refusing. The empty checkout — the other side of that branch — is pinned by a test of its own.

## Verification

| checkout state | result |
| --- | --- |
| clean | passes, and leaves nothing behind in `target/` |
| result bundle present (the executor's state) | passes |

`cargo test -p xtask`: 414 + 8 + 23 + 8 + 6 + 18 passed, 0 failed. `just fmt` and the commit gate are clean.