### PR TITLE
fix(ci): retry the source fetch a job fails on

### DIFF
--- a/.gitlab/ci/pipeline.yml
+++ b/.gitlab/ci/pipeline.yml
@@ -32,6 +32,14 @@ stages:
 # instead by keeping the build directory between jobs.
 variables:
   CARGO_INCREMENTAL: "0"
+  # A job fetches the sources before it runs anything, and the runner charges a
+  # failure there to the job: `apple:xcframework` reported a script failure two
+  # seconds in, having compiled nothing, because the GitLab web front end
+  # answered that one fetch with 502. Neighbouring jobs on the same host fetched
+  # normally minutes either side, so the outage lasted seconds while the job it
+  # landed on was already red for the gate. The runner will repeat the fetch on
+  # its own; it does so once unless told a number.
+  GET_SOURCES_ATTEMPTS: "3"
   # GitHub's HTTP/2 ref listing stalls in the Linux runner.
   GIT_CONFIG_COUNT: "1"
   GIT_CONFIG_KEY_0: http.version


### PR DESCRIPTION
## What

Set `GET_SOURCES_ATTEMPTS: "3"` in the child pipeline's variables.

## Why

A job fetches the sources before it runs anything, and the runner charges a failure there to the job itself. On 2026-09-05 the quarantine gate for #254 went red because `apple:xcframework` reported a script failure 2.4 seconds in, having compiled nothing:

```
remote: GitLab is not responding
fatal: unable to access 'https://gitlab.zvq.me/disrupt/kithara.git/': The requested URL returned error: 502
ERROR: Job failed: exit status 128
```

The other five jobs in that pipeline passed, and jobs on the same host fetched normally minutes either side — the outage lasted seconds and happened to land on one job's fetch.

The runner already knows how to repeat a fetch. Without a number it tries once.

## Why not `retry:`

GitLab recorded the job with `failure_reason=script_failure`, so `retry: when: runner_system_failure` would not catch it, and `when: script_failure` would also re-run genuine build and test failures. `GET_SOURCES_ATTEMPTS` reaches the fetch and nothing else.

## Validation

`lint-fast` passed on commit. The variable takes effect on the next pipeline; nothing in the repository can exercise a 502 locally.