### PR TITLE
fix(ci): pin the FFmpeg line the encoder binds against

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,11 +2,6 @@
 xtask = "run --package xtask --"
 
 [env]
-# The keg-only FFmpeg line `ffmpeg-next` binds to; `.config/ci-pins.toml` owns
-# why it is pinned. Absent prefixes are skipped, so one value serves Apple
-# silicon, Intel, and the Linux image alike, and a `PKG_CONFIG_PATH` already in
-# the environment still wins because Cargo does not force this key.
-PKG_CONFIG_PATH = "/opt/homebrew/opt/ffmpeg@8/lib/pkgconfig:/usr/local/opt/ffmpeg@8/lib/pkgconfig"
 RUST_TEST_THREADS = "4"
 
 [target.wasm32-unknown-unknown]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,6 +2,11 @@
 xtask = "run --package xtask --"
 
 [env]
+# The keg-only FFmpeg line `ffmpeg-next` binds to; `.config/ci-pins.toml` owns
+# why it is pinned. Absent prefixes are skipped, so one value serves Apple
+# silicon, Intel, and the Linux image alike, and a `PKG_CONFIG_PATH` already in
+# the environment still wins because Cargo does not force this key.
+PKG_CONFIG_PATH = "/opt/homebrew/opt/ffmpeg@8/lib/pkgconfig:/usr/local/opt/ffmpeg@8/lib/pkgconfig"
 RUST_TEST_THREADS = "4"
 
 [target.wasm32-unknown-unknown]

