### PR TITLE
fix(ci): unbreak the feature, semver and style gates on main

### DIFF
--- a/.config/style/thresholds.toml
+++ b/.config/style/thresholds.toml
@@ -95,6 +95,7 @@ deny = 16000
 [doc_staleness]
 # Platform, upstream, and illustrative names the workspace sources never define.
 allow_terms = [
+  "CMAKE_BUILD_TYPE",
   "Constraints",
   "FuturesUnordered",
   "HTTPMaximumConnectionsPerHost",
@@ -103,9 +104,11 @@ allow_terms = [
   "LOOM_MAX_PREEMPTIONS",
   "LockFileEx",
   "MediaExtractor",
+  "MinSizeRel",
   "MpaDecoder",
   "MyFileAssetLayout",
   "MyHlsAssetLayout",
+  "OPT_LEVEL",
   "SetGlobalDefault",
   "StateFlow",
   "Stretcher",

--- a/.config/xtask.toml
+++ b/.config/xtask.toml
@@ -176,6 +176,20 @@ always = ["symphonia"]
 when_feature = "backend-cpal"
 always = ["backend-cpal"]
 
+# kithara-beat embeds one model and says so with compile_error!.
+# `embed-model` is the marker the three choices share; selected on its own it
+# names no bytes and the re-export it gates resolves to nothing.
+# `embed-full-int8-model` is quantized on a developer machine with onnxruntime
+# and the upstream release publishes only the unquantized model, so no runner
+# can produce its input. It costs no coverage to leave out: it compiles the
+# same `include_bytes!(env!(..))` arm `embed-full-model` does, and that one
+# resolves from the release. cargo-hack refuses a feature named by both lists,
+# so what stays mutually exclusive is what is still selectable.
+[[health.feature_invariants]]
+when_feature = "embed-model"
+never = ["embed-model", "embed-full-int8-model"]
+mutually_exclusive = [["embed-small-model", "embed-full-model"]]
+
 [stress]
 # One run, both clocks. The first collapses the fixtures' artificial
 # delays and is fast; the second keeps them and is the only one where a defect

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -14,65 +14,30 @@ the change that lands the work, and keep it short.
   reported deck scenario on a release build with the full model, and the size
   of the resume blob.
 
-- `SpectralBeats`, a beat detector needing no model, beside the neural one. It
-  searches the `Tempo` its caller hands it, and a build picks the model it
-  embeds; the cache tag names both. Left: nothing.
-
 - Harness and document revision. `AGENTS.md` routes instead of restating; the
   `style` namespace budgets documents with `doc_size`, blocks drift with
   `doc_staleness`, and holds every crate README to one shape with
-  `readme_shape`. All three queues are at zero.
-
-- Release optimization for every third-party package. `[profile.release]` sets
-  `opt-level = "z"` workspace-wide, and the `[profile.dev.package.*]` block right
-  above it is the repository's own list of what is too slow unoptimised - release
-  threw that list away, so both time-stretch backends, the AAC decoder and the
-  pure-Rust DSP all shipped compiled for size. `[profile.release.package."*"]`
-  now raises every non-workspace package to 3 (329 on wasm, 339 Apple, 405
-  Android, 708 workspace-wide); the workspace's own crates keep `"z"`. The
-  override moves each build script's `OPT_LEVEL`, which is what reaches native C
-  and C++. Captured A/B for `fdk-aac-sys`: 171 files, `-Oz` -> `-O3`, zero
-  crossover, `aacdecoder.cpp` among them. `bungee-sys` is partial by construction
-  - its `build.rs` reads `PROFILE`, not `OPT_LEVEL`, so CMake was already
-  building the vendored core `Release`.
-
-  Measured cost: `test-release` and `bench` inherit the overrides, so the
-  seventeen lanes on that profile pay ~+82% compile CPU (319 of 676 units move
-  from opt-level 0 to 3); the Apple release graph goes 476 -> 1105 CPU-seconds
-  (2.32x); `web-size` +42% CPU and dist 3137 -> 3565 KiB. `build-override` does
-  not beat the glob - verified in the unit graph - so build scripts cannot be
-  held back while the natives move.
-
-  Two side effects the glob cannot express. The `-Z build-std` sysroot is
-  non-workspace, so its codegen moves to 3 while `optimize_for_size` still
-  applies. And the TLS natives grow for nothing on symmetric crypto: their AES,
-  ChaCha20-Poly1305 and SHA kernels are assembly (123 assembled `.S` objects in
-  `btls-sys`, 98 in `aws-lc-sys`) that is byte-identical at `-Os` and `-O3`, so
-  BoringSSL `libcrypto` `__TEXT` +55% buys throughput nowhere. Named
-  `[profile.release.package.<name>]` entries beat the glob if they are pinned
-  back.
+  `readme_shape`. All three queues are at zero, and `just lint full` runs the
+  namespace on the Apple lint lane.
 
 ## Next
 
-- The workspace's own crates are still at `"z"` - `kithara-audio`, `-decode`,
-  `-resampler` and the rest carry the size setting a per-package glob cannot
-  reach. Raising them is a measured change of its own.
+- The workspace's own crates are still at `"z"` - a per-package glob reaches
+  every third-party package but not them, and raising them is a measured
+  change of its own.
+- No runtime number backs the release optimization. Decode throughput, stretch
+  cost and render-budget headroom were never measured before or after, so the
+  case rests on codegen rather than on a benchmark.
 - `crates/kithara-ffi/.wasm-slim.toml` budgets the wasm bundle at
   29000/31000/33000 KiB against a May baseline of ~28.2 MiB, while a local
   `dist` weighs 3565 KiB. Either the gate is an order of magnitude stale or the
   two numbers weigh different things; the `web-size` lane on GitLab is the only
-  place that settles it, and nothing here has run it.
-- No runtime number backs the optimization yet. Decode throughput, stretch cost
-  and render-budget headroom were never measured before or after, so the case
-  rests on codegen rather than on a benchmark.
-- Work the comment queue down by hand: `--fix` is exhausted for comments, so
-  all 668 are decisions (497 body comments, 105 long doc blocks, 50 oversized
-  inline comments, 16 dense functions).
+  place that settles it.
+- Work the comment queue down by hand: `--fix` is exhausted, so all 668
+  findings are decisions.
 - 439 ordering findings are mechanical; one `just lint style --fix` clears
   them but rewrites declarations across every crate, so it wants its own
   change.
-- Wire `just lint style` to a gate: nothing runs it today. A warm run is 58 s,
-  too much for every commit, nothing for a lane. The lane catalog owns that.
 
 ## Blocked
 

--- a/crates/kithara-devtools/src/common/project.rs
+++ b/crates/kithara-devtools/src/common/project.rs
@@ -323,7 +323,8 @@ pub struct FeatureInvariant {
     pub always: Vec<String>,
     /// Groups the powerset must pick from rather than leave empty.
     pub at_least_one_of: Vec<Vec<String>>,
-    /// Features no combination carries: a shared name that selects nothing.
+    /// Features no combination carries: a shared name that selects nothing,
+    /// or one whose input no runner can produce.
     pub never: Vec<String>,
     /// Groups the powerset must pick at most one member of.
     pub mutually_exclusive: Vec<Vec<String>>,

--- a/crates/kithara-devtools/src/semver.rs
+++ b/crates/kithara-devtools/src/semver.rs
@@ -67,8 +67,16 @@ fn packages_to_compare<'a>(
         .partition(|name| baseline_members.contains(*name))
 }
 
+/// The comparison, pinned to the default feature set.
+///
+/// Left alone, cargo-semver-checks turns on every feature whose name does not
+/// look experimental. The facade does not survive that: its beat backend names
+/// three models, the crate embeds one and refuses the rest with
+/// `compile_error!`, and one of the three needs bytes that are quantized on a
+/// developer machine. The surface this stage is about is the one a consumer
+/// gets from a plain dependency, and that is the default set.
 fn semver_args<'a>(baseline: &'a str, packages: &[&'a str]) -> Vec<&'a str> {
-    let mut args = vec!["semver-checks", "check-release"];
+    let mut args = vec!["semver-checks", "check-release", "--default-features"];
     for package in packages {
         args.extend(["--package", *package]);
     }
@@ -190,5 +198,15 @@ source = "git+https://github.com/example/firewheel#0000000"
                 .any(|pair| pair == ["--release-type", "minor"])
         );
         assert!(!args.contains(&"--workspace"));
+    }
+
+    /// The heuristic feature set enables everything that does not look
+    /// experimental, which for this facade means three mutually exclusive beat
+    /// models at once and a build that cannot resolve its own model bytes.
+    #[test]
+    fn semver_command_pins_the_default_feature_set() {
+        let args = semver_args("origin/main", &["kithara"]);
+
+        assert!(args.contains(&"--default-features"), "{args:?}");
     }
 }


### PR DESCRIPTION
`main` is red on three lanes that no product change can fix, because each one
is the tooling disagreeing with a crate about what a build can be. This is one
branch per cause.

## `deps-features`: the beat model choices are not a powerset

`kithara-beat` embeds exactly one model and enforces it with `compile_error!`.
The powerset walker did not know that, so it built combinations the crate
refuses.

`embed-model` is the marker the three choices share. Selected on its own it
names no bytes, and the re-export it gates resolves to nothing, so it is
`never` rather than a member of the group.

`embed-full-int8-model` is quantized on a developer machine with onnxruntime,
and the upstream release publishes only the unquantized model, so no runner can
produce its input. Leaving it out costs no coverage: it compiles the same
`include_bytes!(env!(..))` arm `embed-full-model` does, and that one resolves
from the release.

`cargo hack` refuses a feature named by both `--exclude-features` and
`--mutually-exclusive-features`, so what stays mutually exclusive is what is
still selectable: `embed-small-model` against `embed-full-model`.

The machinery for this already existed - `powerset.rs` has a test for exactly
this shape - it was simply never wired into the config.

## `deps-semver`: the heuristic feature set is not the published surface

Left alone, `cargo-semver-checks` turns on every feature whose name does not
look experimental. The facade does not survive that: it names three beat
models, the crate embeds one and refuses the rest, and one of the three needs
bytes no runner has. There is no `--exclude-features` on that tool.

The surface this stage is about is the one a consumer gets from a plain
dependency, so the comparison is pinned with `--default-features`.

## `apple:lint`: four deny-level style violations

`just lint full` runs the `style` namespace, and the ratchet fails on new
deny-level findings. There are four.

Three are `doc_staleness` on `docs/guides/performance/dispatch-build.md`:
`CMAKE_BUILD_TYPE`, `MinSizeRel` and `OPT_LEVEL`. None of them is stale - they
are CMake and Cargo build-script names that workspace sources never define,
which is what `allow_terms` exists for, alongside `LOOM_MAX_PREEMPTIONS` and
`LockFileEx`.

The fourth is `doc_size`: `PROGRESS.md` at 4324 bytes against a 4000 limit. It
had grown a landed change's full A/B measurements, which git already owns. The
file is back to intent - what is in flight, what is next, what is stuck - at
1991 bytes.

## Verification

- `just lint style`: `0 deny, 1311 warn, 0 regression(s), 0 new across 10
  check(s)`, exit 0. Before: `4 deny ... 4 new`, exit 1.
- `cargo hack` over the beat powerset: 13/13, exit 0.
- `kithara-devtools` unit tests on the tooling lane.

## Why the wasm lanes are red here

This branch is cut from `main`, which still calls `task::spawn_blocking` at
`crates/kithara-queue/src/queue/selection/apply.rs:39` with a `!Send` closure.
`linux-wasm`, `web-chromium` and `web-size` fail on that, not on anything in
this diff - the same `E0277` on `QueueControl<S>` each time. #310 fixes it and
is green. The two branches are red on exactly the lanes the other one fixes;
neither touches a file the other does, so the merge order does not matter.
