### PR TITLE
fix(ci): read the Homebrew prefix off brew instead of running it

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -8,13 +8,11 @@ the change that lands the work, and keep it short.
 
 ## In Flight
 
-- The Windows guest asks the machine's profile where `qemu` is. Both binaries
-  it launches were absolute paths into one Homebrew prefix, so a host whose
-  Homebrew answers elsewhere could not start the guest, and the error named
-  neither `qemu` nor the prefix. `CiHost::brew_root` already owns that answer
-  and fifteen other tools already go through it. The guard that kept the build
-  configuration from writing a prefix down now reads the executor's sources as
-  well, so the class cannot come back through Rust.
+- Where the machine keeps its tools is asked, not written down, and asking is
+  cheap. `CiHost::brew_root` answers for the executor, `qemu` included. The
+  root `justfile` ran `brew --prefix`, which `just` evaluates before it knows
+  the recipe, so every nested invocation a test drove waited on it; it reads
+  the prefix off where `brew` sits now. A guard holds each half.
 
 - Mac CI host cleanup. The host spent a day refusing jobs for space while its
   hourly pass was gone: the agent hung inside `opendir` on a volume that had

--- a/justfile
+++ b/justfile
@@ -8,15 +8,20 @@ export RUSTC_WRAPPER := sccache
 # Where this machine keeps the FFmpeg line the workspace binds to. `ffmpeg-next`
 # generates its bindings from the headers pkg-config finds, so a host whose
 # unversioned FFmpeg has moved on has to reach the keg-only formula
-# `.config/ci-pins.toml` installs before it. The prefix is asked of the package
-# manager instead of written down, because it belongs to the machine and differs
-# between them; without brew, or without the formula, this is empty and the
-# machine's own search path stands alone. `xtask` cannot own this: it is itself
-# a cargo build that would need the answer before it could run.
+# `.config/ci-pins.toml` installs before it. Both halves belong to the machine
+# and are read off it: the line from the pins, the prefix from where `brew`
+# itself sits. Nothing here runs the package manager, because `just` evaluates
+# every variable before it knows which recipe was asked for, so this is on the
+# clock of every invocation including the nested ones a test drives. A keg the
+# machine does not have leaves this empty and its own search path stands alone.
+# `xtask` cannot own this: it is itself a cargo build that would need the answer
+# before it could run.
 export PKG_CONFIG_PATH := ```
-    formula=$(grep -om1 'ffmpeg@[0-9][0-9]*' .config/ci-pins.toml || true)
-    prefix=$(command -v brew >/dev/null 2>&1 && brew --prefix "${formula:-none}" 2>/dev/null || true)
-    printf '%s' "${prefix:+$prefix/lib/pkgconfig}:${PKG_CONFIG_PATH:-}" | sed 's/^://; s/:$//'
+    formula=$(grep -om1 'ffmpeg@[0-9][0-9]*' .config/ci-pins.toml 2>/dev/null || true)
+    brew=$(command -v brew || true)
+    keg="${brew%/bin/brew}/opt/$formula/lib/pkgconfig"
+    [ -n "$brew" ] && [ -n "$formula" ] && [ -d "$keg" ] || keg=
+    printf '%s' "$keg:${PKG_CONFIG_PATH:-}" | sed 's/^://; s/:$//'
 ```
 
 # sccache refuses incremental compilations, so a wrapper without this is never

--- a/xtask/src/ci/config/pins.rs
+++ b/xtask/src/ci/config/pins.rs
@@ -354,6 +354,68 @@ mod tests {
         }
     }
 