--- a/.config/ci-pins.toml
+++ b/.config/ci-pins.toml
@@ -16,6 +16,7 @@ brew_formulae = [
   "docker",
   "docker-buildx",
   "ffmpeg",
+  "ffmpeg@8",
   "gh",
   "git-lfs",
   "gitlab-runner",

--- a/justfile
+++ b/justfile
@@ -5,6 +5,20 @@ sccache := `command -v sccache 2>/dev/null || true`
 
 export RUSTC_WRAPPER := sccache
 
+# Where this machine keeps the FFmpeg line the workspace binds to. `ffmpeg-next`
+# generates its bindings from the headers pkg-config finds, so a host whose
+# unversioned FFmpeg has moved on has to reach the keg-only formula
+# `.config/ci-pins.toml` installs before it. The prefix is asked of the package
+# manager instead of written down, because it belongs to the machine and differs
+# between them; without brew, or without the formula, this is empty and the
+# machine's own search path stands alone. `xtask` cannot own this: it is itself
+# a cargo build that would need the answer before it could run.
+export PKG_CONFIG_PATH := ```
+    formula=$(grep -om1 'ffmpeg@[0-9][0-9]*' .config/ci-pins.toml || true)
+    prefix=$(command -v brew >/dev/null 2>&1 && brew --prefix "${formula:-none}" 2>/dev/null || true)
+    printf '%s' "${prefix:+$prefix/lib/pkgconfig}:${PKG_CONFIG_PATH:-}" | sed 's/^://; s/:$//'
+```
+
 # sccache refuses incremental compilations, so a wrapper without this is never
 # hit. `check clippy` opts back in on a workstation, where the dependencies are
 # already built and incremental turns 15s into 2.4s, and leaves the shared cache

--- a/xtask/src/ci/config/pins.rs
+++ b/xtask/src/ci/config/pins.rs
@@ -28,9 +28,10 @@ pub(crate) struct CiPins {
     /// for the reference decoder the fixture tests compare against, and it
     /// may track whatever release Homebrew ships. The versioned one is
     /// keg-only and exists for `ffmpeg-next`, which generates its bindings
-    /// against the headers it finds: `.cargo/config.toml` points
-    /// `PKG_CONFIG_PATH` at it so the crate binds to the ABI it declares
-    /// rather than to whatever the unversioned formula became overnight.
+    /// against the headers it finds: the root `justfile` asks brew where this
+    /// formula sits and puts it first on `PKG_CONFIG_PATH`, so the crate binds
+    /// to the ABI it declares rather than to whatever the unversioned formula
+    /// became overnight.
     pub(crate) brew_formulae: Vec<String>,
     /// Chromium the browser lane may run, and the version its `chromedriver` must
     /// report. The image installs both from Debian as one version-matched pair,
@@ -281,13 +282,14 @@ mod tests {
         }
     }
 
-    /// `ffmpeg-next` generates its bindings from the `FFmpeg` headers present on
-    /// the build host, so the crate version and the installed library are one
-    /// fact stated in three files: the formula the image installs, the
-    /// `PKG_CONFIG_PATH` that reaches it past the unversioned formula Homebrew
-    /// keeps upgrading, and the crate version itself. A disagreement surfaces
-    /// deep inside generated code — a missing `AV_CODEC_ID_V408`, or a match
-    /// that stopped being exhaustive — naming neither `FFmpeg` nor the pin.
+    /// `ffmpeg-next` generates its bindings from the `FFmpeg` headers present
+    /// on the build host, so the ABI line the workspace binds to is one fact
+    /// stated twice: the formula the image installs, and the crate version
+    /// itself. A disagreement surfaces deep inside generated code — a missing
+    /// `AV_CODEC_ID_V408`, or a match that stopped being exhaustive — naming
+    /// neither `FFmpeg` nor the pin. Where that formula sits on disk is the
+    /// machine's answer rather than this repository's, so nothing here pins a
+    /// path.
     #[test]
     fn the_installed_ffmpeg_line_matches_the_crate_that_binds_to_it() {
         let pins = CiPins::load(&workspace_root().join(PINS_PATH)).unwrap();
@@ -296,16 +298,6 @@ mod tests {
             .iter()
             .find_map(|formula| formula.strip_prefix("ffmpeg@"))
             .expect("the pins install a versioned ffmpeg formula");
-
-        let cargo_config: toml::Value = toml::from_str(
-            &fs::read_to_string(workspace_root().join(".cargo/config.toml")).unwrap(),
-        )
-        .unwrap();
-        let search_path = cargo_config["env"]["PKG_CONFIG_PATH"].as_str().unwrap();
-        assert!(
-            search_path.contains(&format!("ffmpeg@{line}/")),
-            "PKG_CONFIG_PATH reaches an ffmpeg the image does not install: {search_path}"
-        );
 
         let manifest: toml::Value =
             toml::from_str(&fs::read_to_string(workspace_root().join("Cargo.toml")).unwrap())
@@ -318,5 +310,36 @@ mod tests {
             line,
             "ffmpeg-next {declared} binds to headers ffmpeg@{line} does not carry"
         );
+    }
+
+    /// A package manager's prefix is machine state: Homebrew answers
+    /// `/opt/homebrew` on Apple silicon, `/usr/local` on Intel and
+    /// `/home/linuxbrew/.linuxbrew` on Linux, and an install built by hand
+    /// answers none of them. The files that configure a build therefore ask
+    /// the machine where a library lives and never write the answer down,
+    /// because a written one only holds on the machine it was copied from.
+    #[test]
+    fn the_build_configuration_asks_for_prefixes_instead_of_declaring_them() {
+        const DECLARED: [&str; 3] = ["/opt/homebrew", "/usr/local/opt", "linuxbrew"];
+
+        let root = workspace_root();
+        let mut configs = vec![root.join(".cargo/config.toml"), root.join("justfile")];
+        for entry in fs::read_dir(root.join(".config/just")).unwrap() {
+            let path = entry.unwrap().path();
+            if path.extension().is_some_and(|kind| kind == "just") {
+                configs.push(path);
+            }
+        }
+
+        for config in configs {
+            let text = fs::read_to_string(&config).unwrap();
+            for prefix in DECLARED {
+                assert!(
+                    !text.contains(prefix),
+                    "{} writes down {prefix}, which is only one machine's answer",
+                    config.display()
+                );
+            }
+        }
     }
 }

--- a/xtask/src/ci/config/pins.rs
+++ b/xtask/src/ci/config/pins.rs
@@ -23,6 +23,14 @@ pub(crate) struct CiPins {
     pub(crate) android_ndk_version: String,
     pub(crate) android_platform_version: u32,
     pub(crate) brew_casks: Vec<String>,
+    /// Two entries name `FFmpeg` because two consumers want different things
+    /// from it. The unversioned formula keeps the `ffmpeg` binary on `PATH`
+    /// for the reference decoder the fixture tests compare against, and it
+    /// may track whatever release Homebrew ships. The versioned one is
+    /// keg-only and exists for `ffmpeg-next`, which generates its bindings
+    /// against the headers it finds: `.cargo/config.toml` points
+    /// `PKG_CONFIG_PATH` at it so the crate binds to the ABI it declares
+    /// rather than to whatever the unversioned formula became overnight.
     pub(crate) brew_formulae: Vec<String>,
     /// Chromium the browser lane may run, and the version its `chromedriver` must
     /// report. The image installs both from Debian as one version-matched pair,
@@ -271,5 +279,44 @@ mod tests {
             let expected = lab["tools"][tool]["version"].as_str().unwrap();
             assert_eq!(pins.cargo_tool_version(tool).unwrap(), expected, "{tool}");
         }
+    }
+
+    /// `ffmpeg-next` generates its bindings from the `FFmpeg` headers present on
+    /// the build host, so the crate version and the installed library are one
+    /// fact stated in three files: the formula the image installs, the
+    /// `PKG_CONFIG_PATH` that reaches it past the unversioned formula Homebrew
+    /// keeps upgrading, and the crate version itself. A disagreement surfaces
+    /// deep inside generated code — a missing `AV_CODEC_ID_V408`, or a match
+    /// that stopped being exhaustive — naming neither `FFmpeg` nor the pin.
+    #[test]
+    fn the_installed_ffmpeg_line_matches_the_crate_that_binds_to_it() {
+        let pins = CiPins::load(&workspace_root().join(PINS_PATH)).unwrap();
+        let line = pins
+            .brew_formulae
+            .iter()
+            .find_map(|formula| formula.strip_prefix("ffmpeg@"))
+            .expect("the pins install a versioned ffmpeg formula");
+
+        let cargo_config: toml::Value = toml::from_str(
+            &fs::read_to_string(workspace_root().join(".cargo/config.toml")).unwrap(),
+        )
+        .unwrap();
+        let search_path = cargo_config["env"]["PKG_CONFIG_PATH"].as_str().unwrap();
+        assert!(
+            search_path.contains(&format!("ffmpeg@{line}/")),
+            "PKG_CONFIG_PATH reaches an ffmpeg the image does not install: {search_path}"
+        );
+
+        let manifest: toml::Value =
+            toml::from_str(&fs::read_to_string(workspace_root().join("Cargo.toml")).unwrap())
+                .unwrap();
+        let declared = manifest["workspace"]["dependencies"]["ffmpeg-next"]
+            .as_str()
+            .unwrap();
+        assert_eq!(
+            declared.split('.').next().unwrap(),
+            line,
+            "ffmpeg-next {declared} binds to headers ffmpeg@{line} does not carry"
+        );
     }
 }


