### PR TITLE
test(app): cover GUI event and update routing

### DIFF
--- a/crates/kithara-app/src/gui/mod.rs
+++ b/crates/kithara-app/src/gui/mod.rs
@@ -9,6 +9,8 @@ mod reads;
 #[cfg(feature = "masonry")]
 pub(crate) mod retained;
 mod subscription;
+#[cfg(all(test, not(feature = "broadcast")))]
+mod test_fixture;
 mod theme;
 mod ui;
 mod update;

--- a/crates/kithara-app/src/gui/test_fixture.rs
+++ b/crates/kithara-app/src/gui/test_fixture.rs
@@ -1,0 +1,85 @@
+use iced::window::Id;
+use kithara::{
+    assets::StorageBackend,
+    host::HostConfig,
+    net::{HttpClient, NetOptions},
+    platform::{CancelToken, sync::Arc},
+    play::PlayWorkerConfig,
+    stream::dl::{Downloader, DownloaderConfig},
+};
+
+use super::{
+    app::{Decks, Kithara},
+    ui::{AppUi, package::Package},
+};
+use crate::{
+    broadcast::Broadcaster,
+    catalog::Catalog,
+    config::{AppBroadcastConfig, AppConfig},
+    deck::{Deck, DeckId, DeckSet},
+    pools::{self, AppHost, AppStore, AppWorker},
+    state::test_fixture::controller,
+};
+
+pub(super) fn state() -> Kithara {
+    let config = config();
+    let mut host = AppHost::new(HostConfig::builder().build()).expect("test host");
+    let decks: Vec<Deck> = (0..2)
+        .map(|index| {
+            Deck::build(DeckId(index), &config, &mut host).expect("host accepts the test deck")
+        })
+        .collect();
+    let controllers = decks
+        .iter()
+        .map(|deck| {
+            (
+                deck.id,
+                controller(
+                    deck.queue.control().clone(),
+                    Arc::clone(&deck.timestretch),
+                    deck.cancel_child(),
+                ),
+            )
+        })
+        .collect();
+    let session = DeckSet::new(host, decks);
+    let decks = Decks::new(controllers).expect("fixture has decks");
+    let catalog = Catalog::new(vec![
+        "/music/local.flac".to_string(),
+        "https://example.test/stream.m3u8".to_string(),
+    ]);
+    let ui =
+        AppUi::new(Package::load(None).expect("shipped UI package")).expect("shipped UI compiles");
+    Kithara::mounted(
+        session,
+        decks,
+        catalog,
+        config,
+        ui,
+        Broadcaster::new(AppBroadcastConfig::default()),
+        Id::unique(),
+    )
+}
+
+fn config() -> AppConfig {
+    let shutdown = CancelToken::root();
+    let pools = pools::build().expect("valid app pool policy");
+    let worker = AppWorker::new(PlayWorkerConfig::builder(pools.clone()).build());
+    let downloader = Downloader::new(
+        DownloaderConfig::for_client(HttpClient::new(
+            NetOptions::builder().build(),
+            pools.clone(),
+            shutdown.child(),
+        ))
+        .build(),
+    );
+    let store = AppStore::builder(pools)
+        .backend(StorageBackend::Memory)
+        .build();
+    AppConfig::builder()
+        .downloader(downloader)
+        .shutdown(shutdown)
+        .worker(worker)
+        .store(store)
+        .build()
+}

--- a/crates/kithara-app/src/gui/ui/events.rs
+++ b/crates/kithara-app/src/gui/ui/events.rs
@@ -462,4 +462,313 @@ mod tests {
 
         assert_eq!(cache.focus_deck(), 0, "the key must reach a deck on screen");
     }
