### PR TITLE
fix(platform): let the off-runtime hop follow the platform it runs on

### DIFF
--- a/crates/kithara-platform/src/flash/tokio/task.rs
+++ b/crates/kithara-platform/src/flash/tokio/task.rs
@@ -5,7 +5,10 @@ pub use crate::backend::tokio::task::{JoinError, JoinHandle};
 // UNDER AMBIENT (a flash(true) test's busy-poll `loop { yield_now().await }` must let the virtual clock advance).
 pub use crate::flash::yield_now;
 use crate::{
-    backend::tokio::{backend, runtime::Handle, task as native_task},
+    backend::{
+        maybe_send::MaybeSend,
+        tokio::{backend, runtime::Handle, task as native_task},
+    },
     flash::system::credit,
 };
 
@@ -95,6 +98,21 @@ where
             f()
         }
     })
+}
+
+/// Run a synchronous body away from the async step that produced it.
+///
+/// Native has a pool for exactly this, so the hop goes through
+/// [`spawn_blocking`] and inherits its pacing: under a virtual clock the body
+/// is work in flight, and a hop that skipped the accounting would let the
+/// clock run past it. The bound follows the platform through [`MaybeSend`]
+/// rather than being stated twice.
+pub fn spawn_sync<F, R>(f: F) -> JoinHandle<R>
+where
+    F: FnOnce() -> R + MaybeSend + 'static,
+    R: MaybeSend + 'static,
+{
+    spawn_blocking(f)
 }
 
 /// Spawn a blocking computation on a specific runtime [`Handle`].

--- a/crates/kithara-platform/src/system/tokio/task.rs
+++ b/crates/kithara-platform/src/system/tokio/task.rs
@@ -2,6 +2,7 @@ use std::panic::Location;
 
 pub use super::backend::task::*;
 use super::runtime::Handle;
+use crate::maybe_send::MaybeSend;
 
 /// Spawn a future on the current runtime through the platform chokepoint.
 #[track_caller]
@@ -32,6 +33,20 @@ where
     R: Send + 'static,
 {
     super::backend::task::spawn_blocking(f)
+}
+
+/// Run a synchronous body away from the async step that produced it.
+///
+/// Native hands it to the blocking pool, which is what that pool is for. A
+/// body carrying a `!Send` value cannot leave its thread on wasm at all, so
+/// there it runs as an ordinary task instead; the bound follows the platform
+/// through [`MaybeSend`] rather than being stated twice.
+pub fn spawn_sync<F, R>(f: F) -> JoinHandle<R>
+where
+    F: FnOnce() -> R + MaybeSend + 'static,
+    R: MaybeSend + 'static,
+{
+    spawn_blocking(f)
 }
 
 /// Spawn a blocking computation on a specific runtime [`Handle`].

--- a/crates/kithara-platform/src/wasm/tokio/task.rs
+++ b/crates/kithara-platform/src/wasm/tokio/task.rs
@@ -8,6 +8,7 @@ use futures::channel::oneshot;
 
 pub use super::backend::task::*;
 use super::{backend::task as tww_task, runtime::Handle};
+use crate::maybe_send::MaybeSend;
 
 /// Forward a `tokio_with_wasm` JoinHandle into our own oneshot-backed
 /// channel, converting any tww join error into our cancelled `JoinError`.
@@ -69,6 +70,18 @@ where
     }
 
     JoinHandle { rx }
+}
+
+/// Run a synchronous body away from the async step that produced it.
+///
+/// A body carrying a `!Send` value cannot leave this thread, and there is no
+/// executor thread here to spare, so it runs as an ordinary task.
+pub fn spawn_sync<F, T>(f: F) -> JoinHandle<T>
+where
+    F: FnOnce() -> T + MaybeSend + 'static,
+    T: MaybeSend + 'static,
+{
+    spawn(async move { f() })
 }
 
 /// Run a blocking closure on a dedicated Web Worker thread.

--- a/crates/kithara-queue/src/queue/selection/apply.rs
+++ b/crates/kithara-queue/src/queue/selection/apply.rs
@@ -36,7 +36,7 @@ where
                     return;
                 }
             };
-            drop(task::spawn_blocking(move || {
+            drop(task::spawn_sync(move || {
                 queue.apply_loaded(id, resource);
             }));
         }));
@@ -46,7 +46,8 @@ where
     ///
     /// Takes the admission lock and dispatches through the session's
     /// synchronous command bridge, so the caller waits for a reply. On a
-    /// runtime worker that wait parks the executor thread.
+    /// runtime worker that wait parks the executor thread, which is why the
+    /// caller hands this to the platform rather than awaiting it in place.
     fn apply_loaded(&self, id: TrackId, resource: Resource) {
         let _admission = self.lock_admission();
         if self.is_closed() {


### PR DESCRIPTION
## What broke

`#299` moved the apply of a finished load off the runtime worker with
`task::spawn_blocking`. On native that is the right pool. On wasm it is not a
pool at all: there is no second thread, and `spawn_blocking` still demands
`Send` from the body. The body captures a `Resource`, which owns a
`Box<dyn AudioReader>` — and `AudioReader: … + MaybeSend`, where `MaybeSend`
is deliberately empty on wasm. So the closure is `!Send` there and the graph
stopped compiling:

```
error[E0277]: `(dyn AudioReader + 'static)` cannot be sent between threads safely
   --> crates/kithara-queue/src/queue/selection/apply.rs:39
```

Three lanes go red on every branch cut from `main`: `linux-wasm`,
`web-chromium`, `web-size`.

## The fix

The requirement `#299` was expressing is "do not run this on the step that
produced it". The blocking pool is one way to satisfy that, not the
requirement itself. `task::spawn_sync` names the requirement:

* native — delegates to `spawn_blocking`, unchanged behaviour;
* wasm — spawns an ordinary task, which is the only off-step hop that exists
  there.

The bound is `MaybeSend`, the trait the workspace already uses to say "`Send`
where the platform has threads, nothing where it does not", so the constraint
follows the platform instead of being restated per call site.

No behaviour changes on native. The off-runtime hop `#299` added is preserved
on both platforms.

## Verification

`just platform wasm` — green, 6m13s, the full `kithara-ffi` graph on
`wasm32-unknown-unknown` with `--features wasm --no-default-features`.
Before the change the same command stops at the error above.
