### PR TITLE
fix(queue): dispatch apply work through platform

### DIFF
--- a/crates/kithara-platform/src/flash/tokio/task.rs
+++ b/crates/kithara-platform/src/flash/tokio/task.rs
@@ -7,6 +7,7 @@ pub use crate::flash::yield_now;
 use crate::{
     backend::tokio::{backend, runtime::Handle, task as native_task},
     flash::system::credit,
+    maybe_send::MaybeSend,
 };
 
 /// Spawn an async task. Under `flash` (native) the future is wrapped in the
@@ -95,6 +96,15 @@ where
             f()
         }
     })
+}
+
+/// Spawn synchronous work without blocking an async runtime worker.
+pub fn spawn_sync<F, R>(f: F) -> JoinHandle<R>
+where
+    F: FnOnce() -> R + MaybeSend + 'static,
+    R: MaybeSend + 'static,
+{
+    spawn_blocking(f)
 }
 
 /// Spawn a blocking computation on a specific runtime [`Handle`].

--- a/crates/kithara-platform/src/system/tokio/task.rs
+++ b/crates/kithara-platform/src/system/tokio/task.rs
@@ -2,6 +2,7 @@ use std::panic::Location;
 
 pub use super::backend::task::*;
 use super::runtime::Handle;
+use crate::maybe_send::MaybeSend;
 
 /// Spawn a future on the current runtime through the platform chokepoint.
 #[track_caller]
@@ -32,6 +33,15 @@ where
     R: Send + 'static,
 {
     super::backend::task::spawn_blocking(f)
+}
+
+/// Spawn synchronous work without blocking an async runtime worker.
+pub fn spawn_sync<F, R>(f: F) -> JoinHandle<R>
+where
+    F: FnOnce() -> R + MaybeSend + 'static,
+    R: MaybeSend + 'static,
+{
+    spawn_blocking(f)
 }
 
 /// Spawn a blocking computation on a specific runtime [`Handle`].

--- a/crates/kithara-platform/src/wasm/tokio/task.rs
+++ b/crates/kithara-platform/src/wasm/tokio/task.rs
@@ -8,6 +8,7 @@ use futures::channel::oneshot;
 
 pub use super::backend::task::*;
 use super::{backend::task as tww_task, runtime::Handle};
+use crate::maybe_send::MaybeSend;
 
 /// Forward a `tokio_with_wasm` JoinHandle into our own oneshot-backed
 /// channel, converting any tww join error into our cancelled `JoinError`.
@@ -47,6 +48,15 @@ where
     }
 
     JoinHandle { rx }
+}
+
+/// Spawn synchronous work after yielding the current async step.
+pub fn spawn_sync<F, T>(f: F) -> JoinHandle<T>
+where
+    F: FnOnce() -> T + MaybeSend + 'static,
+    T: MaybeSend + 'static,
+{
+    spawn(async move { f() })
 }
 
 /// Run a blocking closure on a dedicated Web Worker thread.

--- a/crates/kithara-queue/src/queue/selection/apply.rs
+++ b/crates/kithara-queue/src/queue/selection/apply.rs
@@ -36,7 +36,7 @@ where
                     return;
                 }
             };
-            drop(task::spawn_blocking(move || {
+            drop(task::spawn_sync(move || {
                 queue.apply_loaded(id, resource);
             }));
         }));


### PR DESCRIPTION
## Summary
Queue selection applied loaded resources through `spawn_blocking`, which requires `Send` and has no valid Wasm-local equivalent. This moves that choice into `kithara-platform`: native and Flash retain blocking-pool execution, while Wasm defers the synchronous apply step on its local async executor. The queue remains target-agnostic and the Flash and Wasm CI paths can compile the same call site.

## Behavior / scope
- contract or behavior: `kithara-platform::tokio::task` adds `spawn_sync`; native and Flash delegate to their existing blocking pool, while Wasm schedules the closure after yielding the current async step.
- affected area: platform task dispatch and queue selection resource application.

## Validation
- `cargo fmt -p kithara-platform -- --check`
- `cargo fmt -p kithara-queue -- --check`
- `cargo clippy -p kithara-platform -p kithara-queue -- -D warnings`
- `cargo check -p kithara-queue --features kithara-platform/flash`
- `just platform wasm`
- commit hook: passed
- exact-head fork CI: [run 34029919978](https://github.com/gerasim13/kithara/actions/runs/34029919978) queued on the shared runner
- explicit `deps-features`: [run 34029951871](https://github.com/gerasim13/kithara/actions/runs/34029951871) queued on the shared runner
- not run locally: full `just test`; hosted CI owns the complete lane matrix

## Surface impact
- Public API: changed: platform task modules add `spawn_sync`.
- Platform/runtime: changed: native and Flash use the blocking pool; Wasm defers synchronous work through the local async executor.
- Perf-sensitive paths: changed: queue selection apply work now uses the platform-owned synchronous dispatch primitive; native behavior remains on the blocking pool.

## Risks / follow-ups
- The two queued hosted runs must pass before merge.