### PR TITLE
fix(host,audio): sanction intentional sync waits

### DIFF
--- a/crates/kithara-audio/src/pipeline/track/tests/rebuild.rs
+++ b/crates/kithara-audio/src/pipeline/track/tests/rebuild.rs
@@ -584,6 +584,8 @@ impl WaitPark {
 
     /// Block until the holder is inside `wait_range` — i.e. the control
     /// mutex is held by a parked blocking read.
+    /// `no_block`: this synchronization point deliberately waits for that state.
+    #[kithara::allow_block]
     pub(super) fn wait_entered(&self) {
         let mut state = self.state.lock();
         while !state.entered {

--- a/crates/kithara-host/src/session/offline/client.rs
+++ b/crates/kithara-host/src/session/offline/client.rs
@@ -2,6 +2,7 @@ use kithara_audio::ConsumerWakeMode;
 use kithara_bufpool::SampleBuffer;
 use kithara_platform::sync::{Mutex, mpsc};
 use kithara_play::{PlayError, SessionDispatcher};
+use kithara_test_utils::kithara;
 use kithara_worker::TaskControl;
 
 use super::{OfflineMsg, OfflineSessionError};
@@ -23,6 +24,8 @@ impl<S> OfflineSessionClient<S> {
         }
     }
 
+    /// `no_block`: sync command-reply bridge to the dedicated offline worker.
+    #[kithara::allow_block]
     fn call(&self, cmd: HostCmd<S>) -> Result<HostReply, HostDispatchError<S>> {
         let (reply_tx, reply_rx) = mpsc::channel();
         let message = OfflineMsg::Host(HostCmdMsg { cmd, reply_tx });
@@ -46,6 +49,8 @@ impl<S> OfflineSessionClient<S> {
         })
     }
 
+    /// `no_block`: sync position-reply bridge to the dedicated offline worker.
+    #[kithara::allow_block]
     pub(crate) fn position(&self) -> Result<u64, OfflineSessionError> {
         let (reply_tx, reply_rx) = mpsc::channel();
         self.send(OfflineMsg::Position { reply_tx })
@@ -55,6 +60,8 @@ impl<S> OfflineSessionClient<S> {
             .map_err(|_| OfflineSessionError::SessionGone)
     }
 
+    /// `no_block`: sync render-reply bridge to the dedicated offline worker.
+    #[kithara::allow_block]
     pub(crate) fn render(
         &self,
         position: u64,


### PR DESCRIPTION
## Summary
Apple's flash + no-block lane rejected synchronous waits that are part of two explicit test-facing boundaries: offline Host command/reply calls and the readiness test's coordination barrier. This marks those owner functions with the existing `allow_block` mechanism, matching the native Host bridge, so the detector continues to catch accidental blocking while accepting these deliberate synchronous APIs.

## Behavior / scope
- contract or behavior: no-block permits the offline Host command, position, and render reply bridges, plus the test-only `WaitPark::wait_entered` synchronization point
- affected area: `kithara-host` offline sessions and one `kithara-audio` test helper

## Validation
- `just fmt check`
- `just check clippy`
- `just lint fast`
- `just test run --no-block=on -p kithara-audio a_readiness_poll_answers_while_a_construction_read_holds_the_mutex`
- `just test run --no-block=on -p kithara-integration-tests sync_listening_mix_is_not_quieter_than_a_solo_deck`
- `just test run --no-block=on -p kithara-integration-tests local_seek_middle_hang_iters_apple_locked_low`
- `just test run --no-block=on -p kithara-integration-tests flac_swallow_fixture_apple`
- not run locally: complete `just test`; full Apple lane is delegated to CI

## Surface impact
- Public API: none
- Platform/runtime: none; the annotations affect test instrumentation only
- Perf-sensitive paths: none

## Risks / follow-ups
- Full Apple lane validation is pending in CI.
