### PR TITLE
test(ffi): cover event enum conversion contracts

### DIFF
--- a/crates/kithara-ffi/src/core/types.rs
+++ b/crates/kithara-ffi/src/core/types.rs
@@ -1157,6 +1157,154 @@ mod tests {
     }
 
     #[kithara::test]
+    fn advance_reason_conversion_preserves_known_variants() {
+        for (source, expected) in [
+            (AdvanceReason::NaturalEof, FfiAdvanceReason::NaturalEof),
+            (
+                AdvanceReason::CrossfadePreArm,
+                FfiAdvanceReason::CrossfadePreArm,
+            ),
+            (AdvanceReason::UserSelect, FfiAdvanceReason::UserSelect),
+            (AdvanceReason::UserNext, FfiAdvanceReason::UserNext),
+            (AdvanceReason::UserPrev, FfiAdvanceReason::UserPrev),
+            (AdvanceReason::TrackFailed, FfiAdvanceReason::TrackFailed),
+            (
+                AdvanceReason::RemovedCurrent,
+                FfiAdvanceReason::RemovedCurrent,
+            ),
+            (AdvanceReason::Repeat, FfiAdvanceReason::Repeat),
+            (AdvanceReason::Cancelled, FfiAdvanceReason::Cancelled),
+        ] {
+            assert_eq!(FfiAdvanceReason::from(source), expected);
+        }
+    }
+
+    #[kithara::test]
+    fn audio_codec_conversion_preserves_known_variants() {
+        for (source, expected) in [
+            (AudioCodecKind::AacLc, FfiAudioCodecKind::AacLc),
+            (AudioCodecKind::AacHe, FfiAudioCodecKind::AacHe),
+            (AudioCodecKind::AacHeV2, FfiAudioCodecKind::AacHeV2),
+            (AudioCodecKind::Mp3, FfiAudioCodecKind::Mp3),
+            (AudioCodecKind::Flac, FfiAudioCodecKind::Flac),
+            (AudioCodecKind::Vorbis, FfiAudioCodecKind::Vorbis),
+            (AudioCodecKind::Opus, FfiAudioCodecKind::Opus),
+            (AudioCodecKind::Alac, FfiAudioCodecKind::Alac),
+            (AudioCodecKind::Pcm, FfiAudioCodecKind::Pcm),
+            (AudioCodecKind::Adpcm, FfiAudioCodecKind::Adpcm),
+        ] {
+            assert_eq!(FfiAudioCodecKind::from(source), expected);
+        }
+    }
+
+    #[kithara::test]
+    fn container_conversion_preserves_known_variants() {
+        for (source, expected) in [
+            (ContainerKind::Mp4, FfiContainerKind::Mp4),
+            (ContainerKind::Fmp4, FfiContainerKind::Fmp4),
+            (ContainerKind::MpegTs, FfiContainerKind::MpegTs),
+            (ContainerKind::MpegAudio, FfiContainerKind::MpegAudio),
+            (ContainerKind::Adts, FfiContainerKind::Adts),
+            (ContainerKind::Flac, FfiContainerKind::Flac),
+            (ContainerKind::Wav, FfiContainerKind::Wav),
+            (ContainerKind::Ogg, FfiContainerKind::Ogg),
+            (ContainerKind::Caf, FfiContainerKind::Caf),
+            (ContainerKind::Mkv, FfiContainerKind::Mkv),
+        ] {
+            assert_eq!(FfiContainerKind::from(source), expected);
+        }
+    }
+
+    #[kithara::test]
+    fn decoder_change_cause_conversion_preserves_known_variants() {
+        for (source, expected) in [
+            (DecoderChangeCause::Initial, FfiDecoderChangeCause::Initial),
+            (
+                DecoderChangeCause::VariantSwitch,
+                FfiDecoderChangeCause::VariantSwitch,
+            ),
+            (
+                DecoderChangeCause::FormatBoundary,
+                FfiDecoderChangeCause::FormatBoundary,
+            ),
+            (
+                DecoderChangeCause::SeekRecreate,
+                FfiDecoderChangeCause::SeekRecreate,
+            ),
+            (
+                DecoderChangeCause::Recovery,
+                FfiDecoderChangeCause::Recovery,
+            ),
+            (
+                DecoderChangeCause::HostRateChange,
+                FfiDecoderChangeCause::HostRateChange,
+            ),
+        ] {
+            assert_eq!(FfiDecoderChangeCause::from(source), expected);
+        }
+    }
+
+    #[kithara::test]
+    fn decode_error_kind_conversion_preserves_known_variants() {
+        for (source, expected) in [
+            (DecodeErrorKind::Io, FfiDecodeErrorKind::Io),
+            (
+                DecodeErrorKind::UnsupportedCodec,
+                FfiDecodeErrorKind::UnsupportedCodec,
+            ),
+            (
+                DecodeErrorKind::UnsupportedContainer,
+                FfiDecodeErrorKind::UnsupportedContainer,
+            ),
+            (
+                DecodeErrorKind::InvalidData,
+                FfiDecodeErrorKind::InvalidData,
+            ),
+            (DecodeErrorKind::SeekFailed, FfiDecodeErrorKind::SeekFailed),
+            (
+                DecodeErrorKind::SeekOutOfRange,
+                FfiDecodeErrorKind::SeekOutOfRange,
+            ),
+            (DecodeErrorKind::Parse, FfiDecodeErrorKind::Parse),
+            (
+                DecodeErrorKind::ProbeFailed,
+                FfiDecodeErrorKind::ProbeFailed,
+            ),
+            (
+                DecodeErrorKind::BackendUnavailable,
+                FfiDecodeErrorKind::BackendUnavailable,
+            ),
+            (
+                DecodeErrorKind::InvalidSampleRate,
+                FfiDecodeErrorKind::InvalidSampleRate,
+            ),
+            (
+                DecodeErrorKind::BackendStatus,
+                FfiDecodeErrorKind::BackendStatus,
+            ),
+            (
+                DecodeErrorKind::Interrupted,
+                FfiDecodeErrorKind::Interrupted,
+            ),
+            (DecodeErrorKind::Backend, FfiDecodeErrorKind::Backend),
+        ] {
+            assert_eq!(FfiDecodeErrorKind::from(source), expected);
+        }
+    }
+
+    #[kithara::test]
+    fn resampler_kind_conversion_preserves_known_variants() {
+        for (source, expected) in [
+            (ResamplerKind::Rubato, FfiResamplerKind::Rubato),
+            (ResamplerKind::Apple, FfiResamplerKind::Apple),
+            (ResamplerKind::Glide, FfiResamplerKind::Glide),
+            (ResamplerKind::None, FfiResamplerKind::None),
+        ] {
+            assert_eq!(FfiResamplerKind::from(source), expected);
+        }
+    }
+
+    #[kithara::test]
     fn queue_repeat_mode_round_trips_through_ffi() {
         for expected in [
             kithara::queue::RepeatMode::Off,


### PR DESCRIPTION
## Summary

Six deterministic FFI enum conversions exceeded CRAP 30 because their known variant mappings were not exercised by tests. This change adds owner-local mapping tests for every constructible variant without changing production matches, APIs, macros, or helpers. On the exact PR head, all six functions are now below CRAP 30; the fresh workspace report contains 833 functions above 30 versus 838 in the previous exact report.

## Behavior / scope

- contract or behavior: every constructible `FfiAdvanceReason`, `FfiAudioCodecKind`, `FfiContainerKind`, `FfiDecodeErrorKind`, `FfiDecoderChangeCause`, and `FfiResamplerKind` source variant maps to the expected public FFI variant
- affected area: tests beside the owning conversions in `crates/kithara-ffi/src/core/types.rs`
- measured exact-head CRAP changes:
  - `FfiDecodeErrorKind::from`: 240 -> 15.046 at 94.12% coverage
  - `FfiAudioCodecKind::from`: 156 -> 12.052 at 92.86% coverage
  - `FfiContainerKind::from`: 156 -> 12.052 at 92.86% coverage
  - `FfiDecoderChangeCause::from`: 72 -> 8.064 at 90.00% coverage
  - `FfiAdvanceReason::from`: 51.15 -> 11.055 at 92.31% coverage
  - `FfiResamplerKind::from`: 42 -> 6.070 at 87.50% coverage

The aggregate 838 -> 833 workspace count is a fresh net comparison because `main` changed between reports; the six function-level changes above are directly attributable to this PR.

## Validation

- `just test run -p kithara-ffi conversion_preserves_known_variants` - 6 passed
- exact built-head `kithara-ffi` test binary - 129 passed
- `just fmt check` - passed
- `just check clippy` - passed
- pre-commit hooks - passed
- `git diff --check` - passed
- [fork coverage-risk run 33960190200](https://github.com/gerasim13/kithara/actions/runs/33960190200) at `66eea268e7326f4284fe2f79b1c8ad6c924fb86e`: coverage test groups passed 5757/5757, 1112/1112, and 74/74; `cargo-crap` completed clean; [artifact 9968082965](https://github.com/gerasim13/kithara/actions/runs/33960190200/artifacts/9968082965)
- GitLab pipeline [2138092](https://gitlab.zvq.me/disrupt/kithara/-/pipelines/2138092): exact-head `apple:test`, `apple:lint`, `apple:xcframework`, `apple:ios`, `deps:deny`, and `verdict` passed

## Surface impact

- Public API: none
- Platform/runtime: none
- Perf-sensitive paths: none

## Risks / follow-ups

- The fork coverage lane failed only after report generation because total line coverage was 79.54% against the existing 80% threshold; all coverage test groups passed and the CRAP report is clean.
- The first GitLab `apple:ios` attempt stopped before build because runner free space was below its 15 GB guard. A retry on the same SHA passed; the GitLab pipeline and GitHub `kithara/gitlab-verification` status are now successful.
- `cargo clippy -p kithara-ffi --tests -- -D warnings` is blocked by the existing `kithara-host/src/host.rs:378` `needless_pass_by_value` warning; the canonical workspace `just check clippy` gate passes.
