### PR TITLE
fix(ci): restore main push lanes

### DIFF
--- a/.config/xtask.toml
+++ b/.config/xtask.toml
@@ -176,6 +176,19 @@ always = ["symphonia"]
 when_feature = "backend-cpal"
 always = ["backend-cpal"]
 
+# `embed-model` is a derived feature with no model of its own. Model features
+# imply it and exclude each other, so the powerset must not select it directly.
+[[health.feature_invariants]]
+when_feature = "embed-model"
+never = ["embed-model"]
+mutually_exclusive = [
+  [
+    "embed-small-model",
+    "embed-full-model",
+    "embed-full-int8-model",
+  ],
+]
+
 [stress]
 # One run, both clocks. The first collapses the fixtures' artificial
 # delays and is fast; the second keeps them and is the only one where a defect

--- a/crates/kithara-devtools/src/semver.rs
+++ b/crates/kithara-devtools/src/semver.rs
@@ -68,7 +68,7 @@ fn packages_to_compare<'a>(
 }
 
 fn semver_args<'a>(baseline: &'a str, packages: &[&'a str]) -> Vec<&'a str> {
-    let mut args = vec!["semver-checks", "check-release"];
+    let mut args = vec!["semver-checks", "check-release", "--default-features"];
     for package in packages {
         args.extend(["--package", *package]);
     }
@@ -189,6 +189,7 @@ source = "git+https://github.com/example/firewheel#0000000"
             args.windows(2)
                 .any(|pair| pair == ["--release-type", "minor"])
         );
+        assert!(args.contains(&"--default-features"));
         assert!(!args.contains(&"--workspace"));
     }
 }

--- a/crates/kithara-platform/src/flash/tokio/task.rs
+++ b/crates/kithara-platform/src/flash/tokio/task.rs
@@ -7,6 +7,7 @@ pub use crate::flash::yield_now;
 use crate::{
     backend::tokio::{backend, runtime::Handle, task as native_task},
     flash::system::credit,
+    maybe_send::MaybeSend,
 };
 
 /// Spawn an async task. Under `flash` (native) the future is wrapped in the
@@ -95,6 +96,15 @@ where
             f()
         }
     })
+}
+
+/// Spawn synchronous work without blocking an async runtime worker.
+pub fn spawn_sync<F, R>(f: F) -> JoinHandle<R>
+where
+    F: FnOnce() -> R + MaybeSend + 'static,
+    R: MaybeSend + 'static,
+{
+    spawn_blocking(f)
 }
 
 /// Spawn a blocking computation on a specific runtime [`Handle`].

--- a/crates/kithara-platform/src/system/tokio/task.rs
+++ b/crates/kithara-platform/src/system/tokio/task.rs
@@ -2,6 +2,7 @@ use std::panic::Location;
 
 pub use super::backend::task::*;
 use super::runtime::Handle;
+use crate::maybe_send::MaybeSend;
 
 /// Spawn a future on the current runtime through the platform chokepoint.
 #[track_caller]
@@ -32,6 +33,15 @@ where
     R: Send + 'static,
 {
     super::backend::task::spawn_blocking(f)
+}
+
+/// Spawn synchronous work without blocking an async runtime worker.
+pub fn spawn_sync<F, R>(f: F) -> JoinHandle<R>
+where
+    F: FnOnce() -> R + MaybeSend + 'static,
+    R: MaybeSend + 'static,
+{
+    spawn_blocking(f)
 }
 
 /// Spawn a blocking computation on a specific runtime [`Handle`].

--- a/crates/kithara-platform/src/wasm/tokio/task.rs
+++ b/crates/kithara-platform/src/wasm/tokio/task.rs
@@ -8,6 +8,7 @@ use futures::channel::oneshot;
 
 pub use super::backend::task::*;
 use super::{backend::task as tww_task, runtime::Handle};
+use crate::maybe_send::MaybeSend;
 
 /// Forward a `tokio_with_wasm` JoinHandle into our own oneshot-backed
 /// channel, converting any tww join error into our cancelled `JoinError`.
@@ -69,6 +70,15 @@ where
     }
 
     JoinHandle { rx }
+}
+
+/// Spawn synchronous work after yielding the current async step.
+pub fn spawn_sync<F, T>(f: F) -> JoinHandle<T>
+where
+    F: FnOnce() -> T + MaybeSend + 'static,
+    T: MaybeSend + 'static,
+{
+    spawn(async move { f() })
 }
 
 /// Run a blocking closure on a dedicated Web Worker thread.

--- a/crates/kithara-queue/src/queue/selection/apply.rs
+++ b/crates/kithara-queue/src/queue/selection/apply.rs
@@ -36,7 +36,7 @@ where
                     return;
                 }
             };
-            drop(task::spawn_blocking(move || {
+            drop(task::spawn_sync(move || {
                 queue.apply_loaded(id, resource);
             }));
         }));


### PR DESCRIPTION
## Summary
Main push CI was failing in independent feature, semver, Flash, and Wasm paths. This fixes each failure at its owning layer: feature powersets no longer construct invalid embedded-model combinations, semver checks include default features, and queue selection delegates synchronous work to a platform-owned task primitive with target-correct implementations.

## Behavior / scope
- contract or behavior: feature powersets exclude the derived `embed-model` feature and keep embedded model variants mutually exclusive; semver checks pass `--default-features`; `kithara-platform` exposes `spawn_sync` for native, Flash, and Wasm task backends.
- affected area: CI feature configuration, semver tooling, platform task dispatch, and queue selection apply work.

## Validation
- `just fmt check`
- `cargo check -p kithara-queue`
- `cargo check -p kithara-queue --features kithara-platform/flash`
- `just platform wasm`
- `just deps semver`
- fork CI: exact-head run pending
- not run locally: full `just test`; hosted CI owns the complete lane matrix

## Surface impact
- Public API: changed: `kithara-platform` task modules add `spawn_sync`.
- Platform/runtime: changed: native and Flash use the blocking pool; Wasm defers synchronous work through the local async executor.
- Perf-sensitive paths: changed: queue selection apply work now uses the platform-owned synchronous dispatch primitive; native behavior remains on the blocking pool.

## Risks / follow-ups
- Exact-head fork CI and the explicit `deps-features` lane must pass before merge.