### PR TITLE
fix(ci): wait for the room a job needs before refusing it

### DIFF
--- a/xtask/src/ci/config/host.rs
+++ b/xtask/src/ci/config/host.rs
@@ -2,6 +2,7 @@ use std::{
     error::Error,
     fmt, fs,
     path::{Path, PathBuf},
+    time::Duration,
 };
 
 use anyhow::{Context, Result, bail};
@@ -52,6 +53,11 @@ pub(crate) struct CiHost {
     #[serde(default)]
     pub(crate) build_root: Option<PathBuf>,
     pub(crate) host_xcode_developer_dir: PathBuf,
+    /// How long a job waits for the volume to give back the room it needs
+    /// before refusing to start. Defaulted: installed profiles predate it, and
+    /// refusing to load would refuse every job on the host.
+    #[serde(default = "default_job_room_wait_seconds")]
+    pub(crate) job_room_wait_seconds: u64,
     pub(crate) quota_bytes: u64,
     pub(crate) reject_bytes: u64,
     /// Aggregate whole-gigabyte sccache budget, divided between host jobs.
@@ -240,6 +246,18 @@ impl CiHost {
         self.quota_bytes.saturating_sub(self.reject_bytes)
     }
 
+    /// How long the gate lets a full volume come back before it refuses.
+    ///
+    /// The room a refused job is missing is room its neighbours hold, not room
+    /// that is gone: eight slots share this volume, and a checkout stops being
+    /// active on its own once the job holding it ends. Six merge requests were
+    /// refused in one afternoon, one of them 53 MB short, and every one of them
+    /// passed on a manual retry against unchanged code. Waiting costs the slot
+    /// that retry costs anyway.
+    pub(crate) const fn job_room_wait(&self) -> Duration {
+        Duration::from_secs(self.job_room_wait_seconds)
+    }
+
     /// `tart` resolves VM names under `TART_HOME`, and the configured bundle
     /// is `<TART_HOME>/vms/<name>`. A launch agent inherits none of the
     /// shell's environment, so without this it looks in `~/.tart` and cannot
@@ -312,6 +330,16 @@ impl Error for BuildCacheSizeError {}
 /// fleet actually builds and what its volume can spare.
 pub(crate) fn default_build_cache_size() -> String {
     "25GB".to_owned()
+}
+
+/// Matched to the heartbeat a dead job leaves behind.
+///
+/// A checkout is held either by a live job or by the stale claim of one that
+/// was killed, and the claim expires after ten minutes. Waiting that long is
+/// what it takes for the worst case to become reclaimable on its own; waiting
+/// longer only holds a slot open against a volume that genuinely has no room.
+pub(crate) const fn default_job_room_wait_seconds() -> u64 {
+    600
 }
 
 pub(crate) fn parse_build_cache_size(value: &str) -> Result<u64, BuildCacheSizeError> {
@@ -420,6 +448,41 @@ mod tests {
         assert_eq!(
             CiHost::load(&path).unwrap().build_cache_size,
             default_build_cache_size()
+        );
+    }
+
+    /// Installed profiles predate the wait. Loading them without one has to
+    /// yield the wait, not zero, or the gate refuses as instantly as before.
+    #[test]
+    fn ci_host_load_accepts_a_profile_without_a_job_room_wait() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("host.toml");
+        let host = super::super::fixture().host;
+        host.write(&path).unwrap();
+        let text = fs::read_to_string(&path).unwrap();
+        let without: String = text
+            .lines()
+            .filter(|line| !line.trim_start().starts_with("job_room_wait_seconds"))
+            .map(|line| format!("{line}\n"))
+            .collect();
+        fs::write(&path, without).unwrap();
+
+        assert_eq!(
+            CiHost::load(&path).unwrap().job_room_wait(),
+            Duration::from_secs(default_job_room_wait_seconds())
+        );
+    }
+
+    /// A host that wants a different wait gets it, so the policy stays the
+    /// profile's rather than this file's.
+    #[test]
+    fn a_configured_job_room_wait_replaces_the_default() {
+        let mut host = super::super::fixture().host;
+        host.job_room_wait_seconds = default_job_room_wait_seconds() + 45;
+
+        assert_eq!(
+            host.job_room_wait(),
+            Duration::from_secs(default_job_room_wait_seconds() + 45)
         );
     }
 

--- a/xtask/src/ci/environment.rs
+++ b/xtask/src/ci/environment.rs
@@ -4,6 +4,8 @@ use std::{
     ffi::{OsStr, OsString},
     fs::{self, OpenOptions},
     path::{Path, PathBuf},
+    thread,
+    time::{Duration, Instant},
 };
 
 use anyhow::{Context, Result, bail};
@@ -17,6 +19,20 @@ use super::{
 };
 
 pub(crate) const PROVISIONED_LINUX_IMAGE_ENV: &str = "KITHARA_CI_PROVISIONED_LINUX_IMAGE";
+
+struct Consts;
+
+impl Consts {
+    /// The integration suite opens far more files across its cache and segment
+    /// fixtures than the 256 descriptor soft limit a macOS session starts
+    /// with. The lane raises its own ceiling so every executor gets the same
+    /// budget.
+    const OPEN_FILES: u64 = 65536;
+    /// How often the gate re-asks a volume it is waiting on. What it waits for
+    /// is a neighbouring job ending, so it re-asks on the scale a job finishes
+    /// on rather than the scale a compiler writes files on.
+    const JOB_ROOM_POLL: Duration = Duration::from_secs(15);
+}
 
 struct SccacheSlot {
     index: usize,
@@ -446,18 +462,13 @@ pub(super) fn scratch_root() -> PathBuf {
     PathBuf::from("/tmp/kithara-ci")
 }
 
-/// The integration suite opens far more files across its cache and segment
-/// fixtures than the 256 descriptor soft limit a macOS session starts with.
-/// The lane raises its own ceiling so every executor gets the same budget.
-const OPEN_FILES: u64 = 65536;
-
 #[cfg(unix)]
 fn raise_open_file_limit() -> Result<()> {
     use nix::sys::resource::{Resource, getrlimit, setrlimit};
 
     let (soft, hard) =
         getrlimit(Resource::RLIMIT_NOFILE).context("reading the file descriptor limit")?;
-    let target = hard.min(OPEN_FILES);
+    let target = hard.min(Consts::OPEN_FILES);
     if soft >= target {
         return Ok(());
     }
@@ -529,7 +540,8 @@ fn prepare_build_target(
     Ok((target, lease))
 }
 
-/// Refuse a job only once there is nothing left to reclaim.
+/// Refuse a job only once there is nothing left to reclaim and nothing left to
+/// wait for.
 ///
 /// The gate and the periodic cleanup never spoke: cleanup ran on a timer and
 /// the job arrived when it arrived, so whether a job started came down to how
@@ -538,19 +550,42 @@ fn prepare_build_target(
 /// and the job landing in that window was refused while tens of gigabytes of
 /// evictable compiler cache sat beside it. Growing the disk only moves the
 /// window; asking for the space back closes it.
+///
+/// Asking once does not, because what a reclaim cannot touch is not lost — it
+/// is held. A checkout an active job leases is skipped by design, so a host
+/// whose slots are all compiling offers no candidate at all, and the refusal
+/// reads as "no room" when it means "not yet". Six merge requests were refused
+/// this way in one afternoon while the branches beside them went green on the
+/// same base; one was 53 MB short, and every one passed on a manual retry
+/// against unchanged code. So the gate re-asks until the room appears or the
+/// profile's wait runs out, and the retry it was asking a human for costs a
+/// poll instead of a whole job.
 fn ensure_room_for_a_job(config: &CiConfig, shared_root: &Path) -> Result<()> {
     let required = config.host.free_bytes_for_a_job();
-    let free = free_bytes(shared_root)?;
-    if !is_ci() || free >= required {
+    if !is_ci() || free_bytes(shared_root)? >= required {
         return Ok(());
     }
     let workspaces = gitlab_workspaces(config.host.build_root());
-    let reclaimed_from = reclaim_build_caches(&workspaces, shared_root, free, required)?;
-    let free = free_bytes(shared_root)?;
-    if free < required {
-        bail!("{}", refusal(free, required, &workspaces, reclaimed_from));
+    let deadline = Instant::now() + config.host.job_room_wait();
+    loop {
+        let free = free_bytes(shared_root)?;
+        let reclaimed_from = reclaim_build_caches(&workspaces, shared_root, free, required)?;
+        let free = free_bytes(shared_root)?;
+        if free >= required {
+            return Ok(());
+        }
+        let Some(left) = deadline.checked_duration_since(Instant::now()) else {
+            bail!("{}", refusal(free, required, &workspaces, reclaimed_from));
+        };
+        warn!(
+            free_bytes = free,
+            required_bytes = required,
+            shortfall_bytes = required.saturating_sub(free),
+            seconds_left = left.as_secs(),
+            "waiting for the CI volume to give the job room"
+        );
+        thread::sleep(Consts::JOB_ROOM_POLL.min(left));
     }
-    Ok(())
 }
 
 /// The checkouts whose build caches the budget owns.


### PR DESCRIPTION
## The failure

Half of the open merge requests on the internal mirror are red, every one of
them on the same blocking job — `apple:ios` — and none of them on the code
under review. The job never reaches a build:

```
Error: the CI cache has 12360290304 bytes free after reclaiming from 8 build
cache(s); a job needs 15000000000 bytes
```

Six refusals in one afternoon, sorted by how much room was missing:

| free bytes | short by |
| --- | --- |
| 14947184640 | 53 MB |
| 13962027008 | 1.04 GB |
| 13583446016 | 1.42 GB |
| 12360290304 | 2.64 GB |
| 10150572032 | 4.85 GB |
| 8413294592 | 6.59 GB |

The other half of the merge requests are green on the same base. What
separates them is which neighbours happened to be compiling when the job
started, not anything in the branch.

## Why reclaiming cannot answer it

The gate reclaims before it refuses, and the reclaim finds nothing to give:

```
targets=8
keeping active build cache .../workspaces/gitlab/on-vqm7-9/0/... bytes_before=69585657856 bytes_freed=0
keeping active build cache .../workspaces/gitlab/on-vqm7-9/1/... bytes_before=27167416320 bytes_freed=0
build cache budget enforced bytes_before=96753074176 bytes_freed=0 held_bytes=96753074176
```

Two checkouts hold 96.7 GB and both are active, so every byte is `held` and
none is a candidate. That is correct — a checkout a live job leases must not be
evicted, and an hourly pass that ignored this once removed the test binaries of
a running job. The room is not lost, though. It is held by work that ends: the
lease goes when the job does, and a killed job's claim expires with its
heartbeat ten minutes later. The refusal treats a transient state as a
permanent one, which is why every one of these six passed on a manual retry
against unchanged code — at the cost of a full re-run of a job that takes
minutes.

## The change

`ensure_room_for_a_job` now waits for the volume instead of refusing the first
time it asks. It re-reclaims and re-reads free space every 15 seconds until the
job has its room or the wait runs out, and only then refuses with the message
it always used.

The wait is a host-profile field, `job_room_wait_seconds`, defaulted to 600 so
installed profiles keep loading. 600 seconds is the heartbeat window: it is
exactly how long the worst case — a checkout still claimed by a job that was
killed — takes to become reclaimable on its own. Setting it to zero restores
the previous behaviour.

Nothing about which caches may be evicted changes; the eviction rules and their
safety are untouched — an earlier pass that removed the build state of a live
job is exactly why they should not be loosened.

#305 attacks the same refusal from the reclaim side: a watchdog for a cleanup
that hangs, and eviction past the ceiling when the volume is short. Neither
reaches this case. Where every candidate is active there is nothing to evict at
any ceiling, which is what `bytes_freed=0` beside `held_bytes=96753074176`
says. The two changes are independent and compose.

## Validation

- `cargo check -p xtask --all-targets`
- `cargo test -p xtask --bin xtask ci::config::host` (16 passed)
- New tests: a profile written without the field loads with the default wait,
  and a profile that sets its own wait keeps it.