+    /// `just` evaluates every assignment before it knows which recipe was
+    /// asked for, so a backtick assignment is on the clock of every
+    /// invocation, the nested ones a test drives included. It may therefore
+    /// read what is already on the machine, but never spawn a program that
+    /// machine might answer slowly or not have at all: `brew --prefix` cost
+    /// the public-runner test its whole timeout budget.
+    #[test]
+    fn no_assignment_in_the_command_surface_spawns_a_program() {
+        const READS_THE_MACHINE: [&str; 7] =
+            ["[", "command", "grep", "printf", "sed", "test", "true"];
+
+        let justfile = fs::read_to_string(workspace_root().join("justfile")).unwrap();
+        for command in assigned_commands(&justfile) {
+            assert!(
+                READS_THE_MACHINE.contains(&command.as_str()),
+                "an assignment spawns `{command}`, which every invocation then waits for"
+            );
+        }
+    }
+
+    /// The leading word of every command a backtick assignment runs. Words
+    /// carrying an `=` are the assignment's own locals, not programs.
+    fn assigned_commands(justfile: &str) -> Vec<String> {
+        let mut scripts = Vec::new();
+        let mut lines = justfile.lines();
+        while let Some(line) = lines.next() {
+            let Some((_, value)) = line.split_once(":=") else {
+                continue;
+            };
+            if let Some(opened) = value.trim().strip_prefix("```") {
+                scripts.push(opened.to_owned());
+                scripts.extend(
+                    lines
+                        .by_ref()
+                        .take_while(|line| !line.contains("```"))
+                        .map(str::to_owned),
+                );
+            } else if let Some(opened) = value.trim().strip_prefix('`') {
+                scripts.push(opened.trim_end_matches('`').to_owned());
+            }
+        }
+
+        scripts
+            .iter()
+            .map(|script| {
+                script
+                    .replace("&&", "\n")
+                    .replace("||", "\n")
+                    .replace("$(", "\n")
+                    .replace(['|', '(', ')'], "\n")
+            })
+            .flat_map(|script| {
+                script
+                    .lines()
+                    .filter_map(|command| command.split_whitespace().next())
+                    .filter(|word| !word.contains('='))
+                    .map(str::to_owned)
+                    .collect::<Vec<_>>()
+            })
+            .collect()
+    }
+
     /// Every `.rs` under the executor, including the modules a `#[path]`
     /// attribute pulls in from a file of their own.
     fn executor_sources(directory: &Path) -> Vec<PathBuf> {


### PR DESCRIPTION
## What

`just` evaluates every variable assignment before it knows which recipe was
asked for, so the assignment is on the clock of every invocation — including
the nested ones `ci_public_just_runner_holds_the_build_target_before_xtask`
drives through its fixture repository. The root `justfile` spent that clock on
`brew --prefix "$formula"`.

In this repository that costs 0.096 s. In the fixture, which has no
`.config/ci-pins.toml`, the formula is empty and `brew --prefix none` misses and
costs **0.831 s** — on every nested call. The test spent its whole budget
waiting for the runner's `ready` file and failed on bare `main`:

```
Error: timed out waiting for /var/folders/.../ready
test ci_public_just_runner_holds_the_build_target_before_xtask ... FAILED (10.38s)
```

## The fix

The package manager was never needed for the answer. A keg-only formula lives at
`<prefix>/opt/<formula>`, and the prefix is the parent of the directory `brew`
itself sits in, so `${brew%/bin/brew}` reads it with no fork at all: **0.028 s**
against 0.096, and the miss disappears entirely because a keg the machine does
not have simply has no directory to find.

Nothing is written down. The FFmpeg line still comes from
`.config/ci-pins.toml`, the prefix still comes from wherever `brew` actually is
on `PATH`, and the resulting value is byte-identical
(`/opt/homebrew/opt/ffmpeg@8/lib/pkgconfig`). Verified on three shapes: with
Homebrew present, with no `brew` on `PATH` (empty, exit 0), and in a repository
without the pins file (empty, exit 0, 0.074 s).

## The class

`no_assignment_in_the_command_surface_spawns_a_program` reads the leading word
of every command the root `justfile`'s backtick assignments run and refuses
anything outside the handful that only read what is already on the machine.
Restoring the old call fails it:

```
an assignment spawns `brew`, which every invocation then waits for
```

## PROGRESS.md

`PROGRESS.md` was 4139 bytes against a `doc_size` deny of 4000, so `just lint
style` was already red on `main` — `summary: 1 deny, 1312 warn, 0
regression(s), 1 new`. The entry replaced here described the same class through
the executor. The file is 3995 bytes now and the ratchet reports `0 deny, 1313
warn, 0 regression(s), 0 new`.

## Evidence

- `cargo test -p xtask --profile test-release --test self_cache_runner` — 18
  passed, 0 failed; the target test in 1.71 s.
- `cargo test -p xtask --profile test-release --bin xtask -- ci::config::pins` —
  5 passed, 0 failed.
- `cargo fmt -p xtask -- --check` — clean.
- `just lint style` — `0 deny, 1313 warn, 0 regression(s), 0 new across 10
  check(s)`, exit 0.
- `just lint fast` — passed through the commit hook.