### PR DESCRIPTION
## Problem

`ffmpeg-next` generates its bindings from the FFmpeg headers found on the build host, so the crate version and the installed library state one fact. The pins named the unversioned Homebrew formula, which upgraded to FFmpeg 9 and left every build reaching `kithara-encode` failing inside generated code:

- cold `target` — `error[E0425]: cannot find value AV_CODEC_ID_V408`, plus `E0004` on a match that stopped being exhaustive;
- warm `target` — `ld: library 'avutil' not found`, from an absolute `-L` baked into a build script pointing at a Cellar directory the upgrade deleted.

Neither signature names FFmpeg. The commit hook runs `just lint fast`, so a machine that took the upgrade could not commit at all. Mac CI hosts install from this same list; only Linux has a pinned image.

## Change

Two consumers want different things from the name, and the pins now say so.

- The fixture tests shell out to the `ffmpeg` **binary** as a reference decoder (`tests/tests/kithara_decode/fixture_integration.rs`) and do not care which release decodes the file. The unversioned formula stays and keeps that binary on `PATH`.
- The encoder links the **library**. The list also installs the keg-only `ffmpeg@8`, and `.cargo/config.toml` puts it first on `PKG_CONFIG_PATH`.

`ffmpeg@8` is a line, not a patch: 8.1.3 and 8.1.4 still arrive on their own, FFmpeg 9 cannot. An absent prefix is skipped rather than fatal, which is what lets one value serve Apple silicon, Intel, and the Linux image alike, and Cargo does not force the key, so an exported `PKG_CONFIG_PATH` still wins.

A test cross-checks the three files that state the major — the formula, the search path, and the crate version — so a future bump fails by name instead of deep inside generated code.

## Validation

On a machine already carrying FFmpeg 9.0.1 as the linked formula, with no `PKG_CONFIG_PATH` in the environment:

- cold `cargo build -p kithara-test-fixtures` — finished in 8m39s;
- `just fmt check` — clean;
- `just lint fast` — `0 regression(s), 0 new across 36 check(s)`;
- `the_installed_ffmpeg_line_matches_the_crate_that_binds_to_it` — passes, and fails when either half of the change is reverted.

The test lives on the `tooling` lane, which no workflow runs, so it guards the developer doing the bump rather than CI. The cure itself does not depend on it: `.cargo/config.toml` applies to every build from this repository.