+
+    #[cfg(not(feature = "broadcast"))]
+    mod routing {
+        use ::kithara::{
+            assets::StorageBackend,
+            host::HostConfig,
+            net::{HttpClient, NetOptions},
+            platform::{CancelToken, sync::Arc},
+            play::PlayWorkerConfig,
+            stream::dl::{Downloader, DownloaderConfig},
+            ui::render::{ControlAction, DragPhase, UiEvent, WindowCommand},
+        };
+        use iced::window::Id;
+        use kithara_test_utils::kithara;
+
+        use super::super::translate;
+        use crate::{
+            broadcast::Broadcaster,
+            catalog::Catalog,
+            config::{AppBroadcastConfig, AppConfig},
+            deck::{Deck, DeckId, DeckSet, EqMode},
+            gui::{
+                app::{Decks, Kithara},
+                deck::DeckMsg,
+                message::Message,
+                mix::MixMsg,
+                ui::{AppUi, package::Package},
+            },
+            pools::{self, AppHost, AppStore, AppWorker},
+            state::{AbrVariant, StateController, UiState},
+        };
+
+        fn config() -> AppConfig {
+            let shutdown = CancelToken::root();
+            let pools = pools::build().expect("valid app pool policy");
+            let worker = AppWorker::new(PlayWorkerConfig::builder(pools.clone()).build());
+            let downloader = Downloader::new(
+                DownloaderConfig::for_client(HttpClient::new(
+                    NetOptions::builder().build(),
+                    pools.clone(),
+                    shutdown.child(),
+                ))
+                .build(),
+            );
+            let store = AppStore::builder(pools)
+                .backend(StorageBackend::Memory)
+                .build();
+            AppConfig::builder()
+                .downloader(downloader)
+                .shutdown(shutdown)
+                .worker(worker)
+                .store(store)
+                .build()
+        }
+
+        fn state() -> Kithara {
+            let config = config();
+            let mut host = AppHost::new(HostConfig::builder().build()).expect("test host");
+            let decks: Vec<Deck> = (0..2)
+                .map(|index| {
+                    Deck::build(DeckId(index), &config, &mut host)
+                        .expect("host accepts the test deck")
+                })
+                .collect();
+            let controllers = decks
+                .iter()
+                .map(|deck| {
+                    let controller = StateController::for_test(
+                        deck.queue.control().clone(),
+                        Arc::clone(&deck.timestretch),
+                        UiState::empty(),
+                        deck.cancel_child(),
+                    );
+                    (deck.id, Arc::new(controller))
+                })
+                .collect();
+            let session = DeckSet::new(host, decks);
+            let decks = Decks::new(controllers).expect("fixture has decks");
+            let catalog = Catalog::new(vec![
+                "/music/local.flac".to_string(),
+                "https://example.test/stream.m3u8".to_string(),
+            ]);
+            let ui = AppUi::new(Package::load(None).expect("shipped UI package"))
+                .expect("shipped UI compiles");
+            Kithara::mounted(
+                session,
+                decks,
+                catalog,
+                config,
+                ui,
+                Broadcaster::new(AppBroadcastConfig::default()),
+                Id::unique(),
+            )
+        }
+
+        fn send(state: &mut Kithara, path: &str, action: ControlAction) -> Option<Message> {
+            translate(
+                state,
+                UiEvent::Control {
+                    path: path.to_string(),
+                    action,
+                },
+            )
+        }
+
+        #[kithara::test(native, flash(false))]
+        fn deck_and_bar_controls_translate_to_their_owned_messages() {
+            let mut state = state();
+            state.decks.get_mut(DeckId(0)).unwrap().ui.duration = 120.0;
+            state
+                .decks
+                .get_mut(DeckId(0))
+                .unwrap()
+                .view
+                .timestretch
+                .tempo = 3.0;
+
+            assert!(matches!(
+                send(&mut state, "deck-a/play", ControlAction::Activate),
+                Some(Message::Deck(DeckId(0), DeckMsg::TogglePlayPause))
+            ));
+            assert!(matches!(
+                send(&mut state, "overview/b/next", ControlAction::Activate),
+                Some(Message::Deck(DeckId(1), DeckMsg::Next))
+            ));
+            assert!(matches!(
+                send(
+                    &mut state,
+                    "deck-a/wave",
+                    ControlAction::SetScalar(0.25)
+                ),
+                Some(Message::Deck(DeckId(0), DeckMsg::SeekTo(position)))
+                    if (position - 30.0).abs() < f64::EPSILON
+            ));
+            assert!(matches!(
+                send(
+                    &mut state,
+                    "deck-a/tempo",
+                    ControlAction::StepScalar(2.0)
+                ),
+                Some(Message::Deck(DeckId(0), DeckMsg::SetTempo(tempo)))
+                    if (tempo - 6.0).abs() < f32::EPSILON
+            ));
+            assert!(matches!(
+                send(&mut state, "bar/broadcast", ControlAction::Activate),
+                Some(Message::BroadcastToggle)
+            ));
+            assert!(matches!(
+                send(
+                    &mut state,
+                    "micro-bar/volume",
+                    ControlAction::SetScalar(2.0)
+                ),
+                Some(Message::Mix(MixMsg::Trim(DeckId(0), trim)))
+                    if (trim - 1.0).abs() < f32::EPSILON
+            ));
+            assert!(send(&mut state, "unknown/play", ControlAction::Activate).is_none());
+        }
+
+        #[kithara::test(native, flash(false))]
+        fn stream_controls_own_the_quality_menu_and_selected_rung() {
+            let mut state = state();
+            state.decks.get_mut(DeckId(0)).unwrap().ui.abr_variants = vec![AbrVariant {
+                index: 7,
+                label: "320k".to_string(),
+                detail: "320 kbps".to_string(),
+            }];
+
+            assert!(send(&mut state, "deck-a/stream/cell", ControlAction::Activate).is_none());
+            assert!(state.ui.cache.deck_mut(0).unwrap().view.quality_menu);
+            assert!(matches!(
+                send(
+                    &mut state,
+                    "deck-a/stream/variant-0/cell",
+                    ControlAction::Activate
+                ),
+                Some(Message::Deck(DeckId(0), DeckMsg::SetQuality(Some(7))))
+            ));
+            assert!(!state.ui.cache.deck_mut(0).unwrap().view.quality_menu);
+            assert!(matches!(
+                send(
+                    &mut state,
+                    "deck-a/stream/auto/cell",
+                    ControlAction::Activate
+                ),
+                Some(Message::Deck(DeckId(0), DeckMsg::SetQuality(None)))
+            ));
+            assert!(
+                send(
+                    &mut state,
+                    "deck-a/stream/cell",
+                    ControlAction::SecondaryActivate
+                )
+                .is_none()
+            );
+        }
+
+        #[kithara::test(native, flash(false))]
+        fn mixer_controls_translate_levels_eq_and_stage_window() {
+            let mut state = state();
+
+            assert!(matches!(
+                send(
+                    &mut state,
+                    "mixer/xfade",
+                    ControlAction::SetScalar(1.5)
+                ),
+                Some(Message::Mix(MixMsg::Crossfader(position)))
+                    if (position - 1.0).abs() < f32::EPSILON
+            ));
+            assert!(matches!(
+                send(
+                    &mut state,
+                    "mixer/master",
+                    ControlAction::SetScalar(-1.0)
+                ),
+                Some(Message::Mix(MixMsg::Master(gain))) if gain.abs() < f32::EPSILON
+            ));
+            assert!(
+                send(
+                    &mut state,
+                    "mixer/window/min",
+                    ControlAction::SetScalar(0.7)
+                )
+                .is_none()
+            );
+            assert!(
+                send(
+                    &mut state,
+                    "mixer/window/max",
+                    ControlAction::SetScalar(0.2)
+                )
+                .is_none()
+            );
+            assert_eq!(state.ui.cache.stage.window, (0.7, 0.7));
+
+            assert!(matches!(
+                send(&mut state, "mixer/a/mute", ControlAction::Activate),
+                Some(Message::Mix(MixMsg::Muted(DeckId(0), true)))
+            ));
+            assert!(matches!(
+                send(
+                    &mut state,
+                    "mixer/a/volume",
+                    ControlAction::SetScalar(0.25)
+                ),
+                Some(Message::Mix(MixMsg::Trim(DeckId(0), trim)))
+                    if (trim - 0.25).abs() < f32::EPSILON
+            ));
+            assert!(matches!(
+                send(&mut state, "mixer/a/low-3", ControlAction::SetScalar(1.0)),
+                Some(Message::Deck(DeckId(0), DeckMsg::EqBandChanged(0, _)))
+            ));
+            assert!(
+                send(
+                    &mut state,
+                    "mixer/a/eq-menu-anchor",
+                    ControlAction::SecondaryActivate
+                )
+                .is_none()
+            );
+            assert!(state.ui.cache.deck_mut(0).unwrap().view.eq_menu_open);
+            assert!(matches!(
+                send(&mut state, "mixer/a/eq-4", ControlAction::Activate),
+                Some(Message::SetEqMode(EqMode::FourBand))
+            ));
+            assert!(!state.ui.cache.deck_mut(0).unwrap().view.eq_menu_open);
+        }
+
+        #[kithara::test(native, flash(false))]
+        fn library_and_host_events_update_view_state_and_keep_row_identity() {
+            let mut state = state();
+
+            assert!(translate(&mut state, UiEvent::LibraryQuery("loc".to_string())).is_none());
+            assert_eq!(state.ui.cache.library.query, "loc");
+            state.ui.cache.library.query.clear();
+            assert!(send(&mut state, "library/browser", ControlAction::SelectIndex(1)).is_none());
+            assert!(matches!(
+                send(&mut state, "library/tracks", ControlAction::SelectIndex(0)),
+                Some(Message::SelectCatalogTrack(0))
+            ));
+            assert!(
+                send(
+                    &mut state,
+                    "library/tracks",
+                    ControlAction::Drag(DragPhase::Start(0))
+                )
+                .is_none()
+            );
+            state.ui.cache.set_hover_deck(1, true);
+            assert!(matches!(
+                send(
+                    &mut state,
+                    "library/tracks",
+                    ControlAction::Drag(DragPhase::Drop)
+                ),
+                Some(Message::LoadOntoDeck(0, DeckId(1)))
+            ));
+
+            let was_collapsed = state.ui.cache.collapsed.contains("ov");
+            assert!(translate(&mut state, UiEvent::ToggleModule("ov".to_string())).is_none());
+            assert_ne!(state.ui.cache.collapsed.contains("ov"), was_collapsed);
+            assert!(matches!(
+                translate(&mut state, UiEvent::Window(WindowCommand::ToggleFullScreen)),
+                Some(Message::Window(WindowCommand::ToggleFullScreen))
+            ));
+            assert!(translate(&mut state, UiEvent::OpenSettings).is_none());
+        }
+    }
 }

