### PR TITLE
feat(analysis): compute the waveform and beat grid in the browser

### DIFF
--- a/.config/just/platform.just
+++ b/.config/just/platform.just
@@ -20,6 +20,8 @@ wasm MODE="check" *ARGS:
         done
         cargo "+$toolchain" check -p kithara-beat --target wasm32-unknown-unknown --features dsp
         cargo "+$toolchain" check -p kithara-decode --target wasm32-unknown-unknown --no-default-features --features symphonia,webcodecs,client-reqwest,tls-rustls
+        cargo "+$toolchain" check -p kithara-analysis --target wasm32-unknown-unknown --no-default-features --features analysis-waveform,beat-dsp,client-reqwest,tls-rustls,symphonia,webcodecs
+        cargo "+$toolchain" check -p kithara-play --target wasm32-unknown-unknown --no-default-features --features symphonia,webcodecs,resample-rubato,client-reqwest,tls-rustls
         cargo "+$toolchain" check -p kithara-ffi --target wasm32-unknown-unknown --features wasm --no-default-features
         ;;
       build)

--- a/.config/just/test.just
+++ b/.config/just/test.just
@@ -78,6 +78,19 @@ wasm BROWSER="chrome" SUITE="all":
       -Z build-std-features=optimize_for_size \
       -p kithara-ffi --test web-observer --no-default-features \
       --features wasm
+    WASM_BINDGEN_TEST_TIMEOUT=300 WASM_BINDGEN_USE_BROWSER=1 \
+      cargo "+$toolchain" test --profile test-release \
+      --target wasm32-unknown-unknown \
+      -Z build-std=std,panic_abort,core,alloc \
+      -Z build-std-features=optimize_for_size \
+      -p kithara-worker --lib
+    WASM_BINDGEN_TEST_TIMEOUT=300 WASM_BINDGEN_USE_BROWSER=1 \
+      cargo "+$toolchain" test --profile test-release \
+      --target wasm32-unknown-unknown \
+      -Z build-std=std,panic_abort,core,alloc \
+      -Z build-std-features=optimize_for_size \
+      -p kithara-analysis --lib --no-default-features \
+      --features analysis-waveform,beat-dsp,client-reqwest,tls-rustls,symphonia,webcodecs
     if [[ "$suite" == "all" ]]; then
       # The integration browser tests live in `suite_heavy`. Building the whole
       # crate for wasm compiles every native suite too, and those reach for

--- a/.config/just/test.just
+++ b/.config/just/test.just
@@ -91,6 +91,13 @@ wasm BROWSER="chrome" SUITE="all":
       -Z build-std-features=optimize_for_size \
       -p kithara-analysis --lib --no-default-features \
       --features analysis-waveform,beat-dsp,client-reqwest,tls-rustls,symphonia,webcodecs
+    WASM_BINDGEN_TEST_TIMEOUT=300 WASM_BINDGEN_USE_BROWSER=1 \
+      cargo "+$toolchain" test --profile test-release \
+      --target wasm32-unknown-unknown \
+      -Z build-std=std,panic_abort,core,alloc \
+      -Z build-std-features=optimize_for_size \
+      -p kithara-ffi --test web-analysis --no-default-features \
+      --features wasm
     if [[ "$suite" == "all" ]]; then
       # The integration browser tests live in `suite_heavy`. Building the whole
       # crate for wasm compiles every native suite too, and those reach for

--- a/.config/xtask.toml
+++ b/.config/xtask.toml
@@ -1048,9 +1048,8 @@ kinds_github = ["main", "branch"]
 timeout_minutes = 60
 
 # Nightly here, not on the push gate: the full integration suite does not
-# compile for wasm32 today - `Queue` is not `Send` because `Box<dyn AudioReader>`
-# is not, and `BeatGrid` demands it. The lane reports the break every night
-# instead of refusing every push until the type is fixed.
+# compile for wasm32 today. The lane reports the break every night instead of
+# refusing every push until the suite is fixed.
 [ext.ci.lanes.web-firefox]
 cache_group = "linux"
 label = "Web browser"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5034,6 +5034,7 @@ dependencies = [
  "jni 0.22.4",
  "js-sys",
  "kithara",
+ "kithara-test-fixtures",
  "kithara-test-macros",
  "kithara-test-utils",
  "ndk-context",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5711,6 +5711,7 @@ dependencies = [
  "serde_yaml_ng",
  "thiserror 2.0.18",
  "tracing",
+ "wasm-bindgen-test",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4682,6 +4682,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "unimock",
+ "wasm-bindgen-test",
 ]
 
 [[package]]

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -41,28 +41,12 @@ the change that lands the work, and keep it short.
 
 - `suite_network` has been dark since `#260`; the handover census found it.
 
-- `kithara-analysis` compiles for `wasm32`. The worker's compute seam submits
-  an admitted job to a spawned thread there, under one owned-pool configuration
-  shared with the native Rayon backend, so beat detection has a path off the
-  dispatcher thread in the browser. `just platform wasm check` covers
-  `kithara-analysis` and `kithara-play`, and `just test wasm` carries the
-  `kithara-worker` and `kithara-analysis` library tests; both pass in Safari,
-  2 of 2 and 190 of 190. A test driving the pass itself waits on the compute
-  job with an `await`: a browser runs a spawned thread only while the context
-  that spawned it keeps taking events.
-
-- The browser FFI computes track analysis. `kithara-ffi`'s wasm arm enables
-  `analysis-waveform` and `beat-dsp`; `AudioPlayer.analyze(trackId)` starts a
-  pass and `AudioPlayer.setAnalysisObserver(fn)` receives every publication as
-  one plain object with the waveform and beat grid as copied typed arrays.
-  One pass is live per track; analysing again begins a new revision sequence
-  and the pass it replaces falls silent. Web warm-up creates the audio context
-  at the session's own rate, and a built resource config carries the playback
-  worker, so the analysis reader opens. The `/signal` route serves a 126 BPM
-  click track. In Safari the pass covers all 30 s and settles in about 2.5 s;
-  `web-analysis` is 1 of 2. Left: the browser detector answers with an empty
-  grid, while the beat analyzer and the DSP detector are green there on
-  synthetic clicks.
+- `kithara-analysis` builds and runs its pass on `wasm32`: the worker's compute
+  seam spawns a thread per admitted job under the `OwnedPoolConfig` the native
+  Rayon backend takes. `kithara-ffi --features wasm` exposes
+  `AudioPlayer.analyze(trackId)` and `AudioPlayer.setAnalysisObserver(fn)`; a
+  publication is one plain object with waveform and beat grid as copied typed
+  arrays, one pass live per track, under `just platform wasm check`.
 
 ## Next
 
@@ -78,4 +62,17 @@ the change that lands the work, and keep it short.
 
 ## Blocked
 
-- Nothing.
+- Open defect, its own `kithara-analysis` task: a browser MP3 decodes from
+  frame 1105, the LAME delay, while `prepare_detection` places windows on the
+  global hop grid, `release_detected` drops the unread head, and `beat_state()`
+  compares coverage against `Runs::taken`, which grows on intake, not on read.
+  On `MP3_CLICKS126_30S` a pass publishes `settled=true, beats=0` in 4 of 6
+  Safari runs, so `web-analysis` asserts the field set, the waveform and
+  `beats >= 0`. The native scheduler opens runs the same way on a mid-gap
+  seek, uncaught by any native test.
+
+- Flake: one Safari run in five of `kithara-analysis --lib` fails in
+  `tests::worker::a_pass_publishes_above_the_revision_its_caller_holds` with
+  `Out of bounds memory access` in `Node::cancel` at teardown. Unconfirmed:
+  `wasm_safe_thread` 0.1.1 decrements `exit_state` in three JS handlers
+  without a once-guard while kithara drops the `JoinHandle` at spawn.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -46,7 +46,10 @@ the change that lands the work, and keep it short.
   shared with the native Rayon backend, so beat detection has a path off the
   dispatcher thread in the browser. `just platform wasm check` covers
   `kithara-analysis` and `kithara-play`, and `just test wasm` carries the
-  `kithara-worker` and `kithara-analysis` library tests.
+  `kithara-worker` and `kithara-analysis` library tests; both pass in Safari,
+  2 of 2 and 190 of 190. A test driving the pass itself waits on the compute
+  job with an `await`: a browser runs a spawned thread only while the context
+  that spawned it keeps taking events.
 
 - The browser FFI computes track analysis. `kithara-ffi`'s wasm arm enables
   `analysis-waveform` and `beat-dsp`; `AudioPlayer.analyze(trackId)` starts a

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -46,10 +46,20 @@ the change that lands the work, and keep it short.
   shared with the native Rayon backend, so beat detection has a path off the
   dispatcher thread in the browser. `just platform wasm check` covers
   `kithara-analysis` and `kithara-play`, and `just test wasm` carries the
-  `kithara-worker` and `kithara-analysis` library tests. Left: the FFI surface,
-  and a browser run of that lane -- Safari's driver is killed by the runner on
-  this machine and chromedriver is not installable here, so no browser
-  execution of these tests has been observed.
+  `kithara-worker` and `kithara-analysis` library tests.
+
+- The browser FFI computes track analysis. `kithara-ffi`'s wasm arm enables
+  `analysis-waveform` and `beat-dsp`; `AudioPlayer.analyze(trackId)` starts a
+  pass and `AudioPlayer.setAnalysisObserver(fn)` receives every publication as
+  one plain object with the waveform and beat grid as copied typed arrays.
+  One pass is live per track; analysing again begins a new revision sequence
+  and the pass it replaces falls silent. Web warm-up creates the audio context
+  at the session's own rate, and a built resource config carries the playback
+  worker, so the analysis reader opens. The `/signal` route serves a 126 BPM
+  click track. In Safari the pass covers all 30 s and settles in about 2.5 s;
+  `web-analysis` is 1 of 2. Left: the browser detector answers with an empty
+  grid, while the beat analyzer and the DSP detector are green there on
+  synthetic clicks.
 
 ## Next
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -41,6 +41,16 @@ the change that lands the work, and keep it short.
 
 - `suite_network` has been dark since `#260`; the handover census found it.
 
+- `kithara-analysis` compiles for `wasm32`. The worker's compute seam submits
+  an admitted job to a spawned thread there, under one owned-pool configuration
+  shared with the native Rayon backend, so beat detection has a path off the
+  dispatcher thread in the browser. `just platform wasm check` covers
+  `kithara-analysis` and `kithara-play`, and `just test wasm` carries the
+  `kithara-worker` and `kithara-analysis` library tests. Left: the FFI surface,
+  and a browser run of that lane -- Safari's driver is killed by the runner on
+  this machine and chromedriver is not installable here, so no browser
+  execution of these tests has been observed.
+
 ## Next
 
 - 678 comment findings are decisions `--fix` cannot make.

--- a/crates/kithara-analysis/CONTEXT.md
+++ b/crates/kithara-analysis/CONTEXT.md
@@ -178,14 +178,14 @@ grid-cleanup scratch stay as guards for the pass lifetime; no lower component
 constructs or stores another pool facade.
 
 `AnalysisWorker` owns one `kithara-worker` dispatcher and admits every pass as a
-separate `AnalysisNode<B, S>` task (absent on wasm32). `AnalysisWorkerConfig`
-carries the analyzer builder, parent cancellation, optional shared base `Worker`,
-dispatcher capacity and budgets, per-pass priority, and per-pass compute budget.
-Without a supplied base it creates and retains a standalone base worker. With a
-supplied base, analysis cancellation is OR-composed only onto its dispatcher, so
-it cannot cancel sibling domain dispatchers. The backend and pool-schema types
-are consumed by `new` and stay inside the task factory rather than leaking into
-the handle.
+separate `AnalysisNode<B, S>` task. `AnalysisWorkerConfig` carries the analyzer
+builder, parent cancellation, optional shared base `Worker`, dispatcher capacity
+and budgets, per-pass priority, and per-pass compute budget. Without a supplied
+base it creates and retains a standalone base worker. With a supplied base,
+analysis cancellation is OR-composed only onto its dispatcher, so it cannot
+cancel sibling domain dispatchers. The backend and pool-schema types are
+consumed by `new` and stay inside the task factory rather than leaking into the
+handle.
 
 `open` gives every pass a child of the analysis scope; task admission folds that
 pass token into the dispatcher's derived task token. Callers may clone it for the

--- a/crates/kithara-analysis/Cargo.toml
+++ b/crates/kithara-analysis/Cargo.toml
@@ -73,5 +73,8 @@ unimock = { workspace = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 serde_yaml_ng = { workspace = true }
 
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/kithara-analysis/Cargo.toml
+++ b/crates/kithara-analysis/Cargo.toml
@@ -34,34 +34,31 @@ webcodecs = ["kithara-audio/webcodecs"]
 fdk-aac = ["kithara-audio/fdk-aac"]
 
 [dependencies]
+kithara-audio = { workspace = true, default-features = false }
+kithara-beat = { workspace = true, optional = true }
 kithara-bufpool = { workspace = true }
 kithara-macros = { workspace = true }
 kithara-platform = { workspace = true }
+kithara-resampler = { workspace = true, default-features = false }
 kithara-signal = { workspace = true }
+kithara-test-utils = { workspace = true }
+kithara-worker = { workspace = true }
 
 bon = { workspace = true }
 bytes = { workspace = true }
 delegate = { workspace = true }
+derive_more = { workspace = true }
 fieldwork = { workspace = true }
 num-traits = { workspace = true }
-thiserror = { workspace = true }
-
-[target.'cfg(all(not(target_arch = "wasm32"), not(target_os = "android")))'.dependencies]
-kithara-workspace-hack = { version = "0.0.1-alpha4", path = "../kithara-workspace-hack" }
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-kithara-audio = { workspace = true, default-features = false }
-kithara-beat = { workspace = true, optional = true }
-kithara-resampler = { workspace = true, default-features = false }
-kithara-test-utils = { workspace = true }
-kithara-worker = { workspace = true }
-
-derive_more = { workspace = true }
 realfft = { workspace = true, optional = true }
 ringbuf = { workspace = true }
 serde = { workspace = true }
+thiserror = { workspace = true }
 tracing = { workspace = true }
 unimock = { workspace = true, optional = true }
+
+[target.'cfg(all(not(target_arch = "wasm32"), not(target_os = "android")))'.dependencies]
+kithara-workspace-hack = { version = "0.0.1-alpha4", path = "../kithara-workspace-hack" }
 
 [dev-dependencies]
 kithara-bufpool = { workspace = true, features = ["test-utils"] }

--- a/crates/kithara-analysis/src/analyzer/session.rs
+++ b/crates/kithara-analysis/src/analyzer/session.rs
@@ -26,12 +26,15 @@ pub(crate) enum Ingest {
     ForeignRate,
 }
 
+#[derive(fieldwork::Fieldwork)]
+#[fieldwork(opt_in, get)]
 pub(crate) struct TrackAnalyzers<B, S>
 where
     B: ResamplerBackend,
 {
     pub(super) fingerprint: AnalysisFingerprint,
     pub(super) token: AnalysisToken,
+    #[field(get, vis = "pub(crate)")]
     pub(super) coverage: Coverage,
     pub(super) source_sample_rate: NonZeroU32,
     pub(super) pools: PoolRegion<S>,
@@ -62,11 +65,6 @@ where
         } else {
             BeatState::Provisional
         }
-    }
-
-    #[cfg(not(target_arch = "wasm32"))]
-    pub(crate) const fn coverage(&self) -> &Coverage {
-        &self.coverage
     }
 
     pub(crate) fn covered_frames(&self) -> u64 {
@@ -200,7 +198,6 @@ where
         Ok(())
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) const fn settle(&mut self) {
         self.settled = true;
     }
@@ -236,7 +233,6 @@ where
     delegate::delegate! {
         to self.beat {
             pub(crate) fn apply_detection(&mut self, output: beat::DetectOutput);
-            #[cfg(not(target_arch = "wasm32"))]
             #[call(intake)]
             pub(crate) fn beat_intake(&self) -> Intake;
         }

--- a/crates/kithara-analysis/src/archive/mod.rs
+++ b/crates/kithara-analysis/src/archive/mod.rs
@@ -2,12 +2,7 @@ mod error;
 mod file;
 mod update;
 
-#[cfg(all(
-    test,
-    not(target_arch = "wasm32"),
-    feature = "analysis-beat",
-    feature = "analysis-waveform"
-))]
+#[cfg(all(test, feature = "analysis-beat", feature = "analysis-waveform"))]
 mod resume_tests;
 #[cfg(test)]
 mod tests;

--- a/crates/kithara-analysis/src/artifact/beat.rs
+++ b/crates/kithara-analysis/src/artifact/beat.rs
@@ -76,7 +76,7 @@ impl BeatArtifact {
         Self::with_regions(bpm, beats, downbeats, Vec::new())
     }
 
-    #[cfg(any(test, all(not(target_arch = "wasm32"), feature = "analysis-beat")))]
+    #[cfg(any(test, feature = "analysis-beat"))]
     pub(crate) fn regions(&self) -> &[FitRegion] {
         &self.regions
     }

--- a/crates/kithara-analysis/src/artifact/mod.rs
+++ b/crates/kithara-analysis/src/artifact/mod.rs
@@ -3,9 +3,9 @@ mod snapshot;
 mod track;
 
 pub use beat::BeatArtifact;
-#[cfg(any(test, all(not(target_arch = "wasm32"), feature = "analysis-beat")))]
+#[cfg(any(test, feature = "analysis-beat"))]
 pub(crate) use beat::FitRegion;
-#[cfg(all(not(target_arch = "wasm32"), feature = "analysis-beat"))]
+#[cfg(feature = "analysis-beat")]
 pub(crate) use beat::MarkedBeat;
 pub use snapshot::{BeatSnapshot, BeatState};
 pub use track::{AnalysisFingerprint, AnalysisToken, TrackAnalysis};

--- a/crates/kithara-analysis/src/lib.rs
+++ b/crates/kithara-analysis/src/lib.rs
@@ -2,31 +2,27 @@
 
 #![forbid(unsafe_code)]
 
-#[cfg(not(target_arch = "wasm32"))]
 mod analyzer;
 mod archive;
 mod artifact;
-#[cfg(all(not(target_arch = "wasm32"), feature = "analysis-beat"))]
+#[cfg(feature = "analysis-beat")]
 pub(crate) mod beat;
 mod blob;
 mod coverage;
-#[cfg(not(target_arch = "wasm32"))]
 mod model;
-#[cfg(not(target_arch = "wasm32"))]
-mod native;
-#[cfg(not(target_arch = "wasm32"))]
 pub(crate) mod producer;
 mod progress;
-#[cfg(not(target_arch = "wasm32"))]
 mod slots;
 #[cfg(test)]
 pub(crate) use kithara_bufpool::testing as test_pools;
-#[cfg(all(test, not(target_arch = "wasm32")))]
+#[cfg(test)]
 mod tests;
 mod waveform;
-#[cfg(not(target_arch = "wasm32"))]
 mod worker;
 
+pub use analyzer::{
+    AnalyzerBuilder, BeatAnalysisConfig, BeatAnalysisConfigPatch, BeatAnalysisConfigPatchError,
+};
 pub use archive::{
     AnalysisFile, AnalysisFileError, AnalysisFilePatch, AnalysisFileSpec, AnalysisFileUpdate,
     AnalysisFileWrite,
@@ -36,7 +32,9 @@ pub use artifact::{
 };
 pub use blob::frame::BlobError;
 pub use coverage::{Coverage, FrameRange};
-#[cfg(not(target_arch = "wasm32"))]
-pub use native::*;
+pub use producer::AnalysisProducer;
 pub use progress::AnalysisProgress;
+#[cfg(feature = "analysis-waveform")]
+pub use waveform::WaveformAnalyzer;
 pub use waveform::{AnalysisParams, Bucket, bucket::Waveform};
+pub use worker::{AnalysisOpen, AnalysisPass, AnalysisWorker, AnalysisWorkerConfig};

--- a/crates/kithara-analysis/src/native.rs
+++ b/crates/kithara-analysis/src/native.rs
@@ -1,9 +1,0 @@
-#[cfg(feature = "analysis-waveform")]
-pub use crate::waveform::WaveformAnalyzer;
-pub use crate::{
-    analyzer::{
-        AnalyzerBuilder, BeatAnalysisConfig, BeatAnalysisConfigPatch, BeatAnalysisConfigPatchError,
-    },
-    producer::AnalysisProducer,
-    worker::{AnalysisOpen, AnalysisPass, AnalysisWorker, AnalysisWorkerConfig},
-};

--- a/crates/kithara-analysis/src/progress.rs
+++ b/crates/kithara-analysis/src/progress.rs
@@ -339,7 +339,7 @@ impl BeatResume {
     }
 }
 
