### PR TITLE
fix(audio,play): deliver reader events by consumer context

### DIFF
--- a/crates/kithara-audio/CONTEXT.md
+++ b/crates/kithara-audio/CONTEXT.md
@@ -59,7 +59,8 @@ Do not re-derive these; each is owned by the named crate's `CONTEXT.md`.
   `finish_deferred` runs after and owns lifecycle events, the reader→peer wake,
   reader-demand filing, rebuild submission, and `Retired::drain`. Drop keeps one
   teardown flush after the scheduler's final pass, because terminal-slot removal
-  performs no further pass.
+  performs no further pass. A reader-born event on the RT path also arms the
+  worker so that the shell cannot leave that event parked in the deferred bus.
 
 ### Preload gate
 

--- a/crates/kithara-audio/src/audio/core.rs
+++ b/crates/kithara-audio/src/audio/core.rs
@@ -152,7 +152,14 @@ impl<S> Audio<S> {
             self.session.playhead.position(),
             self.ring.validator.epoch,
         );
+        self.wake_for_events();
         filled
+    }
+
+    fn wake_for_events(&mut self) {
+        if self.events.take_wake_pending() {
+            self.ring.wake_worker(Some(self.runtime.wake.as_ref()));
+        }
     }
 
     #[must_use]
@@ -202,9 +209,11 @@ impl<S> Audio<S> {
             recv,
             buf,
         )?;
-        Ok(self
+        let outcome = self
             .events
-            .commit_read(&self.session, self.ring.validator.epoch, read))
+            .commit_read(&self.session, self.ring.validator.epoch, read);
+        self.wake_for_events();
+        Ok(outcome)
     }
 
     /// Starts a non-blocking seek to `position`.
@@ -287,6 +296,7 @@ impl<S: kithara_platform::maybe_send::MaybeSend> AudioRead for Audio<S> {
                 self.session.playhead.position(),
                 self.ring.validator.epoch,
             );
