### PR TITLE
feat(warp): trace live rate delivery

### DIFF
--- a/crates/kithara-audio/src/audio/cursor.rs
+++ b/crates/kithara-audio/src/audio/cursor.rs
@@ -157,6 +157,7 @@ impl ChunkCursor {
                     if let Some(next) = copied.source_span {
                         source_span = source_span.map_or(Some(next), |current| {
                             SourceSpan::new(current.start(), next.end(), current.sample_rate())
+                                .map(|span| span.with_render_revision(current.render_revision()))
                         });
                         source_output_frames = source_output_frames
                             .checked_add(copied.output_frames)
@@ -300,6 +301,7 @@ fn source_spans_coalesce(
     };
     if current.end() != next.start()
         || current.sample_rate() != next.sample_rate()
+        || current.render_revision() != next.render_revision()
         || current_output_frames == 0
         || next_output_frames == 0
     {
@@ -340,6 +342,7 @@ fn source_subspan(
         source_at(output_end)?
     };
     SourceSpan::new(start, end, span.sample_rate())
+        .map(|subspan| subspan.with_render_revision(span.render_revision()))
 }
 
 fn frames_to_samples(frames: u64, channels: u64) -> Result<usize, DecodeError> {
@@ -453,7 +456,7 @@ mod tests {
     }
 
     #[kithara::test]
-    fn reads_preserve_each_rendered_source_span() {
+    fn reads_preserve_each_rendered_source_revision() {
         let pools = pools();
         let rate = NonZeroU32::new(48_000).expect("test rate");
         let spec = AudioSpec::new(1, rate);
@@ -470,6 +473,7 @@ mod tests {
         ring.preloaded = true;
         let mut first = timed_chunk(&pools, spec, 3, Duration::ZERO, Duration::from_millis(3));
         first.meta.frame_offset = 100;
+        first.meta.render_revision = 7;
         let mut second = timed_chunk(
             &pools,
             spec,
@@ -478,6 +482,7 @@ mod tests {
             Duration::from_millis(5),
         );
         second.meta.frame_offset = 106;
+        second.meta.render_revision = 7;
         let mut changed = timed_chunk(
             &pools,
             spec,
@@ -486,6 +491,7 @@ mod tests {
             Duration::from_millis(7),
         );
         changed.meta.frame_offset = 110;
+        changed.meta.render_revision = 8;
         data_tx
             .try_push(Fetch::rendered(first, 0, SourceEnd::new(106, rate)))
             .expect("first rendered chunk reaches ring");
@@ -493,8 +499,8 @@ mod tests {
             .try_push(Fetch::rendered(second, 0, SourceEnd::new(110, rate)))
             .expect("second rendered chunk reaches ring");
         data_tx
-            .try_push(Fetch::rendered(changed, 0, SourceEnd::new(115, rate)))
-            .expect("changed-slope rendered chunk reaches ring");
+            .try_push(Fetch::rendered(changed, 0, SourceEnd::new(114, rate)))
+            .expect("changed-revision rendered chunk reaches ring");
 
         let playhead = PlayheadState::new();
         let mut cursor = ChunkCursor::new(&pools, spec).expect("cursor scratch fits test pools");
@@ -524,7 +530,10 @@ mod tests {
             panic!("expected first rendered frames");
         };
         assert_eq!(count.get(), 5);
-        assert_eq!(source_span, SourceSpan::new(100, 110, rate));
+        assert_eq!(
+            source_span,
+            SourceSpan::new(100, 110, rate).map(|span| span.with_render_revision(7))
+        );
 
         let second_read = cursor
             .read(
@@ -538,11 +547,14 @@ mod tests {
                 },
                 &mut output[..1],
             )
-            .expect("partial changed-slope read succeeds");
+            .expect("partial changed-revision read succeeds");
         let ReadOutcome::Frames { source_span, .. } = second_read.outcome else {
-            panic!("expected partial changed-slope frames");
+            panic!("expected partial changed-revision frames");
         };
-        assert_eq!(source_span, SourceSpan::new(110, 112, rate));
+        assert_eq!(
+            source_span,
+            SourceSpan::new(110, 112, rate).map(|span| span.with_render_revision(8))
+        );
 
         let final_read = cursor
             .read(
@@ -556,11 +568,14 @@ mod tests {
                 },
                 &mut output,
             )
-            .expect("final changed-slope read succeeds");
+            .expect("final changed-revision read succeeds");
         let ReadOutcome::Frames { source_span, .. } = final_read.outcome else {
-            panic!("expected final rendered frames");
+            panic!("expected final changed-revision frames");
         };
-        assert_eq!(source_span, SourceSpan::new(112, 115, rate));
+        assert_eq!(
+            source_span,
+            SourceSpan::new(112, 114, rate).map(|span| span.with_render_revision(8))
+        );
     }
 
     #[kithara::test]

--- a/crates/kithara-audio/src/audio/ring.rs
+++ b/crates/kithara-audio/src/audio/ring.rs
@@ -312,6 +312,7 @@ fn source_span(data: &AudioChunk, source_end: Option<SourceEnd>) -> Option<Sourc
         source_end.frame(),
         source_end.sample_rate(),
     )
+    .map(|span| span.with_render_revision(data.meta.render_revision))
 }
 
 pub(super) fn create_channels(

--- a/crates/kithara-audio/src/pipeline/blend/tests.rs
+++ b/crates/kithara-audio/src/pipeline/blend/tests.rs
@@ -27,6 +27,7 @@ fn chunk(pools: &Pools, spec: AudioSpec, samples: Vec<f32>) -> AudioChunk {
             variant_index: Some(2),
             frames: u32::try_from(frames).expect("fixture frame count"),
             epoch: 11,
+            render_revision: 13,
             frame_offset: 9_876,
             source_bytes: 512,
         },

--- a/crates/kithara-audio/src/pipeline/fetch.rs
+++ b/crates/kithara-audio/src/pipeline/fetch.rs
@@ -35,6 +35,9 @@ pub struct SourceSpan {
     /// Sample rate of the decoded source coordinate.
     #[field(get, copy)]
     sample_rate: NonZeroU32,
+    /// Opaque producer render revision represented by this output span.
+    #[field(get, copy, with)]
+    render_revision: u64,
 }
 
 impl SourceSpan {
@@ -48,6 +51,7 @@ impl SourceSpan {
             start,
             end,
             sample_rate,
+            render_revision: 0,
         })
     }
 }

--- a/crates/kithara-decode/src/composed.rs
+++ b/crates/kithara-decode/src/composed.rs
@@ -168,6 +168,7 @@ where
             variant_index: self.demuxer.current_variant_index(),
             spec: live_spec,
             epoch: self.epoch,
+            render_revision: 0,
         };
         AudioChunk::new(meta, buf)
     }

--- a/crates/kithara-play/src/bridge/channels.rs
+++ b/crates/kithara-play/src/bridge/channels.rs
@@ -9,6 +9,7 @@ use kithara_platform::{
     time::Duration,
 };
 use kithara_signal::AudioSpec;
+use kithara_warp::{RenderReader, RenderSnapshot};
 use ringbuf::{
     HeapCons, HeapProd, HeapRb,
     traits::{Observer, Producer, Split},
@@ -84,12 +85,18 @@ pub struct SlotControl {
     pub cmd_tx: HeapProd<PlayerCmd>,
     pub eq: SharedEq,
     seek: SeekBindings,
+    render: RenderBindings,
 }
 
 #[derive(Default)]
 struct SeekBindings(SmallVec<[SeekBinding; SLOT_TRACKS]>);
 
 type SeekBinding = (TrackId, Arc<dyn SeekBegin>);
+
+#[derive(Default)]
+struct RenderBindings(SmallVec<[RenderBinding; SLOT_TRACKS]>);
+
+type RenderBinding = (TrackId, RenderReader);
 
 const SLOT_TRACKS: usize = PlayerNodeProcessor::MAX_TRACKS;
 
@@ -111,6 +118,30 @@ impl SlotControl {
         self.seek.0.retain(|(bound_id, bound_handle)| {
             *bound_id != item_id || !Arc::ptr_eq(bound_handle, handle)
         });
+    }
+
+    pub(crate) fn bind_render(&mut self, item_id: TrackId, reader: RenderReader) {
+        self.render.0.push((item_id, reader));
+    }
+
+    pub(crate) fn unbind_render(&mut self, item_id: TrackId, reader: &RenderReader) {
+        self.render
+            .0
+            .retain(|(bound_id, bound_reader)| *bound_id != item_id || bound_reader != reader);
+    }
+
+    pub(crate) fn latest_render_snapshot(&self) -> Option<RenderSnapshot> {
+        self.render
+            .0
+            .iter()
+            .filter_map(|(_, reader)| reader.load())
+            .max_by_key(|snapshot| {
+                let context = snapshot.context();
+                (
+                    u64::from(context.session_epoch()),
+                    i64::from(context.output_frames().end),
+                )
+            })
     }
 }
 
@@ -138,6 +169,7 @@ pub fn slot_channels(eq: SharedEq) -> (NodeInputs, SlotControl) {
         cmd_tx,
         eq,
         seek: SeekBindings::default(),
+        render: RenderBindings::default(),
     };
     (inputs, control)
 }

--- a/crates/kithara-play/src/engine/core.rs
+++ b/crates/kithara-play/src/engine/core.rs
@@ -9,6 +9,7 @@ use kithara_platform::{
     time::Duration,
     tokio::runtime::Handle as RuntimeHandle,
 };
+use kithara_warp::RenderSnapshot;
 use portable_atomic::AtomicF32;
 use ringbuf::traits::{Consumer, Producer};
 use tracing::{debug, info};
@@ -117,6 +118,9 @@ impl<S> EngineImpl<S> {
             if let Some(seek) = track.seek_handle() {
                 handle.unbind_seek(track.item_id(), &seek);
             }
+            if let Some(render) = track.render_reader() {
+                handle.unbind_render(track.item_id(), &render);
+            }
         }
     }
 
@@ -171,9 +175,9 @@ impl<S> EngineImpl<S> {
                 // A resource crossing to the audio thread leaves its seek handle behind: beginning
                 // a seek takes locks, so it stays on this side. Bind only after the command is
                 // accepted; the exact resource generation is released when it returns as trash.
-                let seek = match &cmd {
+                let bindings = match &cmd {
                     PlayerCmd::LoadTrack { resource, item_id } => {
-                        resource.seek_handle().map(|handle| (*item_id, handle))
+                        Some((*item_id, resource.seek_handle(), resource.render_reader()))
                     }
                     _ => None,
                 };
@@ -182,9 +186,14 @@ impl<S> EngineImpl<S> {
                     .try_push(cmd)
                     .map_err(|_| PlayError::SlotChannelFull { slot });
                 if result.is_ok()
-                    && let Some((item_id, seek)) = seek
+                    && let Some((item_id, seek, render)) = bindings
                 {
-                    handle.bind_seek(item_id, seek);
+                    if let Some(seek) = seek {
+                        handle.bind_seek(item_id, seek);
+                    }
+                    if let Some(render) = render {
+                        handle.bind_render(item_id, render);
+                    }
                 }
                 result
             }
@@ -231,6 +240,8 @@ impl<S> EngineImpl<S> {
             pub(crate) fn slot_eq(&self, slot: SlotId) -> Option<SharedEq>;
             #[call(playback)]
             pub(crate) fn slot_playback(&self, slot: SlotId) -> Option<Arc<PlaybackShared>>;
+            #[call(render_snapshot)]
+            pub(crate) fn slot_render_snapshot(&self, slot: SlotId) -> Option<RenderSnapshot>;
         }
     }
 

--- a/crates/kithara-play/src/engine/slots.rs
+++ b/crates/kithara-play/src/engine/slots.rs
@@ -1,4 +1,5 @@
 use kithara_platform::sync::Arc;
+use kithara_warp::RenderSnapshot;
 
 use crate::{
     api::SlotId,
@@ -61,6 +62,9 @@ impl SlotTable {
             #[expr($.map(|control| control.eq.clone()))]
             #[call(get)]
             pub(super) fn slot_eq(&self, slot: SlotId) -> Option<SharedEq>;
+            #[expr($.and_then(SlotControl::latest_render_snapshot))]
+            #[call(get)]
+            pub(super) fn render_snapshot(&self, slot: SlotId) -> Option<RenderSnapshot>;
         }
     }
 }

--- a/crates/kithara-play/src/player/flow/control.rs
+++ b/crates/kithara-play/src/player/flow/control.rs
@@ -1,4 +1,6 @@
 use kithara_events::RouteDescription;
+use kithara_test_macros as kithara;
+use kithara_warp::{RenderSnapshot, StretchControls};
 
 use super::super::core::PlayerRuntime;
 use crate::{
@@ -10,6 +12,21 @@ use crate::{
 };
 
 impl<S> PlayerRuntime<S> {
+    #[kithara::probe(
+        request_revision,
+        target_rate_bits = target.to_bits(),
+        session_epoch = u64::from(snapshot.context().session_epoch()),
+        transport_revision = snapshot.context().transport_revision().map_or(0, u64::from),
+        session_frame = i64::from(snapshot.context().output_frames().end),
+        session_beat_bits = snapshot.context().session_beats().map_or(
+            f64::NAN.to_bits(),
+            |beats| f64::from(beats.end).to_bits()
+        )
+    )]
+    fn rate_requested(&self, target: f32, request_revision: u64, snapshot: &RenderSnapshot) {
+        let _ = self.send_to_slot(PlayerCmd::SetPlaybackRate(target));
+    }
+
     /// Ensure we have an active slot, allocating one if needed.
     pub fn ensure_slot(&self) -> Result<SlotId, PlayError> {
         if let Some(id) = self.slot() {
@@ -114,9 +131,16 @@ impl<S> PlayerRuntime<S> {
     /// Set the requested rate target, clamped to
     /// [`kithara_warp::StretchControls::MIN_SPEED`].
     pub fn set_rate(&self, rate: f32) {
-        self.core.warp.stretch().set_speed(rate);
-        let target = self.core.warp.stretch().speed();
-        let _ = self.send_to_slot(PlayerCmd::SetPlaybackRate(target));
+        let target = rate.max(StretchControls::MIN_SPEED);
+        let revision = self.core.warp.stretch().set_speed(target);
+        let snapshot = self
+            .slot()
+            .and_then(|slot| self.core.engine.slot_render_snapshot(slot));
+        if let Some(snapshot) = snapshot {
+            self.rate_requested(target, revision, &snapshot);
+        } else {
+            let _ = self.send_to_slot(PlayerCmd::SetPlaybackRate(target));
+        }
     }
 
     /// Set volume, clamped to `0.0..=1.0`.

--- a/crates/kithara-play/src/resource/reader.rs
+++ b/crates/kithara-play/src/resource/reader.rs
@@ -10,7 +10,9 @@ use kithara_events::EventBus;
 use kithara_platform::{CancelToken, sync::Arc, time::Duration};
 use kithara_signal::AudioSpec;
 use kithara_stream::{Stream, StreamType};
-use kithara_warp::{PresentationFrontier, RenderContext, RenderPublisher, StretchControls};
+use kithara_warp::{
+    PresentationFrontier, RenderContext, RenderPublisher, RenderReader, StretchControls,
+};
 use tracing::warn;
 
 use super::{ResourceConfig, SourceType};
@@ -278,6 +280,10 @@ impl Resource {
         if let Some(publisher) = &self.render_publisher {
             publisher.publish(context, frontier);
         }
+    }
+
+    pub(crate) fn render_reader(&self) -> Option<RenderReader> {
+        self.render_publisher.as_ref().map(RenderPublisher::reader)
     }
 
     pub(crate) fn apply_playback_rate(&self, rate: f32) -> f32 {

--- a/crates/kithara-play/src/rt/track/core.rs
+++ b/crates/kithara-play/src/rt/track/core.rs
@@ -4,6 +4,7 @@ use bon::bon;
 use firewheel::dsp::fade::FadeCurve;
 use kithara_events::TrackId;
 use kithara_platform::sync::Arc;
+use kithara_warp::RenderReader;
 use num_traits::cast::{AsPrimitive, ToPrimitive};
 
 use super::{PlayerResource, fade::TrackFade, triggers::TrackTriggers};
@@ -207,6 +208,7 @@ impl PlayerTrack {
             /// Control-plane handle used to begin this track's seeks off the audio thread.
             #[must_use]
             pub fn seek_handle(&self) -> Option<Arc<dyn kithara_audio::SeekBegin>>;
+            pub(crate) fn render_reader(&self) -> Option<RenderReader>;
             /// Source identifier.
             #[must_use]
             pub fn src(&self) -> &Arc<str>;

--- a/crates/kithara-play/src/rt/track/feeder.rs
+++ b/crates/kithara-play/src/rt/track/feeder.rs
@@ -38,22 +38,23 @@ struct SourceWindow {
 }
 
 impl SourceWindow {
-    fn take(&mut self, frames: usize) -> Option<SourceEnd> {
-        let source_end = match self.source {
-            Some(source) if frames >= self.frames => {
-                self.source = None;
-                Some(SourceEnd::new(source.end(), source.sample_rate()))
-            }
-            Some(source) => {
-                let split = partial_source_end(source, frames, self.frames);
-                self.source = split
-                    .and_then(|split| SourceSpan::new(split, source.end(), source.sample_rate()));
-                split.map(|split| SourceEnd::new(split, source.sample_rate()))
-            }
-            None => None,
-        };
-        self.frames = self.frames.saturating_sub(frames);
-        source_end
+    fn source_for(&self, frames: usize) -> Option<SourceSpan> {
+        let source = self.source?;
+        let end = partial_source_end(source, frames.min(self.frames), self.frames)?;
+        SourceSpan::new(source.start(), end, source.sample_rate())
+            .map(|span| span.with_render_revision(source.render_revision()))
+    }
+
+    fn take(&mut self, frames: usize) -> Option<SourceSpan> {
+        let consumed = frames.min(self.frames);
+        let taken = self.source_for(consumed);
+        if let (Some(source), Some(taken)) = (self.source, taken) {
+            self.source = SourceSpan::new(taken.end(), source.end(), source.sample_rate())
+                .filter(|remaining| remaining.start() < remaining.end())
+                .map(|remaining| remaining.with_render_revision(source.render_revision()));
+        }
+        self.frames -= consumed;
+        taken
     }
 }
 
@@ -213,7 +214,9 @@ impl PlayerResource {
                 break;
             };
             let consumed = frames.min(span.frames);
-            source_end = span.take(consumed);
+            source_end = span
+                .take(consumed)
+                .map(|source| SourceEnd::new(source.end(), source.sample_rate()));
             frames -= consumed;
             if span.frames > 0 {
                 self.source_spans.push_front(span);
@@ -389,15 +392,19 @@ mod tests {
     }
 
     #[kithara::test]
-    fn partial_scratch_consumption_advances_the_exact_source_span() {
+    fn partial_scratch_consumption_preserves_the_render_revision() {
         let rate = NonZeroU32::new(48_000).expect("fixture sample rate is non-zero");
-        let mut span = SourceWindow {
-            frames: 10,
-            source: SourceSpan::new(100, 130, rate),
-        };
+        let source = SourceSpan::new(100, 130, rate).map(|span| span.with_render_revision(7));
+        let mut span = SourceWindow { frames: 10, source };
 
-        assert_eq!(span.take(4), Some(SourceEnd::new(112, rate)));
+        assert_eq!(
+            span.take(4),
+            SourceSpan::new(100, 112, rate).map(|span| span.with_render_revision(7))
+        );
         assert_eq!(span.source.map(|source| source.start()), Some(112));
-        assert_eq!(span.take(6), Some(SourceEnd::new(130, rate)));
+        assert_eq!(
+            span.take(6),
+            SourceSpan::new(112, 130, rate).map(|span| span.with_render_revision(7))
+        );
     }
 }

--- a/crates/kithara-play/src/rt/track/feeder.rs
+++ b/crates/kithara-play/src/rt/track/feeder.rs
@@ -4,7 +4,8 @@ use kithara_audio::{SourceEnd, SourceSpan};
 use kithara_bufpool::{HasPool, PoolError, PoolRegion, SampleBuffer};
 use kithara_platform::{maybe_send::WasmSend, sync::Arc};
 use kithara_signal::FrameCount;
-use kithara_warp::{PresentationFrontier, RenderContext};
+use kithara_test_macros as kithara;
+use kithara_warp::{PresentationFrontier, RenderContext, RenderReader};
 
 #[rustfmt::skip]
 use crate::resource::Resource;
@@ -207,25 +208,46 @@ impl PlayerResource {
             .min(self.channel_buffers[0].len())
     }
 
-    fn consume_source(&mut self, mut frames: usize) {
-        let mut source_end = self.last_source_end;
+    #[kithara::probe(
+        render_revision = source.render_revision(),
+        session_epoch = u64::from(context.session_epoch()),
+        output_start = i64::from(context.output_frames().start)
+            .saturating_add(i64::try_from(output.start).unwrap_or(i64::MAX)),
+        output_end = i64::from(context.output_frames().start)
+            .saturating_add(i64::try_from(output.end).unwrap_or(i64::MAX)),
+        source_start = source.start(),
+        source_end = source.end()
+    )]
+    fn pcm_consumed(&mut self, context: &RenderContext, output: Range<usize>, source: SourceSpan) {
+        self.last_source_end = Some(SourceEnd::new(source.end(), source.sample_rate()));
+    }
+
+    fn consume_source(&mut self, mut frames: usize, context: Option<&RenderContext>) {
+        let mut output_start = 0usize;
         while frames > 0 {
             let Some(mut span) = self.source_spans.pop_front() else {
                 break;
             };
             let consumed = frames.min(span.frames);
-            source_end = span
-                .take(consumed)
-                .map(|source| SourceEnd::new(source.end(), source.sample_rate()));
+            let output_end = output_start.saturating_add(consumed);
+            match (context, span.take(consumed)) {
+                (Some(context), Some(source)) => {
+                    self.pcm_consumed(context, output_start..output_end, source);
+                }
+                (_, source) => {
+                    self.last_source_end =
+                        source.map(|source| SourceEnd::new(source.end(), source.sample_rate()));
+                }
+            }
             frames -= consumed;
+            output_start = output_end;
             if span.frames > 0 {
                 self.source_spans.push_front(span);
             }
         }
         if frames > 0 {
-            source_end = None;
+            self.last_source_end = None;
         }
-        self.last_source_end = source_end;
     }
 
     pub(crate) fn presentation_source_end(&self, sample_rate: NonZeroU32) -> Option<SourceEnd> {
@@ -252,6 +274,16 @@ impl PlayerResource {
         range: Range<usize>,
         metrics: &RtMetrics,
     ) -> ReadOutcome {
+        self.read_with_context(None, output, range, metrics)
+    }
+
+    pub(crate) fn read_with_context(
+        &mut self,
+        context: Option<&RenderContext>,
+        output: &mut [&mut [f32]],
+        range: Range<usize>,
+        metrics: &RtMetrics,
+    ) -> ReadOutcome {
         let frames_to_read = range.end - range.start;
         let mut eof_reached = self.fill_scratch(frames_to_read, metrics);
 
@@ -274,7 +306,7 @@ impl PlayerResource {
                     .copy_from_slice(&self.channel_buffers[1][..frames_to_write]);
             }
 
-            self.consume_source(frames_to_write);
+            self.consume_source(frames_to_write, context);
 
             if tail_size > 0 {
                 self.channel_buffers[0]
@@ -341,6 +373,10 @@ impl PlayerResource {
     #[must_use]
     pub fn seek_handle(&self) -> Option<Arc<dyn kithara_audio::SeekBegin>> {
         self.resource.get().seek_handle()
+    }
+
+    pub(crate) fn render_reader(&self) -> Option<RenderReader> {
+        self.resource.get().render_reader()
     }
 
     delegate::delegate! {

--- a/crates/kithara-play/src/rt/track/read.rs
+++ b/crates/kithara-play/src/rt/track/read.rs
@@ -60,7 +60,7 @@ impl PlayerTrack {
     ) -> TrackReadOutcome {
         let Some(context) = context else {
             self.resource.clear_render();
-            return self.read(scratch_bufs, mix_bufs, range, sink);
+            return self.read_with_context(None, scratch_bufs, mix_bufs, range, sink);
         };
         if context.sample_rate().get() != self.sample_rate {
             self.resource.clear_render();
@@ -78,7 +78,7 @@ impl PlayerTrack {
         } else {
             self.resource.clear_render();
         }
-        self.read(scratch_bufs, mix_bufs, range, sink)
+        self.read_with_context(Some(&context), scratch_bufs, mix_bufs, range, sink)
     }
 
     /// Advance the media clock by `frames` of mixed output.
@@ -279,11 +279,22 @@ impl PlayerTrack {
         range: Range<usize>,
         sink: &mut RtSink<'_>,
     ) -> TrackReadOutcome {
+        self.read_with_context(None, scratch_bufs, mix_bufs, range, sink)
+    }
+
+    fn read_with_context(
+        &mut self,
+        context: Option<&RenderContext>,
+        scratch_bufs: &mut [&mut [f32]],
+        mix_bufs: &mut [&mut [f32]],
+        range: Range<usize>,
+        sink: &mut RtSink<'_>,
+    ) -> TrackReadOutcome {
         if self.state == TrackState::Finished {
             return TrackReadOutcome::Eof;
         }
 
-        let read_outcome = self.read_resource(scratch_bufs, range.clone(), sink.metrics);
+        let read_outcome = self.read_resource(context, scratch_bufs, range.clone(), sink.metrics);
         match read_outcome {
             TrackReadOutcome::Full { .. } => self.handle_full_read(
                 scratch_bufs,
@@ -316,6 +327,7 @@ impl PlayerTrack {
 
     fn read_resource(
         &mut self,
+        context: Option<&RenderContext>,
         scratch_bufs: &mut [&mut [f32]],
         range: Range<usize>,
         metrics: &RtMetrics,
@@ -327,7 +339,7 @@ impl PlayerTrack {
             &mut scratch_right[0][range.clone()],
         ];
 
-        match resource.read(&mut scratch_window, 0..range.len(), metrics) {
+        match resource.read_with_context(context, &mut scratch_window, 0..range.len(), metrics) {
             ReadOutcome::Full { frames } => TrackReadOutcome::Full {
                 frames,
                 duration: resource.duration(),

--- a/crates/kithara-signal/src/chunk.rs
+++ b/crates/kithara-signal/src/chunk.rs
@@ -24,6 +24,8 @@ pub struct AudioChunkInfo {
     pub frames: u32,
     /// Decoder generation, incremented on decoder recreation.
     pub epoch: u64,
+    /// Opaque producer render revision represented by this chunk.
+    pub render_revision: u64,
     /// Absolute frame offset from the start of the track.
     pub frame_offset: u64,
     /// Source bytes that produced this chunk, or zero when unknown.
@@ -46,6 +48,7 @@ impl Default for AudioChunkInfo {
             variant_index: None,
             frames: 0,
             epoch: 0,
+            render_revision: 0,
             frame_offset: 0,
             source_bytes: 0,
         }

--- a/crates/kithara-warp/src/temporal/controls.rs
+++ b/crates/kithara-warp/src/temporal/controls.rs
@@ -12,9 +12,9 @@ use kithara_platform::sync::Arc;
     any(feature = "stretch-signalsmith", feature = "stretch-bungee")
 ))]
 use kithara_stretch::StretchKind;
-use portable_atomic::AtomicF32;
+use portable_atomic::AtomicU64;
 
-use super::RegionPlan;
+use super::{RateTarget, RegionPlan};
 
 #[cfg(all(
     not(target_arch = "wasm32"),
@@ -33,7 +33,7 @@ struct EngineControls {
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct StretchControls {
-    speed: Arc<AtomicF32>,
+    target: AtomicU64,
     region_plan: ArcSwapOption<RegionPlan>,
     #[cfg(all(
         not(target_arch = "wasm32"),
@@ -52,7 +52,7 @@ impl StretchControls {
     #[must_use]
     pub fn new(speed: f32) -> Arc<Self> {
         Arc::new(Self {
-            speed: Arc::new(AtomicF32::new(speed.max(Self::MIN_SPEED))),
+            target: AtomicU64::new(RateTarget::pack(speed.max(Self::MIN_SPEED), 0)),
             region_plan: ArcSwapOption::const_empty(),
             #[cfg(all(
                 not(target_arch = "wasm32"),
@@ -101,14 +101,28 @@ impl StretchControls {
         self.engine.keylock.store(on, Ordering::Relaxed);
     }
 
-    pub fn set_speed(&self, speed: f32) {
-        self.speed
-            .store(speed.max(Self::MIN_SPEED), Ordering::Relaxed);
+    pub fn set_speed(&self, speed: f32) -> u64 {
+        let speed = speed.max(Self::MIN_SPEED);
+        let mut revision = 0;
+        let _ = self
+            .target
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                revision = RateTarget::revision_from(current).wrapping_add(1);
+                if revision == 0 {
+                    revision = 1;
+                }
+                Some(RateTarget::pack(speed, revision))
+            });
+        u64::from(revision)
     }
 
     #[must_use]
     pub fn speed(&self) -> f32 {
-        self.speed.load(Ordering::Relaxed)
+        self.rate_target().speed()
+    }
+
+    pub(crate) fn rate_target(&self) -> RateTarget {
+        RateTarget::unpack(self.target.load(Ordering::Acquire))
     }
 
     delegate::delegate! {
@@ -126,6 +140,8 @@ impl StretchControls {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use kithara_test_utils::kithara;
 
     use super::*;
@@ -141,5 +157,41 @@ mod tests {
         controls.set_speed(1.0);
         controls.set_speed(input);
         assert!((controls.speed() - StretchControls::MIN_SPEED).abs() < f32::EPSILON);
+    }
+
+    #[kithara::test]
+    fn concurrent_rate_publications_keep_one_coherent_revision_order() {
+        let controls = StretchControls::new(1.0);
+        let published = Mutex::new(Vec::new());
+
+        std::thread::scope(|scope| {
+            for writer in 0..4_u16 {
+                let controls = &controls;
+                let published = &published;
+                scope.spawn(move || {
+                    for step in 0..64_u16 {
+                        let speed = f32::from(writer * 64 + step + 1) / 100.0;
+                        let revision = controls.set_speed(speed);
+                        published
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner)
+                            .push((revision, speed.max(StretchControls::MIN_SPEED)));
+                    }
+                });
+            }
+        });
+
+        let mut published = published
+            .into_inner()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        published.sort_unstable_by_key(|(revision, _)| *revision);
+        assert_eq!(published.len(), 256);
+        assert!(
+            published
+                .windows(2)
+                .all(|pair| pair[0].0.checked_add(1) == Some(pair[1].0))
+        );
+        let latest = published.last().copied().expect("fixture publishes rates");
+        assert_eq!(controls.rate_target().speed(), latest.1);
     }
 }

--- a/crates/kithara-warp/src/temporal/live.rs
+++ b/crates/kithara-warp/src/temporal/live.rs
@@ -179,6 +179,14 @@ impl RenderPublisher {
 #[derive(Clone, Debug)]
 pub struct RenderReader(Arc<RenderCell>);
 
+impl PartialEq for RenderReader {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl Eq for RenderReader {}
+
 impl RenderReader {
     #[cfg(feature = "render")]
     pub(crate) fn is_current(&self, snapshot: &RenderSnapshot) -> bool {

--- a/crates/kithara-warp/src/temporal/mod.rs
+++ b/crates/kithara-warp/src/temporal/mod.rs
@@ -1,6 +1,7 @@
 mod context;
 mod controls;
 mod live;
+mod rate;
 mod region;
 
 pub use context::RenderContext;
@@ -11,4 +12,5 @@ pub use controls::StretchControls;
 ))]
 pub use kithara_stretch::StretchKind;
 pub use live::{RenderPublisher, RenderReader, RenderSnapshot};
+pub(crate) use rate::RateTarget;
 pub use region::{ActiveRegion, GridSegment, RegionPlan, RegionPlanError};

--- a/crates/kithara-warp/src/temporal/rate.rs
+++ b/crates/kithara-warp/src/temporal/rate.rs
@@ -20,4 +20,8 @@ impl RateTarget {
         let [_, _, _, _, a, b, c, d] = self.0.to_be_bytes();
         f32::from_bits(u32::from_be_bytes([a, b, c, d]))
     }
+
+    pub(crate) fn revision(self) -> u64 {
+        u64::from(Self::revision_from(self.0))
+    }
 }

--- a/crates/kithara-warp/src/temporal/rate.rs
+++ b/crates/kithara-warp/src/temporal/rate.rs
@@ -1,0 +1,23 @@
+/// One coherent live rate target loaded from a single atomic word.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct RateTarget(u64);
+
+impl RateTarget {
+    pub(super) fn pack(speed: f32, revision: u32) -> u64 {
+        (u64::from(revision) << u32::BITS) | u64::from(speed.to_bits())
+    }
+
+    pub(super) fn revision_from(packed: u64) -> u32 {
+        let [a, b, c, d, _, _, _, _] = packed.to_be_bytes();
+        u32::from_be_bytes([a, b, c, d])
+    }
+
+    pub(super) const fn unpack(packed: u64) -> Self {
+        Self(packed)
+    }
+
+    pub(crate) fn speed(self) -> f32 {
+        let [_, _, _, _, a, b, c, d] = self.0.to_be_bytes();
+        f32::from_bits(u32::from_be_bytes([a, b, c, d]))
+    }
+}

--- a/crates/kithara-warp/src/warp/render/renderer.rs
+++ b/crates/kithara-warp/src/warp/render/renderer.rs
@@ -315,21 +315,67 @@ where
         ));
     }
 
+    fn next_render_snapshot(
+        &self,
+        snapshot: RenderSnapshot,
+        output_frames: usize,
+    ) -> Option<(RenderSnapshot, i64, u64, u64)> {
+        if !self.context.is_current(&snapshot) {
+            return None;
+        }
+        let (source_end, _) = self.rendered_source_end?;
+        let source_start = self
+            .committed
+            .as_ref()
+            .filter(|previous| {
+                previous.context().session_epoch() == snapshot.context().session_epoch()
+            })
+            .map_or_else(
+                || snapshot.frontier().source(),
+                |previous| previous.frontier().source(),
+            )
+            .max(snapshot.frontier().source());
+        let committed = snapshot.advance(self.committed.as_ref(), source_end, output_frames)?;
+        let output_frames = i64::try_from(output_frames).ok()?;
+        let output_start = i64::from(committed.frontier().output()).checked_sub(output_frames)?;
+        Some((committed, output_start, source_start, source_end))
+    }
+
     pub(super) fn commit_render(&mut self, snapshot: Option<RenderSnapshot>, output_frames: usize) {
         let Some(snapshot) = snapshot else {
             return;
         };
-        if !self.context.is_current(&snapshot) {
-            return;
-        }
-        let Some((source, _)) = self.rendered_source_end else {
+        let Some((committed, output_start, source_start, _)) =
+            self.next_render_snapshot(snapshot, output_frames)
+        else {
             return;
         };
-        let source_start = snapshot.frontier().source();
-        let output_start = i64::from(snapshot.frontier().output());
-        if let Some(committed) = snapshot.advance(self.committed.as_ref(), source, output_frames) {
-            self.render_committed(committed, source_start, output_start);
-        }
+        self.render_committed(committed, source_start, output_start);
+    }
+
+    pub(super) fn commit_rate_render(
+        &mut self,
+        snapshot: Option<RenderSnapshot>,
+        output_frames: usize,
+        request_revision: u64,
+        applied_rate: f32,
+    ) {
+        let Some(snapshot) = snapshot else {
+            return;
+        };
+        let Some((committed, session_frame, source_start, source_end)) =
+            self.next_render_snapshot(snapshot, output_frames)
+        else {
+            return;
+        };
+        self.rate_applied(
+            committed,
+            request_revision,
+            applied_rate.to_bits(),
+            session_frame,
+            source_start,
+            source_end,
+        );
     }
 
     #[kithara::probe(
@@ -345,6 +391,26 @@ where
         committed: RenderSnapshot,
         source_start: u64,
         output_start: i64,
+    ) {
+        self.committed = Some(committed);
+    }
+
+    #[kithara::probe(
+        request_revision,
+        applied_rate_bits,
+        session_epoch = u64::from(committed.context().session_epoch()),
+        session_frame,
+        source_start,
+        source_end
+    )]
+    fn rate_applied(
+        &mut self,
+        committed: RenderSnapshot,
+        request_revision: u64,
+        applied_rate_bits: u32,
+        session_frame: i64,
+        source_start: u64,
+        source_end: u64,
     ) {
         self.committed = Some(committed);
     }

--- a/crates/kithara-warp/src/warp/render/renderer.rs
+++ b/crates/kithara-warp/src/warp/render/renderer.rs
@@ -7,7 +7,10 @@ use kithara_stretch::{ElasticEngine, ElasticError, StretchKind};
 use kithara_test_macros as kithara;
 use tracing::warn;
 
-use crate::{ActiveRegion, RegionPlan, RenderReader, RenderSnapshot, StretchControls, WarpConfig};
+use crate::{
+    ActiveRegion, RegionPlan, RenderReader, RenderSnapshot, StretchControls, WarpConfig,
+    temporal::RateTarget,
+};
 
 #[cfg(test)]
 mod tests;
@@ -15,7 +18,7 @@ mod tests;
 #[derive(Clone, Copy)]
 pub(super) struct PreparedQuantum {
     pub(super) frames: usize,
-    pub(super) speed: f32,
+    pub(super) rate: RateTarget,
 }
 
 /// Source-timeline exact-span time-stretch driven by shared live controls.
@@ -137,10 +140,10 @@ where
         remaining: usize,
     ) -> Option<FrameCount> {
         self.sync_plan();
-        let speed = self.controls.speed();
-        match self.source_frames_for_quantum(meta, remaining, speed) {
+        let rate = self.controls.rate_target();
+        match self.source_frames_for_quantum(meta, remaining, rate.speed()) {
             Ok(frames) => {
-                self.prepared_quantum = Some(PreparedQuantum { frames, speed });
+                self.prepared_quantum = Some(PreparedQuantum { frames, rate });
                 Some(FrameCount::new(frames))
             }
             Err(error) => {

--- a/crates/kithara-warp/src/warp/render/renderer/tests/playback.rs
+++ b/crates/kithara-warp/src/warp/render/renderer/tests/playback.rs
@@ -60,6 +60,27 @@ fn source_span_is_planned_from_the_output_quantum(
     assert_eq!(frames.get(), expected_source_frames);
 }
 
+#[kithara::test]
+fn rendered_quantum_keeps_the_rate_revision_selected_during_planning() {
+    let controls = StretchControls::new(1.0);
+    let expected_revision = controls.set_speed(1.0);
+    let mut renderer = renderer(Arc::clone(&controls));
+    renderer.prepare(spec());
+    let pools = renderer.pools.clone();
+    let input = chunk(&pools, &sine(128));
+
+    let frames = renderer
+        .prepare_quantum(input.meta, input.frames())
+        .expect("test source span is plannable");
+    assert_eq!(frames.get(), input.frames());
+    controls.set_speed(0.5);
+
+    let output = renderer
+        .render_quantum(input)
+        .expect("prepared unity quantum renders");
+    assert_eq!(output.meta.render_revision, expected_revision);
+}
+
 fn keylocked(kind: StretchKind, speed: f32) -> WarpRenderer {
     let controls = StretchControls::new(speed);
     controls.set_keylock(true);

--- a/crates/kithara-warp/src/warp/render/renderer_lifecycle.rs
+++ b/crates/kithara-warp/src/warp/render/renderer_lifecycle.rs
@@ -303,7 +303,12 @@ where
         let held_source_frames = self.held_source_frames();
         self.emit(Some(samples), held_source_frames)
     }
+}
 
+impl<S> WarpRenderer<S>
+where
+    S: HasPool<f32>,
+{
     /// Prepare deferred renderer state for the current source format.
     pub fn prepare(&mut self, spec: AudioSpec) {
         self.service_target(spec);
@@ -394,7 +399,12 @@ where
             self.process_active(chunk, speed)
         };
         if let Some(output) = output.as_ref() {
-            self.commit_render(snapshot, output.frames());
+            self.commit_rate_render(
+                snapshot,
+                output.frames(),
+                output.meta.render_revision,
+                speed,
+            );
         }
         output
     }

--- a/crates/kithara-warp/src/warp/render/renderer_lifecycle.rs
+++ b/crates/kithara-warp/src/warp/render/renderer_lifecycle.rs
@@ -348,20 +348,23 @@ where
     }
 
     /// Render one complete decoded source chunk.
-    pub fn render(&mut self, chunk: AudioChunk) -> Option<AudioChunk> {
+    pub fn render(&mut self, mut chunk: AudioChunk) -> Option<AudioChunk> {
         let snapshot = self.context.load();
         self.prepared_quantum = None;
-        self.render_at(chunk, self.controls.speed(), snapshot)
+        let rate = self.controls.rate_target();
+        chunk.meta.render_revision = rate.revision();
+        self.render_at(chunk, rate.speed(), snapshot)
     }
 
     /// Render the source span selected by [`Self::prepare_quantum`].
-    pub fn render_quantum(&mut self, chunk: AudioChunk) -> Option<AudioChunk> {
+    pub fn render_quantum(&mut self, mut chunk: AudioChunk) -> Option<AudioChunk> {
         let prepared = self.prepared_quantum.take()?;
         if chunk.frames() != prepared.frames {
             return None;
         }
         let snapshot = self.context.load();
-        self.render_at(chunk, prepared.speed, snapshot)
+        chunk.meta.render_revision = prepared.rate.revision();
+        self.render_at(chunk, prepared.rate.speed(), snapshot)
     }
 
     fn render_at(

--- a/tests/tests/kithara_hls/abr_mode_switch.rs
+++ b/tests/tests/kithara_hls/abr_mode_switch.rs
@@ -1356,7 +1356,7 @@ async fn runtime_cross_codec_manual_switch_no_hang() {
 
     // Warmup: read until enough AAC samples are produced (state target, not a
     // wall-clock deadline). The outer test timeout is the only backstop.
-    let (mut audio, pre_total) =
+    let (audio, pre_total) =
         read_until_samples_blocking(audio, 16_384, "cross-codec manual warmup").await;
     assert!(
         pre_total > 0,
@@ -1366,33 +1366,45 @@ async fn runtime_cross_codec_manual_switch_no_hang() {
     let handle = audio
         .abr_handle()
         .expect("HLS stream must expose AbrHandle");
+    let applied_before = collector.applied_transitions().len();
     handle
         .set_mode(AbrMode::manual(3))
         .expect("Manual(3) (FLAC variant) target must be valid");
 
-    // Read for several seconds after the flip — if the decoder hangs on
-    // `Pending(VariantChange)` without recovery, the hang_watchdog or
-    // the test timeout will fail. Otherwise we should see post-switch
-    // samples coming from the FLAC variant.
+    let (mut audio, transition) = read_until_manual_applied(
+        audio,
+        &collector,
+        applied_before,
+        3,
+        "cross-codec manual transition",
+    )
+    .await;
+
+    // Continue through EOF after observing the exact transition. If the
+    // decoder hangs on `Pending(VariantChange)` without recovery, the
+    // hang_watchdog or the test timeout will fail.
     let post_total = spawn_blocking(move || read_to_eof(&mut audio))
         .await
         .expect("read");
 
-    let targets = collector.applied_targets();
-    let saw_flac = targets.contains(&3);
+    let transitions = collector.applied_transitions();
+    let saw_flac = transitions[applied_before..].contains(&(3, AbrReason::ManualOverride));
 
     info!(
-        ?targets,
-        pre_total, post_total, "L2: cross-codec Manual switch result"
+        ?transitions,
+        ?transition,
+        pre_total,
+        post_total,
+        "L2: cross-codec Manual switch result"
     );
 
     assert!(
-        !targets.is_empty(),
-        "cross-codec Manual(3) must fire at least one VariantApplied"
+        !transition.saw_eof,
+        "cross-codec Manual(3) must apply before EOF: {transition:?}"
     );
     assert!(
         saw_flac,
-        "Manual(3) must publish a VariantApplied with to=3, saw: {targets:?}"
+        "Manual(3) must publish VariantApplied with to=3 and ManualOverride, saw: {transitions:?}"
     );
     assert!(
         post_total > 0,


### PR DESCRIPTION
## Summary

Add correlation IDs and production probes to the existing rate-control path so the final response fix can be measured from the UI request through Warp rendering to exact PCM presentation. The same slice strengthens the existing cross-codec ABR scenario to require the target transition before EOF. This is observability and data propagation only: scheduling, smoothing, DSP, synchronization, and worker behavior remain unchanged.

## Behavior / scope

- contract or behavior: every live rate target has a coherent revision that survives Warp planning, rendered audio chunks, partial Player reads, and callback presentation
- contract or behavior: `rate_requested`, `rate_applied`, and `pcm_consumed` USDT probes carry the same revision plus Host musical transport and exact source/presentation intervals
- contract or behavior: the cross-codec manual ABR scenario publishes the selected transition before EOF and continues producing audio through EOF
- affected area: decoded audio metadata, Player delivery, Warp live controls/rendering, and the existing HLS stress scenario

## Validation

- `cargo check -p kithara-warp -p kithara-play --lib`: passed
- `cargo clippy -p kithara-warp -p kithara-play --all-targets -- -D warnings`: passed
- `just fmt check`: passed
- `just platform wasm check`: passed
- `git diff --check`: passed
- exact-head GitHub non-UI CI at `35bf8336019e1141823391f08bf11653010343bc`: passed, including the failed-only Chromium rerun — https://github.com/gerasim13/kithara/actions/runs/33970610144
- exact-head GitLab verification: passed
- full workspace tests were not run locally; exact-head CI is the broad acceptance proof

## Surface impact

- Public API: changed: live Warp rate targets and decoded chunk metadata expose their render revision
- Platform/runtime: changed: native and wasm playback paths carry observability metadata; audio behavior is unchanged
- Perf-sensitive paths: changed: the existing render and callback path copies scalar revision/context metadata and emits feature-gated USDT probes

## Risks / follow-ups

- This PR deliberately does not implement latest-wins rate delivery, smoothing, synchronization, or the response-budget fix; those remain in final PR #232
- After merge, PR #232 must be updated from the resulting `main` and revalidated at its new exact head