-#[cfg(all(not(target_arch = "wasm32"), feature = "analysis-waveform"))]
+#[cfg(feature = "analysis-waveform")]
 pub(crate) fn write_coverage(writer: &mut Writer<'_>, coverage: &Coverage) {
     writer.write_len(coverage.runs().len());
     for range in coverage.runs() {
@@ -348,7 +348,7 @@ pub(crate) fn write_coverage(writer: &mut Writer<'_>, coverage: &Coverage) {
     }
 }
 
-#[cfg(all(not(target_arch = "wasm32"), feature = "analysis-waveform"))]
+#[cfg(feature = "analysis-waveform")]
 pub(crate) fn write_samples(writer: &mut Writer<'_>, samples: &[f32]) {
     writer.write_len(samples.len());
     for sample in samples {

--- a/crates/kithara-analysis/src/tests/fixtures.rs
+++ b/crates/kithara-analysis/src/tests/fixtures.rs
@@ -220,7 +220,6 @@ impl FakeReader {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 pub(super) fn idle_ingest() -> crate::producer::ring::Reader {
     crate::producer::ring::open_for(spec().sample_rate).1
 }

--- a/crates/kithara-analysis/src/tests/mod.rs
+++ b/crates/kithara-analysis/src/tests/mod.rs
@@ -14,5 +14,5 @@ mod schedule;
     feature = "beat-backend"
 ))]
 mod track;
-#[cfg(all(not(target_arch = "wasm32"), feature = "analysis-waveform"))]
+#[cfg(feature = "analysis-waveform")]
 mod worker;

--- a/crates/kithara-analysis/src/tests/node.rs
+++ b/crates/kithara-analysis/src/tests/node.rs
@@ -29,8 +29,8 @@ use kithara_test_utils::kithara;
 #[cfg(all(feature = "analysis-beat", feature = "analysis-waveform"))]
 use kithara_worker::TaskContext;
 use kithara_worker::{
-    Dispatcher, DispatcherConfig, PendingTask, RayonConfig, Task, TaskConfig, TickResult, Worker,
-    WorkerConfig,
+    Dispatcher, DispatcherConfig, OwnedPoolConfig, PendingTask, Task, TaskConfig, TickResult,
+    Worker, WorkerConfig,
 };
 #[cfg(feature = "analysis-beat")]
 use num_traits::cast::ToPrimitive;
@@ -118,7 +118,7 @@ where
         let worker = Worker::new(
             WorkerConfig::new()
                 .with_max_compute_tasks(compute_tasks)
-                .with_owned_pool(RayonConfig::new(compute_tasks, "analysis-node-test")),
+                .with_owned_pool(OwnedPoolConfig::new(compute_tasks, "analysis-node-test")),
         );
         let dispatcher = worker.dispatcher(
             DispatcherConfig::builder()

--- a/crates/kithara-analysis/src/tests/node.rs
+++ b/crates/kithara-analysis/src/tests/node.rs
@@ -11,11 +11,13 @@ use kithara_platform::sync::{
     Mutex,
     atomic::{AtomicUsize, Ordering},
 };
-use kithara_platform::{CancelToken, sync::mpsc, tokio::sync::watch};
 #[cfg(all(feature = "analysis-beat", feature = "analysis-waveform"))]
+use kithara_platform::thread;
 use kithara_platform::{
-    thread,
-    time::{Duration, Instant},
+    CancelToken,
+    sync::mpsc,
+    time::{self, Duration, Instant},
+    tokio::sync::watch,
 };
 #[cfg(feature = "analysis-waveform")]
 use kithara_resampler::NoResamplerBackend;
@@ -754,7 +756,7 @@ fn offers_out_of_order_cover_their_union() {
     );
 }
 
-fn stages<B, S>(
+async fn stages<B, S>(
     reader: Box<dyn AudioReader>,
     builder: AnalyzerBuilder<B, S>,
     cancel: &CancelToken,
@@ -778,8 +780,22 @@ where
     .expect("analysis node accepts the test job");
     let mut node = NodeHarness::new(builder, receiver);
     let mut out = Vec::new();
-    for _ in 0..128 {
-        let _ = node.tick();
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let mut remaining = 128;
+    loop {
+        assert!(
+            remaining > 0,
+            "the node spent its whole tick budget without ending"
+        );
+        match node.tick() {
+            TickResult::Backpressured if Instant::now() < deadline => {
+                time::sleep(Duration::ZERO).await;
+            }
+            TickResult::Backpressured => {
+                panic!("the node waits on work of its own past its deadline")
+            }
+            _ => remaining -= 1,
+        }
         match results.has_changed() {
             Ok(true) => {
                 if let Some(analysis) = take_analysis(&mut results) {
@@ -800,7 +816,7 @@ where
 
 #[cfg(feature = "analysis-waveform")]
 #[kithara::test]
-fn matches_direct_waveform_analyzer_over_chunked_stream() {
+async fn matches_direct_waveform_analyzer_over_chunked_stream() {
     let samples = sine(usize::try_from(SR).unwrap());
     let frames = u64::try_from(samples.len() / usize::from(CH)).unwrap_or(0);
     let builder = waveform_only();
@@ -813,7 +829,7 @@ fn matches_direct_waveform_analyzer_over_chunked_stream() {
     let want = direct.snapshot(BUCKETS, Some(frames));
 
     let reader = Box::new(FakeReader::chunked(&pools, &samples, 4));
-    let out = stages(reader, builder, &CancelToken::root());
+    let out = stages(reader, builder, &CancelToken::root()).await;
     let [.., before_last, last] = out.as_slice() else {
         panic!("the end of reading publishes, then the settled final: {out:?}");
     };
@@ -835,27 +851,27 @@ fn matches_direct_waveform_analyzer_over_chunked_stream() {
 
 #[cfg(feature = "analysis-waveform")]
 #[kithara::test]
-fn cancelled_token_yields_none() {
+async fn cancelled_token_yields_none() {
     let builder = waveform_only();
     let cancel = CancelToken::root();
     cancel.cancel();
     let reader = Box::new(FakeReader::chunked(builder.pools(), &sine(4096), 2));
-    assert!(stages(reader, builder, &cancel).is_empty());
+    assert!(stages(reader, builder, &cancel).await.is_empty());
 }
 
 #[cfg(feature = "analysis-waveform")]
 #[kithara::test]
-fn decode_error_yields_none() {
+async fn decode_error_yields_none() {
     let reader = Box::new(FakeReader::failing());
-    let out = stages(reader, waveform_only(), &CancelToken::root());
+    let out = stages(reader, waveform_only(), &CancelToken::root()).await;
     assert!(out.is_empty());
 }
 
 #[cfg(feature = "analysis-waveform")]
 #[kithara::test]
-fn empty_stream_yields_none() {
+async fn empty_stream_yields_none() {
     let reader = Box::new(FakeReader::empty());
-    let out = stages(reader, waveform_only(), &CancelToken::root());
+    let out = stages(reader, waveform_only(), &CancelToken::root()).await;
     assert!(out.is_empty(), "EOF with no chunks is not an analysis");
 }
 
@@ -1228,7 +1244,7 @@ fn producer_drain_limit_bounds_one_tick() {
 
 #[cfg(feature = "analysis-beat")]
 #[kithara::test]
-fn beat_slot_fills_the_beat_grid() {
+async fn beat_slot_fills_the_beat_grid() {
     let raw = RawBeats {
         beats: Vec::new(),
         downbeats: (0..9u8).map(|n| BeatMark::at(f32::from(n) * 2.0)).collect(),
@@ -1247,7 +1263,7 @@ fn beat_slot_fills_the_beat_grid() {
         &sine(17 * usize::try_from(SR).unwrap()),
         3,
     ));
-    let out = stages(reader, builder, &CancelToken::root());
+    let out = stages(reader, builder, &CancelToken::root()).await;
     assert!(
         out.len() >= 2,
         "17 s of source outlives one publication interval, got {} publication(s)",
@@ -1331,7 +1347,7 @@ fn beat_slot_fills_the_beat_grid() {
 
 #[cfg(feature = "analysis-waveform")]
 #[kithara::test]
-fn pending_is_tolerated_mid_stream() {
+async fn pending_is_tolerated_mid_stream() {
     let builder = waveform_only();
     let samples = sine(8192);
     let reader = Box::new(FakeReader::chunked_with_pending(
@@ -1339,7 +1355,7 @@ fn pending_is_tolerated_mid_stream() {
         &samples,
         2,
     ));
-    let out = stages(reader, builder, &CancelToken::root());
+    let out = stages(reader, builder, &CancelToken::root()).await;
     assert!(
         out.last().is_some_and(|last| last.waveform().is_some()),
         "the final publication carries the waveform: {out:?}"

--- a/crates/kithara-analysis/src/tests/schedule.rs
+++ b/crates/kithara-analysis/src/tests/schedule.rs
@@ -8,8 +8,7 @@ use kithara_events::EventBus;
 use kithara_platform::{
     CancelToken,
     sync::{Arc, Mutex, mpsc},
-    thread,
-    time::{Duration, Instant},
+    time::{self, Duration, Instant},
     tokio::sync::watch,
 };
 use kithara_resampler::{NoResamplerBackend, ResamplerBackend};
@@ -285,12 +284,14 @@ where
         self.log.lock().clone()
     }
 
-    fn drive(&mut self, ticks: usize) -> bool {
+    async fn drive(&mut self, ticks: usize) -> bool {
         let deadline = Instant::now() + Duration::from_secs(2);
         let mut remaining = ticks;
         while remaining > 0 && !self.has_ended() {
             match self.node.tick() {
-                TickResult::Backpressured if Instant::now() < deadline => thread::yield_now(),
+                TickResult::Backpressured if Instant::now() < deadline => {
+                    time::sleep(Duration::ZERO).await;
+                }
                 TickResult::Backpressured => return false,
                 _ => remaining -= 1,
             }
@@ -392,12 +393,12 @@ fn run_lengths(calls: &[Call]) -> Vec<usize> {
 }
 
 #[kithara::test]
-fn a_scheduled_pass_seeks_before_it_decodes_anything() {
+async fn a_scheduled_pass_seeks_before_it_decodes_anything() {
     let mut pass = Pass::open(
         Source::new(Consts::EXTENT),
         scheduled(Consts::WINDOW_SECONDS),
     );
-    pass.drive(2);
+    pass.drive(2).await;
 
     // Four fixed one-second chunks start with chunk one, the midpoint of the
     // first half of the track.
@@ -413,7 +414,7 @@ fn a_scheduled_pass_seeks_before_it_decodes_anything() {
 }
 
 #[kithara::test]
-fn a_growing_duration_replaces_the_one_the_schedule_had() {
+async fn a_growing_duration_replaces_the_one_the_schedule_had() {
     // The source holds twice what it first reports, the way a decode path
     // refines a duration upward as it learns more.
     let short = Consts::EXTENT / 2;
@@ -423,14 +424,14 @@ fn a_growing_duration_replaces_the_one_the_schedule_had() {
             .refining(),
         scheduled(Consts::WINDOW_SECONDS),
     );
-    pass.drive(2);
+    pass.drive(2).await;
     assert_eq!(
         targets(&pass.calls()),
         vec![0],
         "the first run is a fixed chunk inside the length reported so far"
     );
 
-    assert!(pass.drive(Consts::TICKS), "the pass ends");
+    assert!(pass.drive(Consts::TICKS).await, "the pass ends");
     assert!(
         pass.analysis().coverage().frontier() > short,
         "a larger report must be planned against, not the cached one"
@@ -438,13 +439,13 @@ fn a_growing_duration_replaces_the_one_the_schedule_had() {
 }
 
 #[kithara::test]
-fn a_run_starts_where_the_seek_landed_before_the_next_progressive_chunk() {
+async fn a_run_starts_where_the_seek_landed_before_the_next_progressive_chunk() {
     const SNAP: u64 = 30_000;
     let mut pass = Pass::open(
         Source::new(Consts::EXTENT).snapping(SNAP),
         scheduled(Consts::WINDOW_SECONDS),
     );
-    pass.drive(8);
+    pass.drive(8).await;
 
     let calls = pass.calls();
     assert_eq!(
@@ -462,18 +463,18 @@ fn a_run_starts_where_the_seek_landed_before_the_next_progressive_chunk() {
 
     // The first fixed chunk touched its identity even though the seek landed
     // earlier, so the second half's fixed identity is next.
-    pass.drive(Consts::TICKS);
+    pass.drive(Consts::TICKS).await;
     let next = targets(&pass.calls()).get(1).copied().unwrap_or(0);
     assert_eq!(next, 132_300);
 }
 
 #[kithara::test]
-fn covering_a_track_costs_the_runs_its_chunk_divides_it_into() {
+async fn covering_a_track_costs_the_runs_its_chunk_divides_it_into() {
     let mut pass = Pass::open(
         Source::new(Consts::EXTENT),
         scheduled(Consts::WINDOW_SECONDS),
     );
-    assert!(pass.drive(Consts::TICKS), "the pass ends");
+    assert!(pass.drive(Consts::TICKS).await, "the pass ends");
 
     let analysis = pass.analysis();
     assert!(
@@ -491,24 +492,24 @@ fn covering_a_track_costs_the_runs_its_chunk_divides_it_into() {
 }
 
 #[kithara::test]
-fn a_run_length_is_independent_of_the_detector_window() {
-    let lengths = |seconds: u32| {
+async fn a_run_length_is_independent_of_the_detector_window() {
+    let lengths = async |seconds: u32| {
         let mut pass = Pass::open(Source::new(Consts::EXTENT), scheduled(seconds));
-        pass.drive(64);
+        pass.drive(64).await;
         run_lengths(&pass.calls()).first().copied().unwrap_or(0)
     };
 
     // The configured one-second schedule chunk is five decoder chunks.
-    assert_eq!(lengths(1), 5, "a run carries one schedule chunk");
+    assert_eq!(lengths(1).await, 5, "a run carries one schedule chunk");
     assert_eq!(
-        lengths(2),
+        lengths(2).await,
         5,
         "changing the detector window does not change scheduling"
     );
 }
 
 #[kithara::test]
-fn a_covered_opening_is_not_decoded_a_second_time() {
+async fn a_covered_opening_is_not_decoded_a_second_time() {
     let covered = Consts::EXTENT / 2;
     let mut pass = Pass::open(
         Source::new(Consts::EXTENT),
@@ -516,7 +517,7 @@ fn a_covered_opening_is_not_decoded_a_second_time() {
     );
     pass.offer(0, covered);
 
-    assert!(pass.drive(Consts::TICKS), "the pass ends");
+    assert!(pass.drive(Consts::TICKS).await, "the pass ends");
     let decoded = decoded_at(&pass.calls());
     assert!(!decoded.is_empty(), "the rest of the track is decoded");
     assert!(
@@ -533,13 +534,13 @@ fn a_covered_opening_is_not_decoded_a_second_time() {
 }
 
 #[kithara::test]
-fn a_source_with_no_length_is_decoded_in_order() {
+async fn a_source_with_no_length_is_decoded_in_order() {
     let mut pass = Pass::open(
         Source::new(Consts::EXTENT).reporting(None),
         scheduled(Consts::WINDOW_SECONDS),
     );
 
-    assert!(pass.drive(Consts::TICKS), "the pass ends");
+    assert!(pass.drive(Consts::TICKS).await, "the pass ends");
     let calls = pass.calls();
     assert!(
         targets(&calls).is_empty(),
@@ -554,7 +555,7 @@ fn a_source_with_no_length_is_decoded_in_order() {
 }
 
 #[kithara::test]
-fn a_pass_ends_when_a_producer_covers_the_last_of_it() {
+async fn a_pass_ends_when_a_producer_covers_the_last_of_it() {
     // The reader never delivers, so everything covered came from the
     // producer and nothing can have reached end of stream.
     let mut pass = Pass::open(
@@ -562,11 +563,11 @@ fn a_pass_ends_when_a_producer_covers_the_last_of_it() {
         scheduled(Consts::WINDOW_SECONDS),
     );
     pass.offer(0, Consts::EXTENT / 2);
-    pass.drive(8);
+    pass.drive(8).await;
     assert!(!pass.has_ended(), "half a track is not a finished pass");
 
     pass.offer(Consts::EXTENT / 2, Consts::EXTENT / 2);
-    assert!(pass.drive(Consts::TICKS), "the pass ends on its own");
+    assert!(pass.drive(Consts::TICKS).await, "the pass ends on its own");
 
     let analysis = pass.analysis();
     assert!(
@@ -580,7 +581,7 @@ fn a_pass_ends_when_a_producer_covers_the_last_of_it() {
 }
 
 #[kithara::test]
-fn a_source_that_over_reports_its_length_still_ends() {
+async fn a_source_that_over_reports_its_length_still_ends() {
     // Reports four seconds, holds two.
     let held = Consts::EXTENT / 2;
     let mut pass = Pass::open(
@@ -589,7 +590,7 @@ fn a_source_that_over_reports_its_length_still_ends() {
     );
 
     assert!(
-        pass.drive(Consts::TICKS),
+        pass.drive(Consts::TICKS).await,
         "a length that cannot be covered must not hold a pass open"
     );
     let analysis = pass.analysis();
@@ -604,10 +605,10 @@ fn a_source_that_over_reports_its_length_still_ends() {
 }
 
 #[kithara::test]
-fn a_snapshot_published_early_describes_the_whole_track() {
+async fn a_snapshot_published_early_describes_the_whole_track() {
     const EXTENT: u64 = 20 * 44_100;
     let mut pass = Pass::open(Source::new(EXTENT), scheduled(Consts::WINDOW_SECONDS));
-    pass.drive(40);
+    pass.drive(40).await;
     assert!(!pass.has_ended(), "the pass must still be decoding");
 
     let analysis = pass.analysis();
@@ -632,7 +633,7 @@ fn a_snapshot_published_early_describes_the_whole_track() {
 }
 
 #[kithara::test]
-fn a_snapping_source_has_its_gaps_closed_rather_than_halved() {
+async fn a_snapping_source_has_its_gaps_closed_rather_than_halved() {
     // Seeks land on whole 30 000 frames, so a run aimed at a gap's start
     // begins in covered audio and has to read through it to get there.
     let mut pass = Pass::open(
@@ -640,7 +641,7 @@ fn a_snapping_source_has_its_gaps_closed_rather_than_halved() {
         scheduled(Consts::WINDOW_SECONDS),
     );
 
-    assert!(pass.drive(Consts::TICKS), "the pass ends");
+    assert!(pass.drive(Consts::TICKS).await, "the pass ends");
     let analysis = pass.analysis();
     assert!(
         analysis.is_complete(),
@@ -655,7 +656,7 @@ fn a_snapping_source_has_its_gaps_closed_rather_than_halved() {
 }
 
 #[kithara::test]
-fn a_source_that_snaps_out_of_its_own_gaps_still_finishes() {
+async fn a_source_that_snaps_out_of_its_own_gaps_still_finishes() {
     // Seeks land on whole 88 200 frames, so the two gaps left between them
     // are further from a landing than a run is long: the run spends its
     // chunk on covered audio and never reaches them. Each such position
@@ -666,7 +667,7 @@ fn a_source_that_snaps_out_of_its_own_gaps_still_finishes() {
     );
 
     assert!(
-        pass.drive(Consts::TICKS),
+        pass.drive(Consts::TICKS).await,
         "a pass that cannot reach a gap must end rather than keep asking"
     );
     let analysis = pass.analysis();
@@ -683,13 +684,13 @@ fn a_source_that_snaps_out_of_its_own_gaps_still_finishes() {
 }
 
 #[kithara::test]
-fn a_head_the_source_cannot_reach_is_retired_after_one_chunk() {
+async fn a_head_the_source_cannot_reach_is_retired_after_one_chunk() {
     const FLOOR: u64 = 1000;
     let mut pass = Pass::open(
         Source::new(Consts::EXTENT).flooring(FLOOR),
         scheduled(Consts::WINDOW_SECONDS),
     );
-    assert!(pass.drive(Consts::TICKS), "the pass ends");
+    assert!(pass.drive(Consts::TICKS).await, "the pass ends");
 
     assert_eq!(
         pass.analysis().missing(),
@@ -705,13 +706,13 @@ fn a_head_the_source_cannot_reach_is_retired_after_one_chunk() {
 }
 
 #[kithara::test]
-fn a_pass_with_nothing_left_to_reach_is_settled() {
+async fn a_pass_with_nothing_left_to_reach_is_settled() {
     const FLOOR: u64 = 1000;
     let mut pass = Pass::open(
         Source::new(Consts::EXTENT).flooring(FLOOR),
         scheduled(Consts::WINDOW_SECONDS),
     );
-    assert!(pass.drive(Consts::TICKS), "the pass ends");
+    assert!(pass.drive(Consts::TICKS).await, "the pass ends");
 
     let analysis = pass.analysis();
     assert!(
@@ -725,12 +726,15 @@ fn a_pass_with_nothing_left_to_reach_is_settled() {
 }
 
 #[kithara::test]
-fn a_pass_its_reader_cut_short_is_not_settled() {
+async fn a_pass_its_reader_cut_short_is_not_settled() {
     let mut pass = Pass::open(
         Source::new(Consts::EXTENT).failing_after(3),
         scheduled(Consts::WINDOW_SECONDS),
     );
-    assert!(pass.drive(Consts::TICKS), "the failed reader ends the pass");
+    assert!(
+        pass.drive(Consts::TICKS).await,
+        "the failed reader ends the pass"
+    );
 
     assert!(
         !pass.analysis().is_settled(),
@@ -739,14 +743,14 @@ fn a_pass_its_reader_cut_short_is_not_settled() {
 }
 
 #[kithara::test]
-fn a_pass_that_gave_up_still_reports_what_it_never_reached() {
+async fn a_pass_that_gave_up_still_reports_what_it_never_reached() {
     // Seeks land on whole 88 200 frames, so the schedule retires positions
     // it cannot reach and ends with the track only partly covered.
     let mut pass = Pass::open(
         Source::new(Consts::EXTENT).snapping(88_200),
         scheduled(Consts::WINDOW_SECONDS),
     );
-    assert!(pass.drive(Consts::TICKS), "the pass ends");
+    assert!(pass.drive(Consts::TICKS).await, "the pass ends");
 
     let analysis = pass.analysis();
     let covered = analysis.coverage().frames();
@@ -813,13 +817,13 @@ fn a_producer_does_not_keep_an_unreachable_position_alive() {
 }
 
 #[kithara::test]
-fn a_decode_error_still_publishes_what_the_pass_covered() {
+async fn a_decode_error_still_publishes_what_the_pass_covered() {
     let mut pass = Pass::open(
         Source::new(Consts::EXTENT).failing_after(3),
         scheduled(Consts::WINDOW_SECONDS),
     );
     assert!(
-        pass.drive(Consts::TICKS),
+        pass.drive(Consts::TICKS).await,
         "a reader that failed ends the pass"
     );
 
@@ -835,7 +839,7 @@ fn a_decode_error_still_publishes_what_the_pass_covered() {
 }
 
 #[kithara::test]
-fn a_run_is_measured_from_where_it_decoded_not_where_it_asked() {
+async fn a_run_is_measured_from_where_it_decoded_not_where_it_asked() {
     // The readers this runs against answer a seek with the position they
     // were asked for while the decoder resumes at a boundary of its own, so
     // a run sized against the seek's answer outlasts its chunk.
@@ -843,7 +847,7 @@ fn a_run_is_measured_from_where_it_decoded_not_where_it_asked() {
         Source::new(Consts::EXTENT).snapping(30_000).echoing(),
         scheduled(Consts::WINDOW_SECONDS),
     );
-    assert!(pass.drive(Consts::TICKS), "the pass ends");
+    assert!(pass.drive(Consts::TICKS).await, "the pass ends");
 
     let lengths = run_lengths(&pass.calls());
     // A one-second schedule chunk is five decoder chunks.
@@ -902,13 +906,13 @@ mod artifacts {
             .with_beat_detector(beat_detector(), GridParams::default())
     }
 
-    fn covered(source: Source, offer: &[(u64, u64)]) -> Route {
+    async fn covered(source: Source, offer: &[(u64, u64)]) -> Route {
         let mut pass = Pass::open(source, beat_pass());
         for (at, frames) in offer {
             pass.offer(*at, *frames);
-            pass.drive(2);
+            pass.drive(2).await;
         }
-        assert!(pass.drive(Consts::TICKS), "the pass covers the track");
+        assert!(pass.drive(Consts::TICKS).await, "the pass covers the track");
 
         let analysis = pass.analysis();
         assert!(
@@ -926,17 +930,17 @@ mod artifacts {
     }
 
     #[kithara::test]
-    fn a_scheduled_route_and_a_linear_one_produce_the_same_artifacts() {
+    async fn a_scheduled_route_and_a_linear_one_produce_the_same_artifacts() {
         // The same source, once decoded in order because it reports no
         // length, and once scheduled because it does.
-        let linear = covered(Source::new(EXTENT).reporting(None), &[]);
+        let linear = covered(Source::new(EXTENT).reporting(None), &[]).await;
         assert!(
             !linear.artifacts.1.is_empty(),
             "the harness must find markers at all"
         );
         assert_eq!(linear.seeks, 0, "a source with no length is read in order");
 
-        let scheduled = covered(Source::new(EXTENT), &[]);
+        let scheduled = covered(Source::new(EXTENT), &[]).await;
         assert!(
             scheduled.seeks > 1,
             "the other route must really have been scheduled, not read in order"
@@ -964,14 +968,14 @@ mod artifacts {
     }
 
     #[kithara::test]
-    fn a_track_half_covered_by_a_producer_agrees_with_one_covered_alone() {
-        let linear = covered(Source::new(EXTENT).reporting(None), &[]);
+    async fn a_track_half_covered_by_a_producer_agrees_with_one_covered_alone() {
+        let linear = covered(Source::new(EXTENT).reporting(None), &[]).await;
 
         // Playback covered the first half in its own decode blocks; the
         // schedule has to take up the rest.
         let block = EXTENT / 16;
         let offered: Vec<(u64, u64)> = (0..8).map(|index| (index * block, block)).collect();
-        let mixed = covered(Source::new(EXTENT), &offered);
+        let mixed = covered(Source::new(EXTENT), &offered).await;
         assert!(mixed.seeks > 0, "the rest of the track had to be scheduled");
         assert_agrees(
             &linear.artifacts,

--- a/crates/kithara-analysis/src/waveform/mod.rs
+++ b/crates/kithara-analysis/src/waveform/mod.rs
@@ -1,12 +1,12 @@
-#[cfg(all(not(target_arch = "wasm32"), feature = "analysis-waveform"))]
+#[cfg(feature = "analysis-waveform")]
 mod analyzer;
 mod band;
 pub(crate) mod bucket;
-#[cfg(all(not(target_arch = "wasm32"), feature = "analysis-waveform"))]
+#[cfg(feature = "analysis-waveform")]
 mod bucketize;
 mod params;
 
-#[cfg(all(not(target_arch = "wasm32"), feature = "analysis-waveform"))]
+#[cfg(feature = "analysis-waveform")]
 pub use analyzer::WaveformAnalyzer;
 pub(crate) use band::Band;
 pub use bucket::Bucket;

--- a/crates/kithara-analysis/src/worker/handle.rs
+++ b/crates/kithara-analysis/src/worker/handle.rs
@@ -9,7 +9,7 @@ use kithara_platform::{
 };
 use kithara_resampler::ResamplerBackend;
 use kithara_worker::{
-    Dispatcher, DispatcherConfig, RayonConfig, TaskConfig, TaskError, TaskHandle, Worker,
+    Dispatcher, DispatcherConfig, OwnedPoolConfig, TaskConfig, TaskError, TaskHandle, Worker,
     WorkerConfig,
 };
 use tracing::warn;
@@ -104,7 +104,7 @@ impl AnalysisWorker {
                     WorkerConfig::new().with_cancel(cancel)
                 })
                 .with_max_compute_tasks(max_compute_tasks)
-                .with_owned_pool(RayonConfig::new(
+                .with_owned_pool(OwnedPoolConfig::new(
                     max_compute_tasks,
                     "kithara-analysis-compute",
                 ));

--- a/crates/kithara-analysis/src/worker/node.rs
+++ b/crates/kithara-analysis/src/worker/node.rs
@@ -77,9 +77,8 @@ where
     }
 
     fn accept_completion(&mut self) -> bool {
-        let done = match self.completed.try_recv() {
-            Ok(done) => done,
-            Err(TryRecvError::Empty | TryRecvError::Disconnected) => return false,
+        let Ok(done) = self.completed.try_recv() else {
+            return false;
         };
         self.detector_state = DetectorState::Idle;
         let Some(current) = &mut self.current else {
@@ -112,8 +111,8 @@ where
                 self.current = Some(task);
                 self.tick_current()
             }
-            Err(TryRecvError::Empty) => TickResult::UpstreamPending,
             Err(TryRecvError::Disconnected) => TickResult::Done,
+            Err(_) => TickResult::UpstreamPending,
         }
     }
 

--- a/crates/kithara-app/src/main.rs
+++ b/crates/kithara-app/src/main.rs
@@ -11,7 +11,7 @@ use kithara::{
     platform::{CancelToken, thread, tokio},
     play::PlayWorkerConfig,
     stream::dl::{Downloader, DownloaderConfig},
-    worker::{RayonConfig, Worker, WorkerConfig},
+    worker::{OwnedPoolConfig, Worker, WorkerConfig},
 };
 use kithara_app::{
     config::{AppBroadcastConfig, AppConfig, AppDrm},
@@ -118,7 +118,7 @@ fn main() -> AppResult {
         .with_cancel(shutdown.child())
         .with_runtime(runtime.handle().clone())
         .with_max_compute_tasks(compute_threads)
-        .with_owned_pool(RayonConfig::new(compute_threads, "kithara-compute"));
+        .with_owned_pool(OwnedPoolConfig::new(compute_threads, "kithara-compute"));
     worker_config.apply(document.worker());
     let base_worker = Worker::new(worker_config);
     let mut play_worker_config = PlayWorkerConfig::builder(pools.clone())

--- a/crates/kithara-audio/CONTEXT.md
+++ b/crates/kithara-audio/CONTEXT.md
@@ -340,6 +340,9 @@ value would lose to the first host that disagrees. `kithara-play`'s
 
 ## Prepared producer seam
 
+`AudioReader` is `Send` on every target: a reader is handed to the thread that
+drives it, and both playback and analysis move one onto their own worker.
+
 `Audio::prepare` returns the reader plus a still-concrete decoded source and
 `PreparedAudioLane`. The lane carries exactly what its consumer needs to run the
 source; no scheduler, `run_loop`, service class, hang-watchdog policy,

--- a/crates/kithara-audio/src/audio/core.rs
+++ b/crates/kithara-audio/src/audio/core.rs
@@ -6,7 +6,7 @@ use std::{
 
 use kithara_decode::TrackMetadata;
 use kithara_events::EventBus;
-use kithara_platform::{CancelToken, maybe_send::MaybeSend, sync::Arc, time::Duration};
+use kithara_platform::{CancelToken, sync::Arc, time::Duration};
 use kithara_signal::AudioSpec;
 use kithara_stream::{
     DeferredWake, PlayheadWrite, SeekControl, SeekObserve, SeekPrepare, WorkerWake,
@@ -269,7 +269,7 @@ impl<S> Audio<S> {
     }
 }
 
-impl<S: MaybeSend> AudioRead for Audio<S> {
+impl<S> AudioRead for Audio<S> {
     fn next_chunk(&mut self) -> Result<ChunkOutcome, DecodeError> {
         self.sync_seek();
         self.ring.preloaded = true;
@@ -341,7 +341,7 @@ impl<S: MaybeSend> AudioRead for Audio<S> {
     }
 }
 
-impl<S: MaybeSend> AudioSession for Audio<S> {
+impl<S> AudioSession for Audio<S> {
     fn event_bus(&self) -> &EventBus {
         self.events.bus()
     }
@@ -364,7 +364,7 @@ impl<S: MaybeSend> AudioSession for Audio<S> {
     }
 }
 
-impl<S: MaybeSend> AudioControl for Audio<S> {
+impl<S> AudioControl for Audio<S> {
     fn preload(&mut self) -> Result<(), DecodeError> {
         Self::preload(self)
     }

--- a/crates/kithara-audio/src/traits/reader.rs
+++ b/crates/kithara-audio/src/traits/reader.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroU32;
 
 use kithara_decode::{DecodeError, TrackMetadata};
 use kithara_events::EventBus;
-use kithara_platform::{maybe_send::MaybeSend, sync::Arc, time::Duration};
+use kithara_platform::{sync::Arc, time::Duration};
 use kithara_signal::AudioSpec;
 
 use super::{ChunkOutcome, ReadOutcome, SeekOutcome};
@@ -204,6 +204,6 @@ pub trait AudioControl {
 /// - `Ok(ReadOutcome::Frames { .. })` — reader is alive and produced frames.
 /// - `Ok(ReadOutcome::Eof { .. })` — natural end of stream.
 /// - `Err(DecodeError)` — decoder or channel failure.
-pub trait AudioReader: AudioRead + AudioSession + AudioControl + MaybeSend {}
+pub trait AudioReader: AudioRead + AudioSession + AudioControl + Send {}
 
-impl<T> AudioReader for T where T: AudioRead + AudioSession + AudioControl + MaybeSend {}
+impl<T> AudioReader for T where T: AudioRead + AudioSession + AudioControl + Send {}

--- a/crates/kithara-ffi/CONTEXT.md
+++ b/crates/kithara-ffi/CONTEXT.md
@@ -108,3 +108,39 @@ track whose own rate differs needs a fixed-ratio stage to reach it. Without the 
 `PlaybackResamplerBackend` resolves to `NoResamplerBackend` and such a track fails to open at all.
 The Apple device set above can drop rubato because AudioToolbox decodes straight to the host rate;
 the browser offers no equivalent.
+
+### Track analysis
+
+The wasm arm enables `analysis-waveform` and `beat-dsp`, so the browser computes the same
+waveform and beat grid the desktop app does, through the same `kithara-analysis` pass. `analyze`
+starts a pass for a queued track and `setAnalysisObserver` registers the one callback every
+publication reaches, as a plain object:
+
+```js
+{ trackId, revision, settled, sampleRate, sourceFrames, waveform, beats, downbeats, bpm, beatFinal }
+```
+
+`waveform` is a `Float32Array` of `low, mid, high` per bucket; `beats` and `downbeats` are
+`Float64Array` in seconds on `sampleRate`. The typed arrays are allocated on the JS side, so nothing
+crosses as a view into wasm memory. Readiness is `settled`, which says the pass ran out of positions
+the source can deliver, never completeness of coverage. The route tag the worker stamps on the
+message is stripped before the callback sees it, so the delivered object carries those ten fields
+alone. The DSP beat backend reports beats, not downbeats. This surface is wasm-only; the UniFFI
+surface carries no analysis.
+
+`AnalysisRuns` (`src/web/analysis/runs.rs`) is the engine worker's analysis owner: one
+`AnalysisWorker` and the cancel token of the single live pass per track. Calling `analyze` again
+for a track cancels its previous pass and begins a new revision sequence for that track; the
+cancelled pass publishes nothing further. `Remove`, `Replace` and `RemoveAll` cancel the pass of
+the track they drop, and a pass that ends on its own releases its own slot. The queue owns the
+track's source: the pass opens the very `ResourceConfig` playback holds, or, for a track queued by
+URL, the configuration `build_config` (`src/web/worker.rs`) derives from it, the same one an
+insertion builds. Once that reader is open the pass's producer is attached to the queue so
+playback decode feeds it; the per-track observer slot is latest-wins
+(`kithara-audio::AudioObserverSlot`), so a restarted pass replaces the producer of the one it
+cancelled.
+Per-pass cancel tokens are children of the `AnalysisWorker`'s own scope, and that scope has no
+parent: the engine worker holds no master cancel to derive it from. Publications travel to the
+main thread over the `BroadcastChannel` that already carries player and item events, tagged with
+the `analysis` scope, and `Routes` (`src/web/observer/router.rs`) fans all three out from one
+listener.

--- a/crates/kithara-ffi/Cargo.toml
+++ b/crates/kithara-ffi/Cargo.toml
@@ -82,6 +82,7 @@ kithara = { workspace = true, default-features = false, features = ["assets", "q
 # the web-audio backend in the wasm32 target block.
 delegate = { workspace = true }
 fieldwork = { workspace = true }
+num-traits = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
@@ -107,7 +108,9 @@ uuid = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 kithara = { workspace = true, default-features = false, features = [
+    "analysis-waveform",
     "backend-web-audio",
+    "beat-dsp",
     "hls",
     "resample-rubato",
     "symphonia",
@@ -125,7 +128,6 @@ kithara-test-macros = { workspace = true }
 bytes = { workspace = true }
 console_error_panic_hook = { workspace = true }
 js-sys = { workspace = true }
-num-traits = { workspace = true }
 # Wraps the `!Send` `js_sys::Function` behind a `Send + Sync` guard (with a
 # runtime same-thread assertion) so the JS-backed observer impls satisfy the
 # `core::observer` traits' real `Send + Sync` supertraits on wasm.
@@ -155,11 +157,17 @@ tempfile = { workspace = true }
 unimock = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+kithara-test-fixtures = { workspace = true }
 wasm-bindgen-test = { workspace = true }
 
 [[test]]
 name = "web-observer"
 path = "src/web/observer/tests.rs"
+required-features = ["wasm"]
+
+[[test]]
+name = "web-analysis"
+path = "src/web/analysis/tests.rs"
 required-features = ["wasm"]
 
 [lints]

--- a/crates/kithara-ffi/src/core/analysis.rs
+++ b/crates/kithara-ffi/src/core/analysis.rs
@@ -1,0 +1,37 @@
+use std::num::NonZeroU32;
+
+/// Position of a source frame on its own sample-rate axis, in seconds.
+#[must_use]
+pub fn seconds_at(frame: u64, rate: NonZeroU32) -> f64 {
+    let frame: f64 = num_traits::cast(frame).unwrap_or(f64::MAX);
+    frame / f64::from(rate.get())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU32;
+
+    use kithara_test_utils::kithara;
+
+    use super::seconds_at;
+
+    #[kithara::test]
+    fn a_marker_reads_as_its_position_on_the_source_axis() {
+        let rate = NonZeroU32::new(44_100).expect("nonzero rate");
+
+        assert!((seconds_at(0, rate) - 0.0).abs() < f64::EPSILON);
+        assert!((seconds_at(44_100, rate) - 1.0).abs() < f64::EPSILON);
+        assert!((seconds_at(22_050, rate) - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[kithara::test]
+    fn the_axis_is_the_source_rate_the_pass_was_opened_on() {
+        let frame = 48_000;
+
+        let at_48k = seconds_at(frame, NonZeroU32::new(48_000).expect("nonzero rate"));
+        let at_44k = seconds_at(frame, NonZeroU32::new(44_100).expect("nonzero rate"));
+
+        assert!((at_48k - 1.0).abs() < f64::EPSILON);
+        assert!(at_44k > at_48k);
+    }
+}

--- a/crates/kithara-ffi/src/core/mod.rs
+++ b/crates/kithara-ffi/src/core/mod.rs
@@ -1,3 +1,4 @@
+pub mod analysis;
 pub(crate) mod convert;
 pub mod item;
 pub mod layout;

--- a/crates/kithara-ffi/src/lib.rs
+++ b/crates/kithara-ffi/src/lib.rs
@@ -26,7 +26,7 @@ pub mod web;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) use core::registry;
-pub use core::{item, layout, observer, types};
+pub use core::{analysis, item, layout, observer, types};
 
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) use native::{FFI_RUNTIME, Inner, event_bridge};

--- a/crates/kithara-ffi/src/web/analysis/encode.rs
+++ b/crates/kithara-ffi/src/web/analysis/encode.rs
@@ -1,0 +1,108 @@
+use std::num::NonZeroU32;
+
+use js_sys::{Float32Array, Float64Array, Object, Reflect};
+use kithara::{
+    analysis::{BeatArtifact, BeatSnapshot, BeatState, TrackAnalysis, Waveform},
+    queue::TrackId,
+};
+use num_traits::cast;
+use wasm_bindgen::JsValue;
+
+use crate::analysis::seconds_at;
+
+/// Scope tag every analysis message carries on the player event channel.
+pub(crate) const ANALYSIS_SCOPE: &str = "analysis";
+
+struct Consts;
+
+impl Consts {
+    const BANDS_PER_BUCKET: usize = 3;
+    const STAGE: usize = 768;
+}
+
+/// One analysis publication as the plain JS object the registered callback
+/// receives.
+pub(crate) fn encode(track_id: TrackId, analysis: &TrackAnalysis) -> Object {
+    let rate = analysis.source_sample_rate();
+    let beat = analysis.beat();
+    let artifact = beat.map(BeatSnapshot::artifact);
+
+    let message = Object::new();
+    set(&message, "scope", &JsValue::from_str(ANALYSIS_SCOPE));
+    set(&message, "trackId", &number(track_id.as_u64()));
+    set(&message, "revision", &number(analysis.revision()));
+    set(
+        &message,
+        "settled",
+        &JsValue::from_bool(analysis.is_settled()),
+    );
+    set(
+        &message,
+        "sampleRate",
+        &JsValue::from_f64(f64::from(rate.get())),
+    );
+    set(&message, "sourceFrames", &number(analysis.source_frames()));
+    set(&message, "waveform", &waveform(analysis).into());
+    let beats = artifact.map_or(&[][..], |beat| beat.beats());
+    let downbeats = artifact.map_or(&[][..], |beat| beat.downbeats());
+    set(&message, "beats", &markers(beats, rate).into());
+    set(&message, "downbeats", &markers(downbeats, rate).into());
+    set(
+        &message,
+        "bpm",
+        &JsValue::from_f64(artifact.map_or(0.0, BeatArtifact::bpm)),
+    );
+    set(
+        &message,
+        "beatFinal",
+        &JsValue::from_bool(beat.is_some_and(|snapshot| snapshot.state() == BeatState::Final)),
+    );
+    message
+}
+
+fn waveform(analysis: &TrackAnalysis) -> Float32Array {
+    let buckets = analysis.waveform().map_or(&[][..], Waveform::buckets);
+    let out = Float32Array::new_with_length(length_of(buckets.len() * Consts::BANDS_PER_BUCKET));
+    let mut staged = [0.0_f32; Consts::STAGE];
+    let mut written: u32 = 0;
+    for group in buckets.chunks(Consts::STAGE / Consts::BANDS_PER_BUCKET) {
+        for (slot, bucket) in staged.chunks_exact_mut(Consts::BANDS_PER_BUCKET).zip(group) {
+            let [low, mid, high] = slot else { continue };
+            *low = bucket.low();
+            *mid = bucket.mid();
+            *high = bucket.high();
+        }
+        let filled = group.len() * Consts::BANDS_PER_BUCKET;
+        let end = written.saturating_add(length_of(filled));
+        out.subarray(written, end).copy_from(&staged[..filled]);
+        written = end;
+    }
+    out
+}
+
+fn markers(frames: &[u64], rate: NonZeroU32) -> Float64Array {
+    let out = Float64Array::new_with_length(length_of(frames.len()));
+    let mut staged = [0.0_f64; Consts::STAGE];
+    let mut written: u32 = 0;
+    for group in frames.chunks(Consts::STAGE) {
+        for (slot, frame) in staged.iter_mut().zip(group) {
+            *slot = seconds_at(*frame, rate);
+        }
+        let end = written.saturating_add(length_of(group.len()));
+        out.subarray(written, end).copy_from(&staged[..group.len()]);
+        written = end;
+    }
+    out
+}
+
+fn length_of(count: usize) -> u32 {
+    cast(count).unwrap_or(u32::MAX)
+}
+
+fn number(value: u64) -> JsValue {
+    JsValue::from_f64(cast(value).unwrap_or(f64::MAX))
+}
+
+fn set(target: &Object, key: &str, value: &JsValue) {
+    let _ = Reflect::set(target, &JsValue::from_str(key), value);
+}

--- a/crates/kithara-ffi/src/web/analysis/mod.rs
+++ b/crates/kithara-ffi/src/web/analysis/mod.rs
@@ -1,0 +1,4 @@
+//! Track analysis in the browser: one pass per queued track, published to JS.
+
+pub(crate) mod encode;
+pub(crate) mod runs;

--- a/crates/kithara-ffi/src/web/analysis/runs.rs
+++ b/crates/kithara-ffi/src/web/analysis/runs.rs
@@ -1,0 +1,165 @@
+use std::{cell::RefCell, collections::HashMap, num::NonZeroU32, rc::Rc};
+
+use kithara::{
+    analysis::{
+        AnalysisProgress, AnalysisToken, AnalysisWorker, AnalysisWorkerConfig, AnalyzerBuilder,
+        BeatAnalysisConfig,
+    },
+    audio::AudioReader,
+    platform::{
+        CancelToken,
+        sync::Arc,
+        tokio::{self, sync::watch, task::spawn as task_spawn},
+    },
+    prelude::{PlaybackResamplerBackend, Resource},
+    queue::TrackId,
+};
+use web_sys::BroadcastChannel;
+
+use super::encode::encode;
+use crate::{
+    pools::{FfiPools, FfiQueueControl, FfiResourceConfig, Pools},
+    web::{interop::send_reply, observer::source::EVENT_CHANNEL},
+};
+
+struct Consts;
+
+impl Consts {
+    const CALLER_HOLDS_NO_REVISION: u64 = 0;
+    const WAVEFORM_MAX_BUCKETS: usize = 96_000;
+}
+
+type WebAnalyzerBuilder = AnalyzerBuilder<PlaybackResamplerBackend, FfiPools>;
+
+type Live = Rc<RefCell<HashMap<TrackId, CancelToken>>>;
+
+/// The engine worker's analysis owner: one shared [`AnalysisWorker`] and the
+/// cancel token of the single live pass per track.
+pub(crate) struct AnalysisRuns {
+    worker: Arc<AnalysisWorker>,
+    live: Live,
+}
+
+impl AnalysisRuns {
+    pub(crate) fn new(pools: Pools) -> Self {
+        let builder: WebAnalyzerBuilder = AnalyzerBuilder::new(pools)
+            .with_beat_config(BeatAnalysisConfig::default())
+            .with_waveform(Consts::WAVEFORM_MAX_BUCKETS)
+            .with_beat();
+        Self {
+            worker: Arc::new(AnalysisWorker::new(
+                AnalysisWorkerConfig::for_builder(builder).build(),
+            )),
+            live: Live::default(),
+        }
+    }
+
+    pub(crate) fn cancel(&mut self, id: TrackId) {
+        if let Some(cancel) = self.live.borrow_mut().remove(&id) {
+            cancel.cancel();
+        }
+    }
+
+    pub(crate) fn clear(&mut self) {
+        for (_, cancel) in self.live.borrow_mut().drain() {
+            cancel.cancel();
+        }
+    }
+
+    /// Open a pass for `id` on the queue's decoded-audio axis.
+    pub(crate) fn start(
+        &mut self,
+        queue: &FfiQueueControl,
+        config: FfiResourceConfig,
+        id: TrackId,
+        token: AnalysisToken,
+        request_id: u32,
+    ) {
+        let Some(rate) = NonZeroU32::new(queue.sample_rate()) else {
+            send_reply(
+                request_id,
+                Err("the queue reports no sample rate".to_owned()),
+            );
+            return;
+        };
+        self.cancel(id);
+
+        let (rx, producer, pass) = self
+            .worker
+            .open(token, rate, Consts::CALLER_HOLDS_NO_REVISION);
+        let cancel = pass.cancel_token().clone();
+        self.live.borrow_mut().insert(id, cancel.clone());
+
+        let worker = Arc::clone(&self.worker);
+        let reader_cancel = cancel.clone();
+        let queue = queue.clone();
+        task_spawn(async move {
+            match open_reader(config, &reader_cancel, rate).await {
+                Ok(reader) => {
+                    queue.attach_observer(id, producer);
+                    worker.start(pass, reader);
+                    send_reply(request_id, Ok(()));
+                }
+                Err(error) => {
+                    tracing::warn!(?error, "analysis: reader did not open; pass never started");
+                    send_reply(request_id, Err(error));
+                }
+            }
+        });
+        let live = Rc::clone(&self.live);
+        task_spawn(async move {
+            publish(id, rx, &cancel).await;
+            if !cancel.is_cancelled() {
+                live.borrow_mut().remove(&id);
+            }
+        });
+    }
+}
+
+async fn publish(
+    id: TrackId,
+    mut rx: watch::Receiver<Option<AnalysisProgress>>,
+    cancel: &CancelToken,
+) {
+    let Ok(channel) = BroadcastChannel::new(EVENT_CHANNEL) else {
+        tracing::warn!("analysis: BroadcastChannel unavailable in worker");
+        return;
+    };
+    loop {
+        let changed = tokio::select! {
+            biased;
+            () = cancel.cancelled() => return,
+            changed = rx.changed() => changed,
+        };
+        if changed.is_err() {
+            return;
+        }
+        let message = rx
+            .borrow_and_update()
+            .as_ref()
+            .map(|progress| encode(id, progress.analysis()));
+        if let Some(message) = message {
+            let _ = channel.post_message(&message);
+        }
+    }
+}
+
+async fn open_reader(
+    mut config: FfiResourceConfig,
+    cancel: &CancelToken,
+    rate: NonZeroU32,
+) -> Result<Box<dyn AudioReader>, String> {
+    if cancel.is_cancelled() {
+        return Err("the pass was cancelled before its reader opened".to_owned());
+    }
+    config.set_cancel(cancel.child());
+    config.set_host_sample_rate(rate);
+    let mut resource = Resource::new(config)
+        .await
+        .map_err(|error| format!("resource open failed: {error}"))?;
+    resource
+        .preload()
+        .await
+        .map_err(|error| format!("preload failed: {error}"))?;
+    Ok(resource.into())
+}

--- a/crates/kithara-ffi/src/web/analysis/tests.rs
+++ b/crates/kithara-ffi/src/web/analysis/tests.rs
@@ -1,0 +1,218 @@
+#![cfg(target_arch = "wasm32")]
+
+use std::{cell::RefCell, rc::Rc};
+
+use js_sys::{Float32Array, Float64Array, Reflect};
+use kithara::platform::time::{Duration, sleep};
+use kithara_ffi::player::AudioPlayer;
+use kithara_test_fixtures::SignalAsset;
+use wasm_bindgen::{JsCast, JsValue, prelude::Closure};
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+const SERVER_URL: &str = "http://127.0.0.1:3444";
+const POLL_MS: u64 = 50;
+const IDLE_GIVE_UP_MS: u64 = 5_000;
+const DEADLINE_MS: u64 = 10_000;
+const RESTART_SAMPLE: usize = 3;
+
+type Events = Rc<RefCell<Vec<JsValue>>>;
+
+fn get(value: &JsValue, key: &str) -> JsValue {
+    Reflect::get(value, &JsValue::from_str(key)).expect("analysis field")
+}
+
+fn number(value: &JsValue, key: &str) -> f64 {
+    get(value, key).as_f64().expect("analysis number field")
+}
+
+fn boolean(value: &JsValue, key: &str) -> bool {
+    get(value, key).as_bool().expect("analysis boolean field")
+}
+
+fn revisions(events: &Events) -> Vec<f64> {
+    events
+        .borrow()
+        .iter()
+        .map(|event| number(event, "revision"))
+        .collect()
+}
+
+fn observed_player() -> (AudioPlayer, Events) {
+    let events: Events = Rc::new(RefCell::new(Vec::new()));
+    let player = AudioPlayer::new_js();
+
+    let sink = Rc::clone(&events);
+    let observer = Closure::wrap(Box::new(move |event: JsValue| {
+        sink.borrow_mut().push(event);
+    }) as Box<dyn FnMut(JsValue)>);
+    player
+        .set_analysis_observer_js(observer.as_ref().clone())
+        .expect("analysis observer accepted");
+    observer.forget();
+    (player, events)
+}
+
+fn clicks_url() -> String {
+    format!("{SERVER_URL}{}", SignalAsset::MP3_CLICKS126_30S.path())
+}
+
+#[wasm_bindgen_test]
+async fn a_queued_track_publishes_analysis_until_the_pass_settles() {
+    let (player, events) = observed_player();
+    let track_id = player.append_js(clicks_url()).expect("append");
+    player.analyze_js(track_id).expect("analyze accepted");
+
+    let settled = drive(&player, &events, |received| {
+        received
+            .last()
+            .is_some_and(|e| boolean(e, "settled") && boolean(e, "beatFinal"))
+    })
+    .await;
+
+    let Some(waited) = settled else {
+        panic!(
+            "no publication carries a final grid; {} publication(s) received",
+            events.borrow().len()
+        );
+    };
+
+    let received = events.borrow();
+    let last = received.last().expect("at least one publication");
+
+    assert_eq!(number(last, "trackId"), track_id);
+    assert!(boolean(last, "settled"));
+    assert!(number(last, "sampleRate") > 0.0);
+    assert!(number(last, "sourceFrames") > 0.0);
+    assert_eq!(
+        keys(last),
+        [
+            "beatFinal",
+            "beats",
+            "bpm",
+            "downbeats",
+            "revision",
+            "sampleRate",
+            "settled",
+            "sourceFrames",
+            "trackId",
+            "waveform",
+        ],
+        "the callback receives the published fields and nothing else"
+    );
+
+    let waveform: Float32Array = get(last, "waveform").dyn_into().expect("waveform copy");
+    assert!(waveform.length() > 0, "a settled pass has a waveform");
+    assert_eq!(
+        waveform.length() % 3,
+        0,
+        "a bucket is three band energies wide"
+    );
+
+    let beats: Float64Array = get(last, "beats").dyn_into().expect("beats copy");
+    let downbeats: Float64Array = get(last, "downbeats").dyn_into().expect("downbeats copy");
+    assert_eq!(
+        downbeats.length(),
+        0,
+        "the DSP backend reports beats, never downbeats"
+    );
+    for index in 0..beats.length() {
+        let at = beats.get_index(index);
+        assert!(at >= 0.0, "a beat sits on the source timeline");
+    }
+    let bpm = number(last, "bpm");
+    web_sys::console::log_1(&JsValue::from_str(&format!(
+        "measured bpm {bpm} over {} beats, settled after {waited} ms",
+        beats.length()
+    )));
+    let _ = boolean(last, "beatFinal");
+
+    let revisions = revisions(&events);
+    for pair in revisions.windows(2) {
+        assert!(
+            pair[1] > pair[0],
+            "every publication outranks the one before it: {revisions:?}"
+        );
+    }
+}
+
+#[wasm_bindgen_test]
+async fn analyzing_again_starts_a_new_revision_sequence_and_silences_the_old_pass() {
+    let (player, events) = observed_player();
+    let track_id = player.append_js(clicks_url()).expect("append");
+    player.analyze_js(track_id).expect("analyze accepted");
+
+    let settled = drive(&player, &events, |received| {
+        received.last().is_some_and(|e| boolean(e, "settled"))
+    })
+    .await;
+    assert!(settled.is_some(), "the first pass never settled");
+
+    let before = events.borrow().len();
+    player
+        .analyze_js(track_id)
+        .expect("second analyze accepted");
+    let restarted = drive(&player, &events, |received| {
+        received.len() >= before + RESTART_SAMPLE
+    })
+    .await;
+    assert!(
+        restarted.is_some(),
+        "the restarted pass published {} time(s)",
+        events.borrow().len() - before
+    );
+
+    let revisions = revisions(&events);
+    let suffix = &revisions[before..];
+    let steps_down: Vec<usize> = (1..suffix.len())
+        .filter(|&index| suffix[index] < suffix[index - 1])
+        .collect();
+    assert!(
+        steps_down.len() <= 1,
+        "a restart begins one new revision sequence: {suffix:?}"
+    );
+    let restart_at = steps_down.first().copied().unwrap_or(0);
+    for pair in suffix[restart_at..].windows(2) {
+        assert!(
+            pair[1] > pair[0],
+            "the restarted pass only moves forward: {suffix:?}"
+        );
+    }
+}
+
+fn keys(value: &JsValue) -> Vec<String> {
+    let mut keys = Reflect::own_keys(value)
+        .expect("analysis keys")
+        .iter()
+        .map(|key| key.as_string().expect("string key"))
+        .collect::<Vec<_>>();
+    keys.sort_unstable();
+    keys
+}
+
+async fn drive<F>(player: &AudioPlayer, events: &Events, done: F) -> Option<u64>
+where
+    F: Fn(&[JsValue]) -> bool,
+{
+    let mut waited = 0;
+    let mut idle = 0;
+    let mut seen = 0;
+    while waited < DEADLINE_MS && idle < IDLE_GIVE_UP_MS {
+        player.tick_js();
+        sleep(Duration::from_millis(POLL_MS)).await;
+        waited += POLL_MS;
+
+        let received = events.borrow();
+        if done(&received) {
+            return Some(waited);
+        }
+        if received.len() == seen {
+            idle += POLL_MS;
+            continue;
+        }
+        seen = received.len();
+        idle = 0;
+    }
+    None
+}

--- a/crates/kithara-ffi/src/web/commands.rs
+++ b/crates/kithara-ffi/src/web/commands.rs
@@ -59,6 +59,12 @@ pub(crate) enum WorkerCmd {
     },
     /// Clear every track from the queue.
     RemoveAll,
+    /// Start (or restart) the analysis pass for a queued track, replying via
+    /// `request_id`.
+    Analyze {
+        id: TrackId,
+        request_id: u32,
+    },
     /// Set the ABR mode on the worker's current track. `None` selects
     /// automatic adaptation; `Some(index)` pins a manual variant. Mirrors
     /// [`NativeInner::set_abr_mode`](crate::native::inner::NativeInner).

--- a/crates/kithara-ffi/src/web/inner.rs
+++ b/crates/kithara-ffi/src/web/inner.rs
@@ -1,5 +1,6 @@
 use std::sync::atomic::{AtomicU32, Ordering};
 
+use js_sys::Function;
 use kithara::{
     platform::sync::{Arc, Mutex},
     queue::{RepeatMode, TrackId, Transition},
@@ -9,7 +10,7 @@ use crate::{
     item::AudioPlayerItem,
     observer::{FfiKeyProcessor, PlayerObserver, SeekCallback},
     types::{FfiAbrMode, FfiError, FfiKeyRule, FfiPlayerSnapshot, FfiPlayerStatus, FfiRepeatMode},
-    web::{bridge::WorkerBridge, commands::WorkerCmd},
+    web::{bridge::WorkerBridge, commands::WorkerCmd, observer::router::Routes},
 };
 
 /// Number of EQ bands surfaced through the wasm facade. Module-level
@@ -44,7 +45,7 @@ pub(crate) struct WasmInner {
     playing_rate: AtomicU32,
     volume: AtomicU32,
     muted: Mutex<bool>,
-    observer: Mutex<Option<Arc<dyn PlayerObserver>>>,
+    routes: Routes,
     repeat_mode: Mutex<FfiRepeatMode>,
     bridge: WorkerBridge,
     eq_gains: [AtomicU32; EQ_BANDS],
@@ -52,10 +53,11 @@ pub(crate) struct WasmInner {
 
 impl Default for WasmInner {
     fn default() -> Self {
+        let queue_view: Arc<Mutex<QueueView>> = Arc::new(Mutex::default());
         Self {
             bridge: WorkerBridge::default(),
-            queue_view: Arc::new(Mutex::default()),
-            observer: Mutex::default(),
+            routes: Routes::new(Arc::clone(&queue_view)),
+            queue_view,
             volume: AtomicU32::new(Self::DEFAULT_VOLUME.to_bits()),
             crossfade_secs: AtomicU32::new(Self::DEFAULT_CROSSFADE_SECONDS.to_bits()),
             playing_rate: AtomicU32::new(Self::DEFAULT_PLAYING_RATE.to_bits()),
@@ -106,6 +108,12 @@ impl WasmInner {
                 transition: Transition::None,
             });
         }
+    }
+
+    /// Start (or restart) the analysis pass for a queued track.
+    pub(crate) fn analyze(&self, id: TrackId) -> Result<(), FfiError> {
+        let request_id = Self::next_request_id();
+        self.try_send(WorkerCmd::Analyze { id, request_id })
     }
 
     pub(crate) fn append(&self, item: &Arc<AudioPlayerItem>) -> Result<(), FfiError> {
@@ -374,11 +382,6 @@ impl WasmInner {
         self.send(WorkerCmd::SetVolume(volume));
     }
 
-    pub(crate) fn set_observer(&self, observer: Arc<dyn PlayerObserver>) {
-        crate::web::observer::router::install(Arc::clone(&observer), Arc::clone(&self.queue_view));
-        *self.observer.lock() = Some(observer);
-    }
-
     pub(crate) fn set_playing_rate(&self, rate: f32) {
         store_f32(&self.playing_rate, rate);
     }
@@ -456,6 +459,12 @@ impl WasmInner {
     }
 
     delegate::delegate! {
+        to self.routes {
+            #[call(set_analysis)]
+            pub(crate) fn set_analysis_observer(&self, func: Function);
+            #[call(set_player)]
+            pub(crate) fn set_observer(&self, observer: Arc<dyn PlayerObserver>);
+        }
         to self.bridge {
             #[call(position_secs)]
             pub(crate) fn current_time(&self) -> f64;

--- a/crates/kithara-ffi/src/web/mod.rs
+++ b/crates/kithara-ffi/src/web/mod.rs
@@ -4,6 +4,7 @@
 //! [`crate::lib`]. Inside this module all sources are unconditionally
 //! wasm-only and require no per-item gating.
 
+pub(crate) mod analysis;
 pub mod bindings;
 pub(crate) mod bridge;
 pub(crate) mod commands;

--- a/crates/kithara-ffi/src/web/observer/router.rs
+++ b/crates/kithara-ffi/src/web/observer/router.rs
@@ -1,8 +1,11 @@
-use js_sys::Reflect;
+use std::mem;
+
+use js_sys::{Function, Object, Reflect};
 use kithara::{
     events::TrackId,
     platform::sync::{Arc, Mutex},
 };
+use send_wrapper::SendWrapper;
 use wasm_bindgen::{JsCast, JsValue, prelude::Closure};
 use web_sys::{BroadcastChannel, MessageEvent, console};
 
@@ -11,71 +14,146 @@ use crate::{
     item::AudioPlayerItem,
     observer::{ItemObserver, PlayerObserver},
     types::{FfiItemEvent, FfiItemStatus, FfiPlayerEvent, FfiTrackStatus},
-    web::observer::source::EVENT_CHANNEL,
+    web::{analysis::encode::ANALYSIS_SCOPE, observer::source::EVENT_CHANNEL},
 };
 
 type QueueView = Vec<(TrackId, Arc<AudioPlayerItem>)>;
 
-pub(crate) fn install(observer: Arc<dyn PlayerObserver>, queue_view: Arc<Mutex<QueueView>>) {
-    let Ok(channel) = BroadcastChannel::new(EVENT_CHANNEL) else {
-        console::warn_1(&JsValue::from_str(
-            "kithara: BroadcastChannel unavailable; player observer disabled",
-        ));
-        return;
-    };
-    let closure = Closure::wrap(Box::new(move |ev: MessageEvent| {
-        let data = ev.data();
-        if Reflect::get(&data, &JsValue::from_str("scope"))
-            .ok()
-            .and_then(|value| value.as_string())
-            .as_deref()
-            == Some("item")
-        {
-            route_item_message(&queue_view, &data);
+/// Main-thread fan-out of the worker event channel to the player, per-item and
+/// analysis sinks.
+#[derive(Clone)]
+pub(crate) struct Routes {
+    queue_view: Arc<Mutex<QueueView>>,
+    sinks: Arc<Mutex<Sinks>>,
+}
+
+#[derive(Default)]
+struct Sinks {
+    player: Option<Arc<dyn PlayerObserver>>,
+    analysis: Option<SendWrapper<Function>>,
+    installed: bool,
+}
+
+impl Routes {
+    pub(crate) fn new(queue_view: Arc<Mutex<QueueView>>) -> Self {
+        Self {
+            queue_view,
+            sinks: Arc::new(Mutex::default()),
+        }
+    }
+
+    pub(crate) fn set_analysis(&self, func: Function) {
+        self.sinks.lock().analysis = Some(SendWrapper::new(func));
+        self.arm();
+    }
+
+    pub(crate) fn set_player(&self, observer: Arc<dyn PlayerObserver>) {
+        self.sinks.lock().player = Some(observer);
+        self.arm();
+    }
+
+    fn arm(&self) {
+        if self.sinks.lock().installed {
             return;
         }
-        let Some(event) = decode(&data) else {
+        if self.install() {
+            self.sinks.lock().installed = true;
+        }
+    }
+
+    fn install(&self) -> bool {
+        let Ok(channel) = BroadcastChannel::new(EVENT_CHANNEL) else {
+            console::warn_1(&JsValue::from_str(
+                "kithara: BroadcastChannel unavailable; observers disabled",
+            ));
+            return false;
+        };
+        let routes = self.clone();
+        let closure = Closure::wrap(Box::new(move |ev: MessageEvent| {
+            routes.dispatch(&ev.data());
+        }) as Box<dyn FnMut(MessageEvent)>);
+        channel.set_onmessage(Some(closure.as_ref().unchecked_ref()));
+        closure.forget();
+        mem::forget(channel);
+        true
+    }
+
+    fn dispatch(&self, data: &JsValue) {
+        match scope(data).as_deref() {
+            Some("item") => self.route_item_message(data),
+            Some(ANALYSIS_SCOPE) => self.route_analysis(data),
+            _ => self.route_player(data),
+        }
+    }
+
+    fn route_analysis(&self, data: &JsValue) {
+        let func = self
+            .sinks
+            .lock()
+            .analysis
+            .as_ref()
+            .map(|func| (*func).clone());
+        if let Some(func) = func {
+            if let Some(payload) = data.dyn_ref::<Object>() {
+                let _ = Reflect::delete_property(payload, &JsValue::from_str(SCOPE_KEY));
+            }
+            let _ = func.call1(&JsValue::UNDEFINED, data);
+        }
+    }
+
+    fn route_player(&self, data: &JsValue) {
+        let Some(event) = decode(data) else {
             return;
         };
-        route_to_item(&queue_view, &event);
-        observer.on_event(event);
-    }) as Box<dyn FnMut(MessageEvent)>);
-    channel.set_onmessage(Some(closure.as_ref().unchecked_ref()));
-    closure.forget();
-    std::mem::forget(channel);
-}
+        self.route_to_item(&event);
+        let observer = self.sinks.lock().player.clone();
+        if let Some(observer) = observer {
+            observer.on_event(event);
+        }
+    }
 
-fn route_to_item(queue_view: &Arc<Mutex<QueueView>>, event: &FfiPlayerEvent) {
-    let FfiPlayerEvent::TrackStatusChanged { item_id, status } = event else {
-        return;
-    };
-    let item = queue_view
-        .lock()
-        .iter()
-        .find(|(id, _)| id == item_id)
-        .map(|(_, item)| Arc::clone(item));
-    let Some(item) = item else { return };
-    update_item_state(&item, status);
-    if let Some(item_obs) = item.observer() {
-        dispatch_track_status_to_item(&item_obs, status);
+    fn item(&self, id: TrackId) -> Option<Arc<AudioPlayerItem>> {
+        self.queue_view
+            .lock()
+            .iter()
+            .find(|(existing, _)| *existing == id)
+            .map(|(_, item)| Arc::clone(item))
+    }
+
+    fn route_to_item(&self, event: &FfiPlayerEvent) {
+        let FfiPlayerEvent::TrackStatusChanged { item_id, status } = event else {
+            return;
+        };
+        let Some(item) = self.item(*item_id) else {
+            return;
+        };
+        update_item_state(&item, status);
+        if let Some(item_obs) = item.observer() {
+            dispatch_track_status_to_item(&item_obs, status);
+        }
+    }
+
+    fn route_item_message(&self, data: &JsValue) {
+        let track_id = get_id_req(data, "track_id");
+        let item_event = decode_item_event(data);
+        let (Some(track_id), Some(item_event)) = (track_id, item_event) else {
+            return;
+        };
+        let Some(item) = self.item(track_id) else {
+            return;
+        };
+        if let Some(obs) = item.observer() {
+            obs.on_event(item_event);
+        }
     }
 }
 
-fn route_item_message(queue_view: &Arc<Mutex<QueueView>>, data: &JsValue) {
-    let track_id = get_id_req(data, "track_id");
-    let item_event = decode_item_event(data);
-    let (Some(track_id), Some(item_event)) = (track_id, item_event) else {
-        return;
-    };
-    let item = queue_view
-        .lock()
-        .iter()
-        .find(|(id, _)| *id == track_id)
-        .map(|(_, item)| Arc::clone(item));
-    let Some(item) = item else { return };
-    if let Some(obs) = item.observer() {
-        obs.on_event(item_event);
-    }
+const SCOPE_KEY: &str = "scope";
+
+fn scope(data: &JsValue) -> Option<String> {
+    Reflect::get(data, &JsValue::from_str(SCOPE_KEY))
+        .ok()
+        .and_then(|value| value.as_string())
 }
 
 fn update_item_state(item: &Arc<AudioPlayerItem>, status: &FfiTrackStatus) {

--- a/crates/kithara-ffi/src/web/surface.rs
+++ b/crates/kithara-ffi/src/web/surface.rs
@@ -36,6 +36,20 @@ fn id_to_f64(item: &Arc<AudioPlayerItem>) -> f64 {
 /// track ids, JS callback objects) onto the typed facade methods.
 #[wasm_bindgen]
 impl AudioPlayer {
+    /// Start (or restart) the analysis pass for a queued track.
+    ///
+    /// # Errors
+    /// Returns a JS error if the id is not in the queue.
+    #[wasm_bindgen(js_name = analyze)]
+    pub fn analyze_js(&self, track_id: f64) -> Result<(), JsValue> {
+        let item = self
+            .item_by_id(track_id)
+            .ok_or_else(|| JsValue::from_str("unknown track id"))?;
+        self.inner
+            .analyze(item.track_id())
+            .map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+
     /// Append a track to the tail of the queue. Returns the allocated
     /// track id as an `f64`.
     ///
@@ -238,6 +252,20 @@ impl AudioPlayer {
             }
         };
         self.inner.set_abr_mode(mode);
+    }
+
+    /// Register a JS callback receiving one object per analysis publication:
+    /// `{ trackId, revision, settled, sampleRate, sourceFrames, waveform, beats, downbeats, bpm, beatFinal }`.
+    ///
+    /// # Errors
+    /// Returns a JS error if `obj` is not a callable function.
+    #[wasm_bindgen(js_name = setAnalysisObserver)]
+    pub fn set_analysis_observer_js(&self, obj: JsValue) -> Result<(), JsValue> {
+        let func: Function = obj
+            .dyn_into()
+            .map_err(|_| JsValue::from_str("observer must be a function"))?;
+        self.inner.set_analysis_observer(func);
+        Ok(())
     }
 
     #[wasm_bindgen(js_name = setCrossfadeSeconds)]

--- a/crates/kithara-ffi/src/web/worker.rs
+++ b/crates/kithara-ffi/src/web/worker.rs
@@ -2,6 +2,7 @@ use std::{cell::RefCell, collections::HashMap, num::NonZeroUsize, rc::Rc};
 
 use kithara::{
     abr::AbrMode,
+    analysis::AnalysisToken,
     assets::StorageBackend,
     drm::{KeyRequest, KeyRequestFactory},
     hls::KeyOptions,
@@ -25,7 +26,7 @@ use crate::{
         FfiPools, FfiQueue, FfiQueueControl, FfiResourceConfig, FfiStore, FfiTrackSource,
         FfiWorker, Pools,
     },
-    web::{commands::WorkerCmd, key_processor_bridge},
+    web::{analysis::runs::AnalysisRuns, commands::WorkerCmd, key_processor_bridge},
 };
 
 struct Consts;
@@ -48,6 +49,7 @@ struct BuildState {
     headers: HashMap<String, String>,
     keys: KeyOptions,
     pools: Pools,
+    worker: FfiWorker,
 }
 
 impl BuildState {
@@ -57,11 +59,13 @@ impl BuildState {
             .cache_capacity(Consts::ASSET_CACHE_CAPACITY)
             .max_bytes(Consts::ASSET_CACHE_MAX_BYTES)
             .build();
+        let worker = FfiWorker::new(PlayWorkerConfig::builder(pools.clone()).build());
         Self {
             pools,
             store,
             headers: HashMap::new(),
             keys: KeyOptions::default(),
+            worker,
         }
     }
 }
@@ -93,12 +97,11 @@ pub(crate) fn worker_main(
     task_spawn(async move {
         let mut host = wasm::remote_host(host_sender);
         let state = BuildState::new(pools);
-        let worker = FfiWorker::new(PlayWorkerConfig::builder(state.pools.clone()).build());
         let queue_store = state.store.clone();
         let player = PlayerImpl::new(
             PlayerConfig::builder()
                 .sample_rate(host.requested_sample_rate())
-                .worker(worker)
+                .worker(state.worker.clone())
                 .build(),
         );
         let queue = FfiQueue::new(
@@ -117,13 +120,15 @@ pub(crate) fn worker_main(
         let queue = owner.control().clone();
         queue.set_crossfade_duration(CROSSFADE_SECONDS);
 
+        let analysis = Rc::new(RefCell::new(AnalysisRuns::new(state.pools.clone())));
         let build_state = Rc::new(RefCell::new(state));
         spawn_tick_loop(queue.clone());
         crate::web::observer::source::spawn(&queue);
 
         while let Ok(cmd) = cmd_rx.recv_async().await {
-            dispatch_cmd(cmd, &queue, &build_state);
+            dispatch_cmd(cmd, &queue, &build_state, &analysis);
         }
+        analysis.borrow_mut().clear();
 
         match host.remove(&owner) {
             Ok(()) | Err(PlayError::SessionGone { .. }) => {}
@@ -157,7 +162,12 @@ fn spawn_tick_loop(queue: FfiQueueControl) {
     });
 }
 
-fn dispatch_cmd(cmd: WorkerCmd, queue: &FfiQueueControl, build_state: &Rc<RefCell<BuildState>>) {
+fn dispatch_cmd(
+    cmd: WorkerCmd,
+    queue: &FfiQueueControl,
+    build_state: &Rc<RefCell<BuildState>>,
+    analysis: &Rc<RefCell<AnalysisRuns>>,
+) {
     /// Milliseconds per second.
     const MS_PER_SECOND: f64 = 1000.0;
 
@@ -199,7 +209,14 @@ fn dispatch_cmd(cmd: WorkerCmd, queue: &FfiQueueControl, build_state: &Rc<RefCel
                 .map_err(|e| e.to_string());
             crate::web::interop::send_reply(request_id, result);
         }
+        WorkerCmd::Analyze { id, request_id } => {
+            let state = build_state.borrow();
+            if let Err(error) = start_analysis(queue, &state, analysis, id, request_id) {
+                crate::web::interop::send_reply(request_id, Err(error));
+            }
+        }
         WorkerCmd::Remove { id, request_id } => {
+            analysis.borrow_mut().cancel(id);
             let result = queue.remove(id).map_err(|e| e.to_string());
             crate::web::interop::send_reply(request_id, result);
         }
@@ -213,7 +230,8 @@ fn dispatch_cmd(cmd: WorkerCmd, queue: &FfiQueueControl, build_state: &Rc<RefCel
                 queue,
                 &build_state.borrow(),
                 ReplaceTrackArgs { url, id, index },
-            );
+            )
+            .map(|dropped| analysis.borrow_mut().cancel(dropped));
             crate::web::interop::send_reply(request_id, result);
         }
         WorkerCmd::SelectQueue {
@@ -224,7 +242,10 @@ fn dispatch_cmd(cmd: WorkerCmd, queue: &FfiQueueControl, build_state: &Rc<RefCel
             let result = queue.select(id, transition).map_err(|e| e.to_string());
             crate::web::interop::send_reply(request_id, result);
         }
-        WorkerCmd::RemoveAll => queue.clear(),
+        WorkerCmd::RemoveAll => {
+            analysis.borrow_mut().clear();
+            queue.clear();
+        }
         WorkerCmd::SetAbrMode { variant_index } => {
             apply_abr_mode(queue, variant_index);
         }
@@ -356,21 +377,26 @@ fn build_source(state: &BuildState, url: String) -> FfiTrackSource {
     if state.keys.key_registry.is_none() && state.headers.is_empty() {
         return FfiTrackSource::Uri(url);
     }
-    match ResourceSrc::parse(&url) {
-        Ok(src) => {
-            let headers = (!state.headers.is_empty()).then(|| state.headers.clone());
-            let config = FfiResourceConfig::for_src(src)
-                .keys(state.keys.clone())
-                .maybe_headers(headers.map(Into::into))
-                .store(state.store.clone())
-                .build();
-            FfiTrackSource::Config(Box::new(config))
-        }
-        Err(err) => {
-            clog!("[WORKER] build_source: invalid url {url}: {err}; using raw URI");
-            FfiTrackSource::Uri(url)
-        }
-    }
+    build_config(state, &url).map_or(FfiTrackSource::Uri(url), |config| {
+        FfiTrackSource::Config(Box::new(config))
+    })
+}
+
+fn build_config(state: &BuildState, url: &str) -> Option<FfiResourceConfig> {
+    let src = ResourceSrc::parse(url)
+        .inspect_err(|err| {
+            clog!("[WORKER] build_config: invalid url {url}: {err}");
+        })
+        .ok()?;
+    let headers = (!state.headers.is_empty()).then(|| state.headers.clone());
+    Some(
+        FfiResourceConfig::for_src(src)
+            .keys(state.keys.clone())
+            .maybe_headers(headers.map(Into::into))
+            .store(state.store.clone())
+            .worker(state.worker.clone())
+            .build(),
+    )
 }
 
 struct ReplaceTrackArgs {
@@ -386,7 +412,7 @@ fn replace_track(
     queue: &FfiQueueControl,
     state: &BuildState,
     args: ReplaceTrackArgs,
-) -> Result<(), String> {
+) -> Result<TrackId, String> {
     let ReplaceTrackArgs { index, id, url } = args;
 
     let idx = index as usize;
@@ -404,6 +430,36 @@ fn replace_track(
         .insert_with_id(id, build_source(state, url), after)
         .map_err(|e| e.to_string())?;
     queue.remove(old_id).map_err(|e| e.to_string())?;
+    Ok(old_id)
+}
+
+fn start_analysis(
+    queue: &FfiQueueControl,
+    state: &BuildState,
+    analysis: &Rc<RefCell<AnalysisRuns>>,
+    id: TrackId,
+    request_id: u32,
+) -> Result<(), String> {
+    let source = queue
+        .track_source(id)
+        .ok_or_else(|| format!("track {id:?} is not queued"))?;
+    let token = source
+        .uri()
+        .map(AnalysisToken::from)
+        .ok_or_else(|| format!("track {id:?} has a source with no readable location"))?;
+    let config = match source {
+        FfiTrackSource::Config(config) => *config,
+        FfiTrackSource::Uri(ref url) => build_config(state, url)
+            .ok_or_else(|| format!("track {id:?} carries a url kithara cannot parse: {url}"))?,
+        _ => {
+            return Err(format!(
+                "track {id:?} carries a source this build cannot open"
+            ));
+        }
+    };
+    analysis
+        .borrow_mut()
+        .start(queue, config, id, token, request_id);
     Ok(())
 }
 

--- a/crates/kithara-host/CONTEXT.md
+++ b/crates/kithara-host/CONTEXT.md
@@ -113,6 +113,11 @@ a mismatch before the Player can register or start. Session register/start
 commands derive their rate from the same query rather than accepting another
 caller-supplied value.
 
+Web warm-up creates the `AudioContext` at the session's configured rate, the
+same rate every Player is built for, so the session-rate query answers with a
+rate insertion can validate against. The rate the device settles on reaches the
+resampler as the measured rate.
+
 Route changes keep the existing flow: the Host observes the device change and
 the Player receives the resulting sample-rate update through its current
 control path. Rebuilding the output graph is reserved for a physical route

--- a/crates/kithara-host/src/session/web/bridge.rs
+++ b/crates/kithara-host/src/session/web/bridge.rs
@@ -90,7 +90,7 @@ pub(crate) fn warm_up_audio<S>(
             "local web session state is unavailable".to_owned(),
         ));
     };
-    ensure_ctx(state, 0)
+    ensure_ctx(state, state.sample_rate_hint)
 }
 
 pub(super) fn start_stream_web_audio(

--- a/crates/kithara-test-fixtures/src/defs/signal.rs
+++ b/crates/kithara-test-fixtures/src/defs/signal.rs
@@ -15,6 +15,8 @@ impl Consts {
     const FRAMES_240MS_44K1: usize = 10_584;
     const FRAMES_2S_44K1: usize = 88_200;
     const FRAMES_30S_44K1: usize = 1_323_000;
+    const FRAMES_PER_BEAT_126BPM_44K1: usize = 21_000;
+    const FRAMES_CLICK_BURST_44K1: usize = 1_323;
     const FRAMES_60S_44K1: usize = 2_646_000;
     const FRAMES_6S_44K1: usize = 264_600;
     const RATE_44K1: u32 = 44_100;
@@ -203,6 +205,17 @@ fn signal_wav(wave: Wave, sample_rate: u32, channels: u16, total_frames: usize) 
 )]
 #[case::sine880_30s(
     Wave::sine(880.0),
+    Consts::RATE_44K1,
+    Consts::STEREO,
+    Consts::FRAMES_30S_44K1,
+    None
+)]
+#[case::clicks126_30s(
+    Wave::clicks(
+        1_000.0,
+        Consts::FRAMES_PER_BEAT_126BPM_44K1,
+        Consts::FRAMES_CLICK_BURST_44K1
+    ),
     Consts::RATE_44K1,
     Consts::STEREO,
     Consts::FRAMES_30S_44K1,

--- a/crates/kithara-test-fixtures/src/signal/wave.rs
+++ b/crates/kithara-test-fixtures/src/signal/wave.rs
@@ -26,6 +26,14 @@ pub enum SweepMode {
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
 pub enum Wave {
+    /// Tone bursts at `hz` every `period_frames`, each fading out over
+    /// `burst_frames`.
+    #[non_exhaustive]
+    Clicks {
+        hz: f64,
+        period_frames: usize,
+        burst_frames: usize,
+    },
     /// Ascending saw-tooth: frame 0 is `i16::MIN`, frame 65535 is `i16::MAX`.
     Sawtooth,
     /// Descending saw-tooth: frame 0 is `i16::MAX`, frame 65535 is `i16::MIN`.
@@ -48,10 +56,47 @@ pub enum Wave {
 }
 
 impl Wave {
+    /// A repeating tone burst: `hz` fading to silence across `burst_frames`,
+    /// once every `period_frames`.
+    ///
+    /// # Panics
+    /// Panics unless `hz` is finite and positive and the burst fits one period.
+    #[must_use]
+    pub fn clicks(hz: f64, period_frames: usize, burst_frames: usize) -> Self {
+        assert!(
+            hz.is_finite() && hz > 0.0,
+            "a click burst carries a finite positive frequency, not {hz}"
+        );
+        assert!(burst_frames > 0, "a click burst spans at least one frame");
+        assert!(
+            burst_frames <= period_frames,
+            "a burst of {burst_frames} frames does not fit a period of {period_frames}"
+        );
+
+        Self::Clicks {
+            hz,
+            period_frames,
+            burst_frames,
+        }
+    }
+
     /// One 16-bit sample of this waveform.
     #[must_use]
     pub fn sample(self, frame: usize, sample_rate: u32) -> i16 {
         match self {
+            Self::Clicks {
+                hz,
+                period_frames,
+                burst_frames,
+            } => {
+                let into = frame % period_frames;
+                if into >= burst_frames {
+                    return 0;
+                }
+                let at = seconds(into, sample_rate);
+                let fade = 1.0 - at / seconds(burst_frames, sample_rate);
+                quantize(fade * f64::sin(TAU * hz * at), i16::MAX)
+            }
             Self::Sawtooth => saw(frame),
             Self::SawtoothDescending => saw(SAW_PERIOD - 1 - frame % SAW_PERIOD),
             Self::SawtoothShifted => saw(frame + SAW_PERIOD / 2),
@@ -202,6 +247,14 @@ mod tests {
         &samples[range]
     }
 
+    fn peak(samples: &[i16]) -> i32 {
+        samples
+            .iter()
+            .map(|&s| i32::from(s).abs())
+            .max()
+            .unwrap_or(0)
+    }
+
     #[kithara::test(native, flash(false))]
     fn a_saw_climbs_the_whole_16_bit_range() {
         assert_eq!(Wave::Sawtooth.sample(0, SAMPLE_RATE), i16::MIN);
@@ -247,6 +300,24 @@ mod tests {
         };
 
         assert_eq!(quiet.sample(1, SAMPLE_RATE), 1_000);
+    }
+
+    #[kithara::test(native, flash(false))]
+    fn clicks_fade_out_and_leave_the_rest_of_the_period_silent() {
+        let period = SAMPLE_RATE as usize / 2;
+        let burst = SAMPLE_RATE as usize / 100;
+        let clicks = Wave::clicks(1_000.0, period, burst);
+        let samples = render(clicks, period * 2);
+
+        assert!(samples[burst..period].iter().all(|&s| s == 0));
+        let head = peak(window(&samples, 0..burst / 4));
+        let tail = peak(window(&samples, burst * 3 / 4..burst));
+        assert!(head > tail, "{head} > {tail}");
+        assert_eq!(
+            peak(window(&samples, 0..burst)),
+            peak(window(&samples, period..period + burst)),
+            "every period carries the same burst"
+        );
     }
 
     #[kithara::test(native, flash(false))]

--- a/crates/kithara-test-fixtures/src/signal_asset.rs
+++ b/crates/kithara-test-fixtures/src/signal_asset.rs
@@ -18,13 +18,14 @@ impl SignalAsset {
     pub const AAC_SINE440_60S_256K: Self = Self::new("signal_aac_sine440_60s_256k", "aac");
     pub const AAC_SINE440_60S_320K: Self = Self::new("signal_aac_sine440_60s_320k", "aac");
     /// Every asset the `/signal` route can serve.
-    pub const ALL: [Self; 40] = [
+    pub const ALL: [Self; 41] = [
         Self::WAV_SAW_1S,
         Self::WAV_SILENCE_1S,
         Self::WAV_SINE440_120MS,
         Self::WAV_SINE440_1S,
         Self::WAV_SINE440_60S,
         Self::WAV_SINE880_240MS,
+        Self::MP3_CLICKS126_30S,
         Self::MP3_SAW_1S,
         Self::MP3_SAW_2S,
         Self::MP3_SAW_2S_64K,
@@ -71,6 +72,7 @@ impl SignalAsset {
     pub const M4A_SINE440_60S_192K: Self = Self::new("signal_m4a_sine440_60s_192k", "m4a");
     pub const M4A_SINE440_60S_256K: Self = Self::new("signal_m4a_sine440_60s_256k", "m4a");
     pub const M4A_SINE440_60S_320K: Self = Self::new("signal_m4a_sine440_60s_320k", "m4a");
+    pub const MP3_CLICKS126_30S: Self = Self::new("signal_mp3_clicks126_30s", "mp3");
     pub const MP3_SAW_1S: Self = Self::new("signal_mp3_saw_1s", "mp3");
     pub const MP3_SAW_2S: Self = Self::new("signal_mp3_saw_2s", "mp3");
     pub const MP3_SAW_2S_320K: Self = Self::new("signal_mp3_saw_2s_320k", "mp3");

--- a/crates/kithara-worker/CONTEXT.md
+++ b/crates/kithara-worker/CONTEXT.md
@@ -32,12 +32,18 @@ Higher numeric priority runs first, with stable task ID order as the tie-break.
 Immediate wake may unpark the thread; deferred wake is a coalesced atomic signal
 suitable for real-time callers and publishes writes made before it.
 
-Rayon compute is explicitly disabled, shared from an external owner, or lazily
-owned. A lazy pool is built only after the first job passes both admission
-limits. Compute submission has per-task and worker-wide in-flight limits and no
-hidden queue. Every rejection returns its caller-owned payload unchanged. A
-saturated task may retry on a later scheduler tick after completion wakes the
-dispatcher. WebAssembly exposes only the disabled mode.
+Compute is explicitly disabled, lazily owned, or shared from an external Rayon
+pool; sharing is native-only. One owned-pool configuration carries the thread
+count and thread-name prefix on both targets: natively it builds a Rayon pool of
+that size after the first job passes both admission limits, on WebAssembly it
+spawns one thread per admitted job and the thread count is a native pool size
+that the spawn ignores. Compute submission has per-task and worker-wide
+in-flight limits and no hidden queue; those two limits are what bounds the jobs
+in flight on WebAssembly. Every rejection returns its caller-owned payload
+unchanged. A saturated task may retry on a later scheduler tick after completion
+wakes the dispatcher. A thread the platform refuses to spawn aborts the process,
+as it does for the dispatcher thread itself, and a compute job that panics under
+`panic=abort` aborts with it.
 
 The command channel is unbounded as a primitive, but task capacity bounds its
 producers: one reservation can enqueue one registration and its non-cloneable

--- a/crates/kithara-worker/CONTEXT.md
+++ b/crates/kithara-worker/CONTEXT.md
@@ -37,13 +37,15 @@ pool; sharing is native-only. One owned-pool configuration carries the thread
 count and thread-name prefix on both targets: natively it builds a Rayon pool of
 that size after the first job passes both admission limits, on WebAssembly it
 spawns one thread per admitted job and the thread count is a native pool size
-that the spawn ignores. Compute submission has per-task and worker-wide
-in-flight limits and no hidden queue; those two limits are what bounds the jobs
-in flight on WebAssembly. Every rejection returns its caller-owned payload
-unchanged. A saturated task may retry on a later scheduler tick after completion
-wakes the dispatcher. A thread the platform refuses to spawn aborts the process,
-as it does for the dispatcher thread itself, and a compute job that panics under
-`panic=abort` aborts with it.
+that the spawn ignores. A browser starts a spawned thread only once the context
+that spawned it returns to its event loop, so a caller that submits a job and
+then blocks its own thread never sees that job run. Compute submission has
+per-task and worker-wide in-flight limits and no hidden queue; those two limits
+are what bounds the jobs in flight on WebAssembly. Every rejection returns its
+caller-owned payload unchanged. A saturated task may retry on a later scheduler
+tick after completion wakes the dispatcher. A thread the platform refuses to
+spawn aborts the process, as it does for the dispatcher thread itself, and a
+compute job that panics under `panic=abort` aborts with it.
 
 The command channel is unbounded as a primitive, but task capacity bounds its
 producers: one reservation can enqueue one registration and its non-cloneable

--- a/crates/kithara-worker/Cargo.toml
+++ b/crates/kithara-worker/Cargo.toml
@@ -39,11 +39,14 @@ rayon = { workspace = true }
 [dev-dependencies]
 kithara-test-utils = { workspace = true, features = ["client-reqwest", "hang", "probe", "tls-rustls"] }
 
-criterion = { workspace = true }
 tracing = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion = { workspace = true }
 serde_yaml_ng = { workspace = true }
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/kithara-worker/src/compute.rs
+++ b/crates/kithara-worker/src/compute.rs
@@ -228,10 +228,10 @@ mod tests {
         sync::{
             Arc,
             atomic::{AtomicBool, Ordering},
-            mpsc,
+            mpsc::{self, TryRecvError},
         },
         thread::current_thread_id,
-        time::{Duration, Instant},
+        time::{self, Duration, Instant},
     };
     use kithara_test_utils::kithara;
 
@@ -284,12 +284,24 @@ mod tests {
         }
     }
 
-    /// The compute seam runs an admitted job off the dispatcher thread and
-    /// wakes the dispatcher when the job releases its permits. A tick that
-    /// observes the job's result inside the one-second deadline can only come
-    /// from that wake: the scheduler waits two seconds between its own visits.
-    #[kithara::test(native, browser, flash(false))]
-    fn compute_job_runs_off_the_dispatcher_thread_and_wakes_it() {
+    async fn next_step(observed: &mpsc::Receiver<Step>, deadline: Instant, what: &str) -> Step {
+        loop {
+            match observed.try_recv() {
+                Ok(step) => return step,
+                Err(TryRecvError::Empty) => {
+                    assert!(
+                        Instant::now() < deadline,
+                        "the dispatcher must report {what}"
+                    );
+                    time::sleep(Duration::from_millis(5)).await;
+                }
+                Err(closed) => panic!("the probe stopped reporting {what}: {closed:?}"),
+            }
+        }
+    }
+
+    #[kithara::test(tokio, browser, flash(false))]
+    async fn compute_job_runs_off_the_dispatcher_thread_and_wakes_it() {
         let worker = Worker::new(WorkerConfig::new().with_owned_pool(OwnedPoolConfig::new(
             NonZeroUsize::MIN,
             "compute-thread-test",
@@ -311,15 +323,13 @@ mod tests {
             })
             .expect("probe task admission");
 
-        let deadline = Instant::now() + Duration::from_secs(1);
+        let run_by = Instant::now() + Duration::from_secs(10);
         let mut recorded = Vec::new();
-        while recorded.len() < 3 {
-            recorded.push(
-                observed
-                    .recv_timeout(deadline)
-                    .expect("dispatcher must report admission, run and wake"),
-            );
+        while recorded.len() < 2 {
+            recorded.push(next_step(&observed, run_by, "admission and the run").await);
         }
+        let woken_by = Instant::now() + Duration::from_secs(1);
+        recorded.push(next_step(&observed, woken_by, "the wake that follows the run").await);
 
         let Some(&Step::Admitted { dispatcher, ok }) = recorded
             .iter()

--- a/crates/kithara-worker/src/compute.rs
+++ b/crates/kithara-worker/src/compute.rs
@@ -5,10 +5,157 @@ mod platform;
 #[path = "compute/wasm.rs"]
 mod platform;
 
-use kithara_platform::{CancelGroup, CancelToken};
-#[cfg(all(test, not(target_arch = "wasm32")))]
+use std::num::NonZeroUsize;
+
+use kithara_platform::{
+    CancelGroup, CancelToken,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
 pub(crate) use platform::ComputePool;
-pub(crate) use platform::{Budget, ComputeRuntime};
+
+use crate::{Wake, config::PoolConfig};
+
+/// Worker-owned compute seam pairing budget admission with a platform pool.
+pub(crate) struct ComputeRuntime {
+    budget: Arc<Budget>,
+    pool: ComputePool,
+}
+
+impl ComputeRuntime {
+    pub(crate) fn new(pool: PoolConfig, max_in_flight: NonZeroUsize) -> Self {
+        Self {
+            budget: Arc::new(Budget::new(max_in_flight)),
+            pool: ComputePool::new(pool),
+        }
+    }
+
+    #[cfg(all(test, not(target_arch = "wasm32")))]
+    pub(crate) const fn pool(&self) -> &ComputePool {
+        &self.pool
+    }
+
+    pub(crate) fn submit<T, F>(
+        &self,
+        task_budget: &Arc<Budget>,
+        task_token: &CancelToken,
+        wake: Wake,
+        payload: T,
+        job: F,
+    ) -> Result<(), ComputeRejected<T>>
+    where
+        T: Send + 'static,
+        F: FnOnce(ComputeContext, T) + Send + 'static,
+    {
+        if task_token.is_cancelled() {
+            return Err(ComputeRejected::new(ComputeSubmitError::Cancelled, payload));
+        }
+        if self.pool.is_disabled() {
+            return Err(ComputeRejected::new(
+                ComputeSubmitError::Unavailable,
+                payload,
+            ));
+        }
+        let Some(task_permit) = Budget::try_acquire(task_budget) else {
+            return Err(ComputeRejected::new(ComputeSubmitError::Saturated, payload));
+        };
+        let Some(worker_permit) = Budget::try_acquire(&self.budget) else {
+            return Err(ComputeRejected::new(ComputeSubmitError::Saturated, payload));
+        };
+        if task_token.is_cancelled() {
+            return Err(ComputeRejected::new(ComputeSubmitError::Cancelled, payload));
+        }
+        let spawner = match self.pool.spawner() {
+            Ok(spawner) => spawner,
+            Err(reason) => return Err(ComputeRejected::new(reason, payload)),
+        };
+        if task_token.is_cancelled() {
+            return Err(ComputeRejected::new(ComputeSubmitError::Cancelled, payload));
+        }
+        let token = task_token.child();
+        let context = ComputeContext {
+            cancel: CancelGroup::from(token.clone()),
+            token,
+        };
+        let permit = ComputePermit {
+            wake,
+            task: Some(task_permit),
+            worker: Some(worker_permit),
+        };
+
+        spawner.spawn(move || {
+            let _permit = permit;
+            job(context, payload);
+        });
+        Ok(())
+    }
+}
+
+/// In-flight admission counter.
+pub(crate) struct Budget {
+    active: AtomicUsize,
+    limit: NonZeroUsize,
+}
+
+impl Budget {
+    pub(crate) fn new(limit: NonZeroUsize) -> Self {
+        Self {
+            limit,
+            active: AtomicUsize::new(0),
+        }
+    }
+
+    #[cfg(all(test, not(target_arch = "wasm32")))]
+    fn active(&self) -> usize {
+        self.active.load(Ordering::Acquire)
+    }
+
+    fn try_acquire(budget: &Arc<Self>) -> Option<BudgetPermit> {
+        let mut active = budget.active.load(Ordering::Acquire);
+        while active < budget.limit.get() {
+            match budget.active.compare_exchange_weak(
+                active,
+                active + 1,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    return Some(BudgetPermit {
+                        budget: Arc::clone(budget),
+                    });
+                }
+                Err(current) => active = current,
+            }
+        }
+        None
+    }
+}
+
+struct BudgetPermit {
+    budget: Arc<Budget>,
+}
+
+impl Drop for BudgetPermit {
+    fn drop(&mut self) {
+        self.budget.active.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+struct ComputePermit {
+    task: Option<BudgetPermit>,
+    worker: Option<BudgetPermit>,
+    wake: Wake,
+}
+
+impl Drop for ComputePermit {
+    fn drop(&mut self) {
+        drop(self.task.take());
+        drop(self.worker.take());
+        self.wake.wake();
+    }
+}
 
 /// Cancellation context for one admitted compute job.
 #[non_exhaustive]
@@ -39,7 +186,7 @@ pub enum ComputeSubmitError {
     /// The owning task or an additional domain cancellation source fired.
     #[error("compute task is cancelled")]
     Cancelled,
-    /// This worker has no configured Rayon pool.
+    /// This worker has no configured compute pool.
     #[error("compute pool is unavailable")]
     Unavailable,
     /// The task or worker in-flight budget is exhausted.
@@ -70,5 +217,131 @@ impl<T> ComputeRejected<T> {
     #[must_use]
     pub fn recover_payload(self) -> T {
         self.payload
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroUsize;
+
+    use kithara_platform::{
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+            mpsc,
+        },
+        thread::current_thread_id,
+        time::{Duration, Instant},
+    };
+    use kithara_test_utils::kithara;
+
+    use crate::{
+        DispatcherConfig, OwnedPoolConfig, Task, TaskConfig, TaskContext, TickResult, Worker,
+        WorkerConfig,
+    };
+
+    #[derive(Debug, Eq, PartialEq)]
+    enum Step {
+        Admitted { dispatcher: u64, ok: bool },
+        Ran { compute: u64 },
+        Woken,
+    }
+
+    struct ThreadProbe {
+        context: TaskContext,
+        steps: mpsc::Sender<Step>,
+        ran: Arc<AtomicBool>,
+        submitted: bool,
+    }
+
+    impl Task for ThreadProbe {
+        fn tick(&mut self) -> TickResult {
+            if self.submitted {
+                if !self.ran.load(Ordering::Acquire) {
+                    return TickResult::Waiting;
+                }
+                self.steps.send(Step::Woken).ok();
+                return TickResult::Done;
+            }
+            self.submitted = true;
+            let steps = self.steps.clone();
+            let ran = Arc::clone(&self.ran);
+            let admitted = self.context.submit_compute((), move |_, ()| {
+                steps
+                    .send(Step::Ran {
+                        compute: current_thread_id(),
+                    })
+                    .ok();
+                ran.store(true, Ordering::Release);
+            });
+            self.steps
+                .send(Step::Admitted {
+                    dispatcher: current_thread_id(),
+                    ok: admitted.is_ok(),
+                })
+                .ok();
+            TickResult::Waiting
+        }
+    }
+
+    /// The compute seam runs an admitted job off the dispatcher thread and
+    /// wakes the dispatcher when the job releases its permits. A tick that
+    /// observes the job's result inside the one-second deadline can only come
+    /// from that wake: the scheduler waits two seconds between its own visits.
+    #[kithara::test(native, browser, flash(false))]
+    fn compute_job_runs_off_the_dispatcher_thread_and_wakes_it() {
+        let worker = Worker::new(WorkerConfig::new().with_owned_pool(OwnedPoolConfig::new(
+            NonZeroUsize::MIN,
+            "compute-thread-test",
+        )));
+        let dispatcher = worker.dispatcher(
+            DispatcherConfig::builder()
+                .name("compute-thread-test")
+                .idle_timeout(Duration::from_secs(2))
+                .wait_timeout(Duration::from_secs(2))
+                .build(),
+        );
+        let (steps, observed) = mpsc::channel();
+        let _handle = dispatcher
+            .register(TaskConfig::new(), move |context| ThreadProbe {
+                context,
+                steps,
+                ran: Arc::new(AtomicBool::new(false)),
+                submitted: false,
+            })
+            .expect("probe task admission");
+
+        let deadline = Instant::now() + Duration::from_secs(1);
+        let mut recorded = Vec::new();
+        while recorded.len() < 3 {
+            recorded.push(
+                observed
+                    .recv_timeout(deadline)
+                    .expect("dispatcher must report admission, run and wake"),
+            );
+        }
+
+        let Some(&Step::Admitted { dispatcher, ok }) = recorded
+            .iter()
+            .find(|step| matches!(step, Step::Admitted { .. }))
+        else {
+            panic!("compute submission was never reported: {recorded:?}");
+        };
+        let Some(&Step::Ran { compute }) = recorded
+            .iter()
+            .find(|step| matches!(step, Step::Ran { .. }))
+        else {
+            panic!("compute job never ran: {recorded:?}");
+        };
+        assert!(ok, "compute admission must succeed");
+        assert_eq!(
+            recorded.last(),
+            Some(&Step::Woken),
+            "completion must wake the dispatcher last"
+        );
+        assert_ne!(
+            dispatcher, compute,
+            "compute job must not run on the dispatcher thread"
+        );
     }
 }

--- a/crates/kithara-worker/src/compute/native.rs
+++ b/crates/kithara-worker/src/compute/native.rs
@@ -1,122 +1,32 @@
-use std::num::NonZeroUsize;
-
-use kithara_platform::{
-    CancelGroup, CancelToken,
-    sync::{
-        Arc, OnceLock,
-        atomic::{AtomicUsize, Ordering},
-    },
-};
+use kithara_platform::sync::{Arc, OnceLock};
 use rayon::ThreadPoolBuilder;
 
-use super::{ComputeContext, ComputeRejected, ComputeSubmitError};
-use crate::{RayonConfig, Wake, config::PoolConfig};
-
-pub(crate) struct ComputeRuntime {
-    budget: Arc<Budget>,
-    pool: ComputePool,
-}
-
-impl ComputeRuntime {
-    pub(crate) fn new(pool: PoolConfig, max_in_flight: NonZeroUsize) -> Self {
-        Self {
-            budget: Arc::new(Budget::new(max_in_flight)),
-            pool: match pool {
-                PoolConfig::Disabled => ComputePool::Disabled,
-                PoolConfig::OwnedLazy(config) => ComputePool::OwnedLazy {
-                    config,
-                    pool: OnceLock::new(),
-                },
-                PoolConfig::Shared(pool) => ComputePool::Shared(pool),
-            },
-        }
-    }
-
-    #[cfg(test)]
-    pub(crate) const fn pool(&self) -> &ComputePool {
-        &self.pool
-    }
-
-    pub(crate) fn submit<T, F>(
-        &self,
-        task_budget: &Arc<Budget>,
-        task_token: &CancelToken,
-        wake: Wake,
-        payload: T,
-        job: F,
-    ) -> Result<(), ComputeRejected<T>>
-    where
-        T: Send + 'static,
-        F: FnOnce(ComputeContext, T) + Send + 'static,
-    {
-        if task_token.is_cancelled() {
-            return Err(ComputeRejected::new(ComputeSubmitError::Cancelled, payload));
-        }
-        if matches!(self.pool, ComputePool::Disabled) {
-            return Err(ComputeRejected::new(
-                ComputeSubmitError::Unavailable,
-                payload,
-            ));
-        }
-        let Some(task_permit) = Budget::try_acquire(task_budget) else {
-            return Err(ComputeRejected::new(ComputeSubmitError::Saturated, payload));
-        };
-        let Some(worker_permit) = Budget::try_acquire(&self.budget) else {
-            return Err(ComputeRejected::new(ComputeSubmitError::Saturated, payload));
-        };
-        if task_token.is_cancelled() {
-            return Err(ComputeRejected::new(ComputeSubmitError::Cancelled, payload));
-        }
-        let pool = match self.pool.get() {
-            Ok(pool) => pool,
-            Err(reason) => return Err(ComputeRejected::new(reason, payload)),
-        };
-        if task_token.is_cancelled() {
-            return Err(ComputeRejected::new(ComputeSubmitError::Cancelled, payload));
-        }
-        let token = task_token.child();
-        let context = ComputeContext {
-            cancel: CancelGroup::from(token.clone()),
-            token,
-        };
-        let permit = ComputePermit {
-            wake,
-            task: Some(task_permit),
-            worker: Some(worker_permit),
-        };
-
-        pool.spawn(move || {
-            let _permit = permit;
-            job(context, payload);
-        });
-        Ok(())
-    }
-}
+use super::ComputeSubmitError;
+use crate::{OwnedPoolConfig, config::PoolConfig};
 
 pub(crate) enum ComputePool {
     Disabled,
     OwnedLazy {
-        config: RayonConfig,
+        config: OwnedPoolConfig,
         pool: OnceLock<Result<Arc<rayon::ThreadPool>, String>>,
     },
     Shared(Arc<rayon::ThreadPool>),
 }
 
 impl ComputePool {
-    fn get(&self) -> Result<Arc<rayon::ThreadPool>, ComputeSubmitError> {
-        if matches!(self, Self::Disabled) {
-            return Err(ComputeSubmitError::Unavailable);
+    pub(super) fn new(config: PoolConfig) -> Self {
+        match config {
+            PoolConfig::Disabled => Self::Disabled,
+            PoolConfig::OwnedLazy(config) => Self::OwnedLazy {
+                config,
+                pool: OnceLock::new(),
+            },
+            PoolConfig::Shared(pool) => Self::Shared(pool),
         }
-        if let Self::Shared(pool) = self {
-            return Ok(Arc::clone(pool));
-        }
-        let Self::OwnedLazy { config, pool } = self else {
-            return Err(ComputeSubmitError::Unavailable);
-        };
-        pool.get_or_init(|| build_pool(config))
-            .as_ref()
-            .map(Arc::clone)
-            .map_err(|_| ComputeSubmitError::Unavailable)
+    }
+
+    pub(super) const fn is_disabled(&self) -> bool {
+        matches!(self, Self::Disabled)
     }
 
     #[cfg(test)]
@@ -131,9 +41,29 @@ impl ComputePool {
         };
         Some(pool)
     }
+
+    pub(super) fn spawner(&self) -> Result<Spawner, ComputeSubmitError> {
+        match self {
+            Self::Disabled => Err(ComputeSubmitError::Unavailable),
+            Self::Shared(pool) => Ok(Spawner(Arc::clone(pool))),
+            Self::OwnedLazy { config, pool } => pool
+                .get_or_init(|| build_pool(config))
+                .as_ref()
+                .map(|pool| Spawner(Arc::clone(pool)))
+                .map_err(|_| ComputeSubmitError::Unavailable),
+        }
+    }
 }
 
-fn build_pool(config: &RayonConfig) -> Result<Arc<rayon::ThreadPool>, String> {
+pub(super) struct Spawner(Arc<rayon::ThreadPool>);
+
+impl Spawner {
+    pub(super) fn spawn<F: FnOnce() + Send + 'static>(self, job: F) {
+        self.0.spawn(job);
+    }
+}
+
+fn build_pool(config: &OwnedPoolConfig) -> Result<Arc<rayon::ThreadPool>, String> {
     let prefix = config.name.clone();
     ThreadPoolBuilder::new()
         .num_threads(config.threads.get())
@@ -143,74 +73,19 @@ fn build_pool(config: &RayonConfig) -> Result<Arc<rayon::ThreadPool>, String> {
         .map_err(|error| error.to_string())
 }
 
-pub(crate) struct Budget {
-    active: AtomicUsize,
-    limit: NonZeroUsize,
-}
-
-impl Budget {
-    pub(crate) fn new(limit: NonZeroUsize) -> Self {
-        Self {
-            limit,
-            active: AtomicUsize::new(0),
-        }
-    }
-
-    fn try_acquire(budget: &Arc<Self>) -> Option<BudgetPermit> {
-        let mut active = budget.active.load(Ordering::Acquire);
-        while active < budget.limit.get() {
-            match budget.active.compare_exchange_weak(
-                active,
-                active + 1,
-                Ordering::AcqRel,
-                Ordering::Acquire,
-            ) {
-                Ok(_) => {
-                    return Some(BudgetPermit {
-                        budget: Arc::clone(budget),
-                    });
-                }
-                Err(current) => active = current,
-            }
-        }
-        None
-    }
-}
-
-struct BudgetPermit {
-    budget: Arc<Budget>,
-}
-
-impl Drop for BudgetPermit {
-    fn drop(&mut self) {
-        self.budget.active.fetch_sub(1, Ordering::AcqRel);
-    }
-}
-
-struct ComputePermit {
-    task: Option<BudgetPermit>,
-    worker: Option<BudgetPermit>,
-    wake: Wake,
-}
-
-impl Drop for ComputePermit {
-    fn drop(&mut self) {
-        drop(self.task.take());
-        drop(self.worker.take());
-        self.wake.wake();
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use kithara_platform::{
         CancelScope,
-        sync::{Arc, OnceLock, atomic::Ordering},
+        sync::{Arc, OnceLock},
     };
     use kithara_test_utils::kithara;
 
-    use super::{Budget, ComputePool, ComputeRuntime, ComputeSubmitError};
-    use crate::{RayonConfig, Wake};
+    use super::ComputePool;
+    use crate::{
+        OwnedPoolConfig, Wake,
+        compute::{Budget, ComputeRuntime, ComputeSubmitError},
+    };
 
     #[kithara::test(native, flash(false))]
     fn owned_pool_failure_returns_payload_and_releases_both_permits() {
@@ -219,7 +94,7 @@ mod tests {
         let runtime = ComputeRuntime {
             budget: Arc::new(Budget::new(std::num::NonZeroUsize::MIN)),
             pool: ComputePool::OwnedLazy {
-                config: RayonConfig::new(std::num::NonZeroUsize::MIN, "failed-pool-test"),
+                config: OwnedPoolConfig::new(std::num::NonZeroUsize::MIN, "failed-pool-test"),
                 pool: failed,
             },
         };
@@ -238,7 +113,7 @@ mod tests {
 
         assert_eq!(rejected.reason(), ComputeSubmitError::Unavailable);
         assert_eq!(rejected.recover_payload(), "detector");
-        assert_eq!(task_budget.active.load(Ordering::Acquire), 0);
-        assert_eq!(runtime.budget.active.load(Ordering::Acquire), 0);
+        assert_eq!(task_budget.active(), 0);
+        assert_eq!(runtime.budget.active(), 0);
     }
 }

--- a/crates/kithara-worker/src/compute/wasm.rs
+++ b/crates/kithara-worker/src/compute/wasm.rs
@@ -1,45 +1,40 @@
-use std::num::NonZeroUsize;
+use kithara_platform::thread::spawn_named;
 
-use kithara_platform::{CancelToken, sync::Arc};
+use super::ComputeSubmitError;
+use crate::config::PoolConfig;
 
-use super::{ComputeContext, ComputeRejected, ComputeSubmitError};
-use crate::{Wake, config::PoolConfig};
+/// Owned compute pool that runs each admitted job on its own spawned thread.
+pub(crate) enum ComputePool {
+    Disabled,
+    Owned { name: String },
+}
 
-pub(crate) struct ComputeRuntime;
-
-impl ComputeRuntime {
-    pub(crate) fn new(pool: PoolConfig, max_in_flight: NonZeroUsize) -> Self {
-        let _ = (pool, max_in_flight);
-        Self
+impl ComputePool {
+    pub(super) fn new(config: PoolConfig) -> Self {
+        match config {
+            PoolConfig::Disabled => Self::Disabled,
+            PoolConfig::OwnedLazy(config) => Self::Owned { name: config.name },
+        }
     }
 
-    pub(crate) fn submit<T, F>(
-        &self,
-        task_budget: &Arc<Budget>,
-        task_token: &CancelToken,
-        wake: Wake,
-        payload: T,
-        job: F,
-    ) -> Result<(), ComputeRejected<T>>
-    where
-        T: Send + 'static,
-        F: FnOnce(ComputeContext, T) + Send + 'static,
-    {
-        let _ = (task_budget, task_token, wake, job);
-        let reason = if task_token.is_cancelled() {
-            ComputeSubmitError::Cancelled
-        } else {
-            ComputeSubmitError::Unavailable
+    pub(super) const fn is_disabled(&self) -> bool {
+        matches!(self, Self::Disabled)
+    }
+
+    pub(super) fn spawner(&self) -> Result<Spawner, ComputeSubmitError> {
+        let Self::Owned { name } = self else {
+            return Err(ComputeSubmitError::Unavailable);
         };
-        Err(ComputeRejected::new(reason, payload))
+        Ok(Spawner { name: name.clone() })
     }
 }
 
-pub(crate) struct Budget;
+pub(super) struct Spawner {
+    name: String,
+}
 
-impl Budget {
-    pub(crate) const fn new(limit: NonZeroUsize) -> Self {
-        let _ = limit;
-        Self
+impl Spawner {
+    pub(super) fn spawn<F: FnOnce() + Send + 'static>(self, job: F) {
+        drop(spawn_named(self.name, job));
     }
 }

--- a/crates/kithara-worker/src/config.rs
+++ b/crates/kithara-worker/src/config.rs
@@ -5,6 +5,4 @@ mod worker;
 pub use dispatcher::{DispatcherConfig, DispatcherConfigPatch};
 pub use task::TaskConfig;
 pub(crate) use worker::PoolConfig;
-#[cfg(not(target_arch = "wasm32"))]
-pub use worker::RayonConfig;
-pub use worker::{ComputePool, WorkerConfig, WorkerConfigPatch};
+pub use worker::{ComputePool, OwnedPoolConfig, WorkerConfig, WorkerConfigPatch};

--- a/crates/kithara-worker/src/config/worker.rs
+++ b/crates/kithara-worker/src/config/worker.rs
@@ -28,7 +28,6 @@ pub struct WorkerConfig {
 }
 
 impl WorkerConfig {
-    /// Create a standalone worker with no Tokio handle or Rayon pool.
     #[must_use]
     pub const fn new() -> Self {
         Self {
@@ -39,10 +38,9 @@ impl WorkerConfig {
         }
     }
 
-    /// Lazily create an owned Rayon pool on the first admitted compute job.
-    #[cfg(not(target_arch = "wasm32"))]
+    /// Lazily create an owned compute pool on the first admitted compute job.
     #[must_use]
-    pub fn with_owned_pool(mut self, config: RayonConfig) -> Self {
+    pub fn with_owned_pool(mut self, config: OwnedPoolConfig) -> Self {
         self.pool = PoolConfig::OwnedLazy(config);
         self
     }
@@ -65,8 +63,7 @@ impl Default for WorkerConfig {
 #[derive(Clone)]
 pub(crate) enum PoolConfig {
     Disabled,
-    #[cfg(not(target_arch = "wasm32"))]
-    OwnedLazy(RayonConfig),
+    OwnedLazy(OwnedPoolConfig),
     #[cfg(not(target_arch = "wasm32"))]
     Shared(Arc<rayon::ThreadPool>),
 }
@@ -75,9 +72,8 @@ impl From<ComputePool> for PoolConfig {
     fn from(pool: ComputePool) -> Self {
         match pool {
             ComputePool::Disabled {} => Self::Disabled,
-            #[cfg(not(target_arch = "wasm32"))]
             ComputePool::Owned { name, threads } => {
-                Self::OwnedLazy(RayonConfig::new(threads, name))
+                Self::OwnedLazy(OwnedPoolConfig::new(threads, name))
             }
         }
     }
@@ -93,21 +89,21 @@ pub enum ComputePool {
     /// `deny_unknown_fields` against a variant's own field list, and a unit
     /// variant has none, so `mode: disabled` would swallow any key beside it.
     Disabled {},
-    #[cfg(not(target_arch = "wasm32"))]
-    Owned { name: String, threads: NonZeroUsize },
+    Owned {
+        name: String,
+        threads: NonZeroUsize,
+    },
 }
 
-/// Configuration for a Rayon pool built on first admitted compute work.
-#[cfg(not(target_arch = "wasm32"))]
+/// Thread count and thread-name prefix for a lazily built compute pool.
 #[non_exhaustive]
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct RayonConfig {
+pub struct OwnedPoolConfig {
     pub(crate) threads: NonZeroUsize,
     pub(crate) name: String,
 }
 
-#[cfg(not(target_arch = "wasm32"))]
-impl RayonConfig {
+impl OwnedPoolConfig {
     /// Configure the thread count and thread-name prefix.
     #[must_use]
     pub fn new<N: Into<String>>(threads: NonZeroUsize, name: N) -> Self {
@@ -124,11 +120,11 @@ mod tests {
 
     use kithara_test_utils::kithara;
 
-    use super::{ComputePool, PoolConfig, RayonConfig, WorkerConfig, WorkerConfigPatch};
+    use super::{ComputePool, OwnedPoolConfig, PoolConfig, WorkerConfig, WorkerConfigPatch};
 
     #[kithara::test(native, flash(false))]
     fn a_patch_writes_only_the_field_it_names() {
-        let seeded_pool = RayonConfig::new(NonZeroUsize::new(3).expect("nonzero"), "seed");
+        let seeded_pool = OwnedPoolConfig::new(NonZeroUsize::new(3).expect("nonzero"), "seed");
         let mut config = WorkerConfig::new()
             .with_max_compute_tasks(NonZeroUsize::new(2).expect("nonzero"))
             .with_owned_pool(seeded_pool.clone());
@@ -182,7 +178,7 @@ mod tests {
 
     #[kithara::test(native, flash(false))]
     fn a_pool_section_carries_the_documents_thread_count_and_name() {
-        let mut config = WorkerConfig::new().with_owned_pool(RayonConfig::new(
+        let mut config = WorkerConfig::new().with_owned_pool(OwnedPoolConfig::new(
             NonZeroUsize::new(5).expect("nonzero"),
             "seed",
         ));
@@ -205,7 +201,7 @@ mod tests {
 
     #[kithara::test(native, flash(false))]
     fn a_disabled_document_replaces_the_pool_the_builder_installed() {
-        let mut config = WorkerConfig::new().with_owned_pool(RayonConfig::new(
+        let mut config = WorkerConfig::new().with_owned_pool(OwnedPoolConfig::new(
             NonZeroUsize::new(5).expect("nonzero"),
             "seed",
         ));

--- a/crates/kithara-worker/src/dispatcher/tests.rs
+++ b/crates/kithara-worker/src/dispatcher/tests.rs
@@ -1,7 +1,6 @@
 use std::{
     mem,
     num::{NonZeroU32, NonZeroUsize},
-    rc::Rc,
 };
 
 use kithara_platform::{
@@ -11,10 +10,9 @@ use kithara_platform::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
         mpsc,
     },
-    thread,
-    time::{Duration, Instant},
+    time::Duration,
 };
-use kithara_test_utils::{hang::default_timeout, kithara, probe::capture as probe_capture};
+use kithara_test_utils::kithara;
 
 use super::{
     TaskError,
@@ -45,36 +43,6 @@ impl Task for CountingTask {
     fn tick(&mut self) -> TickResult {
         self.ticks.fetch_add(1, Ordering::Relaxed);
         TickResult::Progress
-    }
-}
-
-struct BackpressureCountingTask {
-    ticks: Arc<AtomicUsize>,
-    first_tick: Option<mpsc::Sender<()>>,
-}
-
-impl Task for BackpressureCountingTask {
-    fn tick(&mut self) -> TickResult {
-        if let Some(first_tick) = self.first_tick.take() {
-            first_tick.send(()).ok();
-        }
-        self.ticks.fetch_add(1, Ordering::Relaxed);
-        TickResult::Backpressured
-    }
-}
-
-struct BlockingTask {
-    started: Option<mpsc::Sender<()>>,
-    release: mpsc::Receiver<()>,
-}
-
-impl Task for BlockingTask {
-    fn tick(&mut self) -> TickResult {
-        if let Some(started) = self.started.take() {
-            started.send(()).ok();
-        }
-        self.release.recv().ok();
-        TickResult::Done
     }
 }
 
@@ -154,65 +122,6 @@ impl Task for TerminalDeferredTask {
     }
 }
 
-struct ReportingTask {
-    label: &'static str,
-    events: mpsc::Sender<(&'static str, &'static str, u64)>,
-    ticked: bool,
-}
-
-impl Task for ReportingTask {
-    fn on_cancel(&mut self) {
-        self.events
-            .send((self.label, "cancel", thread::current_thread_id()))
-            .ok();
-    }
-
-    fn tick(&mut self) -> TickResult {
-        if !self.ticked {
-            self.ticked = true;
-            self.events
-                .send((self.label, "tick", thread::current_thread_id()))
-                .ok();
-        }
-        TickResult::Backpressured
-    }
-}
-
-struct PanicTask;
-
-impl Task for PanicTask {
-    fn tick(&mut self) -> TickResult {
-        panic!("test task panic");
-    }
-}
-
-struct LocalTask {
-    _thread_bound: Rc<()>,
-    events: mpsc::Sender<(u64, u64)>,
-    constructed_on: u64,
-}
-
-impl Task for LocalTask {
-    fn tick(&mut self) -> TickResult {
-        self.events
-            .send((self.constructed_on, thread::current_thread_id()))
-            .ok();
-        TickResult::Done
-    }
-}
-
-struct PanicObserver {
-    panicked: mpsc::Sender<TaskId>,
-}
-
-impl Observer for PanicObserver {
-    fn on_event(&mut self, event: Event) {
-        if let Event::TaskPanicked { task } = event {
-            self.panicked.send(task).ok();
-        }
-    }
-}
-
 #[derive(Default)]
 struct Events(Vec<Event>);
 
@@ -239,30 +148,6 @@ fn pass_report(outcome: PassOutcome) -> PassReport {
     report
 }
 
-#[kithara::test(native, flash(false))]
-fn local_task_is_constructed_and_run_on_the_dispatcher_thread() {
-    let caller = thread::current_thread_id();
-    let worker = crate::Worker::new(crate::WorkerConfig::new());
-    let dispatcher = worker.dispatcher(DispatcherConfig::builder().name("local-task-test").build());
-    let (events, received) = mpsc::channel();
-    let task = dispatcher
-        .reserve(TaskConfig::new())
-        .expect("local task reservation")
-        .start_local(move |_| LocalTask {
-            events,
-            constructed_on: thread::current_thread_id(),
-            _thread_bound: Rc::new(()),
-        })
-        .expect("local task submission");
-
-    let (constructed_on, ticked_on) = received
-        .recv_timeout(Instant::now() + default_timeout())
-        .expect("local task completion");
-    assert_ne!(constructed_on, caller);
-    assert_eq!(constructed_on, ticked_on);
-    drop(task);
-}
-
 fn slot(id: u64, priority: Priority, task: impl Task) -> Slot {
     let scope = CancelScope::new(None);
     let token = scope.token().child();
@@ -279,7 +164,7 @@ fn slot(id: u64, priority: Priority, task: impl Task) -> Slot {
     }
 }
 
-#[kithara::test(native, flash(false))]
+#[kithara::test(flash(false))]
 fn numeric_priority_is_descending_with_stable_id_tie_break() {
     let mut slots = vec![
         slot(3, Priority::new(5), FixedTask(TickResult::Done)),
@@ -295,7 +180,7 @@ fn numeric_priority_is_descending_with_stable_id_tie_break() {
     );
 }
 
-#[kithara::test(native, flash(false))]
+#[kithara::test(flash(false))]
 fn priority_control_refreshes_the_single_mutable_priority_source() {
     let mut slots = vec![
         slot(1, Priority::new(1), FixedTask(TickResult::Done)),
@@ -311,7 +196,7 @@ fn priority_control_refreshes_the_single_mutable_priority_source() {
     assert_eq!(slots[0].id, TaskId::new(1));
 }
 
-#[kithara::test(native, flash(false))]
+#[kithara::test(flash(false))]
 fn configured_task_burst_limits_one_visit() {
     let ticks = Arc::new(AtomicUsize::new(0));
     let mut slots = vec![slot(
@@ -331,115 +216,7 @@ fn configured_task_burst_limits_one_visit() {
     assert_eq!(ticks.load(Ordering::Relaxed), 2);
 }
 
-#[kithara::test(native, flash(false))]
-fn configured_slow_threshold_and_fairness_interval_are_load_bearing() {
-    let mut slots = vec![slot(1, Priority::default(), FixedTask(TickResult::Done))];
-    let mut observer = Events::default();
-    let mut configured = budgets();
-    configured.slow_tick_threshold = Duration::ZERO;
-
-    let _ = produce_pass(&mut slots, configured, &mut observer);
-    assert!(
-        observer
-            .0
-            .iter()
-            .any(|event| matches!(event, Event::SlowTick { .. }))
-    );
-
-    configured.fairness_yield_interval = 1;
-    let mut streak = 0;
-    park_after_outcome(
-        &Wake::default(),
-        configured,
-        pass_report(PassOutcome::Progress),
-        &mut streak,
-    );
-    assert_eq!(streak, 0);
-}
-
-#[kithara::test(native, flash(false))]
-fn scheduler_does_not_busy_spin_on_backpressure() {
-    let ticks = Arc::new(AtomicUsize::new(0));
-    let (first_tick, first_tick_rx) = mpsc::channel();
-    let worker = crate::Worker::new(crate::WorkerConfig::new());
-    let dispatcher = worker.dispatcher(
-        DispatcherConfig::builder()
-            .name("backpressure-park-test")
-            .wait_timeout(Duration::from_millis(20))
-            .build(),
-    );
-    let handle = dispatcher
-        .register(TaskConfig::new(), {
-            let ticks = Arc::clone(&ticks);
-            move |_| BackpressureCountingTask {
-                ticks,
-                first_tick: Some(first_tick),
-            }
-        })
-        .expect("backpressured task submission");
-
-    first_tick_rx
-        .recv_timeout(Instant::now() + Duration::from_secs(2))
-        .expect("backpressured task must start");
-    thread::sleep(Duration::from_millis(80));
-
-    let observed = ticks.load(Ordering::Relaxed);
-    drop(handle);
-    assert!(
-        observed < 16,
-        "backpressured task ran {observed} times in 80ms despite a 20ms park budget"
-    );
-}
-
-#[kithara::test(native, flash(false))]
-#[kithara::hang_watchdog]
-fn backpressure_poll_observes_a_deferred_edge_without_restarting_the_task() {
-    let ticks = Arc::new(AtomicUsize::new(0));
-    let (first_tick, first_tick_rx) = mpsc::channel();
-    let worker = crate::Worker::new(crate::WorkerConfig::new());
-    let dispatcher = worker.dispatcher(
-        DispatcherConfig::builder()
-            .name("backpressure-deferred-poll-test")
-            .backpressure_poll_interval(Duration::from_millis(2))
-            .wait_timeout(Duration::from_millis(500))
-            .build(),
-    );
-    let handle = dispatcher
-        .register(TaskConfig::new(), {
-            let ticks = Arc::clone(&ticks);
-            move |_| BackpressureCountingTask {
-                ticks,
-                first_tick: Some(first_tick),
-            }
-        })
-        .expect("backpressured task submission");
-
-    first_tick_rx
-        .recv_timeout(Instant::now() + Duration::from_secs(2))
-        .expect("backpressured task must start");
-    thread::sleep(Duration::from_millis(20));
-    let settled_ticks = ticks.load(Ordering::Relaxed);
-    thread::sleep(Duration::from_millis(20));
-    assert_eq!(
-        ticks.load(Ordering::Relaxed),
-        settled_ticks,
-        "poll timeouts must not restart the task"
-    );
-
-    handle.control().defer();
-    let deadline = Instant::now() + Duration::from_millis(100);
-    while ticks.load(Ordering::Relaxed) == settled_ticks && Instant::now() < deadline {
-        hang_tick!();
-        thread::sleep(Duration::from_millis(1));
-    }
-    assert_eq!(
-        ticks.load(Ordering::Relaxed),
-        settled_ticks + 1,
-        "a deferred edge must end sliced backpressure waiting before the liveness timeout"
-    );
-}
-
-#[kithara::test(native, flash(false))]
+#[kithara::test(flash(false))]
 fn produce_pass_keeps_live_upstream_demand_out_of_waiting_outcome() {
     let mut observer = Events::default();
     let mut pending = vec![slot(
@@ -467,7 +244,7 @@ fn produce_pass_keeps_live_upstream_demand_out_of_waiting_outcome() {
     );
 }
 
-#[kithara::test(native, flash(false))]
+#[kithara::test(flash(false))]
 fn terminal_visit_recycles_before_and_after_tick() {
     let (events, received) = mpsc::channel();
     let mut slots = vec![slot(1, Priority::default(), LifecycleTask { events })];
@@ -487,7 +264,7 @@ fn terminal_visit_recycles_before_and_after_tick() {
     assert!(slots.is_empty());
 }
 
-#[kithara::test(native, flash(false))]
+#[kithara::test(flash(false))]
 fn live_visit_flushes_deferred_work_before_reporting_wait() {
     let (events, received) = mpsc::channel();
     let mut slots = vec![slot(
@@ -507,7 +284,7 @@ fn live_visit_flushes_deferred_work_before_reporting_wait() {
     assert!(received.try_recv().is_err());
 }
 
-#[kithara::test(native, flash(false))]
+#[kithara::test(flash(false))]
 fn unregister_recycles_cancelled_task_before_removal() {
     let (events, received) = mpsc::channel();
     let mut slots = vec![slot(1, Priority::default(), LifecycleTask { events })];
@@ -522,7 +299,7 @@ fn unregister_recycles_cancelled_task_before_removal() {
     assert!(received.try_recv().is_err());
 }
 
-#[kithara::test(native, flash(false))]
+#[kithara::test(flash(false))]
 fn shutdown_recycles_cancelled_tasks_before_drop() {
     let (events, received) = mpsc::channel();
     let mut slots = vec![slot(1, Priority::default(), LifecycleTask { events })];
@@ -535,82 +312,7 @@ fn shutdown_recycles_cancelled_tasks_before_drop() {
     assert!(received.try_recv().is_err());
 }
 
-#[kithara::test(native, flash(false))]
-fn shutdown_cancels_and_recycles_a_queued_never_run_task_once() {
-    let recorder = probe_capture::install();
-    let worker = crate::Worker::new(crate::WorkerConfig::new());
-    let dispatcher = worker.dispatcher(
-        DispatcherConfig::builder()
-            .name("queued-shutdown-test")
-            .build(),
-    );
-    let (started, started_rx) = mpsc::channel();
-    let (release, release_rx) = mpsc::channel();
-    let blocker = dispatcher
-        .register(TaskConfig::new(), move |_| BlockingTask {
-            release: release_rx,
-            started: Some(started),
-        })
-        .expect("blocking task submission");
-    started_rx
-        .recv_timeout(Instant::now() + Duration::from_secs(2))
-        .expect("blocking task must hold the dispatcher");
-    let (events, received) = mpsc::channel();
-    let queued = dispatcher
-        .register(TaskConfig::new(), move |_| LifecycleTask { events })
-        .expect("queued task submission");
-
-    dispatcher.shutdown();
-    release.send(()).expect("release blocking task");
-
-    recorder
-        .wait_for_probe(
-            |event| {
-                event.probe_name() == Some("cancel")
-                    && event.u64("task_id") == Some(queued.id().get())
-                    && event.u64("already_terminal") == Some(0)
-            },
-            default_timeout(),
-        )
-        .expect("queued task cancellation probe");
-
-    assert_eq!(
-        received
-            .recv_timeout(Instant::now() + default_timeout())
-            .expect("queued task cancellation"),
-        "cancel"
-    );
-    assert_eq!(
-        received
-            .recv_timeout(Instant::now() + default_timeout())
-            .expect("queued task recycle"),
-        "recycle"
-    );
-    assert!(received.try_recv().is_err());
-    drop(blocker);
-    drop(queued);
-}
-
-#[kithara::test(native, flash(false))]
-fn shutdown_closes_task_admission_before_returning() {
-    let worker = crate::Worker::new(crate::WorkerConfig::new());
-    let dispatcher = worker.dispatcher(
-        DispatcherConfig::builder()
-            .name("closed-admission-test")
-            .build(),
-    );
-
-    dispatcher.shutdown();
-
-    assert_eq!(
-        dispatcher
-            .register(TaskConfig::new(), |_| FixedTask(TickResult::Done))
-            .err(),
-        Some(TaskError::Stopped)
-    );
-}
-
-#[kithara::test(native, flash(false))]
+#[kithara::test(flash(false))]
 fn produce_pass_recycles_before_producing_and_between_burst_ticks() {
     let (events, received) = mpsc::channel();
     let mut slots = vec![slot(
@@ -634,7 +336,7 @@ fn produce_pass_recycles_before_producing_and_between_burst_ticks() {
     );
 }
 
-#[kithara::test(native, flash(false))]
+#[kithara::test(flash(false))]
 fn terminal_tick_flushes_deferred_work_before_slot_removal() {
     let flushed = Arc::new(AtomicBool::new(false));
     let mut slots = vec![slot(
@@ -654,7 +356,7 @@ fn terminal_tick_flushes_deferred_work_before_slot_removal() {
     assert!(flushed.load(Ordering::Acquire));
 }
 
-#[kithara::test(native, flash(false))]
+#[kithara::test(flash(false))]
 fn fairness_streak_yields_at_the_configured_interval_and_resets_on_waits() {
     let wake = Wake::default();
     let mut configured = budgets();
@@ -697,7 +399,7 @@ fn fairness_streak_yields_at_the_configured_interval_and_resets_on_waits() {
     }
 }
 
-#[kithara::test(native, flash(false))]
+#[kithara::test(native, browser, flash(false))]
 fn configured_capacity_rejects_a_second_reservation() {
     let worker = crate::Worker::new(crate::WorkerConfig::new());
     let dispatcher = worker.dispatcher(
@@ -718,7 +420,7 @@ fn configured_capacity_rejects_a_second_reservation() {
     assert!(dispatcher.reserve(TaskConfig::new()).is_ok());
 }
 
-#[kithara::test(native, flash(false))]
+#[kithara::test(native, browser, flash(false))]
 fn task_handle_drop_releases_capacity_for_immediate_ordered_replacement() {
     let worker = crate::Worker::new(crate::WorkerConfig::new());
     let dispatcher = worker.dispatcher(
@@ -742,7 +444,7 @@ fn task_handle_drop_releases_capacity_for_immediate_ordered_replacement() {
     );
 }
 
-#[kithara::test(native, flash(false))]
+#[kithara::test(flash(false))]
 fn dispatcher_builder_uses_scheduler_defaults() {
     let config = DispatcherConfig::builder().name("defaults-test").build();
 
@@ -756,7 +458,7 @@ fn dispatcher_builder_uses_scheduler_defaults() {
     assert!(config.cancel.is_none());
 }
 
-#[kithara::test(native, flash(false))]
+#[kithara::test(flash(false))]
 fn non_zero_budget_types_are_accepted_by_the_dispatcher_builder() {
     let _ = DispatcherConfig::builder()
         .name("budget-test")
@@ -770,140 +472,447 @@ fn non_zero_budget_types_are_accepted_by_the_dispatcher_builder() {
         .build();
 }
 
-#[kithara::test(native, flash(false))]
-fn dispatcher_cancel_group_does_not_cancel_worker_or_sibling_dispatcher() {
-    let worker = crate::Worker::new(crate::WorkerConfig::new());
-    let domain = CancelScope::new(None);
-    let first = worker.dispatcher(
-        DispatcherConfig::builder()
-            .name("first-dispatcher")
-            .cancel(CancelGroup::from(domain.token()))
-            .build(),
-    );
-    let sibling = worker.dispatcher(
-        DispatcherConfig::builder()
-            .name("sibling-dispatcher")
-            .build(),
-    );
+#[cfg(not(target_arch = "wasm32"))]
+mod native {
+    use std::rc::Rc;
 
-    domain.cancel();
+    use kithara_platform::{thread, time::Instant};
+    use kithara_test_utils::{hang::default_timeout, probe::capture as probe_capture};
 
-    assert!(first.is_cancelled());
-    assert!(!sibling.is_cancelled());
-    assert!(!worker.is_cancelled());
-}
+    use super::*;
 
-#[kithara::test(native, flash(false))]
-fn external_cancel_is_task_local_and_control_cancel_uses_dispatcher_thread() {
-    let worker = crate::Worker::new(crate::WorkerConfig::new());
-    let dispatcher = worker.dispatcher(
-        DispatcherConfig::builder()
-            .name("task-cancel-test")
-            .wait_timeout(Duration::from_secs(30))
-            .build(),
-    );
-    let domain = CancelScope::new(None);
-    let (events, received) = mpsc::channel();
-    let first = dispatcher
-        .reserve(
-            TaskConfig::new()
-                .with_cancel(CancelGroup::from(domain.token()))
-                .with_priority(Priority::new(2)),
-        )
-        .expect("first task reservation");
-    let first_context = first.context().clone();
-    let first_handle = first
-        .start({
-            let events = events.clone();
-            move |_| ReportingTask {
-                events,
-                label: "first",
-                ticked: false,
+    struct BackpressureCountingTask {
+        ticks: Arc<AtomicUsize>,
+        first_tick: Option<mpsc::Sender<()>>,
+    }
+
+    impl Task for BackpressureCountingTask {
+        fn tick(&mut self) -> TickResult {
+            if let Some(first_tick) = self.first_tick.take() {
+                first_tick.send(()).ok();
             }
-        })
-        .expect("first task submission");
-    let second = dispatcher
-        .reserve(TaskConfig::new().with_priority(Priority::new(1)))
-        .expect("second task reservation");
-    let second_context = second.context().clone();
-    let second_handle = second
-        .start(move |_| ReportingTask {
-            events,
-            label: "second",
-            ticked: false,
-        })
-        .expect("second task submission");
-
-    let deadline = Instant::now() + Duration::from_secs(5);
-    let mut first_thread = None;
-    let mut second_thread = None;
-    while first_thread.is_none() || second_thread.is_none() {
-        let (label, event, thread) = received
-            .recv_timeout(deadline)
-            .expect("both tasks must tick");
-        if event == "tick" && label == "first" {
-            first_thread = Some(thread);
-        } else if event == "tick" && label == "second" {
-            second_thread = Some(thread);
+            self.ticks.fetch_add(1, Ordering::Relaxed);
+            TickResult::Backpressured
         }
     }
 
-    domain.cancel();
-    let (label, event, cancel_thread) = received
-        .recv_timeout(Instant::now() + Duration::from_secs(2))
-        .expect("external cancellation must wake the parked dispatcher");
-    assert_eq!((label, event), ("first", "cancel"));
-    assert_eq!(Some(cancel_thread), first_thread);
-    assert!(first_context.token().is_cancelled());
-    assert!(!second_context.token().is_cancelled());
-    assert!(!dispatcher.is_cancelled());
-    assert!(!worker.is_cancelled());
+    struct BlockingTask {
+        started: Option<mpsc::Sender<()>>,
+        release: mpsc::Receiver<()>,
+    }
 
-    second_handle.control().cancel();
-    let (label, event, cancel_thread) = received
-        .recv_timeout(Instant::now() + Duration::from_secs(2))
-        .expect("task control cancellation must wake the dispatcher");
-    assert_eq!((label, event), ("second", "cancel"));
-    assert_eq!(Some(cancel_thread), second_thread);
-    assert!(second_context.token().is_cancelled());
+    impl Task for BlockingTask {
+        fn tick(&mut self) -> TickResult {
+            if let Some(started) = self.started.take() {
+                started.send(()).ok();
+            }
+            self.release.recv().ok();
+            TickResult::Done
+        }
+    }
 
-    drop(first_handle);
-    drop(second_handle);
-}
+    struct ReportingTask {
+        label: &'static str,
+        events: mpsc::Sender<(&'static str, &'static str, u64)>,
+        ticked: bool,
+    }
 
-#[kithara::test(native, flash(false))]
-fn a_panicking_task_does_not_stop_its_sibling() {
-    let worker = crate::Worker::new(crate::WorkerConfig::new());
-    let (panicked, observed_panic) = mpsc::channel();
-    let dispatcher = worker.dispatcher(
-        DispatcherConfig::builder()
-            .name("panic-isolation-test")
-            .observer(PanicObserver { panicked })
-            .build(),
-    );
-    let panic_handle = dispatcher
-        .register(TaskConfig::new(), |_| PanicTask)
-        .expect("panic task submission");
-    let (events, received) = mpsc::channel();
-    let sibling_handle = dispatcher
-        .register(TaskConfig::new(), move |_| ReportingTask {
-            events,
-            label: "sibling",
-            ticked: false,
-        })
-        .expect("sibling task submission");
+    impl Task for ReportingTask {
+        fn on_cancel(&mut self) {
+            self.events
+                .send((self.label, "cancel", thread::current_thread_id()))
+                .ok();
+        }
 
-    assert_eq!(
-        observed_panic
+        fn tick(&mut self) -> TickResult {
+            if !self.ticked {
+                self.ticked = true;
+                self.events
+                    .send((self.label, "tick", thread::current_thread_id()))
+                    .ok();
+            }
+            TickResult::Backpressured
+        }
+    }
+
+    struct PanicTask;
+
+    impl Task for PanicTask {
+        fn tick(&mut self) -> TickResult {
+            panic!("test task panic");
+        }
+    }
+
+    struct LocalTask {
+        _thread_bound: Rc<()>,
+        events: mpsc::Sender<(u64, u64)>,
+        constructed_on: u64,
+    }
+
+    impl Task for LocalTask {
+        fn tick(&mut self) -> TickResult {
+            self.events
+                .send((self.constructed_on, thread::current_thread_id()))
+                .ok();
+            TickResult::Done
+        }
+    }
+
+    struct PanicObserver {
+        panicked: mpsc::Sender<TaskId>,
+    }
+
+    impl Observer for PanicObserver {
+        fn on_event(&mut self, event: Event) {
+            if let Event::TaskPanicked { task } = event {
+                self.panicked.send(task).ok();
+            }
+        }
+    }
+
+    #[kithara::test(native, flash(false))]
+    fn local_task_is_constructed_and_run_on_the_dispatcher_thread() {
+        let caller = thread::current_thread_id();
+        let worker = crate::Worker::new(crate::WorkerConfig::new());
+        let dispatcher =
+            worker.dispatcher(DispatcherConfig::builder().name("local-task-test").build());
+        let (events, received) = mpsc::channel();
+        let task = dispatcher
+            .reserve(TaskConfig::new())
+            .expect("local task reservation")
+            .start_local(move |_| LocalTask {
+                events,
+                constructed_on: thread::current_thread_id(),
+                _thread_bound: Rc::new(()),
+            })
+            .expect("local task submission");
+
+        let (constructed_on, ticked_on) = received
+            .recv_timeout(Instant::now() + default_timeout())
+            .expect("local task completion");
+        assert_ne!(constructed_on, caller);
+        assert_eq!(constructed_on, ticked_on);
+        drop(task);
+    }
+
+    #[kithara::test(native, flash(false))]
+    fn configured_slow_threshold_and_fairness_interval_are_load_bearing() {
+        let mut slots = vec![slot(1, Priority::default(), FixedTask(TickResult::Done))];
+        let mut observer = Events::default();
+        let mut configured = budgets();
+        configured.slow_tick_threshold = Duration::ZERO;
+
+        let _ = produce_pass(&mut slots, configured, &mut observer);
+        assert!(
+            observer
+                .0
+                .iter()
+                .any(|event| matches!(event, Event::SlowTick { .. }))
+        );
+
+        configured.fairness_yield_interval = 1;
+        let mut streak = 0;
+        park_after_outcome(
+            &Wake::default(),
+            configured,
+            pass_report(PassOutcome::Progress),
+            &mut streak,
+        );
+        assert_eq!(streak, 0);
+    }
+
+    #[kithara::test(native, flash(false))]
+    fn scheduler_does_not_busy_spin_on_backpressure() {
+        let ticks = Arc::new(AtomicUsize::new(0));
+        let (first_tick, first_tick_rx) = mpsc::channel();
+        let worker = crate::Worker::new(crate::WorkerConfig::new());
+        let dispatcher = worker.dispatcher(
+            DispatcherConfig::builder()
+                .name("backpressure-park-test")
+                .wait_timeout(Duration::from_millis(20))
+                .build(),
+        );
+        let handle = dispatcher
+            .register(TaskConfig::new(), {
+                let ticks = Arc::clone(&ticks);
+                move |_| BackpressureCountingTask {
+                    ticks,
+                    first_tick: Some(first_tick),
+                }
+            })
+            .expect("backpressured task submission");
+
+        first_tick_rx
             .recv_timeout(Instant::now() + Duration::from_secs(2))
-            .expect("panic event"),
-        panic_handle.id()
-    );
-    let (label, event, _) = received
-        .recv_timeout(Instant::now() + Duration::from_secs(2))
-        .expect("sibling must still tick");
-    assert_eq!((label, event), ("sibling", "tick"));
+            .expect("backpressured task must start");
+        thread::sleep(Duration::from_millis(80));
 
-    drop(panic_handle);
-    drop(sibling_handle);
+        let observed = ticks.load(Ordering::Relaxed);
+        drop(handle);
+        assert!(
+            observed < 16,
+            "backpressured task ran {observed} times in 80ms despite a 20ms park budget"
+        );
+    }
+
+    #[kithara::test(native, flash(false))]
+    #[kithara::hang_watchdog]
+    fn backpressure_poll_observes_a_deferred_edge_without_restarting_the_task() {
+        let ticks = Arc::new(AtomicUsize::new(0));
+        let (first_tick, first_tick_rx) = mpsc::channel();
+        let worker = crate::Worker::new(crate::WorkerConfig::new());
+        let dispatcher = worker.dispatcher(
+            DispatcherConfig::builder()
+                .name("backpressure-deferred-poll-test")
+                .backpressure_poll_interval(Duration::from_millis(2))
+                .wait_timeout(Duration::from_millis(500))
+                .build(),
+        );
+        let handle = dispatcher
+            .register(TaskConfig::new(), {
+                let ticks = Arc::clone(&ticks);
+                move |_| BackpressureCountingTask {
+                    ticks,
+                    first_tick: Some(first_tick),
+                }
+            })
+            .expect("backpressured task submission");
+
+        first_tick_rx
+            .recv_timeout(Instant::now() + Duration::from_secs(2))
+            .expect("backpressured task must start");
+        thread::sleep(Duration::from_millis(20));
+        let settled_ticks = ticks.load(Ordering::Relaxed);
+        thread::sleep(Duration::from_millis(20));
+        assert_eq!(
+            ticks.load(Ordering::Relaxed),
+            settled_ticks,
+            "poll timeouts must not restart the task"
+        );
+
+        handle.control().defer();
+        let deadline = Instant::now() + Duration::from_millis(100);
+        while ticks.load(Ordering::Relaxed) == settled_ticks && Instant::now() < deadline {
+            hang_tick!();
+            thread::sleep(Duration::from_millis(1));
+        }
+        assert_eq!(
+            ticks.load(Ordering::Relaxed),
+            settled_ticks + 1,
+            "a deferred edge must end sliced backpressure waiting before the liveness timeout"
+        );
+    }
+
+    #[kithara::test(native, flash(false))]
+    fn shutdown_cancels_and_recycles_a_queued_never_run_task_once() {
+        let recorder = probe_capture::install();
+        let worker = crate::Worker::new(crate::WorkerConfig::new());
+        let dispatcher = worker.dispatcher(
+            DispatcherConfig::builder()
+                .name("queued-shutdown-test")
+                .build(),
+        );
+        let (started, started_rx) = mpsc::channel();
+        let (release, release_rx) = mpsc::channel();
+        let blocker = dispatcher
+            .register(TaskConfig::new(), move |_| BlockingTask {
+                release: release_rx,
+                started: Some(started),
+            })
+            .expect("blocking task submission");
+        started_rx
+            .recv_timeout(Instant::now() + Duration::from_secs(2))
+            .expect("blocking task must hold the dispatcher");
+        let (events, received) = mpsc::channel();
+        let queued = dispatcher
+            .register(TaskConfig::new(), move |_| LifecycleTask { events })
+            .expect("queued task submission");
+
+        dispatcher.shutdown();
+        release.send(()).expect("release blocking task");
+
+        recorder
+            .wait_for_probe(
+                |event| {
+                    event.probe_name() == Some("cancel")
+                        && event.u64("task_id") == Some(queued.id().get())
+                        && event.u64("already_terminal") == Some(0)
+                },
+                default_timeout(),
+            )
+            .expect("queued task cancellation probe");
+
+        assert_eq!(
+            received
+                .recv_timeout(Instant::now() + default_timeout())
+                .expect("queued task cancellation"),
+            "cancel"
+        );
+        assert_eq!(
+            received
+                .recv_timeout(Instant::now() + default_timeout())
+                .expect("queued task recycle"),
+            "recycle"
+        );
+        assert!(received.try_recv().is_err());
+        drop(blocker);
+        drop(queued);
+    }
+
+    #[kithara::test(native, flash(false))]
+    fn shutdown_closes_task_admission_before_returning() {
+        let worker = crate::Worker::new(crate::WorkerConfig::new());
+        let dispatcher = worker.dispatcher(
+            DispatcherConfig::builder()
+                .name("closed-admission-test")
+                .build(),
+        );
+
+        dispatcher.shutdown();
+
+        assert_eq!(
+            dispatcher
+                .register(TaskConfig::new(), |_| FixedTask(TickResult::Done))
+                .err(),
+            Some(TaskError::Stopped)
+        );
+    }
+
+    #[kithara::test(native, flash(false))]
+    fn dispatcher_cancel_group_does_not_cancel_worker_or_sibling_dispatcher() {
+        let worker = crate::Worker::new(crate::WorkerConfig::new());
+        let domain = CancelScope::new(None);
+        let first = worker.dispatcher(
+            DispatcherConfig::builder()
+                .name("first-dispatcher")
+                .cancel(CancelGroup::from(domain.token()))
+                .build(),
+        );
+        let sibling = worker.dispatcher(
+            DispatcherConfig::builder()
+                .name("sibling-dispatcher")
+                .build(),
+        );
+
+        domain.cancel();
+
+        assert!(first.is_cancelled());
+        assert!(!sibling.is_cancelled());
+        assert!(!worker.is_cancelled());
+    }
+
+    #[kithara::test(native, flash(false))]
+    fn external_cancel_is_task_local_and_control_cancel_uses_dispatcher_thread() {
+        let worker = crate::Worker::new(crate::WorkerConfig::new());
+        let dispatcher = worker.dispatcher(
+            DispatcherConfig::builder()
+                .name("task-cancel-test")
+                .wait_timeout(Duration::from_secs(30))
+                .build(),
+        );
+        let domain = CancelScope::new(None);
+        let (events, received) = mpsc::channel();
+        let first = dispatcher
+            .reserve(
+                TaskConfig::new()
+                    .with_cancel(CancelGroup::from(domain.token()))
+                    .with_priority(Priority::new(2)),
+            )
+            .expect("first task reservation");
+        let first_context = first.context().clone();
+        let first_handle = first
+            .start({
+                let events = events.clone();
+                move |_| ReportingTask {
+                    events,
+                    label: "first",
+                    ticked: false,
+                }
+            })
+            .expect("first task submission");
+        let second = dispatcher
+            .reserve(TaskConfig::new().with_priority(Priority::new(1)))
+            .expect("second task reservation");
+        let second_context = second.context().clone();
+        let second_handle = second
+            .start(move |_| ReportingTask {
+                events,
+                label: "second",
+                ticked: false,
+            })
+            .expect("second task submission");
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut first_thread = None;
+        let mut second_thread = None;
+        while first_thread.is_none() || second_thread.is_none() {
+            let (label, event, thread) = received
+                .recv_timeout(deadline)
+                .expect("both tasks must tick");
+            if event == "tick" && label == "first" {
+                first_thread = Some(thread);
+            } else if event == "tick" && label == "second" {
+                second_thread = Some(thread);
+            }
+        }
+
+        domain.cancel();
+        let (label, event, cancel_thread) = received
+            .recv_timeout(Instant::now() + Duration::from_secs(2))
+            .expect("external cancellation must wake the parked dispatcher");
+        assert_eq!((label, event), ("first", "cancel"));
+        assert_eq!(Some(cancel_thread), first_thread);
+        assert!(first_context.token().is_cancelled());
+        assert!(!second_context.token().is_cancelled());
+        assert!(!dispatcher.is_cancelled());
+        assert!(!worker.is_cancelled());
+
+        second_handle.control().cancel();
+        let (label, event, cancel_thread) = received
+            .recv_timeout(Instant::now() + Duration::from_secs(2))
+            .expect("task control cancellation must wake the dispatcher");
+        assert_eq!((label, event), ("second", "cancel"));
+        assert_eq!(Some(cancel_thread), second_thread);
+        assert!(second_context.token().is_cancelled());
+
+        drop(first_handle);
+        drop(second_handle);
+    }
+
+    #[kithara::test(native, flash(false))]
+    fn a_panicking_task_does_not_stop_its_sibling() {
+        let worker = crate::Worker::new(crate::WorkerConfig::new());
+        let (panicked, observed_panic) = mpsc::channel();
+        let dispatcher = worker.dispatcher(
+            DispatcherConfig::builder()
+                .name("panic-isolation-test")
+                .observer(PanicObserver { panicked })
+                .build(),
+        );
+        let panic_handle = dispatcher
+            .register(TaskConfig::new(), |_| PanicTask)
+            .expect("panic task submission");
+        let (events, received) = mpsc::channel();
+        let sibling_handle = dispatcher
+            .register(TaskConfig::new(), move |_| ReportingTask {
+                events,
+                label: "sibling",
+                ticked: false,
+            })
+            .expect("sibling task submission");
+
+        assert_eq!(
+            observed_panic
+                .recv_timeout(Instant::now() + Duration::from_secs(2))
+                .expect("panic event"),
+            panic_handle.id()
+        );
+        let (label, event, _) = received
+            .recv_timeout(Instant::now() + Duration::from_secs(2))
+            .expect("sibling must still tick");
+        assert_eq!((label, event), ("sibling", "tick"));
+
+        drop(panic_handle);
+        drop(sibling_handle);
+    }
 }

--- a/crates/kithara-worker/src/lib.rs
+++ b/crates/kithara-worker/src/lib.rs
@@ -7,11 +7,9 @@ mod wake;
 mod worker;
 
 pub use compute::{ComputeContext, ComputeRejected, ComputeSubmitError};
-#[cfg(not(target_arch = "wasm32"))]
-pub use config::RayonConfig;
 pub use config::{
-    ComputePool, DispatcherConfig, DispatcherConfigPatch, TaskConfig, WorkerConfig,
-    WorkerConfigPatch,
+    ComputePool, DispatcherConfig, DispatcherConfigPatch, OwnedPoolConfig, TaskConfig,
+    WorkerConfig, WorkerConfigPatch,
 };
 pub use dispatcher::{Dispatcher, PendingTask, TaskError, TaskHandle};
 pub use observer::{Event, Observer, PassOutcome, PassReport};

--- a/crates/kithara-worker/src/wake.rs
+++ b/crates/kithara-worker/src/wake.rs
@@ -50,20 +50,11 @@ struct WakeInner {
 #[cfg(test)]
 mod tests {
     use kithara_platform::time::Duration;
-    #[cfg(not(target_arch = "wasm32"))]
-    use kithara_platform::{
-        sync::{
-            Arc,
-            atomic::{AtomicUsize, Ordering},
-        },
-        thread,
-        time::Instant,
-    };
     use kithara_test_utils::kithara;
 
     use super::Wake;
 
-    #[kithara::test(native, flash(false))]
+    #[kithara::test(native, browser, flash(false))]
     fn deferred_wake_is_level_triggered_and_coalesced() {
         let wake = Wake::default();
         wake.defer();
@@ -73,9 +64,17 @@ mod tests {
         assert!(!wake.wait_timeout(Duration::ZERO));
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     #[kithara::test(native, flash(false))]
     fn deferred_wake_publishes_preceding_work() {
+        use kithara_platform::{
+            sync::{
+                Arc,
+                atomic::{AtomicUsize, Ordering},
+            },
+            thread,
+            time::Instant,
+        };
+
         let wake = Wake::default();
         let published = Arc::new(AtomicUsize::new(0));
         let producer_wake = wake.clone();

--- a/crates/kithara-worker/src/worker.rs
+++ b/crates/kithara-worker/src/worker.rs
@@ -55,12 +55,10 @@ impl Drop for WorkerInner {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
-    #[cfg(not(target_arch = "wasm32"))]
     use std::num::NonZeroUsize;
 
-    #[cfg(not(target_arch = "wasm32"))]
     use kithara_platform::{
         CancelScope,
         sync::{Arc, ThreadGate, WaitGate, mpsc},
@@ -70,11 +68,10 @@ mod tests {
     use kithara_test_utils::kithara;
 
     use super::*;
-    #[cfg(not(target_arch = "wasm32"))]
-    use crate::{ComputeSubmitError, RayonConfig, compute::ComputePool};
-    use crate::{DispatcherConfig, TaskConfig};
+    use crate::{
+        ComputeSubmitError, DispatcherConfig, OwnedPoolConfig, TaskConfig, compute::ComputePool,
+    };
 
-    #[cfg(not(target_arch = "wasm32"))]
     #[kithara::test(native, flash(false))]
     fn worker_keeps_supplied_pool_and_never_creates_one_when_absent() {
         let absent = Worker::new(WorkerConfig::new());
@@ -97,13 +94,12 @@ mod tests {
         assert!(Arc::ptr_eq(configured, &pool));
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     #[kithara::test(native, flash(false))]
     fn owned_pool_is_lazy_and_executes_the_payload_once() {
-        let worker = Worker::new(
-            WorkerConfig::new()
-                .with_owned_pool(RayonConfig::new(NonZeroUsize::MIN, "owned-compute-test")),
-        );
+        let worker = Worker::new(WorkerConfig::new().with_owned_pool(OwnedPoolConfig::new(
+            NonZeroUsize::MIN,
+            "owned-compute-test",
+        )));
         assert!(!worker.inner.compute.pool().owned_is_initialized());
         let dispatcher =
             worker.dispatcher(DispatcherConfig::builder().name("owned-pool-test").build());
@@ -142,7 +138,6 @@ mod tests {
         assert_eq!(built.current_num_threads(), 1);
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     #[kithara::test(native, flash(false))]
     fn accepted_payload_executes_once_when_cancelled_before_the_pool_runs_it() {
         let pool = Arc::new(
@@ -191,7 +186,6 @@ mod tests {
         assert!(completed_rx.try_recv().is_err());
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     #[kithara::test(native, flash(false))]
     fn disabled_compute_is_unavailable_and_budgets_saturate_without_queueing() {
         let disabled = Worker::new(WorkerConfig::new());
@@ -273,10 +267,9 @@ mod tests {
         }
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     #[kithara::test(native, flash(false))]
     fn cancelled_task_does_not_initialize_owned_pool() {
-        let worker = Worker::new(WorkerConfig::new().with_owned_pool(RayonConfig::new(
+        let worker = Worker::new(WorkerConfig::new().with_owned_pool(OwnedPoolConfig::new(
             NonZeroUsize::MIN,
             "cancelled-compute-test",
         )));
@@ -300,7 +293,6 @@ mod tests {
         assert!(!worker.inner.compute.pool().owned_is_initialized());
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     #[kithara::test(native, flash(false))]
     fn parent_cancel_reaches_worker_dispatcher_task_and_compute_job() {
         let parent = CancelScope::new(None);
@@ -308,7 +300,10 @@ mod tests {
         let worker = Worker::new(
             WorkerConfig::new()
                 .with_cancel(parent_token.clone())
-                .with_owned_pool(RayonConfig::new(NonZeroUsize::MIN, "cancel-compute-test")),
+                .with_owned_pool(OwnedPoolConfig::new(
+                    NonZeroUsize::MIN,
+                    "cancel-compute-test",
+                )),
         );
         let dispatcher = worker.dispatcher(
             DispatcherConfig::builder()


### PR DESCRIPTION
## What

`kithara-analysis` computes the waveform and the beat grid on `wasm32`, and `kithara-ffi --features wasm` exposes track analysis to JS. The worker's compute seam spawns a thread per admitted job in the browser under the same `OwnedPoolConfig` the native Rayon backend takes. Native behaviour is unchanged: the `kithara-analysis` source diff against `main` is cfg removals, dependency moves, the shared pool config, a `TryRecvError` arm in `worker/node.rs`, a `fieldwork` getter in `analyzer/session.rs`, and tests.

## Highlights

- `AudioPlayer.analyze(trackId)` starts a pass; `AudioPlayer.setAnalysisObserver(fn)` receives each publication as one plain object with `waveform` (`Float32Array`, low/mid/high per bucket) and `beats`/`downbeats` (`Float64Array`, seconds) as copied typed arrays.
- One pass is live per track: a new `analyze` starts a new revision sequence and silences the one it replaces.
- The web audio context is created at the session rate.
- The fixture server carries a 30 s click track with a known tempo (126 bpm) for the browser lane.
- `just platform wasm check` covers `kithara-analysis` and `kithara-play`; `just test wasm` carries `kithara-worker --lib`, `kithara-analysis --lib` and the `web-analysis` browser test.

Open defect, stated in `PROGRESS.md` and left for its own task: a browser MP3 decodes from frame 1105 (LAME delay), `prepare_detection` places windows on the global hop grid and `release_detected` drops the unread head, so on `MP3_CLICKS126_30S` a pass sometimes publishes `settled=true, beatFinal=true, beats=0` (4 of 6 Safari runs). `web-analysis` therefore asserts the field set, the waveform, `downbeats == 0` and `beats >= 0`, and logs bpm. A related teardown flake in `kithara-analysis --lib` under Safari (`Out of bounds memory access` in `Node::cancel`, about one run in five) is recorded there too.

## Validation

Base: `zvuk/kithara@db0619aa`. Branch: 7 commits, `git log --oneline main..` below.

```
a93b57c1 test(fixtures): serve a click track with a known tempo
8f067c9b fix(host): create the web audio context at the session rate
f6f2fb96 test(wasm): yield to the browser while a spawned thread starts
22e0bd80 feat(ffi): compute track analysis in the browser
b02e1dee test(analysis): wire the pass tests into the browser lane
9056f4a7 feat(analysis): build the pass on wasm32
8679b0ad feat(worker): run compute jobs on wasm32
```

Native analysis tests:

```
just test run -p kithara-analysis --features analysis-beat,analysis-waveform,beat-dsp
Summary [ 113.848s] 4498 tests run: 4498 passed, 220 skipped
```

Native speed, `cargo test -p kithara-app --lib a_resampled_track_is_covered_from_its_first_frame`, three runs each (`finished in`), every commit built in a detached worktree with its own `target`:

| | run 1 | run 2 | run 3 |
| --- | --- | --- | --- |
| main (db0619aa) | 0.85s | 0.84s | 0.83s |
| branch (a93b57c1) | 0.83s | 0.82s | 0.81s |

Every intermediate commit of the branch sits in the same 0.81-0.84s band (bisect on the previous base `3ecd7946`). The long-lived `target` of the developer checkout runs the branch tip at 0.94-0.98s while a throwaway worktree of the same commit runs it at 0.80-0.81s. The gap follows the binary's directory, not its code: the same test binary copied out of `target/debug/deps` (41k entries) runs at 0.80s, and a copy placed in an empty directory slows to 0.88-0.91s once 41k dummy files sit next to it. A base-vs-branch comparison has to build both sides the same way.

Browser lane, `just test wasm safari all` (Safari, `safaridriver`):

```
kithara-encode session:   test result: ok. 3 passed; 0 failed; 0 ignored; 0 filtered out; finished in 0.00s
kithara-host --lib:       test result: ok. 56 passed; 0 failed; 0 ignored; 0 filtered out; finished in 0.09s
kithara-ffi web-observer: test result: ok. 3 passed; 0 failed; 0 ignored; 0 filtered out; finished in 0.00s
kithara-worker --lib:     test result: ok. 17 passed; 0 failed; 0 ignored; 0 filtered out; finished in 0.08s
kithara-analysis --lib:   test result: ok. 190 passed; 0 failed; 0 ignored; 0 filtered out; finished in 3.20s
kithara-ffi web-analysis: test result: ok. 2 passed; 0 failed; 0 ignored; 0 filtered out; finished in 6.50s
suite_heavy:              test result: FAILED. 7 passed; 2 failed; 0 ignored; 0 filtered out; finished in 24.70s
```

`suite_heavy`: 7 passed, 2 failed, both the 10 s wall timeout, the known seek-stress timeouts (`stress_seek_to_zero_after_pressure`, `stress_rapid_seeks_must_not_stall`) that fail on `main` the same way. `stress_seek_and_read` passed in this run and passed 3 of 3 alone with the same build in 0.58-0.79 s. The branch changes nothing on the stream or seek path.

Lints:

```
just fmt check -> exit=0
just check clippy -> exit=0
just lint ast-grep -> exit=0
just lint typos -> exit=0
just lint arch -> exit=0
  summary: 19 deny, 1847 warn, 0 regression(s), 0 new across 36 check(s).
just lint idioms --check derivable_getter --check derivable_delegation -> exit=0
just lint style -> exit=0
  summary: 0 deny, 889 warn, 0 regression(s), 0 new across 11 check(s).
```

