### PR TITLE
fix(quality): include headless UI coverage

### DIFF
--- a/.config/just/test.just
+++ b/.config/just/test.just
@@ -236,6 +236,15 @@ coverage:
     cargo llvm-cov nextest --no-report \
       --workspace --exclude kithara-fuzz \
       --cargo-profile test-release || test_rc=$?
+    cargo llvm-cov nextest --no-report \
+      -p kithara-ui \
+      --cargo-profile test-release \
+      --ignore-default-filter || test_rc=$?
+    cargo llvm-cov nextest --no-report \
+      -p kithara-app \
+      --cargo-profile test-release \
+      --ignore-default-filter \
+      -E 'package(kithara-app) & test(/^gui::/)' || test_rc=$?
     report_rc=0
     cargo llvm-cov report \
       --profile test-release \


### PR DESCRIPTION
## Summary
The scheduled coverage-risk lane used the workspace's default nextest filter, so the headless `kithara-ui` suite and `kithara-app` GUI tests did not contribute to LCOV or CRAP. This change adds two accumulating coverage passes for those existing tests before the current Cobertura, LCOV, and threshold reports are generated.

On the measured base `3c348470f`, line coverage increased from 64.16% to 80.32% and functions above CRAP 30 fell from 978 to 817. The largest corrections were `kithara-ui` (233 to 87) and `kithara-app` (53 to 38).

## Behavior / scope
- contract or behavior: `just test coverage` now includes 1,112 headless UI tests and 74 app GUI tests that the default filter excludes
- affected area: coverage artifacts and the existing nightly/weekly `quality-coverage-risk` report

## Validation
- `just fmt check`
- `just --dry-run test coverage`
- `cargo llvm-cov nextest --no-report -p kithara-ui --cargo-profile test-release --ignore-default-filter` (1,112 passed)
- `cargo llvm-cov nextest --no-report -p kithara-app --cargo-profile test-release --ignore-default-filter -E 'package(kithara-app) & test(/^gui::/)'` (74 passed, 65 filtered)
- `cargo llvm-cov report --profile test-release --summary-only --ignore-filename-regex '(tests/|examples/|benches/|xtask/)' --fail-under-lines 80` (passed at 80.32% lines)
- `just quality lab run coverage --lcov coverage/lcov.info --baseline target/crap-baselines/3c348470fcad4852001af2836fe5610c3e89432d/report.json` produced 817 CRAP findings above 30, down by 161; it exited with findings because five sub-threshold functions had small score increases, with zero new high-risk regressions

## Surface impact
- Public API: none
- Platform/runtime: tooling surface only
- Perf-sensitive paths: none

## Risks / follow-ups
- The retained high-risk findings with missing coverage remain 532; this change corrects report input for existing headless tests and does not add tests for other project surfaces.
- The quantitative comparison was measured on `3c348470f`; the branch was then fast-forwarded to current `production/main` at `4e2ea9182`, so CI should provide the exact-head report.
