### PR TITLE
test(ui): include capture workflows in coverage

### DIFF
--- a/.config/just/test.just
+++ b/.config/just/test.just
@@ -238,6 +238,7 @@ coverage:
       --cargo-profile test-release || test_rc=$?
     cargo llvm-cov nextest --no-report \
       -p kithara-ui \
+      --features kithara-ui/capture \
       --cargo-profile test-release \
       --ignore-default-filter || test_rc=$?
     cargo llvm-cov nextest --no-report \

--- a/crates/kithara-ui/src/capture/diff.rs
+++ b/crates/kithara-ui/src/capture/diff.rs
@@ -476,11 +476,51 @@ mod tests {
         let budget_path = root.join("budget.txt");
         fs::write(&budget_path, "page.png 5\n").unwrap();
 
-        let report = compare(&left_dir, &right_dir, &masks, Some(&budget_path));
-        let passed = report.map(|report| report.passed());
+        let report = compare(&left_dir, &right_dir, &masks, Some(&budget_path))
+            .expect("two complete capture sets");
+        let passed = report.passed();
+        let message = report.to_string();
 
         fs::remove_dir_all(&root).ok();
 
-        assert_eq!(passed, Ok(false));
+        assert!(!passed);
+        assert!(message.contains("over budget: page.png differs by 10.0%, allowed 5.0%"));
+        assert!(message.contains("1 page(s) compared, 1 over budget"));
+    }
+
+    #[kithara::test]
+    fn an_unjudged_comparison_reports_a_missing_page_without_failing() {
+        let root = scratch_dir("missing");
+        let left_dir = root.join("left");
+        let right_dir = root.join("right");
+        let masks = root.join("out");
+        create_dir_all(&left_dir).unwrap();
+        create_dir_all(&right_dir).unwrap();
+
+        let frame = Geometry {
+            height: 1,
+            scale: 1.0,
+            width: 1,
+        };
+        write_geometry(&left_dir, frame).unwrap();
+        write_geometry(&right_dir, frame).unwrap();
+        write_png(
+            &left_dir.join("missing.png"),
+            1,
+            1,
+            once([0, 0, 0, 255].as_slice()),
+        )
+        .unwrap();
+
+        let report = compare(&left_dir, &right_dir, &masks, None)
+            .expect("matching geometry is enough for an unjudged comparison");
+        let message = report.to_string();
+
+        fs::remove_dir_all(&root).ok();
+
+        assert!(report.passed());
+        assert!(message.contains("missing.png"));
+        assert!(message.contains("missing"));
+        assert!(message.contains("0 page(s) compared; no budget given, so nothing was decided"));
     }
 }

--- a/crates/kithara-ui/src/capture/set.rs
+++ b/crates/kithara-ui/src/capture/set.rs
@@ -42,3 +42,77 @@ where
     }
     Ok(written)
 }
+
+#[cfg(test)]
+mod tests {
+    use kithara_test_utils::kithara;
+    use tempfile::tempdir;
+
+    use super::{Film, Stage, shoot_set};
+    use crate::capture::{Geometry, read_geometry};
+
+    struct Cards {
+        frame: Geometry,
+        page: &'static str,
+        pixels: Vec<u8>,
+        ticks: usize,
+    }
+
+    impl Stage for Cards {
+        type Page = &'static str;
+
+        fn geometry(&self) -> Geometry {
+            self.frame
+        }
+
+        fn shoot(&mut self) -> Result<&[u8], String> {
+            Ok(&self.pixels)
+        }
+
+        fn tick(&mut self) {
+            self.ticks += 1;
+        }
+
+        fn turn(&mut self, page: &Self::Page) -> Result<(), String> {
+            self.page = page;
+            Ok(())
+        }
+    }
+
+    fn cards() -> Cards {
+        Cards {
+            frame: Geometry {
+                height: 1,
+                scale: 2.0,
+                width: 1,
+            },
+            page: "",
+            pixels: vec![0, 0, 0, 255],
+            ticks: 0,
+        }
+    }
+
+    #[kithara::test]
+    fn a_film_writes_every_photo_and_advances_between_them() {
+        let dir = tempdir().expect("a private capture directory");
+        let film = Film::new(vec!["clock", "wave"], 2, 3).expect("a moving film");
+        let mut stage = cards();
+
+        let written = shoot_set(&mut stage, &film, dir.path()).expect("a complete capture set");
+
+        assert_eq!(written.len(), 4);
+        assert!(written.iter().all(|path| path.exists()));
+        assert_eq!(stage.page, "wave");
+        assert_eq!(stage.ticks, 6);
+        assert_eq!(read_geometry(dir.path()), Some(stage.frame));
+    }
+
+    #[kithara::test]
+    fn a_film_without_pages_is_refused() {
+        let dir = tempdir().expect("a private capture directory");
+        let film = Film::stills(Vec::<&str>::new());
+
+        assert!(shoot_set(&mut cards(), &film, dir.path()).is_err());
+        assert!(!dir.path().join("frame.txt").exists());
+    }
+}


### PR DESCRIPTION
## Summary
The feature-gated `kithara-ui::capture` module already had focused tests, but the canonical coverage pass built `kithara-ui` only with its default `iced` feature. As a result, production capture functions were reported at zero coverage and dominated the CRAP report. This change runs the existing capture suite in coverage and adds observable contracts for the remaining report and full-film branches.

## Behavior / scope
- contract or behavior: the canonical coverage pass now instruments and runs `kithara-ui` with `kithara-ui/capture`; capture tests verify complete multi-page films, empty-film rejection, over-budget report output, and unjudged missing-page output;
- affected area: the coverage recipe and tests owned by `kithara-ui::capture`;
- CRAP target: five capture functions with aggregate baseline CRAP 730 (`compare` 272, `Report::fmt` 182, `shoot_set` 132, `read_geometry` 72, `shoot_part` 72).

## Validation
- `cargo nextest run -p kithara-ui --features capture --cargo-profile test-release --ignore-default-filter -E 'package(kithara-ui) & test(/^capture::/)'` - 21 passed;
- `just fmt check`;
- `just lint fast`;
- `git diff --check`;
- repository pre-commit hook;
- [exact-head fork CI](https://github.com/gerasim13/kithara/actions/runs/33989713648) - running;
- [exact-head coverage-risk](https://github.com/gerasim13/kithara/actions/runs/33990064867) - queued for a self-hosted runner; post-change CRAP comparison is pending.

## Surface impact
- Public API: none
- Platform/runtime: none
- Perf-sensitive paths: none
- Tooling surface: coverage now includes the feature-gated capture module.

## Risks / follow-ups
- The additional capture pass increases coverage-lane work; exact-head CI timing and CRAP output will be added after the fork run completes.
