### PR TITLE
fix(storage): preserve mmap snapshot when reopen fails

### DIFF
--- a/crates/kithara-storage/src/backend/mmap/driver.rs
+++ b/crates/kithara-storage/src/backend/mmap/driver.rs
@@ -185,6 +185,7 @@ mod tests {
     use super::*;
     use crate::{
         Resource, ResourceRead, StorageError,
+        backend::traits::DriverIo,
         resource::{ResourceStatus, WaitOutcome},
     };
 
@@ -369,6 +370,27 @@ mod tests {
         let n = res.read_at(0, &mut buf).unwrap();
         assert_eq!(n, 1024);
         assert!(buf.iter().all(|&b| b == 42));
+    }
+
+    #[kithara::test(timeout(Duration::from_secs(1)))]
+    fn failed_post_commit_reopen_keeps_snapshot() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("original.dat");
+        let (mut driver, _) = MmapDriver::open(
+            MmapOptions::for_path(path)
+                .mode(OpenMode::ReadWrite)
+                .build(),
+        )
+        .unwrap();
+        driver.write_at(0, b"data", false).unwrap();
+        driver.commit(Some(4)).unwrap();
+
+        driver.path = dir.path().join("missing").join("resource.dat");
+        assert!(driver.write_at(0, b"lost", true).is_err());
+
+        let mut buf = [0; 4];
+        assert_eq!(driver.read_committed(0, &mut buf).unwrap(), Some(4));
+        assert_eq!(&buf, b"data");
     }
 
     fn create_resource_growing_by(dir: &TempDir, initial: u64, factor: u64) -> MmapResource {

--- a/crates/kithara-storage/src/backend/mmap/io.rs
+++ b/crates/kithara-storage/src/backend/mmap/io.rs
@@ -214,9 +214,8 @@ impl DriverIo for MmapDriver {
         if committed {
             match (&*mmap_guard, self.mode) {
                 (MmapState::Committed(_), OpenMode::ReadWrite) => {
-                    self.committed.store(None);
-                    *mmap_guard = MmapState::Empty;
                     let rw = MemoryMappedFile::open_rw(&self.path)?;
+                    self.committed.store(None);
                     *mmap_guard = MmapState::Active(rw);
                 }
                 (MmapState::Active(_), _)
@@ -229,35 +228,24 @@ impl DriverIo for MmapDriver {
             }
         }
 
-        let mmap = match &*mmap_guard {
-            MmapState::Active(m) => {
-                if end > m.len() {
-                    let new_size = end.max(m.len() * self.growth_factor);
-                    m.resize(new_size)?;
-                }
-                m
-            }
-            MmapState::Committed(_) => {
-                return Err(StorageError::Failed(
-                    "cannot write to committed resource".to_string(),
-                ));
-            }
-            MmapState::Empty => {
-                let size = end.max(self.initial_len);
-                let m = MemoryMappedFile::create_rw(&self.path, size)?;
-                *mmap_guard = MmapState::Active(m);
-                match &*mmap_guard {
-                    MmapState::Active(m) => m,
-                    _ => {
-                        return Err(StorageError::Failed(
-                            "mmap not available after create".to_string(),
-                        ));
-                    }
-                }
-            }
+        if matches!(*mmap_guard, MmapState::Empty) {
+            let size = end.max(self.initial_len);
+            let mmap = MemoryMappedFile::create_rw(&self.path, size)?;
+            *mmap_guard = MmapState::Active(mmap);
+        }
+
+        let MmapState::Active(mmap) = &*mmap_guard else {
+            return Err(StorageError::Failed(
+                "cannot write to committed resource".to_string(),
+            ));
         };
+        if end > mmap.len() {
+            let new_size = end.max(mmap.len() * self.growth_factor);
+            mmap.resize(new_size)?;
+        }
 
         mmap.update_region(offset, data)?;
+        drop(mmap_guard);
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

A failed post-commit reopen discarded the committed mmap snapshot before the replacement mapping had opened. This change opens the writable mapping first, preserves the readable snapshot when that fallible operation fails, and simplifies the write-state transition.

Fresh exact-head coverage confirms that `MmapDriver::write_at` moved below the CRAP threshold:

- cyclomatic complexity: `15 → 11`
- CRAP: `56.983 → 18.744`
- line coverage: `60%`

## Behavior / scope

- contract or behavior: a failed post-commit reopen leaves the previous committed bytes readable
- affected area: `kithara-storage` mmap driver write path
- architecture signal: reduces the `DriverIo for MmapDriver` implementation already identified by the `single_impl_size` baseline

## Validation

- `just fmt check`
- `just check clippy`
- `cargo nextest run -p kithara-storage` — 85 passed
- `just test run -p kithara-storage failed_post_commit_reopen_keeps_snapshot` — passed on the fixed implementation
- the same regression test on `production/main` — failed with `left: None / right: Some(4)`
- `git diff --check`
- fresh exact-head coverage/CRAP: [fork run 33954567068](https://github.com/gerasim13/kithara/actions/runs/33954567068), artifact `coverage-risk-33954567068-1`, revision `982a48426e02b8df1cbedb99164993b7990868fb`
- exact-head GitLab quarantine `#2137914` — passed

The coverage workflow produced the complete clean CRAP artifact, then failed on the pre-existing integration budget test `kithara_play::resource_regressions::stress_offline_crossfade_no_gaps`: 5724/5725 workspace tests passed; the failure reported 3 HLS→MP3 blocks above budget, max render 29.97411 ms. The later UI/app coverage suites passed (1112/1112 and 74/74).

## Surface impact

- Public API: none
- Platform/runtime: changed native mmap storage failure behavior
- Perf-sensitive paths: the mmap write path has fewer branches; no new allocation or synchronization primitive
