### PR TITLE
fix(ci): take the guest's qemu from the machine's profile

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -8,6 +8,14 @@ the change that lands the work, and keep it short.
 
 ## In Flight
 
+- The Windows guest asks the machine's profile where `qemu` is. Both binaries
+  it launches were absolute paths into one Homebrew prefix, so a host whose
+  Homebrew answers elsewhere could not start the guest, and the error named
+  neither `qemu` nor the prefix. `CiHost::brew_root` already owns that answer
+  and fifteen other tools already go through it. The guard that kept the build
+  configuration from writing a prefix down now reads the executor's sources as
+  well, so the class cannot come back through Rust.
+
 - Mac CI host cleanup. The host spent a day refusing jobs for space while its
   hourly pass was gone: the agent hung inside `opendir` on a volume that had
   stopped answering, and launchd starts no second instance while the first is

--- a/xtask/src/ci/config/pins.rs
+++ b/xtask/src/ci/config/pins.rs
@@ -250,6 +250,8 @@ fn is_sha256(value: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use super::*;
     use crate::ci::config::profile::workspace_root;
 
@@ -315,31 +317,80 @@ mod tests {
     /// A package manager's prefix is machine state: Homebrew answers
     /// `/opt/homebrew` on Apple silicon, `/usr/local` on Intel and
     /// `/home/linuxbrew/.linuxbrew` on Linux, and an install built by hand
-    /// answers none of them. The files that configure a build therefore ask
-    /// the machine where a library lives and never write the answer down,
-    /// because a written one only holds on the machine it was copied from.
+    /// answers none of them. Whoever needs an installed tool therefore asks
+    /// where it lives and never writes the answer down, because a written one
+    /// only holds on the machine it was copied from. The build configuration
+    /// asks the package manager; the executor asks `CiHost::brew_root`, the
+    /// field the machine's own profile fills in.
     #[test]
-    fn the_build_configuration_asks_for_prefixes_instead_of_declaring_them() {
-        const DECLARED: [&str; 3] = ["/opt/homebrew", "/usr/local/opt", "linuxbrew"];
+    fn nothing_writes_down_a_package_managers_prefix() {
+        const DECLARED: [&str; 5] = [
+            "/opt/homebrew",
+            "/usr/local/opt",
+            "/usr/local/Cellar",
+            "linuxbrew",
+            "/opt/local/bin",
+        ];
 
         let root = workspace_root();
-        let mut configs = vec![root.join(".cargo/config.toml"), root.join("justfile")];
+        let mut sources = vec![root.join(".cargo/config.toml"), root.join("justfile")];
         for entry in fs::read_dir(root.join(".config/just")).unwrap() {
             let path = entry.unwrap().path();
             if path.extension().is_some_and(|kind| kind == "just") {
-                configs.push(path);
+                sources.push(path);
             }
         }
+        sources.extend(executor_sources(&root.join("xtask/src")));
 
-        for config in configs {
-            let text = fs::read_to_string(&config).unwrap();
+        for source in sources {
+            let text = fs::read_to_string(&source).unwrap();
             for prefix in DECLARED {
                 assert!(
-                    !text.contains(prefix),
+                    !production_text(&source, &text).contains(prefix),
                     "{} writes down {prefix}, which is only one machine's answer",
-                    config.display()
+                    source.display()
                 );
             }
         }
+    }
+
+    /// Every `.rs` under the executor, including the modules a `#[path]`
+    /// attribute pulls in from a file of their own.
+    fn executor_sources(directory: &Path) -> Vec<PathBuf> {
+        let mut sources = Vec::new();
+        for entry in fs::read_dir(directory).unwrap() {
+            let path = entry.unwrap().path();
+            if path.is_dir() {
+                sources.extend(executor_sources(&path));
+            } else if path.extension().is_some_and(|kind| kind == "rs") {
+                sources.push(path);
+            }
+        }
+        sources
+    }
+
+    /// A test states the answer one machine gave, which is its job: the mac
+    /// fixture says `/opt/homebrew` and the launch agents built from it are
+    /// asserted against that. So the claim is about production text, and a
+    /// module's tests are its tail, from `#[cfg(test)] mod tests` to the end
+    /// of the file. A test module living in a file of its own is named for it.
+    fn production_text(source: &Path, text: &str) -> String {
+        if source
+            .file_stem()
+            .is_some_and(|stem| stem.to_string_lossy().ends_with("_tests"))
+        {
+            return String::new();
+        }
+        let lines: Vec<&str> = text.lines().collect();
+        let tail = lines.iter().enumerate().find_map(|(index, line)| {
+            let opens_tests = lines
+                .get(index + 1..)
+                .unwrap_or_default()
+                .iter()
+                .find(|next| !next.starts_with("#["))
+                .is_some_and(|next| next.starts_with("mod tests"));
+            (*line == "#[cfg(test)]" && opens_tests).then_some(index)
+        });
+        lines[..tail.unwrap_or(lines.len())].join("\n")
     }
 }

--- a/xtask/src/ci/host/windows.rs
+++ b/xtask/src/ci/host/windows.rs
@@ -28,13 +28,12 @@ pub(super) enum Boot {
 pub(super) struct WindowsHost<'a> {
     guest: &'a WindowsGuest,
     root: PathBuf,
+    qemu: PathBuf,
+    qemu_img: PathBuf,
     process: &'a Process,
 }
 
 impl<'a> WindowsHost<'a> {
-    const QEMU: &'static str = "/opt/homebrew/bin/qemu-system-aarch64";
-    const QEMU_IMG: &'static str = "/opt/homebrew/bin/qemu-img";
-
     pub(super) fn new(config: &'a CiConfig, process: &'a Process) -> Result<Self> {
         let guest = config
             .host
@@ -44,6 +43,8 @@ impl<'a> WindowsHost<'a> {
         Ok(Self {
             guest,
             root: config.host.host_root.join("vm/windows"),
+            qemu: config.host.brew_tool("qemu-system-aarch64"),
+            qemu_img: config.host.brew_tool("qemu-img"),
             process,
         })
     }
@@ -66,7 +67,7 @@ impl<'a> WindowsHost<'a> {
             return Ok(());
         }
         self.process.run(
-            Self::QEMU_IMG,
+            &self.qemu_img.display().to_string(),
             &[
                 "create",
                 "-f",
@@ -181,18 +182,12 @@ impl<'a> WindowsHost<'a> {
         }
         let owned = self.boot_arguments(boot);
         let arguments: Vec<&str> = owned.iter().map(String::as_str).collect();
-        self.process
-            .run(Self::QEMU, &arguments, "start the Windows guest")?;
+        self.process.run(
+            &self.qemu.display().to_string(),
+            &arguments,
+            "start the Windows guest",
+        )?;
         Ok(())
-    }
-
-    #[cfg(test)]
-    fn for_test(guest: &'a WindowsGuest, root: &Path, process: &'a Process) -> Self {
-        Self {
-            guest,
-            root: root.to_path_buf(),
-            process,
-        }
     }
 }
 
@@ -201,20 +196,49 @@ mod tests {
     use std::collections::BTreeMap;
 
     use super::*;
+    use crate::ci::config::fixture;
 
-    fn guest() -> WindowsGuest {
-        WindowsGuest {
+    /// The tracked fixture describes a mac without a Windows guest, because
+    /// the guest is the one part of a machine profile most hosts do not have.
+    fn config() -> CiConfig {
+        let mut config = fixture();
+        config.host.windows = Some(WindowsGuest {
             vcpus: 4,
             memory_mib: 8192,
             data_disk_gib: 80,
-        }
+        });
+        config
+    }
+
+    fn process() -> Process {
+        Process::new(Path::new("/Volumes/KitharaCI"), BTreeMap::new())
     }
 
     fn arguments(boot: Boot) -> Vec<String> {
-        let guest = guest();
-        let process = Process::new(Path::new("/Volumes/CI"), BTreeMap::new());
-        WindowsHost::for_test(&guest, Path::new("/Volumes/CI/vm/windows"), &process)
+        let config = config();
+        let process = process();
+        WindowsHost::new(&config, &process)
+            .expect("the profile describes a Windows guest")
             .boot_arguments(boot)
+    }
+
+    /// `qemu` is installed by Homebrew, whose prefix is machine state: the
+    /// default on Apple silicon is `/opt/homebrew`, but a host is free to
+    /// answer elsewhere and the profile is where it says so. Writing one
+    /// machine's answer into this file would leave the guest unstartable on
+    /// every other, with an error naming neither `qemu` nor the prefix.
+    #[test]
+    fn the_guest_boots_the_qemu_its_profile_points_at() {
+        let mut config = config();
+        config.host.brew_root = PathBuf::from("/opt/elsewhere");
+        let process = process();
+        let host = WindowsHost::new(&config, &process).expect("the profile describes a guest");
+
+        assert_eq!(
+            host.qemu,
+            Path::new("/opt/elsewhere/bin/qemu-system-aarch64")
+        );
+        assert_eq!(host.qemu_img, Path::new("/opt/elsewhere/bin/qemu-img"));
     }
 
     /// The page file and `TEMP` are what grow the system image, and Windows
@@ -222,11 +246,9 @@ mod tests {
     /// image the host cannot shrink in place.
     #[test]
     fn what_the_guest_writes_lands_on_a_disk_of_its_own() {
-        assert!(
-            arguments(Boot::Installed)
-                .iter()
-                .any(|argument| { argument.contains("file=/Volumes/CI/vm/windows/data.qcow2") })
-        );
+        assert!(arguments(Boot::Installed).iter().any(|argument| {
+            argument.contains("file=/Volumes/KitharaCI/vm/windows/data.qcow2")
+        }));
     }
 
     /// Without it a guest that deletes a file keeps the blocks forever, which


### PR DESCRIPTION
`WindowsHost` launched `qemu-system-aarch64` and `qemu-img` through absolute paths into one Homebrew prefix:

```rust
const QEMU: &'static str = "/opt/homebrew/bin/qemu-system-aarch64";
const QEMU_IMG: &'static str = "/opt/homebrew/bin/qemu-img";
```

A mac whose Homebrew answers elsewhere could not start the Windows guest at all, and the failure named neither `qemu` nor the prefix — `Process::run` reports the step's label, so the operator reads `failed to start create the Windows guest's data disk: No such file or directory`. `start` calls `ensure_data_disk` first, so `qemu-img` broke before `qemu` did.

## The owner already exists

`CiHost::brew_root` is the machine profile's own answer to where Homebrew put things, and it is the field `agent_path` composes a launch agent's `PATH` from. Fifteen production call sites already reach their binary through `brew_tool` — `brew`, `docker`, `tart`, `colima`, `limactl`, `gitlab-runner`. The two constants were a second, unreviewable source of truth for a question the profile already answers, and `WindowsHost::new` was holding the config that carries it.

The constructor now resolves both binaries there. Dropping the constants also drops `for_test`: the tests build the host the way the executor does — the tracked fixture with a guest attached — so there is one construction path instead of two, and `the_guest_boots_the_qemu_its_profile_points_at` proves a profile pointing elsewhere is followed.

## The class, not the instance

`the_build_configuration_asks_for_prefixes_instead_of_declaring_them` already refused a package manager's prefix in `.cargo/config.toml`, the `justfile` and the `just` recipes. It did not read Rust, which is how these two constants survived it. It now reads the executor's sources as well and is renamed for the wider claim: `nothing_writes_down_a_package_managers_prefix`.

A source file's tests are its tail, and a test that states the answer one machine gave is doing its job — the mac fixture says `/opt/homebrew` and the launch agents built from it are asserted against exactly that. So the check reads what comes before `#[cfg(test)] mod tests`, and treats a `#[path]` module's own file as test text.

Verified by relapse: reinstating a prefix in production text fails the test with the file and prefix named.

## Validation

- `cargo test -p xtask --profile test-release` — the `windows` and `pins` modules, 11 passed.
- `just lint fast` — `18 deny, 1828 warn, 0 regression(s), 0 new across 36 check(s)`.