--- a/crates/kithara-app/src/gui/ui/events.rs
+++ b/crates/kithara-app/src/gui/ui/events.rs
@@ -465,97 +465,15 @@ mod tests {
 
     #[cfg(not(feature = "broadcast"))]
     mod routing {
-        use ::kithara::{
-            assets::StorageBackend,
-            host::HostConfig,
-            net::{HttpClient, NetOptions},
-            platform::{CancelToken, sync::Arc},
-            play::PlayWorkerConfig,
-            stream::dl::{Downloader, DownloaderConfig},
-            ui::render::{ControlAction, DragPhase, UiEvent, WindowCommand},
-        };
-        use iced::window::Id;
+        use ::kithara::ui::render::{ControlAction, DragPhase, UiEvent, WindowCommand};
         use kithara_test_utils::kithara;
 
         use super::super::translate;
         use crate::{
-            broadcast::Broadcaster,
-            catalog::Catalog,
-            config::{AppBroadcastConfig, AppConfig},
-            deck::{Deck, DeckId, DeckSet, EqMode},
-            gui::{
-                app::{Decks, Kithara},
-                deck::DeckMsg,
-                message::Message,
-                mix::MixMsg,
-                ui::{AppUi, package::Package},
-            },
-            pools::{self, AppHost, AppStore, AppWorker},
-            state::{AbrVariant, StateController, UiState},
+            deck::{DeckId, EqMode},
+            gui::{app::Kithara, deck::DeckMsg, message::Message, mix::MixMsg, test_fixture},
+            state::AbrVariant,
         };
-
-        fn config() -> AppConfig {
-            let shutdown = CancelToken::root();
-            let pools = pools::build().expect("valid app pool policy");
-            let worker = AppWorker::new(PlayWorkerConfig::builder(pools.clone()).build());
-            let downloader = Downloader::new(
-                DownloaderConfig::for_client(HttpClient::new(
-                    NetOptions::builder().build(),
-                    pools.clone(),
-                    shutdown.child(),
-                ))
-                .build(),
-            );
-            let store = AppStore::builder(pools)
-                .backend(StorageBackend::Memory)
-                .build();
-            AppConfig::builder()
-                .downloader(downloader)
-                .shutdown(shutdown)
-                .worker(worker)
-                .store(store)
-                .build()
-        }
-
-        fn state() -> Kithara {
-            let config = config();
-            let mut host = AppHost::new(HostConfig::builder().build()).expect("test host");
-            let decks: Vec<Deck> = (0..2)
-                .map(|index| {
-                    Deck::build(DeckId(index), &config, &mut host)
-                        .expect("host accepts the test deck")
-                })
-                .collect();
-            let controllers = decks
-                .iter()
-                .map(|deck| {
-                    let controller = StateController::for_test(
-                        deck.queue.control().clone(),
-                        Arc::clone(&deck.timestretch),
-                        UiState::empty(),
-                        deck.cancel_child(),
-                    );
-                    (deck.id, Arc::new(controller))
-                })
-                .collect();
-            let session = DeckSet::new(host, decks);
-            let decks = Decks::new(controllers).expect("fixture has decks");
-            let catalog = Catalog::new(vec![
-                "/music/local.flac".to_string(),
-                "https://example.test/stream.m3u8".to_string(),
-            ]);
-            let ui = AppUi::new(Package::load(None).expect("shipped UI package"))
-                .expect("shipped UI compiles");
-            Kithara::mounted(
-                session,
-                decks,
-                catalog,
-                config,
-                ui,
-                Broadcaster::new(AppBroadcastConfig::default()),
-                Id::unique(),
-            )
-        }
 
         fn send(state: &mut Kithara, path: &str, action: ControlAction) -> Option<Message> {
             translate(
@@ -569,7 +487,7 @@ mod tests {
 
         #[kithara::test(native, flash(false))]
         fn deck_and_bar_controls_translate_to_their_owned_messages() {
-            let mut state = state();
+            let mut state = test_fixture::state();
             state.decks.get_mut(DeckId(0)).unwrap().ui.duration = 120.0;
             state
                 .decks
@@ -623,7 +541,7 @@ mod tests {
 
         #[kithara::test(native, flash(false))]
         fn stream_controls_own_the_quality_menu_and_selected_rung() {
-            let mut state = state();
+            let mut state = test_fixture::state();
             state.decks.get_mut(DeckId(0)).unwrap().ui.abr_variants = vec![AbrVariant {
                 index: 7,
                 label: "320k".to_string(),
@@ -661,7 +579,7 @@ mod tests {
 
         #[kithara::test(native, flash(false))]
         fn mixer_controls_translate_levels_eq_and_stage_window() {
-            let mut state = state();
+            let mut state = test_fixture::state();
 
             assert!(matches!(
                 send(
@@ -733,7 +651,7 @@ mod tests {
 
         #[kithara::test(native, flash(false))]
         fn library_and_host_events_update_view_state_and_keep_row_identity() {
-            let mut state = state();
+            let mut state = test_fixture::state();
 
             assert!(translate(&mut state, UiEvent::LibraryQuery("loc".to_string())).is_none());
             assert_eq!(state.ui.cache.library.query, "loc");

--- a/crates/kithara-app/src/gui/update.rs
+++ b/crates/kithara-app/src/gui/update.rs
@@ -282,3 +282,206 @@ fn refresh_snapshots(state: &mut Kithara) {
     }
     state.ui.cache.refresh(&state.decks, &state.catalog);
 }
+
+#[cfg(all(test, not(feature = "broadcast")))]
+mod tests {
+    use std::mem;
+
+    use ::kithara::{
+        play::effects::eq::GainDb,
+        ui::render::{ControlAction, UiEvent, WindowCommand, WindowEdge},
+    };
+    use iced::{Size, window::Direction};
+    use kithara_test_utils::kithara;
+
+    use super::*;
+    use crate::gui::{test_fixture, ui::cache::DeckLayout};
+
+    fn apply(state: &mut Kithara, message: Message) {
+        assert_eq!(update(state, message).units(), 0);
+    }
+
+    #[kithara::test(native, flash(false))]
+    fn window_edges_keep_their_native_direction() {
+        let cases = [
+            (WindowEdge::North, Direction::North),
+            (WindowEdge::South, Direction::South),
+            (WindowEdge::East, Direction::East),
+            (WindowEdge::West, Direction::West),
+            (WindowEdge::NorthEast, Direction::NorthEast),
+            (WindowEdge::NorthWest, Direction::NorthWest),
+            (WindowEdge::SouthEast, Direction::SouthEast),
+            (WindowEdge::SouthWest, Direction::SouthWest),
+        ];
+
+        for (edge, expected) in cases {
+            let actual = direction(edge).expect("window edge has a native direction");
+            assert_eq!(mem::discriminant(&actual), mem::discriminant(&expected));
+        }
+    }
+
+    #[kithara::test(native, flash(false))]
+    fn every_window_command_schedules_host_work() {
+        let state = test_fixture::state();
+        let commands = [
+            WindowCommand::Drag,
+            WindowCommand::Resize(WindowEdge::North),
+            WindowCommand::Minimize,
+            WindowCommand::ToggleMaximize,
+            WindowCommand::ToggleFullScreen,
+            WindowCommand::Close,
+        ];
+
+        for command in commands {
+            assert_eq!(window_task(&state, command).units(), 1, "{command:?}");
+        }
+    }
+
+    #[kithara::test(native, tokio, flash(false))]
+    async fn update_routes_messages_and_refreshes_their_state() {
+        let mut state = test_fixture::state();
+
+        assert_eq!(
+            update(
+                &mut state,
+                Message::Ui(UiEvent::Control {
+                    path: "mixer/xfade".to_string(),
+                    action: ControlAction::SetScalar(1.0),
+                }),
+            )
+            .units(),
+            0
+        );
+        assert_eq!(state.session.mix().position, 1.0);
+
+        assert_eq!(
+            update(
+                &mut state,
+                Message::Ui(UiEvent::LibraryQuery("local".to_string())),
+            )
+            .units(),
+            0
+        );
+        assert_eq!(state.ui.cache.library.query, "local");
+
+        apply(&mut state, Message::SelectCatalogTrack(1));
+        assert_eq!(state.selected_track, Some(1));
+
+        apply(
+            &mut state,
+            Message::Deck(DeckId(0), DeckMsg::SetTempo(80.0)),
+        );
+        let deck = state.decks.get(DeckId(0)).expect("deck A");
+        assert_eq!(deck.view.timestretch.tempo, 50.0);
+
+        apply(&mut state, Message::LoadOntoDeck(usize::MAX, DeckId(0)));
+        let tracks = {
+            let queue = state
+                .decks
+                .get(DeckId(0))
+                .expect("deck A")
+                .controller
+                .queue();
+            queue.append("https://example.test/pending.mp3").unwrap();
+            queue.tracks()
+        };
+        let deck = state.decks.get_mut(DeckId(0)).expect("deck A");
+        deck.ui.tracks = tracks;
+        deck.ui.current_track_index = Some(0);
+        apply(&mut state, Message::DeleteFocusedTrack);
+        assert!(
+            state
+                .decks
+                .get(DeckId(0))
+                .expect("deck A")
+                .controller
+                .queue()
+                .tracks()
+                .is_empty()
+        );
+
+        state.ui.cache.set_layout(DeckLayout::Single);
+        let hidden = state
+            .decks
+            .get(DeckId(1))
+            .expect("deck B")
+            .controller
+            .clone();
+        apply(&mut state, Message::PauseHiddenDecks);
+        assert!(!hidden.queue().is_playing());
+
+        apply(&mut state, Message::WindowResized(Size::new(640.0, 480.0)));
+        assert!(state.ui.cache.window.caption().starts_with("640 × 480"));
+
+        assert_eq!(
+            update(
+                &mut state,
+                Message::Ui(UiEvent::Window(WindowCommand::Minimize)),
+            )
+            .units(),
+            1
+        );
+        assert_eq!(update(&mut state, Message::Tick).units(), 0);
+        assert_eq!(update(&mut state, Message::BroadcastToggle).units(), 0);
+        assert_eq!(update(&mut state, Message::BroadcastToggle).units(), 0);
+        assert_eq!(
+            update(
+                &mut state,
+                Message::BroadcastStopped(Some(Duration::from_millis(10))),
+            )
+            .units(),
+            0
+        );
+        assert_eq!(update(&mut state, Message::WindowCloseRequested).units(), 1);
+    }
+
+    #[kithara::test(native, flash(false))]
+    fn eq_mode_changes_every_deck_as_one_transaction() {
+        let mut state = test_fixture::state();
+        let initial = [
+            [-6.0f32, 2.0, 5.0].map(GainDb::from),
+            [1.0f32, 3.0, 7.0].map(GainDb::from),
+        ];
+        for (deck, gains) in state.decks.iter().zip(initial) {
+            deck.controller
+                .mutate(|snapshot| snapshot.eq_bands = gains.to_vec());
+        }
+
+        apply(&mut state, Message::SetEqMode(EqMode::FourBand));
+        assert_eq!(state.eq_mode, EqMode::FourBand);
+        for (deck, gains) in state.decks.iter().zip(initial) {
+            let expected = vec![gains[0], gains[1], gains[1], gains[2]];
+            assert_eq!(deck.controller.snapshot().eq_bands, expected);
+            assert_eq!(deck.controller.queue().eq_band_count(), 4);
+        }
+
+        apply(&mut state, Message::SetEqMode(EqMode::FourBand));
+        apply(&mut state, Message::SetEqMode(EqMode::ThreeBand));
+        assert_eq!(state.eq_mode, EqMode::ThreeBand);
+        for (deck, gains) in state.decks.iter().zip(initial) {
+            assert_eq!(deck.controller.snapshot().eq_bands, gains);
+            assert_eq!(deck.controller.queue().eq_band_count(), 3);
+        }
+    }
+
+    #[kithara::test(native, flash(false))]
+    fn invalid_eq_snapshot_keeps_the_shared_mode_unchanged() {
+        let mut state = test_fixture::state();
+        state
+            .decks
+            .get(DeckId(0))
+            .expect("deck A")
+            .controller
+            .mutate(|snapshot| snapshot.eq_bands.clear());
+
+        apply(&mut state, Message::SetEqMode(EqMode::FourBand));
+
+        assert_eq!(state.eq_mode, EqMode::ThreeBand);
+        assert!(
+            state
+                .decks
+                .iter()
+                .all(|deck| deck.controller.queue().eq_band_count() == 3)
+        );
+    }
+}

--- a/crates/kithara-app/src/state.rs
+++ b/crates/kithara-app/src/state.rs
@@ -268,6 +268,22 @@ impl StateController {
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn for_test(
+        queue: AppQueueControl,
+        timestretch: Arc<StretchControls>,
+        state: UiState,
+        cancel: CancelToken,
+    ) -> Self {
+        Self {
+            queue,
+            state: Arc::new(Mutex::new(state)),
+            timestretch,
+            cancel,
+            beat_clock: Mutex::new(BeatClockState::default()),
+        }
+    }
+
     /// Apply a closure under the lock. Returns the closure's result.
     /// Used for UI-driven optimistic mutations (seek scrub, crossfade,
     /// abr selection) that must outlive the next event echo.

--- a/crates/kithara-app/src/state.rs
+++ b/crates/kithara-app/src/state.rs
@@ -268,22 +268,6 @@ impl StateController {
         }
     }
 
-    #[cfg(test)]
-    pub(crate) fn for_test(
-        queue: AppQueueControl,
-        timestretch: Arc<StretchControls>,
-        state: UiState,
-        cancel: CancelToken,
-    ) -> Self {
-        Self {
-            queue,
-            state: Arc::new(Mutex::new(state)),
-            timestretch,
-            cancel,
-            beat_clock: Mutex::new(BeatClockState::default()),
-        }
-    }
-
     /// Apply a closure under the lock. Returns the closure's result.
     /// Used for UI-driven optimistic mutations (seek scrub, crossfade,
     /// abr selection) that must outlive the next event echo.
@@ -333,6 +317,26 @@ impl StateController {
     #[must_use]
     pub fn snapshot(&self) -> UiState {
         self.state.lock().clone()
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test_fixture {
+    use super::*;
+
+    pub(crate) fn controller(
+        queue: AppQueueControl,
+        timestretch: Arc<StretchControls>,
+        cancel: CancelToken,
+    ) -> Arc<StateController> {
+        let state = Arc::new(Mutex::new(UiState::new(&queue)));
+        Arc::new(StateController {
+            queue,
+            state,
+            timestretch,
+            cancel,
+            beat_clock: Mutex::new(BeatClockState::default()),
+        })
     }
 }
 


### PR DESCRIPTION
## Summary
The native GUI event translator and update loop contained 12 measured CRAP hotspots because their deck, stream, mixer, library, host-window, and EQ routes were not exercised through application state. This change adds contract tests backed by one shared two-deck fixture, covering the complete event boundary and related update routing without changing production behavior.

## Behavior / scope
- contract or behavior: preserve control-path routing, clamping, deck identity, ABR rung selection, drag-and-drop row identity, host-owned view state, native resize directions, window commands, snapshot refresh, and transactional EQ topology changes;
- affected area: test code in `gui/ui/events.rs` and `gui/update.rs`, one shared test-only GUI fixture, and its test-only state-controller constructor;
- CRAP target: 12 GUI functions with aggregate baseline CRAP 1,738; every target is now below 30.

## Validation
- `cargo test -p kithara-app --lib gui::update::tests --profile test-release` — 5 passed;
- `cargo test -p kithara-app --lib gui::ui::events --profile test-release` — 11 passed;
- `just test run -p kithara-app --lib` — the repository harness selected the general workspace lane; 2,735 passed;
- `just lint fast`;
- `just fmt check`;
- `git diff --check`;
- local exact-head `just quality coverage-risk` at `a6b29bfd00975091a3300fcdbff211f83c5905c4` ran the workspace coverage pass across 5,919 tests (5,918 passed, one HLS stress test failed), the UI pass across 1,112 tests (all passed), and the app pass across 83 tests (all passed);
- isolated rerun of `packaged_abr_switch_keeps_player_continuity` from the coverage binary — 1 passed, 4.76s;
- the exact-head `cargo-crap` invocation completed successfully with a clean manifest after the coverage passes;
- workspace CRAP > 30: 833 → 795 (-38 functions);
- `kithara-app` CRAP > 30: 37 → 23 (-14 functions);
- the 12 targeted functions: aggregate CRAP 1,738 → 136.113 (-92.2%), with every target below 30;
- [exact-head fork CI](https://github.com/gerasim13/kithara/actions/runs/33983160537): every ordinary code, test, lint, architecture, wasm, support, and perf-memory lane passed;
- [exact-head fork coverage-risk](https://github.com/gerasim13/kithara/actions/runs/33983618651): the coverage job was terminated by its self-hosted runner before the running step or report upload was finalized, so it produced no coverage artifact.

## Surface impact
- Public API: none
- Platform/runtime: none
- Perf-sensitive paths: none

## Risks / follow-ups
- Fork CI is red only because all three RTSan lanes failed before tests when rustup could not write `/usr/local/rustup/toolchains/...` (`Permission denied (os error 13)`), and `web-chromium` found Chromium 152.0.7977.75 instead of the expected 151.0.7922.137.
- Remote coverage evidence is unavailable because the self-hosted runner terminated the job while its main step was still recorded as running; local exact-head coverage and CRAP reports completed as described above.
- `kithara/gitlab-verification` remains pending.