+            self.wake_for_events();
             chunk.map(|(chunk, _source_span)| chunk)
         };
         let Some(chunk) = chunk else {
@@ -319,9 +329,11 @@ impl<S: kithara_platform::maybe_send::MaybeSend> AudioRead for Audio<S> {
             recv_ctx(&self.session, &self.runtime),
             output,
         )?;
-        Ok(self
+        let outcome = self
             .events
-            .commit_read(&self.session, self.ring.validator.epoch, read))
+            .commit_read(&self.session, self.ring.validator.epoch, read);
+        self.wake_for_events();
+        Ok(outcome)
     }
 
     fn spec(&self) -> AudioSpec {

--- a/crates/kithara-audio/src/audio/cursor.rs
+++ b/crates/kithara-audio/src/audio/cursor.rs
@@ -15,7 +15,7 @@ use crate::SourceSpan;
 
 #[derive(Clone, Copy)]
 pub(super) struct CursorRead {
-    pub(super) last_output_meta: Option<AudioChunkInfo>,
+    pub(super) first_output_meta: Option<AudioChunkInfo>,
     pub(super) outcome: ReadOutcome,
 }
 
@@ -130,7 +130,7 @@ impl ChunkCursor {
         }
 
         let mut written = 0;
-        let mut last_output_meta = None;
+        let mut first_output_meta = None;
         let mut source_span = None;
         let mut source_output_frames = 0_u64;
         while written < buf.len() {
@@ -152,7 +152,7 @@ impl ChunkCursor {
                     self.copy_into(chunk, chunk_source_span, &mut buf[written..], playhead)?;
                 if copied.samples > 0 {
                     hang_reset!();
-                    last_output_meta = Some(chunk.meta);
+                    first_output_meta.get_or_insert(chunk.meta);
                     written += copied.samples;
                     if let Some(next) = copied.source_span {
                         source_span = source_span.map_or(Some(next), |current| {
@@ -199,7 +199,7 @@ impl ChunkCursor {
                     .is_none_or(|duration| position <= duration)
             );
             return Ok(CursorRead {
-                last_output_meta,
+                first_output_meta,
                 outcome: ReadOutcome::Frames {
                     count,
                     position,
@@ -364,7 +364,7 @@ fn pending(playhead: &dyn PlayheadWrite, reason: PendingReason) -> CursorRead {
             reason,
             position: playhead.position(),
         },
-        last_output_meta: None,
+        first_output_meta: None,
     }
 }
 
@@ -373,7 +373,7 @@ fn eof(playhead: &dyn PlayheadWrite) -> CursorRead {
         outcome: ReadOutcome::Eof {
             position: playhead.position(),
         },
-        last_output_meta: None,
+        first_output_meta: None,
     }
 }
 
@@ -513,6 +513,10 @@ mod tests {
                 &mut output,
             )
             .expect("first read succeeds");
+        assert_eq!(
+            first_read.first_output_meta.map(|meta| meta.timestamp),
+            Some(Duration::ZERO)
+        );
         let ReadOutcome::Frames {
             count, source_span, ..
         } = first_read.outcome

--- a/crates/kithara-audio/src/audio/event.rs
+++ b/crates/kithara-audio/src/audio/event.rs
@@ -36,6 +36,7 @@ impl Consts {
 /// returns, and the deferred ring keeps the shell as its only flusher.
 pub(super) struct AudioEvents {
     emit: Arc<DeferredBus<Event>>,
+    wake_pending: bool,
     wake_mode: ConsumerWakeMode,
     last_progress_emit: Option<(u64, u64)>,
     underrun_active: bool,
@@ -45,6 +46,7 @@ impl AudioEvents {
     pub(super) const fn new(emit: Arc<DeferredBus<Event>>, wake_mode: ConsumerWakeMode) -> Self {
         Self {
             emit,
+            wake_pending: false,
             wake_mode,
             last_progress_emit: None,
             underrun_active: false,
@@ -59,11 +61,17 @@ impl AudioEvents {
     ) -> ReadOutcome {
         let super::cursor::CursorRead {
             outcome,
-            last_output_meta,
+            first_output_meta,
         } = read;
         if matches!(outcome, ReadOutcome::Frames { .. }) {
             let position = session.playhead.position();
-            self.post_seek_output(session.seek_obs.as_ref(), epoch, last_output_meta, position);
+            self.fill_result(true, false, false, position, epoch);
+            self.post_seek_output(
+                session.seek_obs.as_ref(),
+                epoch,
+                first_output_meta,
+                position,
+            );
             self.progress(session.playhead.as_ref(), epoch);
         }
         outcome
@@ -104,7 +112,7 @@ impl AudioEvents {
 
     #[kithara::probe(epoch, pending = seek.pending_epoch().unwrap_or(0))]
     pub(super) fn post_seek_output(
-        &self,
+        &mut self,
         seek: &dyn SeekObserve,
         epoch: u64,
         meta: Option<AudioChunkInfo>,
@@ -126,7 +134,7 @@ impl AudioEvents {
         });
         self.publish(AudioEvent::SeekComplete {
             seek_epoch,
-            position,
+            position: meta.map_or(position, |chunk| chunk.timestamp),
         });
         let _ = seek.clear_pending_epoch(seek_epoch);
     }
@@ -152,11 +160,20 @@ impl AudioEvents {
         });
     }
 
-    pub(super) fn publish(&self, event: AudioEvent) {
+    pub(super) fn publish(&mut self, event: AudioEvent) {
         match self.wake_mode {
-            ConsumerWakeMode::RealtimeDeferred => self.emit.enqueue(event.into()),
+            ConsumerWakeMode::RealtimeDeferred => {
+                self.emit.enqueue(event.into());
+                self.wake_pending = true;
+            }
             ConsumerWakeMode::ImmediateOffRt => self.emit.bus().publish(event),
         }
+    }
+
+    pub(super) const fn take_wake_pending(&mut self) -> bool {
+        let pending = self.wake_pending;
+        self.wake_pending = false;
+        pending
     }
 
     pub(super) const fn reset_underrun(&mut self) {
@@ -437,13 +454,24 @@ mod tests {
         let bus = EventBus::new(8);
         let mut receiver = bus.subscribe();
         let emit = AudioEvents::deferred(&bus);
-        let events = AudioEvents::new(Arc::clone(&emit), ConsumerWakeMode::RealtimeDeferred);
+        let mut events = AudioEvents::new(Arc::clone(&emit), ConsumerWakeMode::RealtimeDeferred);
         let seek = SeekState::new();
-        let position = Duration::from_millis(500);
-        let epoch = seek.begin(position);
+        let target = Duration::from_millis(500);
+        let epoch = seek.begin(target);
         seek.mark_pending(epoch);
 
-        events.post_seek_output(&seek, epoch, None, position);
+        events.post_seek_output(
+            &seek,
+            epoch,
+            Some(AudioChunkInfo {
+                timestamp: target,
+                end_timestamp: Duration::from_millis(521),
+                ..Default::default()
+            }),
+            Duration::from_millis(521),
+        );
+        assert!(events.take_wake_pending());
+        assert!(!events.take_wake_pending());
 
         assert!(
             receiver.try_recv().is_err(),
@@ -461,8 +489,10 @@ mod tests {
         ));
         assert!(matches!(
             receiver.try_recv().map(|envelope| envelope.event),
-            Ok(Event::Audio(AudioEvent::SeekComplete { seek_epoch, .. }))
-                if seek_epoch == epoch
+            Ok(Event::Audio(AudioEvent::SeekComplete {
+                seek_epoch,
+                position,
+            })) if seek_epoch == epoch && position == target
         ));
         assert_eq!(seek.pending_epoch(), None);
     }

--- a/crates/kithara-play/CONTEXT.md
+++ b/crates/kithara-play/CONTEXT.md
@@ -256,10 +256,9 @@ a grid identity nor converts analysis facts into a second representation.
 `SessionDispatcher::consumer_wake_mode` is a **required** object-safe capability,
 not a trait default, so a wrapper cannot silently erase an off-RT capability by
 omission. `ConfigPrep` copies it into `ResourceConfig::consumer_wake_mode`,
-*unconditionally overwriting whatever the builder carried*, so a player-managed
-resource has no second source of wake policy; the builder setter exists only for
-direct `Resource` readers that never pass through a player
-(`prepare_config_overwrites_a_builder_declared_wake_mode` and siblings). The
+so a player-managed resource has no second source of wake policy. An unset field
+identifies a direct `Resource` reader and resolves to `ImmediateOffRt` while its
+config becomes an `AudioConfig`. The
 Host's `TransportCommitState` is the sole owner of when the session
 beat-to-frame relation changes: a stream restart drops the transport snapshot
 because the frame axis restarted, and the first block on the new axis reanchors

--- a/crates/kithara-play/src/player/flow/prepare.rs
+++ b/crates/kithara-play/src/player/flow/prepare.rs
@@ -61,7 +61,7 @@ where
             bus,
             cancel,
             worker: Some(self.player.core.worker.clone()),
-            consumer_wake_mode: self.player.core.engine.consumer_wake_mode(),
+            consumer_wake_mode: Some(self.player.core.engine.consumer_wake_mode()),
             block_on_underrun: self.player.core.block_on_underrun,
             host_sample_rate,
             decoder,
@@ -155,7 +155,7 @@ mod tests {
             .expect("test session answers stream-shape queries");
         assert_eq!(
             prepared.consumer_wake_mode,
-            ConsumerWakeMode::ImmediateOffRt
+            Some(ConsumerWakeMode::ImmediateOffRt)
         );
         assert!(prepared.decoder.resampler().is_none());
         let audio = prepared.build_file_config(player.worker(), None);
@@ -171,31 +171,6 @@ mod tests {
     }
 
     #[kithara::test]
-    fn prepare_config_overwrites_a_builder_declared_wake_mode() {
-        let player = PlayerImpl::new(
-            PlayerConfig::builder()
-                .sample_rate(testing::TEST_SAMPLE_RATE)
-                .worker(worker())
-                .session(testing::test_session())
-                .build(),
-        );
-
-        let src = ResourceSrc::parse("https://example.com/song.mp3").expect("valid test source");
-        let config = ResourceConfig::<TestPools>::for_src(src)
-            .store(AssetStore::builder(pools()).build())
-            .consumer_wake_mode(ConsumerWakeMode::ImmediateOffRt)
-            .build();
-
-        let prepared = player
-            .prepare_config(config)
-            .expect("test session answers stream-shape queries");
-        assert_eq!(
-            prepared.consumer_wake_mode,
-            ConsumerWakeMode::RealtimeDeferred,
-            "a player-managed resource cannot smuggle an off-RT capability past the session policy"
-        );
-    }
-
     #[kithara::test]
     fn prepare_config_sizes_default_resampling_work_to_the_output_block() {
         let shape = StreamShape::new(

--- a/crates/kithara-play/src/resource/build.rs
+++ b/crates/kithara-play/src/resource/build.rs
@@ -1,4 +1,4 @@
-use kithara_audio::{AudioConfig, AudioObserver, ResamplerBackend};
+use kithara_audio::{AudioConfig, AudioObserver, ConsumerWakeMode, ResamplerBackend};
 use kithara_bufpool::HasPool;
 use kithara_decode::DecodeError;
 use kithara_file::{FileConfig, FileSrc};
@@ -80,7 +80,10 @@ where
             .maybe_observer(observer)
             .preload_chunks(self.preload_chunks)
             .decoder(self.decoder)
-            .consumer_wake_mode(self.consumer_wake_mode)
+            .consumer_wake_mode(
+                self.consumer_wake_mode
+                    .unwrap_or(ConsumerWakeMode::ImmediateOffRt),
+            )
             .block_on_underrun(self.block_on_underrun)
             .build()
     }
@@ -126,7 +129,10 @@ where
                 .maybe_observer(observer)
                 .preload_chunks(self.preload_chunks)
                 .decoder(self.decoder)
-                .consumer_wake_mode(self.consumer_wake_mode)
+                .consumer_wake_mode(
+                    self.consumer_wake_mode
+                        .unwrap_or(ConsumerWakeMode::ImmediateOffRt),
+                )
                 .block_on_underrun(self.block_on_underrun)
                 .build(),
         )

--- a/crates/kithara-play/src/resource/config.rs
+++ b/crates/kithara-play/src/resource/config.rs
@@ -78,17 +78,10 @@ where
     /// Explicit playback worker. Player preparation fills this field; direct
     /// Resource callers must configure it themselves.
     pub(crate) worker: Option<PlayWorker<S>>,
-    /// Audio-consumer wake capability for this resource's reader. The default
-    /// is safe for a consumer on the real-time render callback.
-    /// `PlayerImpl::prepare_config` always overwrites it with the session
-    /// policy, so a player-managed resource cannot carry a second source of
-    /// that policy. A direct reader off the real-time thread opts into
-    /// [`ConsumerWakeMode::ImmediateOffRt`] itself for immediate worker wakes
-    /// and inline reader-event delivery. Never declare `ImmediateOffRt` on a
-    /// resource headed into a player without `prepare_config`: its reads would
-    /// then publish inline on the render callback.
-    #[builder(default)]
-    pub(crate) consumer_wake_mode: ConsumerWakeMode,
+    /// Session-owned audio-consumer wake capability. Player preparation fills
+    /// this field; `None` identifies a direct resource consumed off RT.
+    #[builder(skip)]
+    pub(crate) consumer_wake_mode: Option<ConsumerWakeMode>,
     /// Make audio-thread reads block on a producer-ring underrun instead of
     /// zero-filling. `PlayerImpl::prepare_config` copies the player's policy
     /// here; a direct reader off the real-time thread may opt in itself.
@@ -170,12 +163,9 @@ mod tests {
     }
 
     #[kithara::test]
-    fn a_config_that_never_passed_a_player_defaults_to_realtime_deferred() {
+    fn direct_config_has_no_session_wake_policy() {
         let config = test_config("https://example.com/track.mp3").expect("valid config");
-        assert_eq!(
-            config.consumer_wake_mode,
-            ConsumerWakeMode::RealtimeDeferred
-        );
+        assert_eq!(config.consumer_wake_mode, None);
     }
 
     fn worker() -> PlayWorker<TestPools> {
@@ -259,6 +249,30 @@ mod tests {
                 .build();
         let audio_config = config.build_hls_config(&worker, None).unwrap();
         assert!(audio_config.stream().bus.is_some());
+    }
+
+    #[kithara::test]
+    fn direct_resources_wake_the_worker_off_rt() {
+        let worker = worker();
+        let file: ResourceConfig<TestPools> =
+            ResourceConfig::for_src(valid_src("https://example.com/a.mp3"))
+                .store(store())
+                .build();
+        assert_eq!(
+            file.build_file_config(&worker, None).consumer_wake_mode(),
+            ConsumerWakeMode::ImmediateOffRt
+        );
+
+        let hls: ResourceConfig<TestPools> =
+            ResourceConfig::for_src(valid_src("https://example.com/a.m3u8"))
+                .store(store())
+                .build();
+        assert_eq!(
+            hls.build_hls_config(&worker, None)
+                .expect("valid HLS config")
+                .consumer_wake_mode(),
+            ConsumerWakeMode::ImmediateOffRt
+        );
     }
 
     #[kithara::test]

--- a/tests/tests/kithara_play/no_sync_real_media.rs
+++ b/tests/tests/kithara_play/no_sync_real_media.rs
@@ -11,7 +11,6 @@ mod runtime;
 use std::{num::NonZeroU32, path::PathBuf};
 
 use kithara::{
-    audio::ConsumerWakeMode,
     bufpool::PoolRegion,
     events::{EventBus, TrackId},
     hls::AbrMode,
@@ -933,7 +932,6 @@ async fn prepare_deck(
         }))
         .store(memory_asset_store())
         .worker(player.worker().clone())
-        .consumer_wake_mode(ConsumerWakeMode::ImmediateOffRt)
         .initial_abr_mode(AbrMode::manual(0))
         .host_sample_rate(NonZeroU32::new(case.host_rate).expect("host rate is non-zero"))
         .events(EventBus::new(16_384))


### PR DESCRIPTION
## Summary

Realtime reads could enqueue lifecycle or progress events without guaranteeing that the off-RT playback shell would run again to flush them. Direct resource readers also inherited the realtime-deferred policy unless every caller remembered to override it. This change restores the final PR #232 delivery contract: reader-born realtime events arm one coalesced shell wake, direct resources resolve to immediate off-RT publication, and player-managed resources keep the session-owned wake capability.

## Behavior / scope

- contract or behavior: deferred reader events cannot remain parked after a productive read; seek completion reports the first served frame; direct Resource readers use ImmediateOffRt while Player preparation supplies the session policy.
- affected area: kithara-audio reader event delivery and kithara-play resource configuration.

## Validation

- `just fmt check`
- `cargo test -p kithara-audio --lib`
- `cargo test -p kithara-play --lib`
- `cargo test -p kithara-audio reads_preserve_each_rendered_source_span --lib`
- `cargo test -p kithara-audio post_seek_output_reaches_the_bus_once_the_shell_flushes --lib`
- `cargo test -p kithara-play direct_resources_wake_the_worker_off_rt --lib`
- `cargo test -p kithara-integration-tests --test suite_heavy --no-run`
- `cargo clippy -p kithara-audio --lib -- -D warnings`
- `cargo clippy -p kithara-play --lib -- -D warnings`
- pre-commit `just lint fast`

## Surface impact

- Public API: changed: ResourceConfig no longer exposes consumer wake policy as caller configuration; ownership is inferred from direct versus Player-managed construction.
- Platform/runtime: changed: realtime callback readers defer publication and wake the off-RT shell; direct off-RT readers publish inline.
- Perf-sensitive paths: changed: one boolean latch and coalesced deferred wake are added only when a realtime read actually emits an event.

## Risks / follow-ups

- ABR transition rebuilding and final live-rate/Warp work remain in later stacked PRs.
