### PR TITLE
fix(play): answer the requested sample rate from the host, and let GitHub gate no_block

### DIFF
--- a/.config/xtask.toml
+++ b/.config/xtask.toml
@@ -1372,10 +1372,11 @@ steps = [
   { args = [
     "test",
     "run",
+    "--no-block=on",
     "--profile",
     "ci",
     "--timings",
-  ], label = "Linux tests", env = { CARGO_BUILD_JOBS = "2", CARGO_TARGET_DIR = "{target}/ci-tests", CARGO_UNSTABLE_CHECKSUM_FRESHNESS = "true", RUSTUP_TOOLCHAIN = "{pin.nightly_toolchain}" } },
+  ], label = "Linux flash and no-block gate", env = { CARGO_BUILD_JOBS = "2", CARGO_TARGET_DIR = "{target}/ci-tests", CARGO_UNSTABLE_CHECKSUM_FRESHNESS = "true", RUSTUP_TOOLCHAIN = "{pin.nightly_toolchain}" } },
 ]
 role = "gate"
 kinds = ["platforms", "main", "nightly"]

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,26 +1,14 @@
 # Progress
 
-What is in flight right now. The
-[GitHub Projects board](https://github.com/users/gerasim13/projects/3) owns
-capability status and the roadmap, and git owns the facts. This file owns
-intent: what is being worked on, what comes next, what is stuck. Update it in
-the change that lands the work, and keep it short.
+Current work, next steps, and blockers. The
+[Projects board](https://github.com/users/gerasim13/projects/3) owns roadmap
+status; git owns completed changes. Keep this file short.
 
 ## In Flight
 
-- Build and test warnings, cleared. The four `Atomic*::fetch_update` sites
-  moved to the `compare_exchange_weak` loop it compiles into, keeping every
-  ordering, because `loom` 0.7.2 carries only the deprecated name. MSRV is
-  1.95, and `kithara-app`'s GUI-only modules are gated on `gui`.
-
-- The `sccache` trap in the Clippy path, closed: a non-zero `CARGO_INCREMENTAL`
-  makes `sccache` abort rather than fall back, for any language, and no site
-  sets one now.
-
-- Lint debt worked down by autofix. `struct_init_order`, `derivable_from` and
-  `qualified_path_depth` answer to the clippy gate they used to break, the arch
-  baseline drops what nothing violates, and `lint fast` runs `style`, so the
-  commit hook refuses what used to reach CI.
+- Build warnings and the Clippy `sccache` configuration trap are resolved.
+  MSRV is 1.95; GUI-only app modules require `gui`. Lint autofixes reduced
+  debt, and the commit hook now includes the style gate.
 
 - Configuration document for `kithara-app`: `app.yaml` plus an optional
   overlay, env-expanded before typing, each section carrying its owning

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -39,7 +39,11 @@ the change that lands the work, and keep it short.
   extent per pass in `kithara-analysis`. Left: the deck scenario on a release
   build with the full model, and the size of the resume blob.
 
-- `suite_network` has been dark since `#260`; the handover census found it.
+- PR #322 review fixes retain the app fixture ticker through teardown and
+  complete async harness calls in the opt-in network suites. Both network
+  binaries compile; the local ticker regression passes with `no_block` and
+  fails when the ticker is stopped at construction.
+  Remote playback and device acceptance remain unverified.
 
 ## Next
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -31,6 +31,7 @@ status; git owns completed changes. Keep this file short.
   complete async harness calls in the opt-in network suites. Both network
   binaries compile; the local ticker regression passes with `no_block` and
   fails when the ticker is stopped at construction.
+  Analysis tests use generated fixture files instead of global `/tmp` paths.
   Remote playback and device acceptance remain unverified.
 
 ## Next

--- a/crates/kithara-app/src/analysis/fixtures.rs
+++ b/crates/kithara-app/src/analysis/fixtures.rs
@@ -1,4 +1,5 @@
 use std::{
+    convert::Infallible,
     num::{NonZeroU32, NonZeroUsize},
     path::Path,
 };
@@ -28,6 +29,7 @@ use kithara::{
     worker::{DispatcherConfig, TaskConfig, Worker, WorkerConfig},
 };
 use kithara_test_fixtures::assets;
+use kithara_test_utils::off_thread::OffThread;
 use num_traits::cast::AsPrimitive;
 
 use super::{Entry, Request};
@@ -134,13 +136,36 @@ pub(crate) fn queue() -> (AppHost, AppQueueControl) {
     (host, control)
 }
 
-pub(crate) fn track(queue: &AppQueueControl, id: u64, url: &str) -> (TrackId, AppTrackSource) {
+pub(crate) async fn queue_off() -> (OffThread<(AppHost, AppQueueControl)>, AppQueueControl) {
+    queue_off_named("app-host").await
+}
+
+pub(crate) async fn queue_off_named(
+    name: &'static str,
+) -> (OffThread<(AppHost, AppQueueControl)>, AppQueueControl) {
+    let host = OffThread::spawn(name, || Ok::<_, Infallible>(queue()))
+        .await
+        .expect("app host fixture is infallible");
+    let control = host.call(|(_, control)| control.clone()).await;
+    (host, control)
+}
+
+/// Appends a track from the host owner thread, as the app would.
+pub(crate) async fn track(
+    host: &OffThread<(AppHost, AppQueueControl)>,
+    id: u64,
+    url: &str,
+) -> (TrackId, AppTrackSource) {
     let track_id = TrackId::from(id);
-    queue
-        .append_with_id(track_id, url.to_owned())
-        .expect("append test track");
-    let source = queue.track_source(track_id).expect("track has a source");
-    (track_id, source)
+    let url = url.to_owned();
+    host.call(move |(_, queue)| {
+        queue
+            .append_with_id(track_id, url)
+            .expect("append test track");
+        let source = queue.track_source(track_id).expect("track has a source");
+        (track_id, source)
+    })
+    .await
 }
 
 pub(crate) fn memory_store() -> AppStore {

--- a/crates/kithara-app/src/analysis/fixtures.rs
+++ b/crates/kithara-app/src/analysis/fixtures.rs
@@ -28,9 +28,10 @@ use kithara::{
     stream::dl::{Downloader, DownloaderConfig},
     worker::{DispatcherConfig, TaskConfig, Worker, WorkerConfig},
 };
-use kithara_test_fixtures::assets;
+use kithara_test_fixtures::{asset::Asset, assets};
 use kithara_test_utils::off_thread::OffThread;
 use num_traits::cast::AsPrimitive;
+use url::Url;
 
 use super::{Entry, Request};
 use crate::{
@@ -210,6 +211,14 @@ pub(crate) fn persistence(cancel: &CancelToken, pools: Pools) -> AnalysisPersist
         TaskConfig::new(),
     ))
     .expect("persistence fixture starts")
+}
+
+pub(crate) fn asset_url(asset: Asset) -> String {
+    let path = asset.path().expect("fixture is stored on disk");
+    assert!(path.is_file(), "fixture file exists: {}", path.display());
+    Url::from_file_path(path)
+        .expect("fixture path is absolute")
+        .into()
 }
 
 pub(crate) fn mp3_track(directory: &Path) -> String {

--- a/crates/kithara-app/src/analysis/tests.rs
+++ b/crates/kithara-app/src/analysis/tests.rs
@@ -14,15 +14,16 @@ use ::kithara::{
         tokio::sync::watch,
     },
 };
+use kithara_test_fixtures::assets;
 use kithara_test_utils::{kithara, off_thread::OffThread};
 
 use super::{
     AnalysisService,
     entry::{Stage, settled_for},
     fixtures::{
-        analysis, app_config, axis, fingerprint, grid, memory_store, mp3_track, mp3_track_48k,
-        other_axis, persistence, progress, queue_off, queue_off_named, revision_held, revision_of,
-        snapshot, test_pools, track, wav_track,
+        analysis, app_config, asset_url, axis, fingerprint, grid, memory_store, mp3_track,
+        mp3_track_48k, other_axis, persistence, progress, queue_off, queue_off_named,
+        revision_held, revision_of, snapshot, test_pools, track, wav_track,
     },
     run::{Activity, Run},
     service::{Owner, resource_config_from_source},
@@ -93,7 +94,7 @@ async fn a_settled_hit_with_a_gap_is_served_without_a_pass() {
     let cancel = CancelToken::root();
     let mut owner = owner(&cancel);
     let (host, queue) = queue_off().await;
-    let (track_id, source) = track(&host, 1, "file:///tmp/track-1.mp3").await;
+    let (track_id, source) = track(&host, 1, &asset_url(assets::sine_mp3_a440_2s())).await;
     let settled = snapshot(
         "test-track".into(),
         3,
@@ -125,7 +126,7 @@ async fn a_hit_missing_an_artifact_is_served_and_refilled() {
         "fixture needs an artifact to omit"
     );
     let (host, queue) = queue_off().await;
-    let (track_id, source) = track(&host, 1, "file:///tmp/track-1.mp3").await;
+    let (track_id, source) = track(&host, 1, &asset_url(assets::sine_mp3_a440_2s())).await;
     owner.cache.put(
         target_of(&owner, &source),
         progress(snapshot("test-track".into(), 7, 1_000, fingerprint, None)),
@@ -148,7 +149,7 @@ async fn an_entry_is_held_only_while_a_deck_keeps_its_receiver() {
     let cancel = CancelToken::root();
     let mut owner = owner(&cancel);
     let (host, queue) = queue_off().await;
-    let (track_id, source) = track(&host, 1, "file:///tmp/track-1.mp3").await;
+    let (track_id, source) = track(&host, 1, &asset_url(assets::sine_mp3_a440_2s())).await;
 
     let rx = owner.subscribe(queue, track_id, source, axis());
     assert!(owner.entries[0].is_held());
@@ -167,7 +168,7 @@ async fn a_complete_hit_is_served_without_a_pass() {
     let cancel = CancelToken::root();
     let mut owner = owner(&cancel);
     let (host, queue) = queue_off().await;
-    let (track_id, source) = track(&host, 1, "file:///tmp/track-1.mp3").await;
+    let (track_id, source) = track(&host, 1, &asset_url(assets::sine_mp3_a440_2s())).await;
     let complete = snapshot(
         "test-track".into(),
         5,
@@ -193,8 +194,8 @@ async fn every_revision_reaches_the_deck_that_holds_the_track() {
     let cancel = CancelToken::root();
     let mut owner = owner(&cancel);
     let (host, queue) = queue_off().await;
-    let (_playing, _) = track(&host, 8, "file:///tmp/track-8.mp3").await;
-    let (held, source) = track(&host, 7, "file:///tmp/track-7.mp3").await;
+    let (_playing, _) = track(&host, 8, &asset_url(assets::rhythm_mp3_deck_a_120bpm_48k())).await;
+    let (held, source) = track(&host, 7, &asset_url(assets::sine_mp3_a440_2s())).await;
     assert_eq!(
         queue.current_index(),
         Some(0),
@@ -226,8 +227,8 @@ async fn two_decks_holding_one_track_share_one_pass() {
     let mut owner = owner(&cancel);
     let (host_a, queue_a) = queue_off_named("app-host-a").await;
     let (host_b, queue_b) = queue_off_named("app-host-b").await;
-    let (track_a, source_a) = track(&host_a, 1, "file:///tmp/shared.mp3").await;
-    let (track_b, source_b) = track(&host_b, 2, "file:///tmp/shared.mp3").await;
+    let (track_a, source_a) = track(&host_a, 1, &asset_url(assets::sine_mp3_a440_2s())).await;
+    let (track_b, source_b) = track(&host_b, 2, &asset_url(assets::sine_mp3_a440_2s())).await;
 
     let rx_a = owner.subscribe(queue_a, track_a, source_a, axis());
     let tx = take_over_run(&mut owner, None);
@@ -251,8 +252,8 @@ async fn a_held_track_preempts_a_background_run() {
     let cancel = CancelToken::root();
     let mut owner = owner(&cancel);
     let (host, queue) = queue_off().await;
-    let (background, _) = track(&host, 1, "file:///tmp/track-1.mp3").await;
-    let (held, source) = track(&host, 2, "file:///tmp/track-2.mp3").await;
+    let (background, _) = track(&host, 1, &asset_url(assets::sine_mp3_a440_2s())).await;
+    let (held, source) = track(&host, 2, &asset_url(assets::rhythm_mp3_deck_a_120bpm_48k())).await;
     owner.warm(&queue, &[background], axis());
     assert_eq!(running_track(&owner), Some(background));
     let tx = take_over_run(&mut owner, None);
@@ -284,9 +285,10 @@ async fn a_background_track_waits_for_a_held_one() {
     let cancel = CancelToken::root();
     let mut owner = owner(&cancel);
     let (host, queue) = queue_off().await;
-    let (held, source) = track(&host, 1, "file:///tmp/track-1.mp3").await;
-    let (background, _) = track(&host, 2, "file:///tmp/track-2.mp3").await;
-    let (later, later_source) = track(&host, 3, "file:///tmp/track-3.mp3").await;
+    let (held, source) = track(&host, 1, &asset_url(assets::sine_mp3_a440_2s())).await;
+    let (background, _) = track(&host, 2, &asset_url(assets::rhythm_mp3_deck_a_120bpm_48k())).await;
+    let (later, later_source) =
+        track(&host, 3, &asset_url(assets::rhythm_mp3_deck_b_120bpm_48k())).await;
     let _rx = owner.subscribe(queue.clone(), held, source, axis());
     let _tx = take_over_run(&mut owner, None);
 
@@ -322,7 +324,7 @@ async fn a_pass_restarts_on_the_axis_the_next_request_names() {
     let cancel = CancelToken::root();
     let mut owner = owner(&cancel);
     let (host, queue) = queue_off().await;
-    let (track_id, source) = track(&host, 1, "file:///tmp/track-1.mp3").await;
+    let (track_id, source) = track(&host, 1, &asset_url(assets::sine_mp3_a440_2s())).await;
     let _rx = owner.subscribe(queue.clone(), track_id, source.clone(), axis());
     let tx = take_over_run(&mut owner, None);
 
@@ -356,8 +358,9 @@ async fn preemption_commits_a_checkpoint_before_starting_the_next_track() {
     let cancel = CancelToken::root();
     let mut owner = owner_in(&cancel, store.clone());
     let (host, queue) = queue_off().await;
-    let (track_a, source_a) = track(&host, 1, "file:///tmp/track-a.mp3").await;
-    let (track_b, source_b) = track(&host, 2, "file:///tmp/track-b.mp3").await;
+    let (track_a, source_a) = track(&host, 1, &asset_url(assets::sine_mp3_a440_2s())).await;
+    let (track_b, source_b) =
+        track(&host, 2, &asset_url(assets::rhythm_mp3_deck_a_120bpm_48k())).await;
     let target = target_of(&owner, &source_a);
     let rx_a = owner.subscribe(queue.clone(), track_a, source_a, axis());
     let publication = take_over_run(&mut owner, Some(progress(analysis())));
@@ -430,7 +433,7 @@ async fn a_close_carrying_a_complete_value_publishes_and_caches_it() {
     let cancel = CancelToken::root();
     let mut run = close_run(
         &cancel,
-        "file:///tmp/track-1.mp3",
+        &asset_url(assets::sine_mp3_a440_2s()),
         Some(progress(analysis())),
     )
     .await;
@@ -449,7 +452,7 @@ async fn a_close_carrying_a_complete_value_publishes_and_caches_it() {
 #[kithara::test(native, tokio)]
 async fn a_close_without_a_value_is_retried_on_the_next_subscribe() {
     let cancel = CancelToken::root();
-    let mut run = close_run(&cancel, "file:///tmp/track-1.mp3", None).await;
+    let mut run = close_run(&cancel, &asset_url(assets::sine_mp3_a440_2s()), None).await;
 
     assert_eq!(revision_held(&run.rx), None);
     assert!(
@@ -572,7 +575,7 @@ async fn an_entry_is_queued_only_while_it_is_in_line() {
     let cancel = CancelToken::root();
     let mut owner = owner(&cancel);
     let (host, queue) = queue_off().await;
-    let (track_id, source) = track(&host, 1, "file:///tmp/track-1.mp3").await;
+    let (track_id, source) = track(&host, 1, &asset_url(assets::sine_mp3_a440_2s())).await;
     let complete = snapshot(
         "test-track".into(),
         5,
@@ -598,7 +601,7 @@ async fn a_finished_background_entry_holds_its_value_only_in_the_cache() {
     let cancel = CancelToken::root();
     let mut owner = owner(&cancel);
     let (host, queue) = queue_off().await;
-    let (track_id, source) = track(&host, 1, "file:///tmp/track-1.mp3").await;
+    let (track_id, source) = track(&host, 1, &asset_url(assets::sine_mp3_a440_2s())).await;
     let target = target_of(&owner, &source);
     owner.warm(&queue, &[track_id], axis());
     let tx = take_over_run(&mut owner, Some(progress(analysis())));
@@ -626,7 +629,7 @@ async fn warm_seeds_nothing_before_the_run_opens() {
     let cancel = CancelToken::root();
     let mut owner = owner(&cancel);
     let (host, queue) = queue_off().await;
-    let (track_id, source) = track(&host, 1, "file:///tmp/track-1.mp3").await;
+    let (track_id, source) = track(&host, 1, &asset_url(assets::sine_mp3_a440_2s())).await;
     let complete = snapshot(
         "test-track".into(),
         5,
@@ -638,7 +641,8 @@ async fn warm_seeds_nothing_before_the_run_opens() {
         .cache
         .put(target_of(&owner, &source), progress(complete));
     let _busy_rx = {
-        let (busy, busy_source) = track(&host, 2, "file:///tmp/track-2.mp3").await;
+        let (busy, busy_source) =
+            track(&host, 2, &asset_url(assets::rhythm_mp3_deck_a_120bpm_48k())).await;
         owner.subscribe(queue.clone(), busy, busy_source, axis())
     };
     take_over_run(&mut owner, None);
@@ -660,8 +664,8 @@ async fn a_background_warm_keeps_the_holder_of_a_held_entry() {
     let mut owner = owner(&cancel);
     let (host_a, queue_a) = queue_off_named("app-host-a").await;
     let (host_b, queue_b) = queue_off_named("app-host-b").await;
-    let (track_a, source_a) = track(&host_a, 1, "file:///tmp/shared.mp3").await;
-    let (track_b, _) = track(&host_b, 2, "file:///tmp/shared.mp3").await;
+    let (track_a, source_a) = track(&host_a, 1, &asset_url(assets::sine_mp3_a440_2s())).await;
+    let (track_b, _) = track(&host_b, 2, &asset_url(assets::sine_mp3_a440_2s())).await;
     let _rx = owner.subscribe(queue_a, track_a, source_a, axis());
 
     owner.warm(&queue_b, &[track_b], axis());
@@ -736,7 +740,7 @@ async fn an_invalid_layout_yields_no_analysis() {
     let cancel = CancelToken::root();
     let mut owner = owner_in(&cancel, store);
     let (host, queue) = queue_off().await;
-    let (track_id, source) = track(&host, 1, "file:///tmp/invalid.mp3").await;
+    let (track_id, source) = track(&host, 1, &asset_url(assets::sine_mp3_a440_2s())).await;
 
     let mut rx = owner.subscribe(queue, track_id, source, axis());
 

--- a/crates/kithara-app/src/analysis/tests.rs
+++ b/crates/kithara-app/src/analysis/tests.rs
@@ -14,15 +14,15 @@ use ::kithara::{
         tokio::sync::watch,
     },
 };
-use kithara_test_utils::kithara;
+use kithara_test_utils::{kithara, off_thread::OffThread};
 
 use super::{
     AnalysisService,
     entry::{Stage, settled_for},
     fixtures::{
         analysis, app_config, axis, fingerprint, grid, memory_store, mp3_track, mp3_track_48k,
-        other_axis, persistence, progress, queue, revision_held, revision_of, snapshot, test_pools,
-        track, wav_track,
+        other_axis, persistence, progress, queue_off, queue_off_named, revision_held, revision_of,
+        snapshot, test_pools, track, wav_track,
     },
     run::{Activity, Run},
     service::{Owner, resource_config_from_source},
@@ -92,8 +92,8 @@ fn take_over_run(
 async fn a_settled_hit_with_a_gap_is_served_without_a_pass() {
     let cancel = CancelToken::root();
     let mut owner = owner(&cancel);
-    let (_host, queue) = queue();
-    let (track_id, source) = track(&queue, 1, "file:///tmp/track-1.mp3");
+    let (host, queue) = queue_off().await;
+    let (track_id, source) = track(&host, 1, "file:///tmp/track-1.mp3").await;
     let settled = snapshot(
         "test-track".into(),
         3,
@@ -112,6 +112,7 @@ async fn a_settled_hit_with_a_gap_is_served_without_a_pass() {
     assert!(owner.active.is_none(), "nothing is left to analyse");
     assert!(owner.pending.is_empty());
     cancel.cancel();
+    host.close().await;
 }
 
 #[kithara::test(native, tokio)]
@@ -123,8 +124,8 @@ async fn a_hit_missing_an_artifact_is_served_and_refilled() {
         fingerprint.beat().is_some(),
         "fixture needs an artifact to omit"
     );
-    let (_host, queue) = queue();
-    let (track_id, source) = track(&queue, 1, "file:///tmp/track-1.mp3");
+    let (host, queue) = queue_off().await;
+    let (track_id, source) = track(&host, 1, "file:///tmp/track-1.mp3").await;
     owner.cache.put(
         target_of(&owner, &source),
         progress(snapshot("test-track".into(), 7, 1_000, fingerprint, None)),
@@ -139,14 +140,15 @@ async fn a_hit_missing_an_artifact_is_served_and_refilled() {
         "the artifact is refilled"
     );
     cancel.cancel();
+    host.close().await;
 }
 
 #[kithara::test(native, tokio)]
 async fn an_entry_is_held_only_while_a_deck_keeps_its_receiver() {
     let cancel = CancelToken::root();
     let mut owner = owner(&cancel);
-    let (_host, queue) = queue();
-    let (track_id, source) = track(&queue, 1, "file:///tmp/track-1.mp3");
+    let (host, queue) = queue_off().await;
+    let (track_id, source) = track(&host, 1, "file:///tmp/track-1.mp3").await;
 
     let rx = owner.subscribe(queue, track_id, source, axis());
     assert!(owner.entries[0].is_held());
@@ -157,14 +159,15 @@ async fn an_entry_is_held_only_while_a_deck_keeps_its_receiver() {
         "the owner's own handle is no receiver"
     );
     cancel.cancel();
+    host.close().await;
 }
 
 #[kithara::test(native, tokio)]
 async fn a_complete_hit_is_served_without_a_pass() {
     let cancel = CancelToken::root();
     let mut owner = owner(&cancel);
-    let (_host, queue) = queue();
-    let (track_id, source) = track(&queue, 1, "file:///tmp/track-1.mp3");
+    let (host, queue) = queue_off().await;
+    let (track_id, source) = track(&host, 1, "file:///tmp/track-1.mp3").await;
     let complete = snapshot(
         "test-track".into(),
         5,
@@ -182,15 +185,16 @@ async fn a_complete_hit_is_served_without_a_pass() {
     assert!(owner.active.is_none(), "nothing is left to analyse");
     assert!(owner.pending.is_empty());
     cancel.cancel();
+    host.close().await;
 }
 
 #[kithara::test(native, tokio)]
 async fn every_revision_reaches_the_deck_that_holds_the_track() {
     let cancel = CancelToken::root();
     let mut owner = owner(&cancel);
-    let (_host, queue) = queue();
-    let (_playing, _) = track(&queue, 8, "file:///tmp/track-8.mp3");
-    let (held, source) = track(&queue, 7, "file:///tmp/track-7.mp3");
+    let (host, queue) = queue_off().await;
+    let (_playing, _) = track(&host, 8, "file:///tmp/track-8.mp3").await;
+    let (held, source) = track(&host, 7, "file:///tmp/track-7.mp3").await;
     assert_eq!(
         queue.current_index(),
         Some(0),
@@ -213,16 +217,17 @@ async fn every_revision_reaches_the_deck_that_holds_the_track() {
         "the deck holding the track sees the latest revision"
     );
     cancel.cancel();
+    host.close().await;
 }
 
 #[kithara::test(native, tokio)]
 async fn two_decks_holding_one_track_share_one_pass() {
     let cancel = CancelToken::root();
     let mut owner = owner(&cancel);
-    let (_host_a, queue_a) = queue();
-    let (_host_b, queue_b) = queue();
-    let (track_a, source_a) = track(&queue_a, 1, "file:///tmp/shared.mp3");
-    let (track_b, source_b) = track(&queue_b, 2, "file:///tmp/shared.mp3");
+    let (host_a, queue_a) = queue_off_named("app-host-a").await;
+    let (host_b, queue_b) = queue_off_named("app-host-b").await;
+    let (track_a, source_a) = track(&host_a, 1, "file:///tmp/shared.mp3").await;
+    let (track_b, source_b) = track(&host_b, 2, "file:///tmp/shared.mp3").await;
 
     let rx_a = owner.subscribe(queue_a, track_a, source_a, axis());
     let tx = take_over_run(&mut owner, None);
@@ -237,15 +242,17 @@ async fn two_decks_holding_one_track_share_one_pass() {
     assert_eq!(revision_held(&rx_a), Some(1));
     assert_eq!(revision_held(&rx_b), Some(1));
     cancel.cancel();
+    host_a.close().await;
+    host_b.close().await;
 }
 
 #[kithara::test(native, tokio)]
 async fn a_held_track_preempts_a_background_run() {
     let cancel = CancelToken::root();
     let mut owner = owner(&cancel);
-    let (_host, queue) = queue();
-    let (background, _) = track(&queue, 1, "file:///tmp/track-1.mp3");
-    let (held, source) = track(&queue, 2, "file:///tmp/track-2.mp3");
+    let (host, queue) = queue_off().await;
+    let (background, _) = track(&host, 1, "file:///tmp/track-1.mp3").await;
+    let (held, source) = track(&host, 2, "file:///tmp/track-2.mp3").await;
     owner.warm(&queue, &[background], axis());
     assert_eq!(running_track(&owner), Some(background));
     let tx = take_over_run(&mut owner, None);
@@ -269,16 +276,17 @@ async fn a_held_track_preempts_a_background_run() {
     );
     assert_eq!(pending_tracks(&owner), vec![background]);
     cancel.cancel();
+    host.close().await;
 }
 
 #[kithara::test(native, tokio)]
 async fn a_background_track_waits_for_a_held_one() {
     let cancel = CancelToken::root();
     let mut owner = owner(&cancel);
-    let (_host, queue) = queue();
-    let (held, source) = track(&queue, 1, "file:///tmp/track-1.mp3");
-    let (background, _) = track(&queue, 2, "file:///tmp/track-2.mp3");
-    let (later, later_source) = track(&queue, 3, "file:///tmp/track-3.mp3");
+    let (host, queue) = queue_off().await;
+    let (held, source) = track(&host, 1, "file:///tmp/track-1.mp3").await;
+    let (background, _) = track(&host, 2, "file:///tmp/track-2.mp3").await;
+    let (later, later_source) = track(&host, 3, "file:///tmp/track-3.mp3").await;
     let _rx = owner.subscribe(queue.clone(), held, source, axis());
     let _tx = take_over_run(&mut owner, None);
 
@@ -306,14 +314,15 @@ async fn a_background_track_waits_for_a_held_one() {
         "the warm track follows"
     );
     cancel.cancel();
+    host.close().await;
 }
 
 #[kithara::test(native, tokio)]
 async fn a_pass_restarts_on_the_axis_the_next_request_names() {
     let cancel = CancelToken::root();
     let mut owner = owner(&cancel);
-    let (_host, queue) = queue();
-    let (track_id, source) = track(&queue, 1, "file:///tmp/track-1.mp3");
+    let (host, queue) = queue_off().await;
+    let (track_id, source) = track(&host, 1, "file:///tmp/track-1.mp3").await;
     let _rx = owner.subscribe(queue.clone(), track_id, source.clone(), axis());
     let tx = take_over_run(&mut owner, None);
 
@@ -332,6 +341,7 @@ async fn a_pass_restarts_on_the_axis_the_next_request_names() {
     assert_eq!(owner.entries[run.entry].track_id(), track_id);
     assert_eq!(run.axis, other_axis(), "on the axis the request named");
     cancel.cancel();
+    host.close().await;
 }
 
 #[kithara::test(native, tokio)]
@@ -345,9 +355,9 @@ async fn preemption_commits_a_checkpoint_before_starting_the_next_track() {
         .build();
     let cancel = CancelToken::root();
     let mut owner = owner_in(&cancel, store.clone());
-    let (_host, queue) = queue();
-    let (track_a, source_a) = track(&queue, 1, "file:///tmp/track-a.mp3");
-    let (track_b, source_b) = track(&queue, 2, "file:///tmp/track-b.mp3");
+    let (host, queue) = queue_off().await;
+    let (track_a, source_a) = track(&host, 1, "file:///tmp/track-a.mp3").await;
+    let (track_b, source_b) = track(&host, 2, "file:///tmp/track-b.mp3").await;
     let target = target_of(&owner, &source_a);
     let rx_a = owner.subscribe(queue.clone(), track_a, source_a, axis());
     let publication = take_over_run(&mut owner, Some(progress(analysis())));
@@ -375,11 +385,12 @@ async fn preemption_commits_a_checkpoint_before_starting_the_next_track() {
         AnalysisFile::parse(&bytes, &fingerprint()).expect("committed checkpoint validates");
     assert_eq!(restored.latest().analysis().revision(), 1);
     cancel.cancel();
+    host.close().await;
 }
 
 struct HeldRun {
     target: AnalysisTarget,
-    _host: AppHost,
+    host: OffThread<(AppHost, AppQueueControl)>,
     queue: AppQueueControl,
     source: AppTrackSource,
     owner: Owner,
@@ -387,10 +398,16 @@ struct HeldRun {
     track_id: TrackId,
 }
 
+impl HeldRun {
+    async fn close(self) {
+        self.host.close().await;
+    }
+}
+
 async fn close_run(cancel: &CancelToken, url: &str, value: Option<AnalysisProgress>) -> HeldRun {
     let mut owner = owner(cancel);
-    let (host, queue) = queue();
-    let (track_id, source) = track(&queue, 1, url);
+    let (host, queue) = queue_off().await;
+    let (track_id, source) = track(&host, 1, url).await;
     let target = target_of(&owner, &source);
     let rx = owner.subscribe(queue.clone(), track_id, source.clone(), axis());
     let tx = take_over_run(&mut owner, value);
@@ -404,7 +421,7 @@ async fn close_run(cancel: &CancelToken, url: &str, value: Option<AnalysisProgre
         source,
         target,
         rx,
-        _host: host,
+        host,
     }
 }
 
@@ -426,6 +443,7 @@ async fn a_close_carrying_a_complete_value_publishes_and_caches_it() {
         "the pass ran its course"
     );
     cancel.cancel();
+    run.close().await;
 }
 
 #[kithara::test(native, tokio)]
@@ -449,13 +467,14 @@ async fn a_close_without_a_value_is_retried_on_the_next_subscribe() {
         "the track is retried on the next subscribe"
     );
     cancel.cancel();
+    run.close().await;
 }
 
 async fn resumable_progress(url: &str) -> AnalysisProgress {
     let cancel = CancelToken::root();
     let mut owner = owner(&cancel);
-    let (_host, queue) = queue();
-    let (track_id, source) = track(&queue, 1, url);
+    let (host, queue) = queue_off().await;
+    let (track_id, source) = track(&host, 1, url).await;
     let rx = owner.subscribe(queue, track_id, source, axis());
     loop {
         time::timeout(Duration::from_secs(2), owner.drive())
@@ -464,6 +483,7 @@ async fn resumable_progress(url: &str) -> AnalysisProgress {
         let held = rx.borrow().clone();
         if let Some(progress) = held.filter(AnalysisProgress::is_resumable) {
             cancel.cancel();
+            host.close().await;
             return progress;
         }
         assert!(owner.active.is_some(), "the pass published no checkpoint");
@@ -496,6 +516,7 @@ async fn a_close_on_an_unsettled_value_is_resumed_on_the_next_subscribe() {
         "the checkpoint is resumed once its commit lands"
     );
     cancel.cancel();
+    run.close().await;
 }
 
 #[kithara::test(native, tokio, flash(false))]
@@ -509,8 +530,8 @@ async fn a_rejected_checkpoint_opens_a_fresh_pass() {
     let (service, _handle) =
         AnalysisService::new(&config, persistence(&cancel, test_pools()), cancel.child());
     let mut owner = service.owner;
-    let (_host, queue) = queue();
-    let (track_id, source) = track(&queue, 1, &url);
+    let (host, queue) = queue_off().await;
+    let (track_id, source) = track(&host, 1, &url).await;
     let target = target_of(&owner, &source);
     assert!(
         owner
@@ -543,14 +564,15 @@ async fn a_rejected_checkpoint_opens_a_fresh_pass() {
     assert!(held.analysis().is_complete(), "which finishes the track");
     assert!(held.analysis().revision() > checkpoint.analysis().revision());
     cancel.cancel();
+    host.close().await;
 }
 
 #[kithara::test(native, tokio)]
 async fn an_entry_is_queued_only_while_it_is_in_line() {
     let cancel = CancelToken::root();
     let mut owner = owner(&cancel);
-    let (_host, queue) = queue();
-    let (track_id, source) = track(&queue, 1, "file:///tmp/track-1.mp3");
+    let (host, queue) = queue_off().await;
+    let (track_id, source) = track(&host, 1, "file:///tmp/track-1.mp3").await;
     let complete = snapshot(
         "test-track".into(),
         5,
@@ -568,14 +590,15 @@ async fn an_entry_is_queued_only_while_it_is_in_line() {
     assert!(owner.pending.is_empty());
     assert_ne!(owner.entries[0].stage(), Stage::Queued);
     cancel.cancel();
+    host.close().await;
 }
 
 #[kithara::test(native, tokio)]
 async fn a_finished_background_entry_holds_its_value_only_in_the_cache() {
     let cancel = CancelToken::root();
     let mut owner = owner(&cancel);
-    let (_host, queue) = queue();
-    let (track_id, source) = track(&queue, 1, "file:///tmp/track-1.mp3");
+    let (host, queue) = queue_off().await;
+    let (track_id, source) = track(&host, 1, "file:///tmp/track-1.mp3").await;
     let target = target_of(&owner, &source);
     owner.warm(&queue, &[track_id], axis());
     let tx = take_over_run(&mut owner, Some(progress(analysis())));
@@ -595,14 +618,15 @@ async fn a_finished_background_entry_holds_its_value_only_in_the_cache() {
         "a deck is served from the cache"
     );
     cancel.cancel();
+    host.close().await;
 }
 
 #[kithara::test(native, tokio)]
 async fn warm_seeds_nothing_before_the_run_opens() {
     let cancel = CancelToken::root();
     let mut owner = owner(&cancel);
-    let (_host, queue) = queue();
-    let (track_id, source) = track(&queue, 1, "file:///tmp/track-1.mp3");
+    let (host, queue) = queue_off().await;
+    let (track_id, source) = track(&host, 1, "file:///tmp/track-1.mp3").await;
     let complete = snapshot(
         "test-track".into(),
         5,
@@ -614,7 +638,7 @@ async fn warm_seeds_nothing_before_the_run_opens() {
         .cache
         .put(target_of(&owner, &source), progress(complete));
     let _busy_rx = {
-        let (busy, busy_source) = track(&queue, 2, "file:///tmp/track-2.mp3");
+        let (busy, busy_source) = track(&host, 2, "file:///tmp/track-2.mp3").await;
         owner.subscribe(queue.clone(), busy, busy_source, axis())
     };
     take_over_run(&mut owner, None);
@@ -627,16 +651,17 @@ async fn warm_seeds_nothing_before_the_run_opens() {
     );
     assert_eq!(owner.entries[1].stage(), Stage::Queued);
     cancel.cancel();
+    host.close().await;
 }
 
 #[kithara::test(native, tokio)]
 async fn a_background_warm_keeps_the_holder_of_a_held_entry() {
     let cancel = CancelToken::root();
     let mut owner = owner(&cancel);
-    let (_host_a, queue_a) = queue();
-    let (_host_b, queue_b) = queue();
-    let (track_a, source_a) = track(&queue_a, 1, "file:///tmp/shared.mp3");
-    let (track_b, _) = track(&queue_b, 2, "file:///tmp/shared.mp3");
+    let (host_a, queue_a) = queue_off_named("app-host-a").await;
+    let (host_b, queue_b) = queue_off_named("app-host-b").await;
+    let (track_a, source_a) = track(&host_a, 1, "file:///tmp/shared.mp3").await;
+    let (track_b, _) = track(&host_b, 2, "file:///tmp/shared.mp3").await;
     let _rx = owner.subscribe(queue_a, track_a, source_a, axis());
 
     owner.warm(&queue_b, &[track_b], axis());
@@ -644,6 +669,8 @@ async fn a_background_warm_keeps_the_holder_of_a_held_entry() {
     assert_eq!(owner.entries.len(), 1, "one resource, one entry");
     assert_eq!(owner.entries[0].track_id(), track_a);
     cancel.cancel();
+    host_a.close().await;
+    host_b.close().await;
 }
 
 async fn settle(owner: &mut Owner) {
@@ -665,8 +692,8 @@ async fn a_fresh_pass_publishes_above_the_seeded_revision() {
         fingerprint.beat().is_some(),
         "fixture needs an artifact to omit"
     );
-    let (_host, queue) = queue();
-    let (track_id, source) = track(&queue, 1, &url);
+    let (host, queue) = queue_off().await;
+    let (track_id, source) = track(&host, 1, &url).await;
     let target = target_of(&owner, &source);
     let wanting = snapshot(token_for(target.key()), 3, 1_000, fingerprint, None);
     owner.cache.put(target, progress(wanting));
@@ -683,6 +710,7 @@ async fn a_fresh_pass_publishes_above_the_seeded_revision() {
         held.analysis().revision()
     );
     cancel.cancel();
+    host.close().await;
 }
 
 #[derive(Debug)]
@@ -707,8 +735,8 @@ async fn an_invalid_layout_yields_no_analysis() {
         .build();
     let cancel = CancelToken::root();
     let mut owner = owner_in(&cancel, store);
-    let (_host, queue) = queue();
-    let (track_id, source) = track(&queue, 1, "file:///tmp/invalid.mp3");
+    let (host, queue) = queue_off().await;
+    let (track_id, source) = track(&host, 1, "file:///tmp/invalid.mp3").await;
 
     let mut rx = owner.subscribe(queue, track_id, source, axis());
 
@@ -716,6 +744,7 @@ async fn an_invalid_layout_yields_no_analysis() {
     assert!(rx.changed().await.is_err(), "and nothing will come");
     assert!(owner.entries.is_empty());
     cancel.cancel();
+    host.close().await;
 }
 
 #[kithara::test(native, tokio, flash(false))]
@@ -733,8 +762,8 @@ async fn a_resampled_track_is_covered_from_its_first_frame() {
 async fn the_source_gave_everything_it_can(url: &str) {
     let cancel = CancelToken::root();
     let mut owner = owner(&cancel);
-    let (_host, queue) = queue();
-    let (track_id, source) = track(&queue, 1, url);
+    let (host, queue) = queue_off().await;
+    let (track_id, source) = track(&host, 1, url).await;
 
     let rx = owner.subscribe(queue.clone(), track_id, source.clone(), axis());
     settle(&mut owner).await;
@@ -770,6 +799,7 @@ async fn the_source_gave_everything_it_can(url: &str) {
         "a track the source gave in full is not analysed again"
     );
     cancel.cancel();
+    host.close().await;
 }
 
 const MPEG_FRAME_SAMPLES: u64 = 1152;

--- a/crates/kithara-app/src/gui/ui/cache.rs
+++ b/crates/kithara-app/src/gui/ui/cache.rs
@@ -406,8 +406,8 @@ mod tests {
     #[kithara::test(native, tokio)]
     async fn a_revision_offered_to_an_entry_redraws_the_deck_waveform() {
         let cancel = CancelToken::root();
-        let (_host, queue) = fixtures::queue();
-        let (track_id, source) = fixtures::track(&queue, 1, "file:///tmp/track-1.mp3");
+        let (host, queue) = fixtures::queue_off().await;
+        let (track_id, source) = fixtures::track(&host, 1, "file:///tmp/track-1.mp3").await;
         let config = fixtures::app_config(&cancel, fixtures::memory_store());
         let entry = fixtures::entry(&config, queue.clone(), track_id, source);
         let state = Arc::new(Mutex::new(UiState::new(&queue)));
@@ -436,6 +436,7 @@ mod tests {
             "the deck draws the revision the entry published"
         );
         cancel.cancel();
+        host.close().await;
     }
 
     fn wave_of(height: u8) -> Waveform {

--- a/crates/kithara-app/src/gui/update.rs
+++ b/crates/kithara-app/src/gui/update.rs
@@ -285,14 +285,14 @@ fn refresh_snapshots(state: &mut Kithara) {
 
 #[cfg(all(test, not(feature = "broadcast")))]
 mod tests {
-    use std::mem;
+    use std::{convert::Infallible, mem};
 
     use ::kithara::{
         play::effects::eq::GainDb,
         ui::render::{ControlAction, UiEvent, WindowCommand, WindowEdge},
     };
     use iced::{Size, window::Direction};
-    use kithara_test_utils::kithara;
+    use kithara_test_utils::{kithara, off_thread::OffThread};
 
     use super::*;
     use crate::gui::{test_fixture, ui::cache::DeckLayout};
@@ -339,100 +339,99 @@ mod tests {
 
     #[kithara::test(native, tokio, flash(false))]
     async fn update_routes_messages_and_refreshes_their_state() {
-        let mut state = test_fixture::state();
+        let state = OffThread::spawn("app-host", || Ok::<_, Infallible>(test_fixture::state()))
+            .await
+            .expect("app state fixture is infallible");
+        state
+            .call(|state| {
+                assert_eq!(
+                    update(
+                        state,
+                        Message::Ui(UiEvent::Control {
+                            path: "mixer/xfade".to_string(),
+                            action: ControlAction::SetScalar(1.0),
+                        }),
+                    )
+                    .units(),
+                    0
+                );
+                assert_eq!(state.session.mix().position, 1.0);
 
-        assert_eq!(
-            update(
-                &mut state,
-                Message::Ui(UiEvent::Control {
-                    path: "mixer/xfade".to_string(),
-                    action: ControlAction::SetScalar(1.0),
-                }),
-            )
-            .units(),
-            0
-        );
-        assert_eq!(state.session.mix().position, 1.0);
+                assert_eq!(
+                    update(
+                        state,
+                        Message::Ui(UiEvent::LibraryQuery("local".to_string())),
+                    )
+                    .units(),
+                    0
+                );
+                assert_eq!(state.ui.cache.library.query, "local");
 
-        assert_eq!(
-            update(
-                &mut state,
-                Message::Ui(UiEvent::LibraryQuery("local".to_string())),
-            )
-            .units(),
-            0
-        );
-        assert_eq!(state.ui.cache.library.query, "local");
+                apply(state, Message::SelectCatalogTrack(1));
+                assert_eq!(state.selected_track, Some(1));
 
-        apply(&mut state, Message::SelectCatalogTrack(1));
-        assert_eq!(state.selected_track, Some(1));
+                apply(state, Message::Deck(DeckId(0), DeckMsg::SetTempo(80.0)));
+                let deck = state.decks.get(DeckId(0)).expect("deck A");
+                assert_eq!(deck.view.timestretch.tempo, 50.0);
 
-        apply(
-            &mut state,
-            Message::Deck(DeckId(0), DeckMsg::SetTempo(80.0)),
-        );
-        let deck = state.decks.get(DeckId(0)).expect("deck A");
-        assert_eq!(deck.view.timestretch.tempo, 50.0);
+                apply(state, Message::LoadOntoDeck(usize::MAX, DeckId(0)));
+                let tracks = {
+                    let queue = state
+                        .decks
+                        .get(DeckId(0))
+                        .expect("deck A")
+                        .controller
+                        .queue();
+                    queue.append("https://example.test/pending.mp3").unwrap();
+                    queue.tracks()
+                };
+                let deck = state.decks.get_mut(DeckId(0)).expect("deck A");
+                deck.ui.tracks = tracks;
+                deck.ui.current_track_index = Some(0);
+                apply(state, Message::DeleteFocusedTrack);
+                assert!(
+                    state
+                        .decks
+                        .get(DeckId(0))
+                        .expect("deck A")
+                        .controller
+                        .queue()
+                        .tracks()
+                        .is_empty()
+                );
 
-        apply(&mut state, Message::LoadOntoDeck(usize::MAX, DeckId(0)));
-        let tracks = {
-            let queue = state
-                .decks
-                .get(DeckId(0))
-                .expect("deck A")
-                .controller
-                .queue();
-            queue.append("https://example.test/pending.mp3").unwrap();
-            queue.tracks()
-        };
-        let deck = state.decks.get_mut(DeckId(0)).expect("deck A");
-        deck.ui.tracks = tracks;
-        deck.ui.current_track_index = Some(0);
-        apply(&mut state, Message::DeleteFocusedTrack);
-        assert!(
-            state
-                .decks
-                .get(DeckId(0))
-                .expect("deck A")
-                .controller
-                .queue()
-                .tracks()
-                .is_empty()
-        );
+                state.ui.cache.set_layout(DeckLayout::Single);
+                let hidden = state
+                    .decks
+                    .get(DeckId(1))
+                    .expect("deck B")
+                    .controller
+                    .clone();
+                apply(state, Message::PauseHiddenDecks);
+                assert!(!hidden.queue().is_playing());
 
-        state.ui.cache.set_layout(DeckLayout::Single);
-        let hidden = state
-            .decks
-            .get(DeckId(1))
-            .expect("deck B")
-            .controller
-            .clone();
-        apply(&mut state, Message::PauseHiddenDecks);
-        assert!(!hidden.queue().is_playing());
+                apply(state, Message::WindowResized(Size::new(640.0, 480.0)));
+                assert!(state.ui.cache.window.caption().starts_with("640 × 480"));
 
-        apply(&mut state, Message::WindowResized(Size::new(640.0, 480.0)));
-        assert!(state.ui.cache.window.caption().starts_with("640 × 480"));
-
-        assert_eq!(
-            update(
-                &mut state,
-                Message::Ui(UiEvent::Window(WindowCommand::Minimize)),
-            )
-            .units(),
-            1
-        );
-        assert_eq!(update(&mut state, Message::Tick).units(), 0);
-        assert_eq!(update(&mut state, Message::BroadcastToggle).units(), 0);
-        assert_eq!(update(&mut state, Message::BroadcastToggle).units(), 0);
-        assert_eq!(
-            update(
-                &mut state,
-                Message::BroadcastStopped(Some(Duration::from_millis(10))),
-            )
-            .units(),
-            0
-        );
-        assert_eq!(update(&mut state, Message::WindowCloseRequested).units(), 1);
+                assert_eq!(
+                    update(state, Message::Ui(UiEvent::Window(WindowCommand::Minimize)),).units(),
+                    1
+                );
+                assert_eq!(update(state, Message::Tick).units(), 0);
+                assert_eq!(update(state, Message::BroadcastToggle).units(), 0);
+                assert_eq!(update(state, Message::BroadcastToggle).units(), 0);
+                assert_eq!(
+                    update(
+                        state,
+                        Message::BroadcastStopped(Some(Duration::from_millis(10))),
+                    )
+                    .units(),
+                    0
+                );
+                assert_eq!(update(state, Message::WindowCloseRequested).units(), 1);
+            })
+            .await;
+        state.close().await;
     }
 
     #[kithara::test(native, flash(false))]

--- a/crates/kithara-app/src/state.rs
+++ b/crates/kithara-app/src/state.rs
@@ -672,7 +672,7 @@ mod tests {
     use crate::{
         analysis::{
             AnalysisHandle, Request,
-            fixtures::{answer_subscribe, next_subscribe, queue, track, wait_for_revision},
+            fixtures::{answer_subscribe, next_subscribe, queue_off, track, wait_for_revision},
         },
         pools::AppQueueControl,
         waveform::TrackAnalysis,
@@ -709,11 +709,11 @@ mod tests {
 
     #[kithara::test(native, tokio, flash(false))]
     async fn a_deck_observes_a_track_added_to_its_empty_queue() {
-        let (_host, queue) = queue();
+        let (host, queue) = queue_off().await;
         let (state, mut requests, cancel) = deck(&queue);
         assert_eq!(state.lock().current_track_index, None);
 
-        let (track_id, _) = track(&queue, 1, "file:///tmp/track-1.mp3");
+        let (track_id, _) = track(&host, 1, "file:///tmp/track-1.mp3").await;
         let tx = time::timeout(
             Duration::from_secs(2),
             answer_subscribe(&mut requests, track_id),
@@ -726,12 +726,13 @@ mod tests {
         tx.send_replace(Some(progress(1)));
         wait_for_revision(&state, 1).await;
         cancel.cancel();
+        host.close().await;
     }
 
     #[kithara::test(native, tokio, flash(false))]
     async fn a_deck_lets_go_of_a_removed_track() {
-        let (_host, queue) = queue();
-        let (track_id, _) = track(&queue, 1, "file:///tmp/track-1.mp3");
+        let (host, queue) = queue_off().await;
+        let (track_id, _) = track(&host, 1, "file:///tmp/track-1.mp3").await;
         let (state, mut requests, cancel) = deck(&queue);
         let tx = answer_subscribe(&mut requests, track_id).await;
         tx.send_replace(Some(progress(1)));
@@ -753,13 +754,15 @@ mod tests {
         let st = state.lock();
         assert_eq!(st.current_track_index, None);
         assert!(st.analysis.is_none(), "nothing is shown for no track");
+        drop(st);
         cancel.cancel();
+        host.close().await;
     }
 
     #[kithara::test(native, tokio)]
     async fn a_current_track_change_resubscribes_the_deck_and_mirrors_the_revisions() {
-        let (_host, queue) = queue();
-        let (track_id, _) = track(&queue, 1, "file:///tmp/track-1.mp3");
+        let (host, queue) = queue_off().await;
+        let (track_id, _) = track(&host, 1, "file:///tmp/track-1.mp3").await;
         let (state, mut requests, cancel) = deck(&queue);
 
         let first = answer_subscribe(&mut requests, track_id).await;
@@ -779,13 +782,14 @@ mod tests {
 
         drop(first);
         cancel.cancel();
+        host.close().await;
     }
 
     #[kithara::test(native, tokio, flash(false))]
     async fn a_deck_lets_go_of_its_track_before_asking_for_the_next() {
-        let (_host, queue) = queue();
-        let (first_id, _) = track(&queue, 1, "file:///tmp/track-1.mp3");
-        let (second_id, _) = track(&queue, 2, "file:///tmp/track-2.mp3");
+        let (host, queue) = queue_off().await;
+        let (first_id, _) = track(&host, 1, "file:///tmp/track-1.mp3").await;
+        let (second_id, _) = track(&host, 2, "file:///tmp/track-2.mp3").await;
         let (_state, mut requests, cancel) = deck(&queue);
         let first = answer_subscribe(&mut requests, first_id).await;
 
@@ -801,15 +805,16 @@ mod tests {
         );
         drop(reply);
         cancel.cancel();
+        host.close().await;
     }
 
     #[kithara::test(native, tokio, flash(false))]
     async fn a_lagged_deck_resyncs_from_its_queue() {
-        let (_host, queue) = queue();
-        let (first_id, _) = track(&queue, 1, "file:///tmp/track-1.mp3");
+        let (host, queue) = queue_off().await;
+        let (first_id, _) = track(&host, 1, "file:///tmp/track-1.mp3").await;
         let (state, mut requests, cancel) = deck(&queue);
         let (_, reply) = next_subscribe(&mut requests).await;
-        let (_second_id, _) = track(&queue, 2, "file:///tmp/track-2.mp3");
+        let (_second_id, _) = track(&host, 2, "file:///tmp/track-2.mp3").await;
         for _ in 0..=::kithara::events::DEFAULT_EVENT_BUS_CAPACITY {
             queue
                 .bus()
@@ -831,6 +836,7 @@ mod tests {
         drop(again);
         drop(first);
         cancel.cancel();
+        host.close().await;
     }
 
     fn beat(beats: Vec<(u64, Option<f32>)>) -> BeatSnapshot {

--- a/crates/kithara-audio/src/pipeline/track/tests/gate.rs
+++ b/crates/kithara-audio/src/pipeline/track/tests/gate.rs
@@ -113,7 +113,7 @@ async fn a_readiness_poll_answers_while_a_construction_read_holds_the_mutex() {
         let mut buf = [0u8; 64];
         reader.read(&mut buf)
     });
-    park.wait_entered();
+    park.wait_entered().await;
 
     assert!(
         !ReadinessGate::new(None).source_is_ready(&shared),

--- a/crates/kithara-audio/src/pipeline/track/tests/rebuild.rs
+++ b/crates/kithara-audio/src/pipeline/track/tests/rebuild.rs
@@ -14,7 +14,7 @@ use kithara_events::{
     AudioEvent, DecoderChangeCause, DecoderEvent, DeferredBus, Event, EventBus, TrackFailureKind,
 };
 use kithara_platform::{
-    sync::{Arc, Condvar, Mutex},
+    sync::{Arc, Condvar, Mutex, Notify},
     time::Duration,
     tokio::runtime::Handle as RuntimeHandle,
 };
@@ -549,6 +549,7 @@ impl VariantControl for TestControl {
 pub(super) struct WaitPark {
     armed: AtomicBool,
     condvar: Condvar,
+    entered: Notify,
     state: Mutex<WaitParkState>,
 }
 
@@ -569,7 +570,7 @@ impl WaitPark {
         }
         let mut state = self.state.lock();
         state.entered = true;
-        self.condvar.notify_all();
+        self.entered.notify_one();
         while !state.released {
             state = self.condvar.wait(state);
         }
@@ -582,15 +583,11 @@ impl WaitPark {
         self.condvar.notify_all();
     }
 
-    /// Block until the holder is inside `wait_range` — i.e. the control
+    /// Wait until the holder is inside `wait_range` — i.e. the control
     /// mutex is held by a parked blocking read.
-    ///
-    /// `no_block`: the rendezvous with the fixture's own holder thread.
-    #[kithara::allow_block]
-    pub(super) fn wait_entered(&self) {
-        let mut state = self.state.lock();
-        while !state.entered {
-            state = self.condvar.wait(state);
+    pub(super) async fn wait_entered(&self) {
+        while !self.state.lock().entered {
+            self.entered.notified().await;
         }
     }
 }

--- a/crates/kithara-audio/src/pipeline/track/tests/rebuild.rs
+++ b/crates/kithara-audio/src/pipeline/track/tests/rebuild.rs
@@ -584,6 +584,9 @@ impl WaitPark {
 
     /// Block until the holder is inside `wait_range` — i.e. the control
     /// mutex is held by a parked blocking read.
+    ///
+    /// `no_block`: the rendezvous with the fixture's own holder thread.
+    #[kithara::allow_block]
     pub(super) fn wait_entered(&self) {
         let mut state = self.state.lock();
         while !state.entered {

--- a/crates/kithara-ffi/src/native/bridge/event_bridge.rs
+++ b/crates/kithara-ffi/src/native/bridge/event_bridge.rs
@@ -384,7 +384,10 @@ mod tests {
             AdvanceReason, Event, EventBus, FileError, FileEvent, HlsError, HlsEvent, ItemRole,
             QueueEvent, QueueRepeatMode, SlotId, TrackId, TrackRef, TrackStatus,
         },
-        platform::sync::{Arc, Mutex},
+        platform::{
+            sync::{Arc, Mutex},
+            tokio::task::spawn_blocking,
+        },
         play::{PlayWorkerConfig, PlayerConfig, PlayerImpl},
         queue::{QueueConfig, test_utils::QueueProbe},
     };
@@ -913,7 +916,11 @@ mod tests {
                 .build(),
         );
         let queue = FfiQueue::new(QueueConfig::builder().player(player).build());
-        let owner = crate::native::session::insert(queue)
+        // The FFI surface calls the session from the caller's thread, never
+        // from a runtime worker.
+        let owner = spawn_blocking(move || crate::native::session::insert(queue))
+            .await
+            .expect("insert task completes")
             .expect("INVARIANT: the FFI test Host accepts its allocated Queue");
         let queue = owner.control().clone();
         let id = queue.register_for_test();
@@ -944,9 +951,15 @@ mod tests {
 
         let reload_started = wait_for_status(&mut events, id, TrackStatus::Pending, 2000).await;
         cancel.cancel();
-        let joined = thread.join();
-        crate::native::session::remove(&owner)
-            .expect("INVARIANT: the FFI test Queue detaches from its Host");
+        let (joined, owner) = spawn_blocking(move || {
+            let joined = thread.join();
+            crate::native::session::remove(&owner)
+                .expect("INVARIANT: the FFI test Queue detaches from its Host");
+            (joined, owner)
+        })
+        .await
+        .expect("teardown task completes");
+        drop(owner);
 
         assert!(
             reload_started,

--- a/crates/kithara-host/src/host.rs
+++ b/crates/kithara-host/src/host.rs
@@ -160,7 +160,10 @@ impl<S> Host<S> {
     {
         let grid_id = player.id();
         let dispatcher: Arc<dyn SessionDispatcher<S>> = self.dispatcher.clone();
-        player.attach_session(SessionBinding::new(dispatcher))?;
+        player.attach_session(SessionBinding::new(
+            dispatcher,
+            self.requested_sample_rate(),
+        ))?;
         Ok((grid_id, player.control()))
     }
 

--- a/crates/kithara-host/src/session/native.rs
+++ b/crates/kithara-host/src/session/native.rs
@@ -27,6 +27,7 @@ use crate::error::PlayError;
 
 pub(crate) struct SessionClient<S> {
     cmd_tx: Mutex<mpsc::Sender<HostCmdMsg<S>>>,
+    requested_sample_rate: NonZeroU32,
 }
 
 impl<S> SessionClient<S> {
@@ -54,6 +55,10 @@ impl<S> SessionClient<S> {
 impl<S: Send + Sync + 'static> SessionDispatcher<S> for SessionClient<S> {
     fn consumer_wake_mode(&self) -> ConsumerWakeMode {
         ConsumerWakeMode::RealtimeDeferred
+    }
+
+    fn requested_sample_rate(&self) -> NonZeroU32 {
+        self.requested_sample_rate
     }
 
     fn exec(&self, cmd: Cmd<S>) -> Result<Reply, PlayError> {
@@ -144,6 +149,7 @@ where
     });
     Arc::new(SessionClient {
         cmd_tx: Mutex::new(cmd_tx),
+        requested_sample_rate: sample_rate,
     })
 }
 

--- a/crates/kithara-host/src/session/native.rs
+++ b/crates/kithara-host/src/session/native.rs
@@ -12,7 +12,6 @@ use kithara_platform::{
     thread::spawn_named,
 };
 use kithara_play::{GroupState, player::PlayerMember};
-use kithara_test_utils::kithara;
 use tracing::{debug, warn};
 
 use super::{
@@ -27,12 +26,9 @@ use crate::error::PlayError;
 
 pub(crate) struct SessionClient<S> {
     cmd_tx: Mutex<mpsc::Sender<HostCmdMsg<S>>>,
-    requested_sample_rate: NonZeroU32,
 }
 
 impl<S> SessionClient<S> {
-    /// `no_block`: sync command-reply bridge to the dedicated session thread for host/FFI dispatch.
-    #[kithara::allow_block]
     fn call(&self, cmd: HostCmd<S>) -> Result<HostReply, HostDispatchError<S>> {
         let (reply_tx, reply_rx) = mpsc::channel();
         if let Err(error) = self.cmd_tx.lock().send(HostCmdMsg { cmd, reply_tx }) {
@@ -55,10 +51,6 @@ impl<S> SessionClient<S> {
 impl<S: Send + Sync + 'static> SessionDispatcher<S> for SessionClient<S> {
     fn consumer_wake_mode(&self) -> ConsumerWakeMode {
         ConsumerWakeMode::RealtimeDeferred
-    }
-
-    fn requested_sample_rate(&self) -> NonZeroU32 {
-        self.requested_sample_rate
     }
 
     fn exec(&self, cmd: Cmd<S>) -> Result<Reply, PlayError> {
@@ -149,7 +141,6 @@ where
     });
     Arc::new(SessionClient {
         cmd_tx: Mutex::new(cmd_tx),
-        requested_sample_rate: sample_rate,
     })
 }
 

--- a/crates/kithara-host/src/session/offline.rs
+++ b/crates/kithara-host/src/session/offline.rs
@@ -220,7 +220,7 @@ where
         PlayError::Internal(format!("offline session task reservation: {error}"))
     })?;
     let control = pending.context().control();
-    let client = Arc::new(OfflineSessionClient::new(cmd_tx, control));
+    let client = Arc::new(OfflineSessionClient::new(cmd_tx, control, sample_rate));
     let task = pending
         .start_local(move |_| {
             let start_stream = move |ctx: &mut firewheel::FirewheelCtx<OfflineBackend>,

--- a/crates/kithara-host/src/session/offline.rs
+++ b/crates/kithara-host/src/session/offline.rs
@@ -220,7 +220,7 @@ where
         PlayError::Internal(format!("offline session task reservation: {error}"))
     })?;
     let control = pending.context().control();
-    let client = Arc::new(OfflineSessionClient::new(cmd_tx, control, sample_rate));
+    let client = Arc::new(OfflineSessionClient::new(cmd_tx, control));
     let task = pending
         .start_local(move |_| {
             let start_stream = move |ctx: &mut firewheel::FirewheelCtx<OfflineBackend>,

--- a/crates/kithara-host/src/session/offline/client.rs
+++ b/crates/kithara-host/src/session/offline/client.rs
@@ -1,7 +1,10 @@
+use std::num::NonZeroU32;
+
 use kithara_audio::ConsumerWakeMode;
 use kithara_bufpool::SampleBuffer;
 use kithara_platform::sync::{Mutex, mpsc};
 use kithara_play::{PlayError, SessionDispatcher};
+use kithara_test_utils::kithara;
 use kithara_worker::TaskControl;
 
 use super::{OfflineMsg, OfflineSessionError};
@@ -10,16 +13,30 @@ use crate::session::{
     protocol::{HostCmdMsg, HostDispatchError},
 };
 
+/// `no_block`: the sync command-reply bridge to the offline session worker, the
+/// same shape the native client already declares. The session graph is `!Send`,
+/// so every command is answered by that worker and the caller waits here.
+#[kithara::allow_block]
+fn await_reply<T>(reply_rx: &mpsc::Receiver<T>) -> Result<T, mpsc::RecvError> {
+    reply_rx.recv()
+}
+
 pub(crate) struct OfflineSessionClient<S> {
     cmd_tx: Mutex<mpsc::Sender<OfflineMsg<S>>>,
     control: TaskControl,
+    requested_sample_rate: NonZeroU32,
 }
 
 impl<S> OfflineSessionClient<S> {
-    pub(super) fn new(cmd_tx: mpsc::Sender<OfflineMsg<S>>, control: TaskControl) -> Self {
+    pub(super) fn new(
+        cmd_tx: mpsc::Sender<OfflineMsg<S>>,
+        control: TaskControl,
+        requested_sample_rate: NonZeroU32,
+    ) -> Self {
         Self {
             control,
             cmd_tx: Mutex::new(cmd_tx),
+            requested_sample_rate,
         }
     }
 
@@ -39,7 +56,7 @@ impl<S> OfflineSessionClient<S> {
                 message.cmd,
             ));
         }
-        reply_rx.recv().map_err(|_| {
+        await_reply(&reply_rx).map_err(|_| {
             HostDispatchError::after_send(PlayError::SessionGone {
                 reason: "offline session dropped the reply channel",
             })
@@ -50,9 +67,7 @@ impl<S> OfflineSessionClient<S> {
         let (reply_tx, reply_rx) = mpsc::channel();
         self.send(OfflineMsg::Position { reply_tx })
             .map_err(|_| OfflineSessionError::SessionGone)?;
-        reply_rx
-            .recv()
-            .map_err(|_| OfflineSessionError::SessionGone)
+        await_reply(&reply_rx).map_err(|_| OfflineSessionError::SessionGone)
     }
 
     pub(crate) fn render(
@@ -67,9 +82,7 @@ impl<S> OfflineSessionClient<S> {
             reply_tx,
         })
         .map_err(|_| OfflineSessionError::SessionGone)?;
-        reply_rx
-            .recv()
-            .map_err(|_| OfflineSessionError::SessionGone)?
+        await_reply(&reply_rx).map_err(|_| OfflineSessionError::SessionGone)?
     }
 
     fn send(&self, message: OfflineMsg<S>) -> Result<(), Box<OfflineMsg<S>>> {
@@ -85,6 +98,10 @@ impl<S> OfflineSessionClient<S> {
 impl<S: Send + Sync + 'static> SessionDispatcher<S> for OfflineSessionClient<S> {
     fn consumer_wake_mode(&self) -> ConsumerWakeMode {
         ConsumerWakeMode::RealtimeDeferred
+    }
+
+    fn requested_sample_rate(&self) -> NonZeroU32 {
+        self.requested_sample_rate
     }
 
     fn exec(&self, cmd: Cmd<S>) -> Result<Reply, PlayError> {

--- a/crates/kithara-host/src/session/offline/client.rs
+++ b/crates/kithara-host/src/session/offline/client.rs
@@ -1,10 +1,7 @@
-use std::num::NonZeroU32;
-
 use kithara_audio::ConsumerWakeMode;
 use kithara_bufpool::SampleBuffer;
 use kithara_platform::sync::{Mutex, mpsc};
 use kithara_play::{PlayError, SessionDispatcher};
-use kithara_test_utils::kithara;
 use kithara_worker::TaskControl;
 
 use super::{OfflineMsg, OfflineSessionError};
@@ -13,30 +10,16 @@ use crate::session::{
     protocol::{HostCmdMsg, HostDispatchError},
 };
 
-/// `no_block`: the sync command-reply bridge to the offline session worker, the
-/// same shape the native client already declares. The session graph is `!Send`,
-/// so every command is answered by that worker and the caller waits here.
-#[kithara::allow_block]
-fn await_reply<T>(reply_rx: &mpsc::Receiver<T>) -> Result<T, mpsc::RecvError> {
-    reply_rx.recv()
-}
-
 pub(crate) struct OfflineSessionClient<S> {
     cmd_tx: Mutex<mpsc::Sender<OfflineMsg<S>>>,
     control: TaskControl,
-    requested_sample_rate: NonZeroU32,
 }
 
 impl<S> OfflineSessionClient<S> {
-    pub(super) fn new(
-        cmd_tx: mpsc::Sender<OfflineMsg<S>>,
-        control: TaskControl,
-        requested_sample_rate: NonZeroU32,
-    ) -> Self {
+    pub(super) fn new(cmd_tx: mpsc::Sender<OfflineMsg<S>>, control: TaskControl) -> Self {
         Self {
             control,
             cmd_tx: Mutex::new(cmd_tx),
-            requested_sample_rate,
         }
     }
 
@@ -56,7 +39,7 @@ impl<S> OfflineSessionClient<S> {
                 message.cmd,
             ));
         }
-        await_reply(&reply_rx).map_err(|_| {
+        reply_rx.recv().map_err(|_| {
             HostDispatchError::after_send(PlayError::SessionGone {
                 reason: "offline session dropped the reply channel",
             })
@@ -67,7 +50,9 @@ impl<S> OfflineSessionClient<S> {
         let (reply_tx, reply_rx) = mpsc::channel();
         self.send(OfflineMsg::Position { reply_tx })
             .map_err(|_| OfflineSessionError::SessionGone)?;
-        await_reply(&reply_rx).map_err(|_| OfflineSessionError::SessionGone)
+        reply_rx
+            .recv()
+            .map_err(|_| OfflineSessionError::SessionGone)
     }
 
     pub(crate) fn render(
@@ -82,7 +67,9 @@ impl<S> OfflineSessionClient<S> {
             reply_tx,
         })
         .map_err(|_| OfflineSessionError::SessionGone)?;
-        await_reply(&reply_rx).map_err(|_| OfflineSessionError::SessionGone)?
+        reply_rx
+            .recv()
+            .map_err(|_| OfflineSessionError::SessionGone)?
     }
 
     fn send(&self, message: OfflineMsg<S>) -> Result<(), Box<OfflineMsg<S>>> {
@@ -98,10 +85,6 @@ impl<S> OfflineSessionClient<S> {
 impl<S: Send + Sync + 'static> SessionDispatcher<S> for OfflineSessionClient<S> {
     fn consumer_wake_mode(&self) -> ConsumerWakeMode {
         ConsumerWakeMode::RealtimeDeferred
-    }
-
-    fn requested_sample_rate(&self) -> NonZeroU32 {
-        self.requested_sample_rate
     }
 
     fn exec(&self, cmd: Cmd<S>) -> Result<Reply, PlayError> {

--- a/crates/kithara-host/src/session/testing.rs
+++ b/crates/kithara-host/src/session/testing.rs
@@ -126,11 +126,20 @@ where
     }
 }
 
+const FIXTURE_SAMPLE_RATE: NonZeroU32 = match NonZeroU32::new(44_100) {
+    Some(rate) => rate,
+    None => unreachable!(),
+};
+
 pub(crate) struct FixtureSession;
 
 impl<S> SessionDispatcher<S> for FixtureSession {
     fn consumer_wake_mode(&self) -> ConsumerWakeMode {
         ConsumerWakeMode::RealtimeDeferred
+    }
+
+    fn requested_sample_rate(&self) -> NonZeroU32 {
+        FIXTURE_SAMPLE_RATE
     }
 
     fn exec(&self, _cmd: Cmd<S>) -> Result<Reply, PlayError> {

--- a/crates/kithara-host/src/session/testing.rs
+++ b/crates/kithara-host/src/session/testing.rs
@@ -10,7 +10,7 @@ use kithara_platform::sync::Arc;
 #[cfg(target_arch = "wasm32")]
 use kithara_play::player::PlayerControlSource;
 use kithara_play::{
-    GroupState, PlayError, PlayWorker, PlayWorkerConfig, PlayerConfig, PlayerImpl,
+    GroupState, PlayError, PlayWorker, PlayWorkerConfig, PlayerConfig, PlayerImpl, SessionBinding,
     SessionDuckingMode, player::PlayerMember,
 };
 use kithara_warp::{
@@ -138,10 +138,6 @@ impl<S> SessionDispatcher<S> for FixtureSession {
         ConsumerWakeMode::RealtimeDeferred
     }
 
-    fn requested_sample_rate(&self) -> NonZeroU32 {
-        FIXTURE_SAMPLE_RATE
-    }
-
     fn exec(&self, _cmd: Cmd<S>) -> Result<Reply, PlayError> {
         Ok(Reply::Ok)
     }
@@ -196,7 +192,10 @@ fn attach_player_with_id<B, S>(
             .grid_id(grid_id)
             .sample_rate(state.root_view.grid().axis().sample_rate())
             .worker(worker)
-            .session(Arc::new(FixtureSession))
+            .session(SessionBinding::new(
+                Arc::new(FixtureSession),
+                FIXTURE_SAMPLE_RATE,
+            ))
             .build(),
     );
     let base = state
@@ -228,7 +227,10 @@ pub(crate) fn fixture_member(grid_id: BeatGridId, sample_rate: NonZeroU32) -> Pl
             .grid_id(grid_id)
             .sample_rate(sample_rate)
             .worker(worker)
-            .session(Arc::new(FixtureSession))
+            .session(SessionBinding::new(
+                Arc::new(FixtureSession),
+                FIXTURE_SAMPLE_RATE,
+            ))
             .build(),
     );
     target_member(player)

--- a/crates/kithara-host/src/session/web/client.rs
+++ b/crates/kithara-host/src/session/web/client.rs
@@ -28,7 +28,6 @@ enum SessionHost<S> {
 
 pub(crate) struct SessionClient<S> {
     host: SessionHost<S>,
-    requested_sample_rate: NonZeroU32,
 }
 
 impl<S> SessionClient<S>
@@ -81,10 +80,6 @@ where
         ConsumerWakeMode::RealtimeDeferred
     }
 
-    fn requested_sample_rate(&self) -> NonZeroU32 {
-        self.requested_sample_rate
-    }
-
     fn exec(&self, cmd: Cmd<S>) -> Result<Reply, PlayError> {
         match self.call(HostCmd::Play(cmd)).map_err(PlayError::from)? {
             HostReply::Play(reply) => Ok(reply),
@@ -132,20 +127,16 @@ pub(crate) fn spawn<S: HasPool<f32> + Send + Sync + 'static>(
         host: SessionHost::Local {
             state: Arc::clone(&state),
         },
-        requested_sample_rate: sample_rate,
     });
     Ok((client, state))
 }
 
 pub(crate) fn remote<S: HasPool<f32> + Send + Sync + 'static>(
     tx: mpsc::Sender<HostCmdMsg<S>>,
-    requested_sample_rate: NonZeroU32,
 ) -> Arc<dyn HostDispatcher<S>> {
-    let client = Arc::new(SessionClient {
+    Arc::new(SessionClient {
         host: SessionHost::Remote { tx },
-        requested_sample_rate,
-    });
-    client
+    })
 }
 
 pub(crate) fn worker_channel<S>() -> (mpsc::Sender<HostCmdMsg<S>>, mpsc::Receiver<HostCmdMsg<S>>) {

--- a/crates/kithara-host/src/session/web/client.rs
+++ b/crates/kithara-host/src/session/web/client.rs
@@ -28,6 +28,7 @@ enum SessionHost<S> {
 
 pub(crate) struct SessionClient<S> {
     host: SessionHost<S>,
+    requested_sample_rate: NonZeroU32,
 }
 
 impl<S> SessionClient<S>
@@ -80,6 +81,10 @@ where
         ConsumerWakeMode::RealtimeDeferred
     }
 
+    fn requested_sample_rate(&self) -> NonZeroU32 {
+        self.requested_sample_rate
+    }
+
     fn exec(&self, cmd: Cmd<S>) -> Result<Reply, PlayError> {
         match self.call(HostCmd::Play(cmd)).map_err(PlayError::from)? {
             HostReply::Play(reply) => Ok(reply),
@@ -127,15 +132,18 @@ pub(crate) fn spawn<S: HasPool<f32> + Send + Sync + 'static>(
         host: SessionHost::Local {
             state: Arc::clone(&state),
         },
+        requested_sample_rate: sample_rate,
     });
     Ok((client, state))
 }
 
 pub(crate) fn remote<S: HasPool<f32> + Send + Sync + 'static>(
     tx: mpsc::Sender<HostCmdMsg<S>>,
+    requested_sample_rate: NonZeroU32,
 ) -> Arc<dyn HostDispatcher<S>> {
     let client = Arc::new(SessionClient {
         host: SessionHost::Remote { tx },
+        requested_sample_rate,
     });
     client
 }

--- a/crates/kithara-host/src/wasm/session.rs
+++ b/crates/kithara-host/src/wasm/session.rs
@@ -81,7 +81,8 @@ pub fn worker_host_channel<S: HasPool<f32> + Send + Sync + 'static>(
 /// Connects a Worker facade to the main thread's canonical Host owner.
 #[must_use]
 pub fn remote_host<S: HasPool<f32> + Send + Sync + 'static>(sender: HostSender<S>) -> Host<S> {
-    let dispatcher = host_session::remote(sender.tx);
+    let requested_sample_rate = sender.root_view.grid().axis().sample_rate();
+    let dispatcher = host_session::remote(sender.tx, requested_sample_rate);
     Host::remote(sender.id, sender.root_view, dispatcher)
 }
 

--- a/crates/kithara-host/src/wasm/session.rs
+++ b/crates/kithara-host/src/wasm/session.rs
@@ -81,8 +81,7 @@ pub fn worker_host_channel<S: HasPool<f32> + Send + Sync + 'static>(
 /// Connects a Worker facade to the main thread's canonical Host owner.
 #[must_use]
 pub fn remote_host<S: HasPool<f32> + Send + Sync + 'static>(sender: HostSender<S>) -> Host<S> {
-    let requested_sample_rate = sender.root_view.grid().axis().sample_rate();
-    let dispatcher = host_session::remote(sender.tx, requested_sample_rate);
+    let dispatcher = host_session::remote(sender.tx);
     Host::remote(sender.id, sender.root_view, dispatcher)
 }
 

--- a/crates/kithara-play/Cargo.toml
+++ b/crates/kithara-play/Cargo.toml
@@ -140,7 +140,7 @@ hotpath = { workspace = true, optional = true }
 [dev-dependencies]
 kithara-audio = { workspace = true, features = ["mock", "probe"] }
 kithara-bufpool = { workspace = true, features = ["test-utils"] }
-kithara-play = { path = ".", default-features = false, features = ["probe"] }
+kithara-play = { path = ".", default-features = false, features = ["mock", "probe"] }
 kithara-test-utils = { path = "../kithara-test-utils", features = ["mock", "probe", "hang"] }
 
 bytes = { workspace = true }

--- a/crates/kithara-play/src/engine/config.rs
+++ b/crates/kithara-play/src/engine/config.rs
@@ -5,12 +5,12 @@ use std::{
 
 use bon::Builder;
 use kithara_bufpool::PoolRegion;
-use kithara_platform::{CancelToken, sync::Arc};
+use kithara_platform::CancelToken;
 use kithara_warp::BeatGridId;
 
 use crate::{
     effects::eq::{EqBandConfig, generate_log_spaced_bands},
-    session::SessionDispatcher,
+    session::SessionBinding,
 };
 
 /// Configuration for the audio engine.
@@ -30,9 +30,9 @@ pub struct EngineConfig<S> {
     pub(crate) cancel: Option<CancelToken>,
     /// Optional resident Warp render quantum supplied by the owning player.
     pub(crate) render_quantum_frames: Option<NonZeroUsize>,
-    /// Optional pre-bound dispatcher for isolated harnesses. Production
-    /// engines receive their session when the owning Player enters a Host.
-    pub(crate) session: Option<Arc<dyn SessionDispatcher<S>>>,
+    /// Optional pre-bound session for isolated harnesses. Production engines
+    /// receive theirs when the owning Player enters a Host.
+    pub(crate) session: Option<SessionBinding<S>>,
     /// Typed pool facade for audio-thread scratch buffers.
     pub(crate) pools: PoolRegion<S>,
     /// EQ band layout per player. Default: 10-band log-spaced. Not a

--- a/crates/kithara-play/src/engine/core.rs
+++ b/crates/kithara-play/src/engine/core.rs
@@ -94,7 +94,7 @@ impl<S> EngineImpl<S> {
     }
 
     pub(crate) fn attach_session(&self, binding: SessionBinding<S>) -> Result<(), PlayError> {
-        self.validate_session_sample_rate(binding.requested_sample_rate()?.get())?;
+        self.validate_session_sample_rate(binding.requested_sample_rate().get())?;
         self.session.bind(binding)
     }
 

--- a/crates/kithara-play/src/engine/mix.rs
+++ b/crates/kithara-play/src/engine/mix.rs
@@ -75,8 +75,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::num::NonZeroU32;
-
     use kithara_audio::ConsumerWakeMode;
     use kithara_test_utils::kithara;
 
@@ -85,7 +83,7 @@ mod tests {
         PlayWorker, PlayWorkerConfig,
         player::PlayerConfig,
         session::{
-            Cmd, Reply, SessionDispatcher, SessionSampleRate,
+            Cmd, Reply, SessionBinding, SessionDispatcher, SessionSampleRate,
             testing::{self, test_session},
         },
         test_pools::{TestPools, pools},
@@ -96,10 +94,6 @@ mod tests {
     impl SessionDispatcher<TestPools> for ForeignSession {
         fn consumer_wake_mode(&self) -> ConsumerWakeMode {
             ConsumerWakeMode::RealtimeDeferred
-        }
-
-        fn requested_sample_rate(&self) -> NonZeroU32 {
-            testing::TEST_SAMPLE_RATE
         }
 
         fn exec(&self, cmd: Cmd<TestPools>) -> Result<Reply, PlayError> {
@@ -113,7 +107,7 @@ mod tests {
         }
     }
 
-    fn player(session: Arc<dyn SessionDispatcher<TestPools>>) -> PlayerImpl<TestPools> {
+    fn player(session: SessionBinding<TestPools>) -> PlayerImpl<TestPools> {
         let worker = PlayWorker::new(PlayWorkerConfig::builder(pools()).build());
         PlayerImpl::new(
             PlayerConfig::builder()
@@ -166,7 +160,10 @@ mod tests {
         let session = test_session();
         let a = player(session.clone());
         a.core.engine.start().unwrap();
-        let foreign = player(Arc::new(ForeignSession) as Arc<dyn SessionDispatcher<TestPools>>);
+        let foreign = player(SessionBinding::new(
+            Arc::new(ForeignSession),
+            testing::TEST_SAMPLE_RATE,
+        ));
 
         let err = apply_mix([(&a, 0.5), (&foreign, 0.5)]).unwrap_err();
         assert!(matches!(err, PlayError::MixForeignSession));

--- a/crates/kithara-play/src/engine/mix.rs
+++ b/crates/kithara-play/src/engine/mix.rs
@@ -75,6 +75,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroU32;
+
     use kithara_audio::ConsumerWakeMode;
     use kithara_test_utils::kithara;
 
@@ -94,6 +96,10 @@ mod tests {
     impl SessionDispatcher<TestPools> for ForeignSession {
         fn consumer_wake_mode(&self) -> ConsumerWakeMode {
             ConsumerWakeMode::RealtimeDeferred
+        }
+
+        fn requested_sample_rate(&self) -> NonZeroU32 {
+            testing::TEST_SAMPLE_RATE
         }
 
         fn exec(&self, cmd: Cmd<TestPools>) -> Result<Reply, PlayError> {

--- a/crates/kithara-play/src/engine/mix.rs
+++ b/crates/kithara-play/src/engine/mix.rs
@@ -80,12 +80,9 @@ mod tests {
 
     use super::*;
     use crate::{
-        PlayWorker, PlayWorkerConfig,
+        PlayWorker, PlayWorkerConfig, mock,
         player::PlayerConfig,
-        session::{
-            Cmd, Reply, SessionBinding, SessionDispatcher, SessionSampleRate,
-            testing::{self, test_session},
-        },
+        session::{Cmd, Reply, SessionBinding, SessionDispatcher, SessionSampleRate},
         test_pools::{TestPools, pools},
     };
 
@@ -100,7 +97,7 @@ mod tests {
             match cmd {
                 Cmd::QuerySampleRate => Ok(Reply::SampleRate(SessionSampleRate::new(
                     None,
-                    testing::TEST_SAMPLE_RATE.get(),
+                    mock::SAMPLE_RATE.get(),
                 ))),
                 _ => Ok(Reply::Ok),
             }
@@ -111,7 +108,7 @@ mod tests {
         let worker = PlayWorker::new(PlayWorkerConfig::builder(pools()).build());
         PlayerImpl::new(
             PlayerConfig::builder()
-                .sample_rate(testing::TEST_SAMPLE_RATE)
+                .sample_rate(mock::SAMPLE_RATE)
                 .worker(worker)
                 .session(session)
                 .build(),
@@ -120,7 +117,7 @@ mod tests {
 
     #[kithara::test]
     fn apply_updates_desired_levels_for_two_players() {
-        let session = test_session();
+        let session = mock::session();
         let a = player(session.clone());
         let b = player(session.clone());
         a.core.engine.start().unwrap();
@@ -133,7 +130,7 @@ mod tests {
 
     #[kithara::test]
     fn apply_rejects_duplicate_player_without_mutation() {
-        let session = test_session();
+        let session = mock::session();
         let a = player(session.clone());
         a.core.engine.start().unwrap();
 
@@ -144,7 +141,7 @@ mod tests {
 
     #[kithara::test]
     fn apply_rejects_invalid_level_without_mutation() {
-        let session = test_session();
+        let session = mock::session();
         let a = player(session.clone());
         a.core.engine.start().unwrap();
 
@@ -157,12 +154,12 @@ mod tests {
 
     #[kithara::test]
     fn apply_rejects_foreign_session() {
-        let session = test_session();
+        let session = mock::session();
         let a = player(session.clone());
         a.core.engine.start().unwrap();
         let foreign = player(SessionBinding::new(
             Arc::new(ForeignSession),
-            testing::TEST_SAMPLE_RATE,
+            mock::SAMPLE_RATE,
         ));
 
         let err = apply_mix([(&a, 0.5), (&foreign, 0.5)]).unwrap_err();
@@ -172,7 +169,7 @@ mod tests {
 
     #[kithara::test]
     fn never_started_player_receives_desired_before_first_start() {
-        let session = test_session();
+        let session = mock::session();
         let a = player(session.clone());
         apply_mix([(&a, 0.2)]).unwrap();
         assert_eq!(a.core.engine.master_volume(), 0.2);
@@ -187,7 +184,7 @@ mod tests {
 
     #[kithara::test]
     fn stopped_player_retains_level_on_restart() {
-        let session = test_session();
+        let session = mock::session();
         let a = player(session.clone());
         a.core.engine.start().unwrap();
 
@@ -201,7 +198,7 @@ mod tests {
 
     #[kithara::test]
     fn empty_batch_is_noop() {
-        let session = test_session();
+        let session = mock::session();
         let a = player(session.clone());
         a.core.engine.start().unwrap();
         let empty: [(&PlayerImpl<TestPools>, f32); 0] = [];

--- a/crates/kithara-play/src/mock.rs
+++ b/crates/kithara-play/src/mock.rs
@@ -1,1 +1,0 @@
-pub use crate::api::equalizer::EqualizerMock;

--- a/crates/kithara-play/src/mock/mod.rs
+++ b/crates/kithara-play/src/mock/mod.rs
@@ -1,0 +1,5 @@
+mod session;
+
+pub use session::{SAMPLE_RATE, SessionMock, session, session_at, session_with_shape};
+
+pub use crate::api::equalizer::EqualizerMock;

--- a/crates/kithara-play/src/mock/session.rs
+++ b/crates/kithara-play/src/mock/session.rs
@@ -6,25 +6,28 @@ use std::{
 use kithara_audio::ConsumerWakeMode;
 use kithara_platform::sync::{Arc, Mutex};
 
-use super::{AllocatedSlot, Cmd, Reply, SessionBinding, SessionDispatcher, SessionSampleRate};
 use crate::{
     PlayError, SessionDuckingMode, SharedEq, SlotId, StreamShape,
     bridge::{NodeInputs, slot_channels},
+    session::{AllocatedSlot, Cmd, Reply, SessionBinding, SessionDispatcher, SessionSampleRate},
 };
 
-pub(crate) const TEST_SAMPLE_RATE: NonZeroU32 = match NonZeroU32::new(44_100) {
+/// Sample rate every `SessionMock` answers with.
+pub const SAMPLE_RATE: NonZeroU32 = match NonZeroU32::new(44_100) {
     Some(sample_rate) => sample_rate,
     None => unreachable!(),
 };
 
-struct TestSession {
+/// A session that registers players and hands out slots without a graph.
+pub struct SessionMock {
     next_player: AtomicU64,
     next_slot: AtomicU64,
     nodes: Mutex<Vec<NodeInputs>>,
     shape: Option<StreamShape>,
+    sample_rate: NonZeroU32,
 }
 
-impl<S> SessionDispatcher<S> for TestSession {
+impl<S> SessionDispatcher<S> for SessionMock {
     fn consumer_wake_mode(&self) -> ConsumerWakeMode {
         ConsumerWakeMode::RealtimeDeferred
     }
@@ -40,7 +43,9 @@ impl<S> SessionDispatcher<S> for TestSession {
                 self.nodes.lock().push(inputs);
                 Reply::SlotAllocated(AllocatedSlot::new(control, slot))
             }
-            Cmd::QuerySampleRate => Reply::SampleRate(SessionSampleRate::new(None, 44_100)),
+            Cmd::QuerySampleRate => {
+                Reply::SampleRate(SessionSampleRate::new(None, self.sample_rate.get()))
+            }
             Cmd::QueryStreamShape => Reply::StreamShape(self.shape),
             Cmd::SessionDucking => Reply::SessionDucking(SessionDuckingMode::Off),
             _ => Reply::Ok,
@@ -49,18 +54,33 @@ impl<S> SessionDispatcher<S> for TestSession {
     }
 }
 
-pub(crate) fn test_session<S>() -> SessionBinding<S> {
-    test_session_with_shape(None)
+/// A binding to a fresh `SessionMock` with no stream shape.
+#[must_use]
+pub fn session<S>() -> SessionBinding<S> {
+    session_with_shape(None)
 }
 
-pub(crate) fn test_session_with_shape<S>(shape: Option<StreamShape>) -> SessionBinding<S> {
+/// A binding to a fresh `SessionMock` answering `shape` to stream-shape queries.
+#[must_use]
+pub fn session_with_shape<S>(shape: Option<StreamShape>) -> SessionBinding<S> {
+    binding(shape, SAMPLE_RATE)
+}
+
+/// A binding to a fresh `SessionMock` running at `sample_rate` instead of `SAMPLE_RATE`.
+#[must_use]
+pub fn session_at<S>(sample_rate: NonZeroU32) -> SessionBinding<S> {
+    binding(None, sample_rate)
+}
+
+fn binding<S>(shape: Option<StreamShape>, sample_rate: NonZeroU32) -> SessionBinding<S> {
     SessionBinding::new(
-        Arc::new(TestSession {
+        Arc::new(SessionMock {
             shape,
+            sample_rate,
             next_player: AtomicU64::new(1),
             next_slot: AtomicU64::new(0),
             nodes: Mutex::default(),
         }),
-        TEST_SAMPLE_RATE,
+        sample_rate,
     )
 }

--- a/crates/kithara-play/src/player/config.rs
+++ b/crates/kithara-play/src/player/config.rs
@@ -14,7 +14,7 @@ use kithara_warp::{BeatGridId, WarpConfig, WarpConfigPatch};
 use crate::{
     PlayWorker,
     effects::eq::{EqBandConfig, generate_log_spaced_bands},
-    session::SessionDispatcher,
+    session::SessionBinding,
 };
 
 fn allocate_grid_id() -> BeatGridId {
@@ -110,7 +110,7 @@ pub struct PlayerConfig<S> {
     /// Optional pre-bound session for isolated harnesses. Production players
     /// are constructed unbound and attached exactly once by their Host.
     #[patch(skip)]
-    pub(crate) session: Option<Arc<dyn SessionDispatcher<S>>>,
+    pub(crate) session: Option<SessionBinding<S>>,
     /// Explicit shared playback worker. Its pools and cancellation lifetime
     /// are configured once in [`crate::PlayWorkerConfig`].
     #[patch(skip)]

--- a/crates/kithara-play/src/player/core.rs
+++ b/crates/kithara-play/src/player/core.rs
@@ -292,6 +292,10 @@ mod tests {
             ConsumerWakeMode::RealtimeDeferred
         }
 
+        fn requested_sample_rate(&self) -> NonZeroU32 {
+            NonZeroU32::new(48_000).expect("fixture sample rate is non-zero")
+        }
+
         fn exec(&self, cmd: Cmd<TestPools>) -> Result<Reply, PlayError> {
             match cmd {
                 Cmd::QuerySampleRate => Ok(Reply::SampleRate(SessionSampleRate::new(None, 48_000))),

--- a/crates/kithara-play/src/player/core.rs
+++ b/crates/kithara-play/src/player/core.rs
@@ -238,7 +238,6 @@ impl<S> PlayerRuntime<S> {
         }
     }
 }
-
 #[cfg(test)]
 mod tests {
     use std::num::NonZeroU32;
@@ -246,32 +245,19 @@ mod tests {
     use std::sync::mpsc::{RecvTimeoutError, channel};
 
     use kithara_assets::AssetStore;
-    use kithara_audio::ConsumerWakeMode;
     use kithara_decode::GaplessMode;
-    use kithara_events::{Envelope, Event};
     use kithara_platform::{CancelToken, time::Duration};
     use kithara_test_utils::kithara;
-    use kithara_warp::{StretchControls, WarpConfig};
 
     use super::*;
     use crate::{
         PlayWorkerConfig,
         bridge::PlayerCmd,
-        effects::eq::generate_log_spaced_bands,
-        player::{PlayerConfig, PlayerConfigPatch, PlayerControlSource},
+        mock,
+        player::{PlayerConfig, PlayerConfigPatch},
         resource::{ResourceConfig, ResourceSrc},
-        session::{Cmd, Reply, SessionBinding, SessionDispatcher, SessionSampleRate, testing},
         test_pools::{TestPools, pools},
     };
-
-    #[derive(Clone, Copy)]
-    enum PlayerBasicScenario {
-        AdvanceOnEmpty,
-        EngineAccessor,
-        QueueStartsEmpty,
-        SendToSlotWithoutSlot,
-        StartsPaused,
-    }
 
     fn resource_config(input: &str) -> ResourceConfig<TestPools> {
         let pools = pools();
@@ -285,32 +271,12 @@ mod tests {
         PlayWorker::new(PlayWorkerConfig::builder(pools()).build())
     }
 
-    const FOREIGN_SAMPLE_RATE: NonZeroU32 = match NonZeroU32::new(48_000) {
-        Some(sample_rate) => sample_rate,
-        None => unreachable!(),
-    };
-
-    struct ForeignRateSession;
-
-    impl SessionDispatcher<TestPools> for ForeignRateSession {
-        fn consumer_wake_mode(&self) -> ConsumerWakeMode {
-            ConsumerWakeMode::RealtimeDeferred
-        }
-
-        fn exec(&self, cmd: Cmd<TestPools>) -> Result<Reply, PlayError> {
-            match cmd {
-                Cmd::QuerySampleRate => Ok(Reply::SampleRate(SessionSampleRate::new(None, 48_000))),
-                _ => Ok(Reply::Ok),
-            }
-        }
-    }
-
     fn player() -> PlayerImpl<TestPools> {
         PlayerImpl::new(
             PlayerConfig::builder()
-                .sample_rate(testing::TEST_SAMPLE_RATE)
+                .sample_rate(mock::SAMPLE_RATE)
                 .worker(worker())
-                .session(testing::test_session())
+                .session(mock::session())
                 .build(),
         )
     }
@@ -442,9 +408,9 @@ mod tests {
     fn prepare_config_applies_player_gapless_mode() {
         let player = PlayerImpl::new(
             PlayerConfig::builder()
-                .sample_rate(testing::TEST_SAMPLE_RATE)
+                .sample_rate(mock::SAMPLE_RATE)
                 .worker(worker())
-                .session(testing::test_session())
+                .session(mock::session())
                 .gapless_mode(GaplessMode::Disabled)
                 .build(),
         );
@@ -472,7 +438,7 @@ mod tests {
             .expect("the document types");
         let mut config = PlayerConfig::builder()
             .worker(worker())
-            .session(testing::test_session())
+            .session(mock::session())
             .sample_rate(NonZeroU32::new(44_100).expect("44100 is not zero"))
             .build();
         config.apply(patch);
@@ -511,9 +477,9 @@ mod tests {
         let parent_master = CancelToken::never();
         let player = PlayerImpl::new(
             PlayerConfig::builder()
-                .sample_rate(testing::TEST_SAMPLE_RATE)
+                .sample_rate(mock::SAMPLE_RATE)
                 .worker(worker())
-                .session(testing::test_session())
+                .session(mock::session())
                 .cancel(parent_master.clone())
                 .build(),
         );
@@ -531,163 +497,6 @@ mod tests {
     }
 
     #[kithara::test]
-    #[case(PlayerBasicScenario::StartsPaused)]
-    #[case(PlayerBasicScenario::QueueStartsEmpty)]
-    #[case(PlayerBasicScenario::AdvanceOnEmpty)]
-    #[case(PlayerBasicScenario::EngineAccessor)]
-    #[case(PlayerBasicScenario::SendToSlotWithoutSlot)]
-    fn player_basic_behaviors(#[case] scenario: PlayerBasicScenario) {
-        let player = player();
-        match scenario {
-            PlayerBasicScenario::StartsPaused => {
-                assert!((player.rate() - 0.0).abs() < f32::EPSILON);
-                assert_eq!(player.status(), PlayerStatus::Unknown);
-            }
-            PlayerBasicScenario::QueueStartsEmpty => {
-                assert_eq!(player.item_count(), 0);
-            }
-            PlayerBasicScenario::AdvanceOnEmpty => {
-                player.advance_to_next_item();
-                assert_eq!(player.current_index(), 0);
-            }
-            PlayerBasicScenario::EngineAccessor => {
-                assert!(!player.engine().is_running());
-            }
-            PlayerBasicScenario::SendToSlotWithoutSlot => {
-                let result = player.send_to_slot(PlayerCmd::SetPaused(true));
-                assert!(result.is_err());
-            }
-        }
-    }
-
-    #[kithara::test]
-    fn player_pause_without_active_slot_keeps_rate_zero() {
-        let player = player();
-        player.pause();
-        assert!((player.rate() - 0.0).abs() < f32::EPSILON);
-    }
-
-    #[kithara::test]
-    fn player_volume_clamps() {
-        let player = player();
-        player.set_volume(2.0);
-        assert!((player.volume() - 1.0).abs() < f32::EPSILON);
-        player.set_volume(-1.0);
-        assert!((player.volume() - 0.0).abs() < f32::EPSILON);
-    }
-
-    #[kithara::test]
-    fn player_muted() {
-        let player = player();
-        assert!(!player.is_muted());
-        player.set_muted(true);
-        assert!(player.is_muted());
-    }
-
-    #[kithara::test]
-    fn player_crossfade_duration() {
-        let player = player();
-        assert!((player.crossfade_duration() - 1.0).abs() < f32::EPSILON);
-        player.set_crossfade_duration(3.0);
-        assert!((player.crossfade_duration() - 3.0).abs() < f32::EPSILON);
-    }
-
-    #[kithara::test]
-    fn player_prefetch_duration() {
-        let player = player();
-        assert!((player.prefetch_duration() - 3.5).abs() < f32::EPSILON);
-        player.set_prefetch_duration(8.0);
-        assert!((player.prefetch_duration() - 8.0).abs() < f32::EPSILON);
-        player.set_prefetch_duration(-1.0);
-        assert!((player.prefetch_duration() - 0.0).abs() < f32::EPSILON);
-    }
-
-    #[kithara::test]
-    fn player_events_subscribe() {
-        let player = player();
-        let mut rx = player.subscribe();
-        player.set_volume(0.5);
-        let event = rx.try_recv();
-        assert!(event.is_ok());
-    }
-
-    #[kithara::test]
-    fn player_config_custom() {
-        let config = PlayerConfig::builder()
-            .sample_rate(testing::TEST_SAMPLE_RATE)
-            .worker(worker())
-            .session(testing::test_session())
-            .crossfade_duration(2.0)
-            .prefetch_duration(5.0)
-            .default_rate(0.5)
-            .gapless_mode(GaplessMode::MediaOnly)
-            .eq_layout(generate_log_spaced_bands(5))
-            .max_slots(2)
-            .warp(
-                WarpConfig::builder()
-                    .stretch(StretchControls::new(1.0))
-                    .build(),
-            )
-            .build();
-        let player = PlayerImpl::new(config);
-        assert!((player.crossfade_duration() - 2.0).abs() < f32::EPSILON);
-    }
-
-    /// `PlayerConfig::sample_rate` is the single place the value lives before
-    /// the `EngineConfig` it configures exists. This pins that the value the
-    /// player reports back out is the exact one the engine runs with, so the
-    /// rate the owning Host hands down cannot land somewhere the engine never
-    /// reads.
-    #[kithara::test]
-    fn a_configured_sample_rate_reaches_the_engine_it_prepares() {
-        let sample_rate = NonZeroU32::new(48_000).expect("invariant: sample rate is non-zero");
-        let player = PlayerImpl::new(
-            PlayerConfig::builder()
-                .worker(worker())
-                .session(testing::test_session())
-                .sample_rate(sample_rate)
-                .build(),
-        );
-
-        assert_eq!(player.sample_rate(), sample_rate.get());
-    }
-
-    #[kithara::test]
-    fn eq_band_count_tracks_a_replacement_layout_before_start() {
-        let player = PlayerImpl::new(
-            PlayerConfig::builder()
-                .sample_rate(testing::TEST_SAMPLE_RATE)
-                .worker(worker())
-                .session(testing::test_session())
-                .eq_layout(generate_log_spaced_bands(3))
-                .build(),
-        );
-        assert_eq!(player.eq_band_count(), 3);
-
-        player.set_eq_layout(generate_log_spaced_bands(4)).unwrap();
-        assert_eq!(player.eq_band_count(), 4);
-    }
-
-    #[kithara::test]
-    fn player_config_builder() {
-        let config = PlayerConfig::builder()
-            .sample_rate(testing::TEST_SAMPLE_RATE)
-            .worker(worker())
-            .session(testing::test_session())
-            .default_rate(0.5)
-            .crossfade_duration(2.5)
-            .prefetch_duration(7.0)
-            .max_slots(8)
-            .eq_layout(generate_log_spaced_bands(5))
-            .build();
-        assert_eq!(config.max_slots, 8);
-        assert!((config.default_rate - 0.5).abs() < f32::EPSILON);
-        assert!((config.crossfade_duration - 2.5).abs() < f32::EPSILON);
-        assert!((config.prefetch_duration - 7.0).abs() < f32::EPSILON);
-        assert_eq!(config.eq_layout.len(), 5);
-    }
-
-    #[kithara::test]
     fn player_default_rate_getter_setter() {
         let player = player();
         assert!((player.default_rate() - 1.0).abs() < f32::EPSILON);
@@ -695,44 +504,6 @@ mod tests {
         assert!((player.default_rate() - 0.75).abs() < f32::EPSILON);
         assert!((player.core.warp.stretch().speed() - 0.75).abs() < f32::EPSILON);
         assert_eq!(player.rate(), 0.0);
-    }
-
-    #[kithara::test(tokio)]
-    async fn synchronous_player_events_remain_in_order() {
-        let player = player();
-        let mut rx = player.subscribe();
-
-        player.set_volume(0.5);
-        player.set_muted(true);
-        player.set_rate(2.0);
-
-        let e1 = rx.try_recv();
-        let e2 = rx.try_recv();
-        assert!(matches!(
-            e1,
-            Ok(Envelope {
-                event: Event::Player(PlayerEvent::VolumeChanged { .. }),
-                ..
-            })
-        ));
-        assert!(matches!(
-            e2,
-            Ok(Envelope {
-                event: Event::Player(PlayerEvent::MuteChanged { .. }),
-                ..
-            })
-        ));
-        assert!(
-            rx.try_recv().is_err(),
-            "rate feedback must wait for the RT processor"
-        );
-    }
-
-    #[kithara::test(tokio)]
-    async fn player_negative_crossfade_duration_clamped() {
-        let player = player();
-        player.set_crossfade_duration(-5.0);
-        assert!((player.crossfade_duration() - 0.0).abs() < f32::EPSILON);
     }
 
     #[kithara::test]
@@ -747,9 +518,9 @@ mod tests {
     fn timestretch_is_address_stable_across_play_pause() {
         let player = PlayerImpl::new(
             PlayerConfig::builder()
-                .sample_rate(testing::TEST_SAMPLE_RATE)
+                .sample_rate(mock::SAMPLE_RATE)
                 .worker(worker())
-                .session(testing::test_session())
+                .session(mock::session())
                 .build(),
         );
         let ptr_before = Arc::as_ptr(player.core.warp.stretch());
@@ -779,87 +550,13 @@ mod tests {
     }
 
     #[kithara::test]
-    fn position_seconds_idle_is_none() {
-        let player = player();
-        assert!(player.position_seconds().is_none());
-        assert!(player.duration_seconds().is_none());
-        assert!(!player.is_playing());
-        assert!(player.current_abr_handle().is_none());
-        assert!(player.armed_next().is_none());
-    }
-
-    #[kithara::test]
-    fn set_rate_without_rt_does_not_emit_rate_changed() {
-        let player = player();
-        let mut rx = player.subscribe();
-        player.set_rate(2.0);
-        assert!(rx.try_recv().is_err());
-    }
-
-    #[kithara::test]
-    fn player_keeps_explicit_worker_and_shared_pools() {
-        let worker = worker();
-        let player = PlayerImpl::new(
-            PlayerConfig::builder()
-                .sample_rate(testing::TEST_SAMPLE_RATE)
-                .worker(worker.clone())
-                .session(testing::test_session())
-                .build(),
-        );
-        assert!(std::ptr::eq(player.worker().pools(), worker.pools()));
-    }
-
-    #[kithara::test]
-    fn auto_advance_enabled_default_and_toggle() {
-        let player = player();
-        assert!(player.auto_advance_enabled(), "default must be on");
-        player.set_auto_advance_enabled(false);
-        assert!(!player.auto_advance_enabled());
-        player.set_auto_advance_enabled(true);
-        assert!(player.auto_advance_enabled());
-    }
-
-    #[kithara::test]
-    fn auto_advance_disabled_via_config() {
-        let player = PlayerImpl::new(
-            PlayerConfig::builder()
-                .sample_rate(testing::TEST_SAMPLE_RATE)
-                .worker(worker())
-                .session(testing::test_session())
-                .auto_advance_enabled(false)
-                .build(),
-        );
-        assert!(!player.auto_advance_enabled());
-    }
-
-    #[kithara::test]
-    fn host_rejects_a_player_built_for_another_sample_rate() {
-        let mut player = PlayerImpl::new(
-            PlayerConfig::builder()
-                .sample_rate(testing::TEST_SAMPLE_RATE)
-                .worker(worker())
-                .build(),
-        );
-        let binding = SessionBinding::new(Arc::new(ForeignRateSession), FOREIGN_SAMPLE_RATE);
-
-        assert!(matches!(
-            PlayerControlSource::attach_session(&mut player, binding),
-            Err(PlayError::SessionSampleRateMismatch {
-                player: 44_100,
-                session: 48_000,
-            })
-        ));
-    }
-
-    #[kithara::test]
     fn prebound_session_rejects_a_player_built_for_another_sample_rate() {
         let player = PlayerImpl::new(
             PlayerConfig::builder()
-                .sample_rate(testing::TEST_SAMPLE_RATE)
+                .sample_rate(mock::SAMPLE_RATE)
                 .worker(worker())
-                .session(SessionBinding::new(
-                    Arc::new(ForeignRateSession),
-                    FOREIGN_SAMPLE_RATE,
+                .session(mock::session_at(
+                    NonZeroU32::new(48_000).expect("48000 is not zero"),
                 ))
                 .build(),
         );
@@ -871,5 +568,11 @@ mod tests {
                 session: 48_000,
             })
         ));
+    }
+
+    #[kithara::test]
+    fn send_to_slot_without_a_slot_is_an_error() {
+        let player = player();
+        assert!(player.send_to_slot(PlayerCmd::SetPaused(true)).is_err());
     }
 }

--- a/crates/kithara-play/src/player/core.rs
+++ b/crates/kithara-play/src/player/core.rs
@@ -285,15 +285,16 @@ mod tests {
         PlayWorker::new(PlayWorkerConfig::builder(pools()).build())
     }
 
+    const FOREIGN_SAMPLE_RATE: NonZeroU32 = match NonZeroU32::new(48_000) {
+        Some(sample_rate) => sample_rate,
+        None => unreachable!(),
+    };
+
     struct ForeignRateSession;
 
     impl SessionDispatcher<TestPools> for ForeignRateSession {
         fn consumer_wake_mode(&self) -> ConsumerWakeMode {
             ConsumerWakeMode::RealtimeDeferred
-        }
-
-        fn requested_sample_rate(&self) -> NonZeroU32 {
-            NonZeroU32::new(48_000).expect("fixture sample rate is non-zero")
         }
 
         fn exec(&self, cmd: Cmd<TestPools>) -> Result<Reply, PlayError> {
@@ -839,7 +840,7 @@ mod tests {
                 .worker(worker())
                 .build(),
         );
-        let binding = SessionBinding::new(Arc::new(ForeignRateSession));
+        let binding = SessionBinding::new(Arc::new(ForeignRateSession), FOREIGN_SAMPLE_RATE);
 
         assert!(matches!(
             PlayerControlSource::attach_session(&mut player, binding),
@@ -856,7 +857,10 @@ mod tests {
             PlayerConfig::builder()
                 .sample_rate(testing::TEST_SAMPLE_RATE)
                 .worker(worker())
-                .session(Arc::new(ForeignRateSession))
+                .session(SessionBinding::new(
+                    Arc::new(ForeignRateSession),
+                    FOREIGN_SAMPLE_RATE,
+                ))
                 .build(),
         );
 

--- a/crates/kithara-play/src/player/flow/handover.rs
+++ b/crates/kithara-play/src/player/flow/handover.rs
@@ -252,9 +252,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        PlayWorker, PlayWorkerConfig,
+        PlayWorker, PlayWorkerConfig, mock,
         player::PlayerConfig,
-        session::testing,
         test_pools::{TestPools, pools},
     };
 
@@ -266,9 +265,9 @@ mod tests {
     fn commit_next_without_arm_returns_not_ready() {
         let player = PlayerImpl::new(
             PlayerConfig::builder()
-                .sample_rate(testing::TEST_SAMPLE_RATE)
+                .sample_rate(mock::SAMPLE_RATE)
                 .worker(worker())
-                .session(testing::test_session())
+                .session(mock::session())
                 .build(),
         );
         let err = player.commit_next(1).expect_err("must error");
@@ -279,9 +278,9 @@ mod tests {
     fn commit_next_publishes_snapshot_before_current_item_changed() {
         let player = PlayerImpl::new(
             PlayerConfig::builder()
-                .sample_rate(testing::TEST_SAMPLE_RATE)
+                .sample_rate(mock::SAMPLE_RATE)
                 .worker(worker())
-                .session(testing::test_session())
+                .session(mock::session())
                 .build(),
         );
         player

--- a/crates/kithara-play/src/player/flow/notify.rs
+++ b/crates/kithara-play/src/player/flow/notify.rs
@@ -313,12 +313,11 @@ mod tests {
 
     use super::*;
     use crate::{
-        PlayWorker, PlayWorkerConfig,
+        PlayWorker, PlayWorkerConfig, mock,
         player::{
             PlayerConfig, PlayerImpl,
             state::{PendingNext, PendingNextState},
         },
-        session::testing,
         test_pools::{TestPools, pools},
     };
 
@@ -335,9 +334,9 @@ mod tests {
         let worker = PlayWorker::new(PlayWorkerConfig::builder(pools()).build());
         let player = PlayerImpl::new(
             PlayerConfig::builder()
-                .sample_rate(testing::TEST_SAMPLE_RATE)
+                .sample_rate(mock::SAMPLE_RATE)
                 .worker(worker)
-                .session(testing::test_session())
+                .session(mock::session())
                 .build(),
         );
         player

--- a/crates/kithara-play/src/player/flow/prepare.rs
+++ b/crates/kithara-play/src/player/flow/prepare.rs
@@ -150,7 +150,7 @@ mod tests {
         PlayError, PlayWorker, PlayWorkerConfig, PlaybackResamplerBackend,
         player::PlayerConfig,
         resource::ResourceSrc,
-        session::{Cmd, Reply, SessionDispatcher, testing},
+        session::{Cmd, Reply, SessionBinding, SessionDispatcher, testing},
         test_pools::{TestPools, pools},
     };
 
@@ -159,10 +159,6 @@ mod tests {
     impl SessionDispatcher<TestPools> for ImmediateSession {
         fn consumer_wake_mode(&self) -> ConsumerWakeMode {
             ConsumerWakeMode::ImmediateOffRt
-        }
-
-        fn requested_sample_rate(&self) -> NonZeroU32 {
-            self.0.requested_sample_rate()
         }
 
         fn exec(&self, cmd: Cmd<TestPools>) -> Result<Reply, PlayError> {
@@ -209,8 +205,10 @@ mod tests {
 
     #[kithara::test]
     fn prepare_config_propagates_session_consumer_wake_mode_to_audio() {
-        let session: Arc<dyn SessionDispatcher<TestPools>> =
-            Arc::new(ImmediateSession(testing::test_session()));
+        let session = SessionBinding::new(
+            Arc::new(ImmediateSession(testing::test_session().dispatcher())),
+            testing::TEST_SAMPLE_RATE,
+        );
         let player = PlayerImpl::new(
             PlayerConfig::builder()
                 .sample_rate(testing::TEST_SAMPLE_RATE)

--- a/crates/kithara-play/src/player/flow/prepare.rs
+++ b/crates/kithara-play/src/player/flow/prepare.rs
@@ -161,6 +161,10 @@ mod tests {
             ConsumerWakeMode::ImmediateOffRt
         }
 
+        fn requested_sample_rate(&self) -> NonZeroU32 {
+            self.0.requested_sample_rate()
+        }
+
         fn exec(&self, cmd: Cmd<TestPools>) -> Result<Reply, PlayError> {
             self.0.exec(cmd)
         }

--- a/crates/kithara-play/src/player/flow/prepare.rs
+++ b/crates/kithara-play/src/player/flow/prepare.rs
@@ -147,10 +147,10 @@ mod tests {
 
     use super::*;
     use crate::{
-        PlayError, PlayWorker, PlayWorkerConfig, PlaybackResamplerBackend,
+        PlayError, PlayWorker, PlayWorkerConfig, PlaybackResamplerBackend, mock,
         player::PlayerConfig,
         resource::ResourceSrc,
-        session::{Cmd, Reply, SessionBinding, SessionDispatcher, testing},
+        session::{Cmd, Reply, SessionBinding, SessionDispatcher},
         test_pools::{TestPools, pools},
     };
 
@@ -185,16 +185,16 @@ mod tests {
     ) -> PlayerImpl<TestPools> {
         let shape = StreamShape::new(
             NonZeroU32::new(output_buffer).expect("fixture output block is non-zero"),
-            testing::TEST_SAMPLE_RATE,
+            mock::SAMPLE_RATE,
         );
         let warp = WarpConfig::builder()
             .render_quantum_frames(NonZeroUsize::new(quantum).expect("fixture quantum is non-zero"))
             .build();
         PlayerImpl::new(
             PlayerConfig::builder()
-                .sample_rate(testing::TEST_SAMPLE_RATE)
+                .sample_rate(mock::SAMPLE_RATE)
                 .worker(worker())
-                .session(testing::test_session_with_shape(Some(shape)))
+                .session(mock::session_with_shape(Some(shape)))
                 .warp(warp)
                 .response_budget_frames(
                     NonZeroUsize::new(response_budget).expect("fixture budget is non-zero"),
@@ -206,12 +206,12 @@ mod tests {
     #[kithara::test]
     fn prepare_config_propagates_session_consumer_wake_mode_to_audio() {
         let session = SessionBinding::new(
-            Arc::new(ImmediateSession(testing::test_session().dispatcher())),
-            testing::TEST_SAMPLE_RATE,
+            Arc::new(ImmediateSession(mock::session().dispatcher())),
+            mock::SAMPLE_RATE,
         );
         let player = PlayerImpl::new(
             PlayerConfig::builder()
-                .sample_rate(testing::TEST_SAMPLE_RATE)
+                .sample_rate(mock::SAMPLE_RATE)
                 .worker(worker())
                 .session(session)
                 .build(),
@@ -242,13 +242,13 @@ mod tests {
     fn prepare_config_sizes_default_resampling_work_to_the_output_block() {
         let shape = StreamShape::new(
             NonZeroU32::new(128).expect("test block is non-zero"),
-            testing::TEST_SAMPLE_RATE,
+            mock::SAMPLE_RATE,
         );
         let player = PlayerImpl::new(
             PlayerConfig::builder()
-                .sample_rate(testing::TEST_SAMPLE_RATE)
+                .sample_rate(mock::SAMPLE_RATE)
                 .worker(worker())
-                .session(testing::test_session_with_shape(Some(shape)))
+                .session(mock::session_with_shape(Some(shape)))
                 .build(),
         );
 
@@ -271,7 +271,7 @@ mod tests {
     fn prepare_config_without_a_session_keeps_default_resampling_work() {
         let player = PlayerImpl::new(
             PlayerConfig::builder()
-                .sample_rate(testing::TEST_SAMPLE_RATE)
+                .sample_rate(mock::SAMPLE_RATE)
                 .worker(worker())
                 .build(),
         );
@@ -293,13 +293,13 @@ mod tests {
         config.decoder = AudioDecoderConfig::builder().resampler(explicit).build();
         let shape = StreamShape::new(
             NonZeroU32::new(128).expect("test block is non-zero"),
-            testing::TEST_SAMPLE_RATE,
+            mock::SAMPLE_RATE,
         );
         let player = PlayerImpl::new(
             PlayerConfig::builder()
-                .sample_rate(testing::TEST_SAMPLE_RATE)
+                .sample_rate(mock::SAMPLE_RATE)
                 .worker(worker())
-                .session(testing::test_session_with_shape(Some(shape)))
+                .session(mock::session_with_shape(Some(shape)))
                 .build(),
         );
 

--- a/crates/kithara-play/src/player/flow/transport.rs
+++ b/crates/kithara-play/src/player/flow/transport.rs
@@ -5,8 +5,6 @@ use kithara_bufpool::HasPool;
 use kithara_platform::time::Duration;
 use tracing::{debug, warn};
 
-#[cfg(test)]
-use super::super::core::PlayerImpl;
 use super::super::core::PlayerRuntime;
 use crate::{
     api::{PlayerStatus, TrackId},
@@ -245,77 +243,5 @@ where
 
     pub(crate) fn start_playback(&self, item_id: TrackId) {
         let _ = self.send_to_slot(PlayerCmd::Transition(TrackTransition::FadeIn(item_id)));
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use kithara_test_utils::kithara;
-
-    use super::*;
-    use crate::{
-        PlayWorker, PlayWorkerConfig,
-        player::PlayerConfig,
-        session::testing,
-        test_pools::{TestPools, pools},
-    };
-
-    fn player() -> PlayerImpl<TestPools> {
-        let worker = PlayWorker::new(PlayWorkerConfig::builder(pools()).build());
-        PlayerImpl::new(
-            PlayerConfig::builder()
-                .sample_rate(testing::TEST_SAMPLE_RATE)
-                .worker(worker)
-                .session(testing::test_session())
-                .build(),
-        )
-    }
-
-    #[kithara::test]
-    fn seek_seconds_without_slot_returns_not_ready() {
-        let player = player();
-        let err = player.seek_seconds(1.0).expect_err("must error");
-        assert!(matches!(err, PlayError::NotReady));
-    }
-
-    #[kithara::test]
-    fn select_item_out_of_range_returns_typed_error() {
-        let player = player();
-        let err = player
-            .select_item_with_crossfade(
-                5,
-                SelectTransition {
-                    autoplay: false,
-                    crossfade_seconds: 0.0,
-                },
-            )
-            .expect_err("must error");
-        assert!(matches!(
-            err,
-            PlayError::IndexOutOfRange { index: 5, len: 0 }
-        ));
-    }
-
-    /// `enqueue_to_processor` takes the resource out of the slot, so a
-    /// select against an emptied (consumed) slot has nothing to load: it
-    /// must fail loudly instead of moving the playlist current index / announcing
-    /// `CurrentItemChanged` while the old audio keeps playing.
-    #[kithara::test]
-    fn select_item_on_consumed_slot_errors_without_bookkeeping() {
-        let player = player();
-        player.reserve_slots(2);
-        let result = player.select_item_with_crossfade(
-            1,
-            SelectTransition {
-                autoplay: false,
-                crossfade_seconds: 0.0,
-            },
-        );
-        assert!(result.is_err(), "selecting an emptied slot must fail");
-        assert_eq!(
-            player.current_index(),
-            0,
-            "bookkeeping must not move on a failed select"
-        );
     }
 }

--- a/crates/kithara-play/src/player/state/phase.rs
+++ b/crates/kithara-play/src/player/state/phase.rs
@@ -361,9 +361,7 @@ mod tests {
     use kithara_test_utils::kithara;
 
     use super::*;
-    use crate::{
-        PlayWorker, PlayWorkerConfig, player::PlayerConfig, session::testing, test_pools::pools,
-    };
+    use crate::{PlayWorker, PlayWorkerConfig, mock, player::PlayerConfig, test_pools::pools};
 
     #[kithara::test]
     fn pending_next_state_maps_activated_bool() {
@@ -425,9 +423,9 @@ mod tests {
         let worker = PlayWorker::new(PlayWorkerConfig::builder(pools()).build());
         let player = PlayerImpl::new(
             PlayerConfig::builder()
-                .sample_rate(testing::TEST_SAMPLE_RATE)
+                .sample_rate(mock::SAMPLE_RATE)
                 .worker(worker)
-                .session(testing::test_session())
+                .session(mock::session())
                 .build(),
         );
         assert_eq!(

--- a/crates/kithara-play/src/session/mod.rs
+++ b/crates/kithara-play/src/session/mod.rs
@@ -1,8 +1,6 @@
 //! Lower player-to-host session protocol.
 
 pub mod protocol;
-#[cfg(test)]
-pub(crate) mod testing;
 pub use protocol::{
     AllocatedSlot, Cmd, PlayerId, PlayerLevel, Reply, SessionBinding, SessionDispatcher,
     SessionError, SessionHandle, SessionSampleRate,

--- a/crates/kithara-play/src/session/protocol.rs
+++ b/crates/kithara-play/src/session/protocol.rs
@@ -252,14 +252,6 @@ mod handle {
             }
         }
 
-        /// Sample rate this session was configured with.
-        ///
-        /// Static session configuration, so the owner already holds it when it
-        /// builds the dispatcher and answers locally. Reading it over the
-        /// command bridge would park the caller on a reply carrying a value the
-        /// caller could have read from its own field.
-        fn requested_sample_rate(&self) -> NonZeroU32;
-
         /// Rate the running backend settled on, which only the session knows.
         fn sample_rate(&self) -> Result<SessionSampleRate, PlayError> {
             match self.exec_ok(Cmd::QuerySampleRate)? {
@@ -286,19 +278,45 @@ mod handle {
     /// this capability down to their resident Player.
     pub struct SessionBinding<S> {
         dispatcher: Arc<dyn SessionDispatcher<S>>,
+        requested_sample_rate: NonZeroU32,
     }
 
     impl<S> SessionBinding<S> {
         /// Wraps the canonical session for one Host insertion.
+        ///
+        /// The rate is the session's own configuration, so it travels from the
+        /// owner that chose it. Asking the session for it would send a command
+        /// and park the caller on a reply carrying a value the owner holds.
         #[doc(hidden)]
         #[must_use]
-        pub fn new(dispatcher: Arc<dyn SessionDispatcher<S>>) -> Self {
-            Self { dispatcher }
+        pub fn new(
+            dispatcher: Arc<dyn SessionDispatcher<S>>,
+            requested_sample_rate: NonZeroU32,
+        ) -> Self {
+            Self {
+                dispatcher,
+                requested_sample_rate,
+            }
         }
 
         #[must_use]
         pub(crate) fn requested_sample_rate(&self) -> NonZeroU32 {
-            self.dispatcher.requested_sample_rate()
+            self.requested_sample_rate
+        }
+
+        #[cfg(test)]
+        #[must_use]
+        pub(crate) fn dispatcher(&self) -> Arc<dyn SessionDispatcher<S>> {
+            Arc::clone(&self.dispatcher)
+        }
+    }
+
+    impl<S> Clone for SessionBinding<S> {
+        fn clone(&self) -> Self {
+            Self {
+                dispatcher: Arc::clone(&self.dispatcher),
+                requested_sample_rate: self.requested_sample_rate,
+            }
         }
     }
 
@@ -316,9 +334,9 @@ mod handle {
 
     impl<S> SessionHandle<S> {
         #[must_use]
-        pub fn new(dispatcher: Arc<dyn SessionDispatcher<S>>) -> Self {
+        pub fn new(binding: SessionBinding<S>) -> Self {
             Self(Arc::new(SessionSlot {
-                binding: Mutex::new(Some(SessionBinding::new(dispatcher))),
+                binding: Mutex::new(Some(binding)),
             }))
         }
 
@@ -504,7 +522,12 @@ mod handle {
         }
 
         pub(crate) fn requested_sample_rate(&self) -> Result<NonZeroU32, PlayError> {
-            Ok(self.dispatcher()?.requested_sample_rate())
+            self.0
+                .binding
+                .lock()
+                .as_ref()
+                .map(SessionBinding::requested_sample_rate)
+                .ok_or(PlayError::SessionUnbound)
         }
 
         delegate::delegate! {
@@ -554,10 +577,6 @@ mod tests {
             ConsumerWakeMode::RealtimeDeferred
         }
 
-        fn requested_sample_rate(&self) -> NonZeroU32 {
-            sample_rate()
-        }
-
         fn exec(&self, _cmd: Cmd<TestPools>) -> Result<Reply, PlayError> {
             Ok(Reply::Ok)
         }
@@ -566,10 +585,6 @@ mod tests {
     impl SessionDispatcher<TestPools> for RateCapture {
         fn consumer_wake_mode(&self) -> ConsumerWakeMode {
             ConsumerWakeMode::RealtimeDeferred
-        }
-
-        fn requested_sample_rate(&self) -> NonZeroU32 {
-            sample_rate()
         }
 
         fn exec(&self, cmd: Cmd<TestPools>) -> Result<Reply, PlayError> {
@@ -596,7 +611,8 @@ mod tests {
 
     #[kithara::test]
     fn session_handle_delegates_explicit_consumer_wake_mode() {
-        let handle: SessionHandle<TestPools> = SessionHandle::new(Arc::new(DefaultSession));
+        let handle: SessionHandle<TestPools> =
+            SessionHandle::new(SessionBinding::new(Arc::new(DefaultSession), sample_rate()));
 
         assert_eq!(
             handle.consumer_wake_mode(),
@@ -617,7 +633,7 @@ mod tests {
         ));
 
         handle
-            .bind(SessionBinding::new(Arc::new(DefaultSession)))
+            .bind(SessionBinding::new(Arc::new(DefaultSession), sample_rate()))
             .expect("bind canonical session");
         assert_eq!(
             handle.consumer_wake_mode(),
@@ -625,7 +641,7 @@ mod tests {
         );
         assert!(matches!(handle.exec(Cmd::Tick), Ok(Reply::Ok)));
         assert!(matches!(
-            handle.bind(SessionBinding::new(Arc::new(DefaultSession))),
+            handle.bind(SessionBinding::new(Arc::new(DefaultSession), sample_rate())),
             Err(PlayError::SessionAlreadyBound)
         ));
     }
@@ -634,7 +650,7 @@ mod tests {
     fn session_commands_use_the_bound_host_rate() {
         let capture = Arc::new(RateCapture::default());
         let dispatcher: Arc<dyn SessionDispatcher<TestPools>> = capture.clone();
-        let handle = SessionHandle::new(dispatcher);
+        let handle = SessionHandle::new(SessionBinding::new(dispatcher, sample_rate()));
 
         let player_id = handle
             .register_player(
@@ -662,7 +678,7 @@ mod tests {
     fn the_requested_rate_never_reaches_the_session() {
         let capture = Arc::new(RateCapture::default());
         let dispatcher: Arc<dyn SessionDispatcher<TestPools>> = capture.clone();
-        let handle = SessionHandle::new(dispatcher);
+        let handle = SessionHandle::new(SessionBinding::new(dispatcher, sample_rate()));
 
         assert_eq!(
             handle.requested_sample_rate().expect("requested rate"),

--- a/crates/kithara-play/src/session/protocol.rs
+++ b/crates/kithara-play/src/session/protocol.rs
@@ -229,7 +229,7 @@ mod handle {
 
     #[cfg(any(test, feature = "probe"))]
     use super::wire::PlayerLevel;
-    use super::wire::{AllocatedSlot, Cmd, PlayerId, Reply, SessionError, SessionSampleRate};
+    use super::wire::{AllocatedSlot, Cmd, PlayerId, Reply, SessionSampleRate};
     use crate::{api::SlotId, effects::eq::EqBandConfig, error::PlayError, rt::StreamShape};
 
     /// Handle used by resident players to reach their session owner.
@@ -252,13 +252,15 @@ mod handle {
             }
         }
 
-        fn requested_sample_rate(&self) -> Result<NonZeroU32, PlayError> {
-            let requested = self.sample_rate()?.requested;
-            NonZeroU32::new(requested).ok_or(PlayError::Session(SessionError::InvalidSampleRate(
-                requested,
-            )))
-        }
+        /// Sample rate this session was configured with.
+        ///
+        /// Static session configuration, so the owner already holds it when it
+        /// builds the dispatcher and answers locally. Reading it over the
+        /// command bridge would park the caller on a reply carrying a value the
+        /// caller could have read from its own field.
+        fn requested_sample_rate(&self) -> NonZeroU32;
 
+        /// Rate the running backend settled on, which only the session knows.
         fn sample_rate(&self) -> Result<SessionSampleRate, PlayError> {
             match self.exec_ok(Cmd::QuerySampleRate)? {
                 Reply::SampleRate(sample_rate) => Ok(sample_rate),
@@ -294,7 +296,8 @@ mod handle {
             Self { dispatcher }
         }
 
-        pub(crate) fn requested_sample_rate(&self) -> Result<NonZeroU32, PlayError> {
+        #[must_use]
+        pub(crate) fn requested_sample_rate(&self) -> NonZeroU32 {
             self.dispatcher.requested_sample_rate()
         }
     }
@@ -500,9 +503,12 @@ mod handle {
                 .map(|_| ())
         }
 
+        pub(crate) fn requested_sample_rate(&self) -> Result<NonZeroU32, PlayError> {
+            Ok(self.dispatcher()?.requested_sample_rate())
+        }
+
         delegate::delegate! {
             to self.dispatcher()? {
-                pub(crate) fn requested_sample_rate(&self) -> Result<NonZeroU32, PlayError>;
                 pub fn sample_rate(&self) -> Result<SessionSampleRate, PlayError>;
             }
         }
@@ -534,7 +540,10 @@ mod tests {
     struct DefaultSession;
 
     #[derive(Default)]
-    struct RateCapture(AtomicU32);
+    struct RateCapture {
+        applied: AtomicU32,
+        queries: AtomicU32,
+    }
 
     fn sample_rate() -> NonZeroU32 {
         NonZeroU32::new(48_000).expect("fixture sample rate is non-zero")
@@ -543,6 +552,10 @@ mod tests {
     impl SessionDispatcher<TestPools> for DefaultSession {
         fn consumer_wake_mode(&self) -> ConsumerWakeMode {
             ConsumerWakeMode::RealtimeDeferred
+        }
+
+        fn requested_sample_rate(&self) -> NonZeroU32 {
+            sample_rate()
         }
 
         fn exec(&self, _cmd: Cmd<TestPools>) -> Result<Reply, PlayError> {
@@ -555,18 +568,25 @@ mod tests {
             ConsumerWakeMode::RealtimeDeferred
         }
 
+        fn requested_sample_rate(&self) -> NonZeroU32 {
+            sample_rate()
+        }
+
         fn exec(&self, cmd: Cmd<TestPools>) -> Result<Reply, PlayError> {
             match cmd {
-                Cmd::QuerySampleRate => Ok(Reply::SampleRate(SessionSampleRate::new(
-                    None,
-                    sample_rate().get(),
-                ))),
+                Cmd::QuerySampleRate => {
+                    self.queries.fetch_add(1, Ordering::Relaxed);
+                    Ok(Reply::SampleRate(SessionSampleRate::new(
+                        None,
+                        sample_rate().get(),
+                    )))
+                }
                 Cmd::RegisterPlayer { sample_rate, .. } => {
-                    self.0.store(sample_rate, Ordering::Relaxed);
+                    self.applied.store(sample_rate, Ordering::Relaxed);
                     Ok(Reply::PlayerRegistered(1))
                 }
                 Cmd::StartPlayer { sample_rate, .. } => {
-                    self.0.store(sample_rate, Ordering::Relaxed);
+                    self.applied.store(sample_rate, Ordering::Relaxed);
                     Ok(Reply::Ok)
                 }
                 _ => Ok(Reply::Ok),
@@ -624,9 +644,9 @@ mod tests {
                 pools(),
             )
             .expect("register player");
-        assert_eq!(capture.0.load(Ordering::Relaxed), sample_rate().get());
+        assert_eq!(capture.applied.load(Ordering::Relaxed), sample_rate().get());
 
-        capture.0.store(0, Ordering::Relaxed);
+        capture.applied.store(0, Ordering::Relaxed);
         handle
             .start_player(
                 player_id,
@@ -635,6 +655,37 @@ mod tests {
                 NonZeroUsize::new(448).expect("fixture response budget is non-zero"),
             )
             .expect("start player");
-        assert_eq!(capture.0.load(Ordering::Relaxed), sample_rate().get());
+        assert_eq!(capture.applied.load(Ordering::Relaxed), sample_rate().get());
+    }
+
+    #[kithara::test]
+    fn the_requested_rate_never_reaches_the_session() {
+        let capture = Arc::new(RateCapture::default());
+        let dispatcher: Arc<dyn SessionDispatcher<TestPools>> = capture.clone();
+        let handle = SessionHandle::new(dispatcher);
+
+        assert_eq!(
+            handle.requested_sample_rate().expect("requested rate"),
+            sample_rate()
+        );
+
+        let player_id = handle
+            .register_player(
+                BeatGridId::allocate().expect("player id"),
+                EventBus::default(),
+                Vec::new(),
+                pools(),
+            )
+            .expect("register player");
+        handle
+            .start_player(
+                player_id,
+                1.0,
+                None,
+                NonZeroUsize::new(448).expect("fixture response budget is non-zero"),
+            )
+            .expect("start player");
+
+        assert_eq!(capture.queries.load(Ordering::Relaxed), 0);
     }
 }

--- a/crates/kithara-play/src/session/testing.rs
+++ b/crates/kithara-play/src/session/testing.rs
@@ -29,6 +29,10 @@ impl<S> SessionDispatcher<S> for TestSession {
         ConsumerWakeMode::RealtimeDeferred
     }
 
+    fn requested_sample_rate(&self) -> NonZeroU32 {
+        NonZeroU32::new(44_100).expect("fixture sample rate is non-zero")
+    }
+
     fn exec(&self, cmd: Cmd<S>) -> Result<Reply, PlayError> {
         let reply = match cmd {
             Cmd::RegisterPlayer { .. } => {

--- a/crates/kithara-play/src/session/testing.rs
+++ b/crates/kithara-play/src/session/testing.rs
@@ -6,7 +6,7 @@ use std::{
 use kithara_audio::ConsumerWakeMode;
 use kithara_platform::sync::{Arc, Mutex};
 
-use super::{AllocatedSlot, Cmd, Reply, SessionDispatcher, SessionSampleRate};
+use super::{AllocatedSlot, Cmd, Reply, SessionBinding, SessionDispatcher, SessionSampleRate};
 use crate::{
     PlayError, SessionDuckingMode, SharedEq, SlotId, StreamShape,
     bridge::{NodeInputs, slot_channels},
@@ -29,10 +29,6 @@ impl<S> SessionDispatcher<S> for TestSession {
         ConsumerWakeMode::RealtimeDeferred
     }
 
-    fn requested_sample_rate(&self) -> NonZeroU32 {
-        NonZeroU32::new(44_100).expect("fixture sample rate is non-zero")
-    }
-
     fn exec(&self, cmd: Cmd<S>) -> Result<Reply, PlayError> {
         let reply = match cmd {
             Cmd::RegisterPlayer { .. } => {
@@ -53,17 +49,18 @@ impl<S> SessionDispatcher<S> for TestSession {
     }
 }
 
-pub(crate) fn test_session<S>() -> Arc<dyn SessionDispatcher<S>> {
+pub(crate) fn test_session<S>() -> SessionBinding<S> {
     test_session_with_shape(None)
 }
 
-pub(crate) fn test_session_with_shape<S>(
-    shape: Option<StreamShape>,
-) -> Arc<dyn SessionDispatcher<S>> {
-    Arc::new(TestSession {
-        shape,
-        next_player: AtomicU64::new(1),
-        next_slot: AtomicU64::new(0),
-        nodes: Mutex::default(),
-    })
+pub(crate) fn test_session_with_shape<S>(shape: Option<StreamShape>) -> SessionBinding<S> {
+    SessionBinding::new(
+        Arc::new(TestSession {
+            shape,
+            next_player: AtomicU64::new(1),
+            next_slot: AtomicU64::new(0),
+            nodes: Mutex::default(),
+        }),
+        TEST_SAMPLE_RATE,
+    )
 }

--- a/crates/kithara-play/tests/player.rs
+++ b/crates/kithara-play/tests/player.rs
@@ -1,0 +1,344 @@
+use std::num::NonZeroU32;
+
+use kithara_bufpool::testing::{TestPools, pools};
+use kithara_decode::GaplessMode;
+use kithara_events::{Envelope, Event, PlayerEvent, PlayerStatus};
+use kithara_play::{
+    PlayError, PlayWorker, PlayWorkerConfig, PlayerConfig, PlayerImpl, SelectTransition,
+    StretchControls, effects::eq::generate_log_spaced_bands, mock, player::PlayerControlSource,
+};
+use kithara_test_utils::kithara;
+use kithara_warp::WarpConfig;
+
+fn worker() -> PlayWorker<TestPools> {
+    PlayWorker::new(PlayWorkerConfig::builder(pools()).build())
+}
+
+fn player() -> PlayerImpl<TestPools> {
+    PlayerImpl::new(
+        PlayerConfig::builder()
+            .sample_rate(mock::SAMPLE_RATE)
+            .worker(worker())
+            .session(mock::session())
+            .build(),
+    )
+}
+
+#[derive(Clone, Copy)]
+enum PlayerBasicScenario {
+    AdvanceOnEmpty,
+    EngineAccessor,
+    QueueStartsEmpty,
+    StartsPaused,
+}
+
+#[kithara::test]
+#[case(PlayerBasicScenario::StartsPaused)]
+#[case(PlayerBasicScenario::QueueStartsEmpty)]
+#[case(PlayerBasicScenario::AdvanceOnEmpty)]
+#[case(PlayerBasicScenario::EngineAccessor)]
+fn player_basic_behaviors(#[case] scenario: PlayerBasicScenario) {
+    let player = player();
+    match scenario {
+        PlayerBasicScenario::StartsPaused => {
+            assert!((player.rate() - 0.0).abs() < f32::EPSILON);
+            assert_eq!(player.status(), PlayerStatus::Unknown);
+        }
+        PlayerBasicScenario::QueueStartsEmpty => {
+            assert_eq!(player.item_count(), 0);
+        }
+        PlayerBasicScenario::AdvanceOnEmpty => {
+            player.advance_to_next_item();
+            assert_eq!(player.current_index(), 0);
+        }
+        PlayerBasicScenario::EngineAccessor => {
+            assert!(!player.engine().is_running());
+        }
+    }
+}
+
+#[kithara::test]
+fn player_pause_without_active_slot_keeps_rate_zero() {
+    let player = player();
+    player.pause();
+    assert!((player.rate() - 0.0).abs() < f32::EPSILON);
+}
+
+#[kithara::test]
+fn player_volume_clamps() {
+    let player = player();
+    player.set_volume(2.0);
+    assert!((player.volume() - 1.0).abs() < f32::EPSILON);
+    player.set_volume(-1.0);
+    assert!((player.volume() - 0.0).abs() < f32::EPSILON);
+}
+
+#[kithara::test]
+fn player_muted() {
+    let player = player();
+    assert!(!player.is_muted());
+    player.set_muted(true);
+    assert!(player.is_muted());
+}
+
+#[kithara::test]
+fn player_crossfade_duration() {
+    let player = player();
+    assert!((player.crossfade_duration() - 1.0).abs() < f32::EPSILON);
+    player.set_crossfade_duration(3.0);
+    assert!((player.crossfade_duration() - 3.0).abs() < f32::EPSILON);
+}
+
+#[kithara::test]
+fn player_prefetch_duration() {
+    let player = player();
+    assert!((player.prefetch_duration() - 3.5).abs() < f32::EPSILON);
+    player.set_prefetch_duration(8.0);
+    assert!((player.prefetch_duration() - 8.0).abs() < f32::EPSILON);
+    player.set_prefetch_duration(-1.0);
+    assert!((player.prefetch_duration() - 0.0).abs() < f32::EPSILON);
+}
+
+#[kithara::test]
+fn player_events_subscribe() {
+    let player = player();
+    let mut rx = player.subscribe();
+    player.set_volume(0.5);
+    let event = rx.try_recv();
+    assert!(event.is_ok());
+}
+
+#[kithara::test]
+fn player_config_custom() {
+    let config = PlayerConfig::builder()
+        .sample_rate(mock::SAMPLE_RATE)
+        .worker(worker())
+        .session(mock::session())
+        .crossfade_duration(2.0)
+        .prefetch_duration(5.0)
+        .default_rate(0.5)
+        .gapless_mode(GaplessMode::MediaOnly)
+        .eq_layout(generate_log_spaced_bands(5))
+        .max_slots(2)
+        .warp(
+            WarpConfig::builder()
+                .stretch(StretchControls::new(1.0))
+                .build(),
+        )
+        .build();
+    let player = PlayerImpl::new(config);
+    assert!((player.crossfade_duration() - 2.0).abs() < f32::EPSILON);
+}
+
+/// `PlayerConfig::sample_rate` is the single place the value lives before
+/// the `EngineConfig` it configures exists. This pins that the value the
+/// player reports back out is the exact one the engine runs with, so the
+/// rate the owning Host hands down cannot land somewhere the engine never
+/// reads.
+#[kithara::test]
+fn a_configured_sample_rate_reaches_the_engine_it_prepares() {
+    let sample_rate = NonZeroU32::new(48_000).expect("invariant: sample rate is non-zero");
+    let player = PlayerImpl::new(
+        PlayerConfig::builder()
+            .worker(worker())
+            .session(mock::session())
+            .sample_rate(sample_rate)
+            .build(),
+    );
+
+    assert_eq!(player.sample_rate(), sample_rate.get());
+}
+
+#[kithara::test]
+fn eq_band_count_tracks_a_replacement_layout_before_start() {
+    let player = PlayerImpl::new(
+        PlayerConfig::builder()
+            .sample_rate(mock::SAMPLE_RATE)
+            .worker(worker())
+            .session(mock::session())
+            .eq_layout(generate_log_spaced_bands(3))
+            .build(),
+    );
+    assert_eq!(player.eq_band_count(), 3);
+
+    player.set_eq_layout(generate_log_spaced_bands(4)).unwrap();
+    assert_eq!(player.eq_band_count(), 4);
+}
+
+#[kithara::test]
+fn player_config_builder() {
+    let config = PlayerConfig::builder()
+        .sample_rate(mock::SAMPLE_RATE)
+        .worker(worker())
+        .session(mock::session())
+        .default_rate(0.5)
+        .crossfade_duration(2.5)
+        .prefetch_duration(7.0)
+        .max_slots(8)
+        .eq_layout(generate_log_spaced_bands(5))
+        .build();
+    assert_eq!(config.max_slots, 8);
+    assert!((config.default_rate - 0.5).abs() < f32::EPSILON);
+    assert!((config.crossfade_duration - 2.5).abs() < f32::EPSILON);
+    assert!((config.prefetch_duration - 7.0).abs() < f32::EPSILON);
+    assert_eq!(config.eq_layout.len(), 5);
+}
+
+#[kithara::test(tokio)]
+async fn synchronous_player_events_remain_in_order() {
+    let player = player();
+    let mut rx = player.subscribe();
+
+    player.set_volume(0.5);
+    player.set_muted(true);
+    player.set_rate(2.0);
+
+    let e1 = rx.try_recv();
+    let e2 = rx.try_recv();
+    assert!(matches!(
+        e1,
+        Ok(Envelope {
+            event: Event::Player(PlayerEvent::VolumeChanged { .. }),
+            ..
+        })
+    ));
+    assert!(matches!(
+        e2,
+        Ok(Envelope {
+            event: Event::Player(PlayerEvent::MuteChanged { .. }),
+            ..
+        })
+    ));
+    assert!(
+        rx.try_recv().is_err(),
+        "rate feedback must wait for the RT processor"
+    );
+}
+
+#[kithara::test(tokio)]
+async fn player_negative_crossfade_duration_clamped() {
+    let player = player();
+    player.set_crossfade_duration(-5.0);
+    assert!((player.crossfade_duration() - 0.0).abs() < f32::EPSILON);
+}
+
+#[kithara::test]
+fn position_seconds_idle_is_none() {
+    let player = player();
+    assert!(player.position_seconds().is_none());
+    assert!(player.duration_seconds().is_none());
+    assert!(!player.is_playing());
+    assert!(player.current_abr_handle().is_none());
+    assert!(player.armed_next().is_none());
+}
+
+#[kithara::test]
+fn set_rate_without_rt_does_not_emit_rate_changed() {
+    let player = player();
+    let mut rx = player.subscribe();
+    player.set_rate(2.0);
+    assert!(rx.try_recv().is_err());
+}
+
+#[kithara::test]
+fn player_keeps_explicit_worker_and_shared_pools() {
+    let worker = worker();
+    let player = PlayerImpl::new(
+        PlayerConfig::builder()
+            .sample_rate(mock::SAMPLE_RATE)
+            .worker(worker.clone())
+            .session(mock::session())
+            .build(),
+    );
+    assert!(std::ptr::eq(player.worker().pools(), worker.pools()));
+}
+
+#[kithara::test]
+fn auto_advance_enabled_default_and_toggle() {
+    let player = player();
+    assert!(player.auto_advance_enabled(), "default must be on");
+    player.set_auto_advance_enabled(false);
+    assert!(!player.auto_advance_enabled());
+    player.set_auto_advance_enabled(true);
+    assert!(player.auto_advance_enabled());
+}
+
+#[kithara::test]
+fn auto_advance_disabled_via_config() {
+    let player = PlayerImpl::new(
+        PlayerConfig::builder()
+            .sample_rate(mock::SAMPLE_RATE)
+            .worker(worker())
+            .session(mock::session())
+            .auto_advance_enabled(false)
+            .build(),
+    );
+    assert!(!player.auto_advance_enabled());
+}
+
+#[kithara::test]
+fn host_rejects_a_player_built_for_another_sample_rate() {
+    let mut player = PlayerImpl::new(
+        PlayerConfig::builder()
+            .sample_rate(mock::SAMPLE_RATE)
+            .worker(worker())
+            .build(),
+    );
+    let binding = mock::session_at(NonZeroU32::new(48_000).expect("48000 is not zero"));
+
+    assert!(matches!(
+        PlayerControlSource::attach_session(&mut player, binding),
+        Err(PlayError::SessionSampleRateMismatch {
+            player: 44_100,
+            session: 48_000,
+        })
+    ));
+}
+
+#[kithara::test]
+fn seek_seconds_without_slot_returns_not_ready() {
+    let player = player();
+    let err = player.seek_seconds(1.0).expect_err("must error");
+    assert!(matches!(err, PlayError::NotReady));
+}
+
+#[kithara::test]
+fn select_item_out_of_range_returns_typed_error() {
+    let player = player();
+    let err = player
+        .select_item_with_crossfade(
+            5,
+            SelectTransition {
+                autoplay: false,
+                crossfade_seconds: 0.0,
+            },
+        )
+        .expect_err("must error");
+    assert!(matches!(
+        err,
+        PlayError::IndexOutOfRange { index: 5, len: 0 }
+    ));
+}
+
+/// `enqueue_to_processor` takes the resource out of the slot, so a
+/// select against an emptied (consumed) slot has nothing to load: it
+/// must fail loudly instead of moving the playlist current index / announcing
+/// `CurrentItemChanged` while the old audio keeps playing.
+#[kithara::test]
+fn select_item_on_consumed_slot_errors_without_bookkeeping() {
+    let player = player();
+    player.reserve_slots(2);
+    let result = player.select_item_with_crossfade(
+        1,
+        SelectTransition {
+            autoplay: false,
+            crossfade_seconds: 0.0,
+        },
+    );
+    assert!(result.is_err(), "selecting an emptied slot must fail");
+    assert_eq!(
+        player.current_index(),
+        0,
+        "bookkeeping must not move on a failed select"
+    );
+}

--- a/crates/kithara-queue/src/queue/state.rs
+++ b/crates/kithara-queue/src/queue/state.rs
@@ -384,8 +384,8 @@ pub(crate) mod tests {
     };
     use kithara_play::{
         AllocatedSlot, BeatGrid, Cmd, NodeInputs, PlayError, PlayWorker, PlayWorkerConfig,
-        PlayerConfig, Reply, SessionDispatcher, SessionDuckingMode, SessionSampleRate, SharedEq,
-        SlotId, bridge::slot_channels,
+        PlayerConfig, Reply, SessionBinding, SessionDispatcher, SessionDuckingMode,
+        SessionSampleRate, SharedEq, SlotId, bridge::slot_channels,
     };
     use kithara_test_utils::kithara;
 
@@ -421,10 +421,6 @@ pub(crate) mod tests {
             ConsumerWakeMode::RealtimeDeferred
         }
 
-        fn requested_sample_rate(&self) -> NonZeroU32 {
-            NonZeroU32::new(44_100).expect("fixture sample rate is non-zero")
-        }
-
         fn exec(&self, cmd: Cmd<TestPools>) -> Result<Reply, PlayError> {
             let reply = match cmd {
                 Cmd::RegisterPlayer { .. } => Reply::PlayerRegistered(1),
@@ -443,11 +439,14 @@ pub(crate) mod tests {
         }
     }
 
-    pub(crate) fn test_session() -> Arc<dyn SessionDispatcher<TestPools>> {
-        Arc::new(TestSession {
-            next_slot: AtomicU64::new(0),
-            nodes: Mutex::default(),
-        })
+    pub(crate) fn test_session() -> SessionBinding<TestPools> {
+        SessionBinding::new(
+            Arc::new(TestSession {
+                next_slot: AtomicU64::new(0),
+                nodes: Mutex::default(),
+            }),
+            TEST_SAMPLE_RATE,
+        )
     }
 
     fn queue_config() -> QueueConfig<TestPools> {

--- a/crates/kithara-queue/src/queue/state.rs
+++ b/crates/kithara-queue/src/queue/state.rs
@@ -421,6 +421,10 @@ pub(crate) mod tests {
             ConsumerWakeMode::RealtimeDeferred
         }
 
+        fn requested_sample_rate(&self) -> NonZeroU32 {
+            NonZeroU32::new(44_100).expect("fixture sample rate is non-zero")
+        }
+
         fn exec(&self, cmd: Cmd<TestPools>) -> Result<Reply, PlayError> {
             let reply = match cmd {
                 Cmd::RegisterPlayer { .. } => Reply::PlayerRegistered(1),

--- a/crates/kithara-test-utils/src/lib.rs
+++ b/crates/kithara-test-utils/src/lib.rs
@@ -17,6 +17,7 @@ pub mod flight;
 pub mod hang;
 pub mod mock;
 pub mod no_block;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod off_thread;
 pub mod probe;
 pub mod rtsan;

--- a/crates/kithara-test-utils/src/lib.rs
+++ b/crates/kithara-test-utils/src/lib.rs
@@ -17,6 +17,7 @@ pub mod flight;
 pub mod hang;
 pub mod mock;
 pub mod no_block;
+pub mod off_thread;
 pub mod probe;
 pub mod rtsan;
 #[cfg(any(test, feature = "probe"))]

--- a/crates/kithara-test-utils/src/off_thread.rs
+++ b/crates/kithara-test-utils/src/off_thread.rs
@@ -1,7 +1,7 @@
 use kithara_platform::{
     sync::{Mutex, mpsc},
     thread::spawn_named,
-    tokio::sync::oneshot,
+    tokio::{runtime::Handle, sync::oneshot},
 };
 
 type Job<T> = Box<dyn FnOnce(&mut T) + Send>;
@@ -14,6 +14,9 @@ pub struct OffThread<T> {
 
 impl<T: 'static> OffThread<T> {
     /// Runs `init` on the owner thread, so `T` does not need to be `Send`.
+    ///
+    /// The owner thread enters the caller's runtime for its whole life, the
+    /// way the product app thread does, so a call may spawn tasks.
     ///
     /// # Errors
     ///
@@ -30,8 +33,10 @@ impl<T: 'static> OffThread<T> {
         let (jobs, receiver) = mpsc::channel::<Job<T>>();
         let (ready, ready_receiver) = oneshot::channel();
         let (done, done_receiver) = oneshot::channel();
+        let runtime = Handle::current();
 
         drop(spawn_named(name, move || {
+            let _runtime = runtime.enter();
             let mut value = match init() {
                 Ok(value) => value,
                 Err(error) => {

--- a/crates/kithara-test-utils/src/off_thread.rs
+++ b/crates/kithara-test-utils/src/off_thread.rs
@@ -1,0 +1,201 @@
+use kithara_platform::{
+    sync::{Mutex, mpsc},
+    thread::spawn_named,
+    tokio::sync::oneshot,
+};
+
+type Job<T> = Box<dyn FnOnce(&mut T) + Send>;
+
+pub struct OffThread<T> {
+    jobs: Mutex<mpsc::Sender<Job<T>>>,
+    done: Mutex<Option<oneshot::Receiver<()>>>,
+    name: &'static str,
+}
+
+impl<T: 'static> OffThread<T> {
+    /// Runs `init` on the owner thread, so `T` does not need to be `Send`.
+    ///
+    /// # Errors
+    ///
+    /// Returns whatever `init` failed with, after the owner thread has exited.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the owner thread dies before it reports readiness.
+    pub async fn spawn<E, I>(name: &'static str, init: I) -> Result<Self, E>
+    where
+        E: Send + 'static,
+        I: FnOnce() -> Result<T, E> + Send + 'static,
+    {
+        let (jobs, receiver) = mpsc::channel::<Job<T>>();
+        let (ready, ready_receiver) = oneshot::channel();
+        let (done, done_receiver) = oneshot::channel();
+
+        drop(spawn_named(name, move || {
+            let mut value = match init() {
+                Ok(value) => value,
+                Err(error) => {
+                    drop(ready.send(Err(error)));
+                    return;
+                }
+            };
+            if ready.send(Ok(())).is_err() {
+                return;
+            }
+            while let Ok(job) = receiver.recv() {
+                job(&mut value);
+            }
+            drop(value);
+            let _ = done.send(());
+        }));
+
+        match ready_receiver.await.unwrap_or_else(|_| {
+            panic!("OffThread owner thread `{name}` panicked during initialization")
+        }) {
+            Ok(()) => Ok(Self {
+                jobs: Mutex::new(jobs),
+                done: Mutex::new(Some(done_receiver)),
+                name,
+            }),
+            Err(error) => {
+                let _ = done_receiver.await;
+                Err(error)
+            }
+        }
+    }
+
+    /// Runs `job` against `T` on the owner thread and awaits its result.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the owner thread has stopped accepting calls, or dies
+    /// before the job returns.
+    pub async fn call<R, F>(&self, job: F) -> R
+    where
+        R: Send + 'static,
+        F: FnOnce(&mut T) -> R + Send + 'static,
+    {
+        let (answer, receiver) = oneshot::channel();
+        let request = Box::new(move |value: &mut T| {
+            drop(answer.send(job(value)));
+        });
+        if self.jobs.lock().send(request).is_err() {
+            panic!(
+                "OffThread owner thread `{}` stopped before accepting a call",
+                self.name
+            );
+        }
+        receiver.await.unwrap_or_else(|_| {
+            panic!(
+                "OffThread owner thread `{}` panicked before returning a call result",
+                self.name
+            )
+        })
+    }
+
+    /// Drops the job sender and waits for the owner to drop `T`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the owner thread dies before teardown completes.
+    pub async fn close(self) {
+        let name = self.name;
+        drop(self.jobs);
+        let done = self
+            .done
+            .lock()
+            .take()
+            .expect("OffThread completion receiver must remain present until close");
+        done.await.unwrap_or_else(|_| {
+            panic!("OffThread owner thread `{name}` panicked before teardown completed")
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        cell::Cell,
+        rc::Rc,
+        sync::atomic::{AtomicBool, Ordering},
+    };
+
+    use kithara_platform::sync::Arc;
+    use kithara_test_utils::kithara;
+
+    use super::OffThread;
+
+    struct DropFlag(Arc<AtomicBool>);
+
+    impl Drop for DropFlag {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::Release);
+        }
+    }
+
+    #[kithara::test(tokio)]
+    async fn call_returns_value_from_owner() {
+        let owner = OffThread::spawn("off-thread-call", || Ok::<_, ()>(41_u32))
+            .await
+            .expect("owner initialization must succeed");
+
+        let value = owner
+            .call(|value| {
+                *value += 1;
+                *value
+            })
+            .await;
+
+        assert_eq!(value, 42);
+        owner.close().await;
+    }
+
+    #[kithara::test(tokio)]
+    async fn non_send_value_stays_on_owner_thread() {
+        let owner = OffThread::spawn("off-thread-non-send", || {
+            Ok::<_, ()>(Rc::new(Cell::new(1_u32)))
+        })
+        .await
+        .expect("owner must initialize its non-Send value");
+
+        let value = owner
+            .call(|value| {
+                value.set(value.get() + 1);
+                value.get()
+            })
+            .await;
+
+        assert_eq!(value, 2);
+        owner.close().await;
+    }
+
+    #[kithara::test(tokio)]
+    async fn init_error_is_returned() {
+        let error = OffThread::<()>::spawn("off-thread-init-error", || Err("init failed"))
+            .await
+            .err()
+            .expect("failed initialization must return its error");
+
+        assert_eq!(error, "init failed");
+    }
+
+    #[kithara::test(tokio)]
+    async fn close_waits_for_value_drop() {
+        let dropped = Arc::new(AtomicBool::new(false));
+        let owner_flag = Arc::clone(&dropped);
+        let owner = OffThread::spawn("off-thread-drop", move || Ok::<_, ()>(DropFlag(owner_flag)))
+            .await
+            .expect("owner initialization must succeed");
+
+        owner.close().await;
+
+        assert!(dropped.load(Ordering::Acquire));
+    }
+
+    #[kithara::test]
+    fn handle_is_send_and_sync_for_non_send_value() {
+        fn assert_send_sync<T: Send + Sync>() {}
+
+        assert_send_sync::<OffThread<Rc<Cell<u32>>>>();
+    }
+}

--- a/tests/src/offline/app.rs
+++ b/tests/src/offline/app.rs
@@ -51,12 +51,6 @@ impl LazyAppQueueFixture {
     pub async fn get(&self) -> &AppQueueFixture {
         self.0.get_or_init(insecure_app_queue).await
     }
-
-    pub async fn close(self) {
-        if let Some(fixture) = self.0.into_inner() {
-            fixture.close().await;
-        }
-    }
 }
 
 /// Build a product offline queue for tests that reach insecure HTTP fixtures.

--- a/tests/src/offline/app.rs
+++ b/tests/src/offline/app.rs
@@ -21,6 +21,7 @@ pub struct AppQueueFixture {
     pub config: AppConfig,
     pub queue: OfflineQueue<AppPools>,
     pub cache: TestTempDir,
+    ticker: QueueTicker,
 }
 
 impl AppQueueFixture {
@@ -29,7 +30,9 @@ impl AppQueueFixture {
             config,
             queue,
             cache,
+            mut ticker,
         } = self;
+        ticker.stop().await;
         drop(config);
         queue.close().await;
         drop(cache);
@@ -51,6 +54,10 @@ impl LazyAppQueueFixture {
 
 /// Build a product offline queue for tests that reach insecure HTTP fixtures.
 pub async fn insecure_app_queue() -> AppQueueFixture {
+    app_queue(Config::load(None, None).expect("the shipped configuration loads")).await
+}
+
+pub async fn app_queue(document: Config) -> AppQueueFixture {
     let pools = app_pools(&PoolsSection::default()).expect("build app pool region");
     let net = NetOptions::builder().is_insecure(true).build();
     let downloader = Downloader::new(
@@ -59,7 +66,6 @@ pub async fn insecure_app_queue() -> AppQueueFixture {
     );
     let flush_hub = FlushHub::new(CancelToken::never(), FlushPolicy::default());
     let shutdown = CancelToken::never();
-    let document = Config::load(None, None).expect("the shipped configuration loads");
     let store = AssetStore::builder(pools.clone())
         .cancel(shutdown.child())
         .backend(StorageBackend::default())
@@ -100,14 +106,12 @@ pub async fn insecure_app_queue() -> AppQueueFixture {
     .expect("create product offline queue");
 
     let queue_for_tick = queue.control();
-    drop(QueueTicker::spawn(
-        queue_for_tick,
-        Duration::from_millis(50),
-    ));
+    let ticker = QueueTicker::spawn(queue_for_tick, Duration::from_millis(50));
 
     AppQueueFixture {
         config,
         queue,
         cache: TestTempDir::new(),
+        ticker,
     }
 }

--- a/tests/src/offline/app.rs
+++ b/tests/src/offline/app.rs
@@ -2,11 +2,7 @@ use kithara::{
     assets::{AssetStore, FlushHub, FlushPolicy, StorageBackend},
     host::HostConfig,
     net::{HttpClient, NetOptions},
-    platform::{
-        CancelToken,
-        time::{Duration, sleep},
-        tokio,
-    },
+    platform::{CancelToken, time::Duration, tokio},
     play::{PlayWorker, PlayWorkerConfig, PlayerConfig, PlayerImpl},
     queue::{Queue, QueueConfig},
     stream::dl::{Downloader, DownloaderConfig},
@@ -17,7 +13,7 @@ use kithara_app::{
     pools::{AppPools, PoolsSection, build as app_pools},
 };
 
-use super::OfflineQueue;
+use super::{OfflineQueue, QueueTicker};
 use crate::TestTempDir;
 
 #[non_exhaustive]
@@ -104,12 +100,10 @@ pub async fn insecure_app_queue() -> AppQueueFixture {
     .expect("create product offline queue");
 
     let queue_for_tick = queue.control();
-    tokio::task::spawn(async move {
-        loop {
-            sleep(Duration::from_millis(50)).await;
-            let _ = queue_for_tick.tick();
-        }
-    });
+    drop(QueueTicker::spawn(
+        queue_for_tick,
+        Duration::from_millis(50),
+    ));
 
     AppQueueFixture {
         config,

--- a/tests/src/offline/app.rs
+++ b/tests/src/offline/app.rs
@@ -27,6 +27,19 @@ pub struct AppQueueFixture {
     pub cache: TestTempDir,
 }
 
+impl AppQueueFixture {
+    pub async fn close(self) {
+        let Self {
+            config,
+            queue,
+            cache,
+        } = self;
+        drop(config);
+        queue.close().await;
+        drop(cache);
+    }
+}
+
 pub struct LazyAppQueueFixture(tokio::sync::OnceCell<AppQueueFixture>);
 
 impl LazyAppQueueFixture {
@@ -36,13 +49,18 @@ impl LazyAppQueueFixture {
     }
 
     pub async fn get(&self) -> &AppQueueFixture {
-        self.0.get_or_init(|| async { insecure_app_queue() }).await
+        self.0.get_or_init(insecure_app_queue).await
+    }
+
+    pub async fn close(self) {
+        if let Some(fixture) = self.0.into_inner() {
+            fixture.close().await;
+        }
     }
 }
 
 /// Build a product offline queue for tests that reach insecure HTTP fixtures.
-#[must_use]
-pub fn insecure_app_queue() -> AppQueueFixture {
+pub async fn insecure_app_queue() -> AppQueueFixture {
     let pools = app_pools(&PoolsSection::default()).expect("build app pool region");
     let net = NetOptions::builder().is_insecure(true).build();
     let downloader = Downloader::new(
@@ -88,6 +106,7 @@ pub fn insecure_app_queue() -> AppQueueFixture {
         session_config,
         Queue::new(QueueConfig::builder().player(player).build()),
     )
+    .await
     .expect("create product offline queue");
 
     let queue_for_tick = queue.control();

--- a/tests/src/offline/harness.rs
+++ b/tests/src/offline/harness.rs
@@ -45,24 +45,26 @@ pub struct OfflinePlayerOptions {
 }
 
 /// Build a paused queue with crossfade disabled for deterministic offline tests.
-#[must_use]
-pub fn offline_queue_fixture(sample_rate: u32) -> (OfflinePlayerHarness, QueueControl<TestPools>) {
+pub async fn offline_queue_fixture(
+    sample_rate: u32,
+) -> (OfflinePlayerHarness, QueueControl<TestPools>) {
     let harness = OfflinePlayerHarness::with_sample_rate(
         OfflinePlayerOptions::builder()
             .crossfade_duration(0.0)
             .build(),
         sample_rate,
-    );
+    )
+    .await;
     let config = QueueConfig::builder()
         .player(harness.take_player())
         .should_autoplay(false)
         .build();
-    let queue = harness.insert_control(Queue::new(config));
+    let queue = harness.insert_control(Queue::new(config)).await;
     (harness, queue)
 }
 
 impl OfflinePlayerHarness {
-    pub fn with_sample_rate(options: OfflinePlayerOptions, sample_rate: u32) -> Self {
+    pub async fn with_sample_rate(options: OfflinePlayerOptions, sample_rate: u32) -> Self {
         let pools = pools();
         let sample_rate =
             NonZeroU32::new(sample_rate).expect("offline player sample rate must be non-zero");
@@ -70,10 +72,10 @@ impl OfflinePlayerHarness {
             .sample_rate(sample_rate)
             .maybe_max_block_frames(options.output_block_frames)
             .build();
-        Self::new(options, session)
+        Self::new(options, session).await
     }
 
-    pub fn new(options: OfflinePlayerOptions, session: HostConfig<TestPools>) -> Self {
+    pub async fn new(options: OfflinePlayerOptions, session: HostConfig<TestPools>) -> Self {
         let sample_rate = session.sample_rate();
         let pools = offline_pools(&session).clone();
         let worker = PlayWorker::new(PlayWorkerConfig::builder(pools).build());
@@ -92,6 +94,7 @@ impl OfflinePlayerHarness {
         let player_control = player.control();
         let events = player.subscribe();
         let host = OfflineHostHarness::new(session)
+            .await
             .unwrap_or_else(|error| panic!("create product offline Host: {error}"));
 
         Self {
@@ -114,8 +117,11 @@ impl OfflinePlayerHarness {
             .expect("offline harness player was already transferred")
     }
 
-    pub fn with_player<R>(&self, use_player: impl FnOnce(&PlayerControl<TestPools>) -> R) -> R {
-        self.ensure_player_inserted();
+    pub async fn with_player<R>(
+        &self,
+        use_player: impl FnOnce(&PlayerControl<TestPools>) -> R,
+    ) -> R {
+        self.ensure_player_inserted().await;
         use_player(&self.player_control)
     }
 
@@ -131,37 +137,54 @@ impl OfflinePlayerHarness {
             .set_host_level(level);
     }
 
-    pub fn insert<P>(&self, player: P) -> HostOwned<P>
+    pub async fn insert<P>(&self, player: P) -> HostOwned<P>
     where
-        P: PlayerControlSource<Schema = TestPools>,
+        P: PlayerControlSource<Schema = TestPools> + Send + 'static,
     {
         self.host
             .insert(player)
+            .await
             .unwrap_or_else(|error| panic!("insert player facade into offline Host: {error}"))
     }
 
-    pub fn insert_control<P>(&self, player: P) -> P::Control
+    pub async fn insert_control<P>(&self, player: P) -> P::Control
     where
-        P: PlayerControlSource<Schema = TestPools>,
+        P: PlayerControlSource<Schema = TestPools> + Send + 'static,
     {
-        self.insert(player).control().clone()
+        self.insert(player).await.control().clone()
     }
 
     pub const fn host(&self) -> &OfflineHostHarness<TestPools> {
         &self.host
     }
 
-    /// Synchronously render `frames` of audio.
-    pub fn render(&self, frames: usize) -> Vec<f32> {
-        self.ensure_player_inserted();
-        self.host.render(frames)
+    pub async fn close(self) {
+        let Self {
+            events,
+            host,
+            player,
+            player_control,
+            worker,
+        } = self;
+        drop(events);
+        drop(player);
+        drop(player_control);
+        drop(worker);
+        host.close().await;
     }
 
-    fn ensure_player_inserted(&self) {
-        let mut player = self.player.lock();
-        if let Some(player) = player.take() {
+    /// Render `frames` of audio through the product Host.
+    pub async fn render(&self, frames: usize) -> Vec<f32> {
+        self.ensure_player_inserted().await;
+        self.host.render(frames).await
+    }
+
+    async fn ensure_player_inserted(&self) {
+        let pending = self.player.lock().take();
+        if let Some(player) = pending {
             self.host
                 .insert(player)
+                .await
                 .unwrap_or_else(|error| panic!("insert offline player into Host: {error}"));
         }
     }

--- a/tests/src/offline/harness.rs
+++ b/tests/src/offline/harness.rs
@@ -117,12 +117,28 @@ impl OfflinePlayerHarness {
             .expect("offline harness player was already transferred")
     }
 
+    /// Issues player control calls from the host owner thread, as the app
+    /// would.
     pub async fn with_player<R>(
         &self,
-        use_player: impl FnOnce(&PlayerControl<TestPools>) -> R,
-    ) -> R {
+        use_player: impl FnOnce(&PlayerControl<TestPools>) -> R + Send + 'static,
+    ) -> R
+    where
+        R: Send + 'static,
+    {
         self.ensure_player_inserted().await;
-        use_player(&self.player_control)
+        self.run(&self.player_control, use_player).await
+    }
+
+    /// Issues a control call on `control` from the host owner thread, as the
+    /// app would.
+    pub async fn run<C, R>(&self, control: &C, f: impl FnOnce(&C) -> R + Send + 'static) -> R
+    where
+        C: Clone + Send + 'static,
+        R: Send + 'static,
+    {
+        let control = control.clone();
+        self.host.run(move || f(&control)).await
     }
 
     pub const fn worker(&self) -> &PlayWorker<TestPools> {
@@ -191,8 +207,9 @@ impl OfflinePlayerHarness {
 
     /// Pump the player's notification ringbuf and drain `PlayerEvent`s
     /// from the bus subscriber.
-    pub fn tick_and_drain(&self) -> Vec<PlayerEvent> {
-        self.player_control.process_notifications();
+    pub async fn tick_and_drain(&self) -> Vec<PlayerEvent> {
+        self.run(&self.player_control, PlayerControl::process_notifications)
+            .await;
 
         let mut events = Vec::new();
         let mut rx = self.events.lock();

--- a/tests/src/offline/host.rs
+++ b/tests/src/offline/host.rs
@@ -10,7 +10,7 @@ use kithara::{
     platform::{
         CancelScope,
         sync::{
-            Arc, Mutex,
+            Arc,
             atomic::{AtomicU64, Ordering},
         },
         time::{Duration, sleep},
@@ -19,6 +19,7 @@ use kithara::{
     queue::{Queue, QueueControl},
     signal::AudioSpec,
 };
+use kithara_test_utils::off_thread::OffThread;
 use ringbuf::{
     HeapCons, HeapRb,
     traits::{Consumer, Observer, Split},
@@ -37,12 +38,13 @@ pub(super) const fn offline_pools<S>(config: &HostConfig<S>) -> &PoolRegion<S> {
 
 struct HostState<S> {
     host: Host<S>,
-    position: u64,
+    position: Arc<AtomicU64>,
 }
 
 /// Test owner for the product offline Host and its monotonic render cursor.
 pub struct OfflineHostHarness<S> {
-    state: Mutex<HostState<S>>,
+    off: OffThread<HostState<S>>,
+    position: Arc<AtomicU64>,
     spec: AudioSpec,
     max_block_frames: NonZeroU32,
     pacing: Option<Duration>,
@@ -59,17 +61,18 @@ where
 
 impl<P, S> OfflineResident<P, S>
 where
-    P: PlayerControlSource<Schema = S>,
+    P: PlayerControlSource<Schema = S> + Send + 'static,
+    P::Control: Send,
     S: HasPool<f32> + Send + Sync + 'static,
 {
-    pub fn new(config: HostConfig<S>, player: P) -> Result<Self, PlayError> {
-        let host = OfflineHostHarness::new(config)?;
-        let member = host.insert(player)?;
+    pub async fn new(config: HostConfig<S>, player: P) -> Result<Self, PlayError> {
+        let host = OfflineHostHarness::new(config).await?;
+        let member = host.insert(player).await?;
         Ok(Self { host, member })
     }
 
-    pub fn render(&self, frames: usize) -> Vec<f32> {
-        self.host.render(frames)
+    pub async fn render(&self, frames: usize) -> Vec<f32> {
+        self.host.render(frames).await
     }
 
     pub fn control(&self) -> P::Control {
@@ -78,6 +81,13 @@ where
 
     pub const fn host(&self) -> &OfflineHostHarness<S> {
         &self.host
+    }
+
+    /// Drops the resident before waiting for Host session teardown.
+    pub async fn close(self) {
+        let Self { host, member } = self;
+        drop(member);
+        host.close().await;
     }
 }
 
@@ -116,63 +126,92 @@ where
     S: HasPool<f32> + Send + Sync + 'static,
 {
     /// Build the same offline Host used by product rendering.
-    pub fn new(config: HostConfig<S>) -> Result<Self, PlayError> {
+    pub async fn new(config: HostConfig<S>) -> Result<Self, PlayError> {
         let spec = AudioSpec::new(CHANNELS, config.sample_rate());
         let max_block_frames = config
             .max_block_frames()
             .expect("offline Host config must have a render block size");
         let pacing = config.pacing();
-        let host = Host::new(config)?;
+        let position = Arc::new(AtomicU64::new(0));
+        let owned = Arc::clone(&position);
+        let off = OffThread::spawn("offline-host", move || {
+            Host::new(config).map(|host| HostState {
+                host,
+                position: owned,
+            })
+        })
+        .await?;
         Ok(Self {
-            state: Mutex::new(HostState { host, position: 0 }),
+            off,
+            position,
             spec,
             max_block_frames,
             pacing,
         })
     }
 
-    /// Transfer one configured player facade into the product Host.
-    pub fn insert<P>(&self, player: P) -> Result<HostOwned<P>, PlayError>
-    where
-        P: PlayerControlSource<Schema = S>,
-    {
-        self.state.lock().host.insert(player)
+    /// Waits until the owner drops Host and session teardown completes.
+    pub async fn close(self) {
+        self.off.close().await;
     }
 
-    pub fn insert_control<P>(&self, player: P) -> Result<P::Control, PlayError>
+    /// Runs an arbitrary Host operation on the owner thread.
+    pub async fn with<R>(&self, f: impl FnOnce(&mut Host<S>) -> R + Send + 'static) -> R
     where
-        P: PlayerControlSource<Schema = S>,
+        R: Send + 'static,
     {
-        self.insert(player).map(|owned| owned.control().clone())
+        self.off.call(move |state| f(&mut state.host)).await
+    }
+
+    /// Transfer one configured player facade into the product Host.
+    pub async fn insert<P>(&self, player: P) -> Result<HostOwned<P>, PlayError>
+    where
+        P: PlayerControlSource<Schema = S> + Send + 'static,
+        P::Control: Send,
+    {
+        self.off.call(move |state| state.host.insert(player)).await
+    }
+
+    pub async fn insert_control<P>(&self, player: P) -> Result<P::Control, PlayError>
+    where
+        P: PlayerControlSource<Schema = S> + Send + 'static,
+        P::Control: Send,
+    {
+        self.insert(player)
+            .await
+            .map(|owned| owned.control().clone())
     }
 
     /// Render the next finite block through the product offline protocol.
-    pub fn render(&self, frames: usize) -> Vec<f32> {
+    pub async fn render(&self, frames: usize) -> Vec<f32> {
         let frames = u64::try_from(frames).expect("offline render frame count fits u64");
-        let mut state = self.state.lock();
-        let end = state
-            .position
-            .checked_add(frames)
-            .expect("offline render timeline fits u64");
-        let request = OfflineRenderRequest::builder()
-            .spec(self.spec)
-            .frames(state.position..end)
-            .build();
-        let cancel = CancelScope::new(None);
-        let mut sink = VecSink::default();
-        state
-            .host
-            .render(&request, &cancel.token(), &mut sink)
-            .unwrap_or_else(|error| panic!("render product offline Host: {error}"));
-        state.position = end;
-        drop(state);
-        sink.samples
+        let spec = self.spec;
+        self.off
+            .call(move |state| {
+                let start = state.position.load(Ordering::Relaxed);
+                let end = start
+                    .checked_add(frames)
+                    .expect("offline render timeline fits u64");
+                let request = OfflineRenderRequest::builder()
+                    .spec(spec)
+                    .frames(start..end)
+                    .build();
+                let cancel = CancelScope::new(None);
+                let mut sink = VecSink::default();
+                state
+                    .host
+                    .render(&request, &cancel.token(), &mut sink)
+                    .unwrap_or_else(|error| panic!("render product offline Host: {error}"));
+                state.position.store(end, Ordering::Relaxed);
+                sink.samples
+            })
+            .await
     }
 
     /// Current finite-render cursor maintained by this harness.
     #[must_use]
     pub fn position(&self) -> u64 {
-        self.state.lock().position
+        self.position.load(Ordering::Relaxed)
     }
 
     /// Product offline output format.
@@ -193,44 +232,55 @@ where
         self.pacing
     }
 
-    pub fn enable_mix_tap(&self, capacity: usize) -> Result<MixTapProbe, PlayError> {
+    pub async fn enable_mix_tap(&self, capacity: usize) -> Result<MixTapProbe, PlayError> {
         let (pcm_tx, pcm_rx) = HeapRb::<f32>::new(capacity).split();
         let drops = Arc::new(AtomicU64::new(0));
-        self.install_mix_tap(MixTapWriter::new(pcm_tx, Arc::clone(&drops)))?;
+        self.install_mix_tap(MixTapWriter::new(pcm_tx, Arc::clone(&drops)))
+            .await?;
         Ok(MixTapProbe { drops, pcm: pcm_rx })
     }
 
-    pub fn install_mix_tap(&self, writer: MixTapWriter) -> Result<(), PlayError> {
+    pub async fn install_mix_tap(&self, writer: MixTapWriter) -> Result<(), PlayError> {
         let mut outputs = OutputGroup::new();
         outputs.push(writer);
-        self.enable_outputs(outputs)
+        self.enable_outputs(outputs).await
     }
 
-    pub fn disable_mix_tap(&self) -> Result<(), PlayError> {
-        self.state.lock().host.disable_outputs()
+    pub async fn disable_mix_tap(&self) -> Result<(), PlayError> {
+        self.off.call(|state| state.host.disable_outputs()).await
     }
 
-    pub fn enable_outputs(&self, outputs: OutputGroup) -> Result<(), PlayError> {
-        self.state.lock().host.enable_outputs(outputs)
+    pub async fn enable_outputs(&self, outputs: OutputGroup) -> Result<(), PlayError> {
+        self.off
+            .call(move |state| state.host.enable_outputs(outputs))
+            .await
     }
 
-    pub fn restart_stream(&self, sample_rate: u32) -> Result<(), PlayError> {
-        self.state.lock().host.restart_stream(sample_rate)
+    pub async fn restart_stream(&self, sample_rate: u32) -> Result<(), PlayError> {
+        self.off
+            .call(move |state| state.host.restart_stream(sample_rate))
+            .await
     }
 
-    pub fn apply_mix<I>(&self, levels: I) -> Result<(), PlayError>
+    pub async fn apply_mix<I>(&self, levels: I) -> Result<(), PlayError>
     where
         I: IntoIterator<Item = HostLevel>,
     {
-        self.state.lock().host.apply_mix(levels)
+        let levels: Vec<HostLevel> = levels.into_iter().collect();
+        self.off
+            .call(move |state| state.host.apply_mix(levels))
+            .await
     }
 
-    pub fn transport_revision(&self) -> Result<TransportRevision, PlayError> {
-        self.state.lock().host.transport_revision()
+    pub async fn transport_revision(&self) -> Result<TransportRevision, PlayError> {
+        self.off.call(|state| state.host.transport_revision()).await
     }
 
-    pub fn invalidate_audio_route(&self, reason: impl Into<String>) -> Result<(), PlayError> {
-        self.state.lock().host.invalidate_audio_route(reason)
+    pub async fn invalidate_audio_route(&self, reason: impl Into<String>) -> Result<(), PlayError> {
+        let reason = reason.into();
+        self.off
+            .call(move |state| state.host.invalidate_audio_route(reason))
+            .await
     }
 }
 

--- a/tests/src/offline/host.rs
+++ b/tests/src/offline/host.rs
@@ -12,8 +12,11 @@ use kithara::{
         sync::{
             Arc,
             atomic::{AtomicU64, Ordering},
+            mpsc::{self, RecvTimeoutError},
         },
-        time::{Duration, sleep},
+        thread::{JoinHandle, spawn_named},
+        time::{Duration, Instant},
+        tokio::{runtime::Handle, task::spawn_blocking},
     },
     play::{MixTapWriter, PlayError, TransportRevision, player::PlayerControlSource},
     queue::{Queue, QueueControl},
@@ -79,6 +82,16 @@ where
         self.member.control().clone()
     }
 
+    /// Issues a control call from the host owner thread, as the app would.
+    pub async fn run<R>(&self, f: impl FnOnce(&P::Control) -> R + Send + 'static) -> R
+    where
+        P::Control: Clone + Send + 'static,
+        R: Send + 'static,
+    {
+        let control = self.control();
+        self.host.run(move || f(&control)).await
+    }
+
     pub const fn host(&self) -> &OfflineHostHarness<S> {
         &self.host
     }
@@ -104,20 +117,72 @@ where
 
 pub type OfflineQueue<S> = OfflineResident<Queue<S>, S>;
 
-/// Drive the periodic queue poll on the active test clock.
-///
-/// The flash gate keeps the spawned task on virtual time. Without it, buffered
-/// sources can outrun the real-time ticker and trigger false hang timeouts.
-#[kithara::flash(true)]
-pub async fn drive_queue_ticks<S>(queue: QueueControl<S>, interval: Duration)
-where
-    S: HasPool<u8> + HasPool<f32> + Send + Sync + 'static,
-{
-    loop {
-        sleep(interval).await;
-        if queue.tick().is_err() {
-            break;
+/// Drives `QueueControl::tick` from a dedicated thread, the way the FFI
+/// bridge and the app update loop do, until the queue closes or `stop`.
+pub struct QueueTicker {
+    stop: Option<mpsc::Sender<()>>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl QueueTicker {
+    /// Spawns the ticker; the thread enters the caller's runtime like the
+    /// product app thread, so a tick may spawn loads.
+    pub fn spawn<S>(queue: QueueControl<S>, interval: Duration) -> Self
+    where
+        S: HasPool<u8> + HasPool<f32> + Send + Sync + 'static,
+    {
+        let (stop, stop_receiver) = mpsc::channel::<()>();
+        let runtime = Handle::current();
+        let thread = spawn_named("queue-ticks", move || {
+            let _runtime = runtime.enter();
+            while let Err(RecvTimeoutError::Timeout) =
+                stop_receiver.recv_timeout(Instant::now() + interval)
+            {
+                if queue.tick().is_err() {
+                    break;
+                }
+            }
+        });
+        Self {
+            stop: Some(stop),
+            thread: Some(thread),
         }
+    }
+
+    /// Whether the thread exited: the queue closed or a tick panicked.
+    pub fn is_finished(&self) -> bool {
+        self.thread.as_ref().is_some_and(JoinHandle::is_finished)
+    }
+
+    /// Stops ticking and joins the thread; `Err` is the message of a tick panic.
+    pub async fn join(&mut self) -> Result<(), String> {
+        drop(self.stop.take());
+        let Some(thread) = self.thread.take() else {
+            return Ok(());
+        };
+        spawn_blocking(move || thread.join())
+            .await
+            .expect("join the queue ticker")
+            .map_err(|payload| {
+                payload
+                    .downcast_ref::<String>()
+                    .cloned()
+                    .or_else(|| payload.downcast_ref::<&str>().map(|s| (*s).to_owned()))
+                    .unwrap_or_else(|| "non-string panic payload".to_owned())
+            })
+    }
+
+    /// Stops ticking and waits for the thread; a tick panic fails the caller.
+    pub async fn stop(&mut self) {
+        if let Err(panic) = self.join().await {
+            panic!("queue ticker panicked: {panic}");
+        }
+    }
+}
+
+impl Drop for QueueTicker {
+    fn drop(&mut self) {
+        drop(self.stop.take());
     }
 }
 

--- a/tests/src/offline/host.rs
+++ b/tests/src/offline/host.rs
@@ -163,6 +163,15 @@ where
         self.off.call(move |state| f(&mut state.host)).await
     }
 
+    /// Runs a control call on the owner thread, the way product callers issue
+    /// it from the app thread rather than from a runtime worker.
+    pub async fn run<R>(&self, f: impl FnOnce() -> R + Send + 'static) -> R
+    where
+        R: Send + 'static,
+    {
+        self.off.call(move |_| f()).await
+    }
+
     /// Transfer one configured player facade into the product Host.
     pub async fn insert<P>(&self, player: P) -> Result<HostOwned<P>, PlayError>
     where

--- a/tests/src/offline/mod.rs
+++ b/tests/src/offline/mod.rs
@@ -4,7 +4,7 @@ pub mod host;
 pub mod player;
 mod window;
 
-pub use app::{AppQueueFixture, LazyAppQueueFixture, insecure_app_queue};
+pub use app::{AppQueueFixture, LazyAppQueueFixture, app_queue, insecure_app_queue};
 pub use harness::{OfflinePlayerHarness, OfflinePlayerOptions, offline_queue_fixture};
 pub use host::{
     MixTapProbe, OfflineHostHarness, OfflineQueue, OfflineResident, QueueTicker,

--- a/tests/src/offline/mod.rs
+++ b/tests/src/offline/mod.rs
@@ -7,7 +7,7 @@ mod window;
 pub use app::{AppQueueFixture, LazyAppQueueFixture, insecure_app_queue};
 pub use harness::{OfflinePlayerHarness, OfflinePlayerOptions, offline_queue_fixture};
 pub use host::{
-    MixTapProbe, OfflineHostHarness, OfflineQueue, OfflineResident, drive_queue_ticks,
+    MixTapProbe, OfflineHostHarness, OfflineQueue, OfflineResident, QueueTicker,
     offline_gain_window,
 };
 pub use player::{

--- a/tests/src/offline/player.rs
+++ b/tests/src/offline/player.rs
@@ -25,7 +25,7 @@ impl OfflinePlayer {
     ///
     /// Panics if the product offline Host cannot be initialised.
     #[must_use]
-    pub fn new(session: HostConfig<TestPools>) -> Self {
+    pub async fn new(session: HostConfig<TestPools>) -> Self {
         let sample_rate = session.sample_rate();
         let pools = offline_pools(&session).clone();
         let worker = PlayWorker::new(PlayWorkerConfig::builder(pools).build());
@@ -37,6 +37,7 @@ impl OfflinePlayer {
         );
         let events = player.subscribe();
         let player = OfflineResident::new(session, player)
+            .await
             .unwrap_or_else(|error| panic!("create product offline player: {error}"));
         Self { events, player }
     }
@@ -77,8 +78,8 @@ impl OfflinePlayer {
     }
 
     /// Render `frames` of interleaved stereo audio through the product Host.
-    pub fn render(&mut self, frames: usize) -> Vec<f32> {
-        let output = self.player.render(frames);
+    pub async fn render(&mut self, frames: usize) -> Vec<f32> {
+        let output = self.player.render(frames).await;
         self.control().process_notifications();
         output
     }
@@ -112,6 +113,12 @@ impl OfflinePlayer {
             notifications.extend(kind);
         }
         notifications
+    }
+
+    pub async fn close(self) {
+        let Self { events, player } = self;
+        drop(events);
+        player.close().await;
     }
 }
 

--- a/tests/src/offline/player.rs
+++ b/tests/src/offline/player.rs
@@ -51,13 +51,16 @@ impl OfflinePlayer {
     /// # Panics
     ///
     /// Panics if the product player rejects the resource.
-    pub fn load_and_fadein(&mut self, resource: Resource) {
-        let control = self.control();
-        control.reserve_slots(1);
-        control
-            .replace_item(0, resource, kithara::events::TrackId::allocate())
-            .expect("replace offline player item");
-        control.play();
+    pub async fn load_and_fadein(&mut self, resource: Resource) {
+        self.player
+            .run(move |control| {
+                control.reserve_slots(1);
+                control
+                    .replace_item(0, resource, kithara::events::TrackId::allocate())
+                    .expect("replace offline player item");
+                control.play();
+            })
+            .await;
     }
 
     /// Set the transition duration used by the next load.

--- a/tests/src/ring/session.rs
+++ b/tests/src/ring/session.rs
@@ -114,6 +114,7 @@ pub struct ManualRingSession {
     lifecycle_gate: Mutex<()>,
     probe: RingBackendProbe,
     reader: Mutex<RingReader>,
+    session_rate: NonZeroU32,
     snapshot: Mutex<RingSnapshot>,
     terminal_error: Mutex<Option<RingSessionError>>,
     worker: Mutex<Option<JoinHandle<()>>>,
@@ -153,6 +154,7 @@ impl ManualRingSession {
             lifecycle_gate: Mutex::new(()),
             probe,
             reader: Mutex::new(reader),
+            session_rate: config.session_rate,
             snapshot: Mutex::new(RingSnapshot::default()),
             terminal_error: Mutex::new(None),
             worker: Mutex::new(Some(worker)),
@@ -318,6 +320,10 @@ impl SessionDispatcher<TestPools> for ManualRingSession {
     /// The ring backend drives the device callback's processor.
     fn consumer_wake_mode(&self) -> ConsumerWakeMode {
         ConsumerWakeMode::RealtimeDeferred
+    }
+
+    fn requested_sample_rate(&self) -> NonZeroU32 {
+        self.session_rate
     }
 }
 

--- a/tests/src/ring/session.rs
+++ b/tests/src/ring/session.rs
@@ -114,7 +114,6 @@ pub struct ManualRingSession {
     lifecycle_gate: Mutex<()>,
     probe: RingBackendProbe,
     reader: Mutex<RingReader>,
-    session_rate: NonZeroU32,
     snapshot: Mutex<RingSnapshot>,
     terminal_error: Mutex<Option<RingSessionError>>,
     worker: Mutex<Option<JoinHandle<()>>>,
@@ -154,7 +153,6 @@ impl ManualRingSession {
             lifecycle_gate: Mutex::new(()),
             probe,
             reader: Mutex::new(reader),
-            session_rate: config.session_rate,
             snapshot: Mutex::new(RingSnapshot::default()),
             terminal_error: Mutex::new(None),
             worker: Mutex::new(Some(worker)),
@@ -320,10 +318,6 @@ impl SessionDispatcher<TestPools> for ManualRingSession {
     /// The ring backend drives the device callback's processor.
     fn consumer_wake_mode(&self) -> ConsumerWakeMode {
         ConsumerWakeMode::RealtimeDeferred
-    }
-
-    fn requested_sample_rate(&self) -> NonZeroU32 {
-        self.session_rate
     }
 }
 

--- a/tests/src/user_sim/harness.rs
+++ b/tests/src/user_sim/harness.rs
@@ -14,7 +14,6 @@ use kithara::{
     platform::{
         CancelToken,
         time::{Duration, Instant, timeout},
-        tokio,
     },
     play::{
         PlayWorker, PlayWorkerConfig, PlayerConfig, PlayerImpl, ResourceConfig, ResourceSrc,
@@ -28,7 +27,7 @@ use url::Url;
 use crate::{
     bufpool_ext::{TestPools, pools},
     kithara,
-    offline::{OfflineQueue, drive_queue_ticks},
+    offline::{OfflineQueue, QueueTicker},
     user_sim::actions::Action,
 };
 
@@ -62,7 +61,7 @@ const SWITCH_PROGRESS_TICKS: u32 = 200;
 pub struct SimHarness {
     queue: QueueControl<TestPools>,
     queue_owner: OfflineQueue<TestPools>,
-    tick: tokio::task::JoinHandle<()>,
+    tick: QueueTicker,
     _downloader: Downloader,
     _store: AssetStore<TestPools>,
     track_ids: Vec<TrackId>,
@@ -139,13 +138,7 @@ impl SimHarness {
         .expect("create product offline queue");
         let queue = queue_owner.control();
         let queue_for_tick = queue.clone();
-        // Spawn through the platform chokepoint, NOT raw `tokio::spawn`: under
-        // flash this installs the quiescence poll-wrapper + ambient gate so the
-        // driver participates in the virtual clock. The active flag that makes
-        // its `sleep` engine-virtual comes from `#[kithara::flash(true)]` on
-        // `drive_queue_ticks` (the async chokepoint propagates ambient only) — see
-        // that fn's doc for why a real-paced driver false-HANGs buffered sources.
-        let tick = tokio::task::spawn(drive_queue_ticks(queue_for_tick, Duration::from_millis(50)));
+        let tick = QueueTicker::spawn(queue_for_tick, Duration::from_millis(50));
 
         let downloader = Downloader::new(
             DownloaderConfig::for_client(HttpClient::new(
@@ -170,8 +163,11 @@ impl SimHarness {
             )
             .initial_abr_mode(spec.abr_mode)
             .build();
-            let id = queue
-                .append(TrackSource::Config(Box::new(cfg)))
+            let control = queue.clone();
+            let id = queue_owner
+                .host()
+                .run(move || control.append(TrackSource::Config(Box::new(cfg))))
+                .await
                 .expect("queue is open while the harness is being built");
             track_ids.push(id);
         }
@@ -191,6 +187,15 @@ impl SimHarness {
         &self.queue
     }
 
+    /// Issues a control call from the host owner thread, as the app would.
+    async fn run<R>(&self, f: impl FnOnce(&QueueControl<TestPools>) -> R + Send + 'static) -> R
+    where
+        R: Send + 'static,
+    {
+        let queue = self.queue.clone();
+        self.queue_owner.host().run(move || f(&queue)).await
+    }
+
     pub fn track_id(&self, idx: usize) -> TrackId {
         self.track_ids[idx]
     }
@@ -204,8 +209,8 @@ impl SimHarness {
     /// pre-roll, then snapshot the codec so `SetQuality` has a baseline.
     pub async fn enter_track(&mut self, idx: usize, warmup: Duration) {
         let id = self.track_ids[idx];
-        self.queue
-            .select(id, Transition::None)
+        self.run(move |queue| queue.select(id, Transition::None))
+            .await
             .unwrap_or_else(|e| panic!("select track {idx}: {e}"));
 
         wait_for_loaded(&self.queue, id, Duration::from_secs(30))
@@ -230,8 +235,8 @@ impl SimHarness {
             Action::SelectAt(i) => self.do_select_at(i).await,
             Action::SetQuality(idx) => self.do_set_quality(idx).await,
             Action::QualityAuto => self.do_quality_auto().await,
-            Action::Pause => self.do_pause(),
-            Action::Resume => self.do_resume(),
+            Action::Pause => self.do_pause().await,
+            Action::Resume => self.do_resume().await,
             Action::PlayFor(d) | Action::RenderFor(d) => self.do_play_for(d).await,
         }
     }
@@ -243,13 +248,12 @@ impl SimHarness {
         let Self {
             queue,
             queue_owner,
-            tick,
+            mut tick,
             _downloader,
             _store,
             ..
         } = self;
-        tick.abort();
-        let _ = tick.await;
+        tick.stop().await;
         drop(queue);
         queue_owner.close().await;
         drop(_downloader);
@@ -446,8 +450,8 @@ impl SimHarness {
     async fn do_select_at(&mut self, idx: usize) {
         let bounded = idx % self.track_ids.len();
         let id = self.track_ids[bounded];
-        self.queue
-            .select(id, Transition::None)
+        self.run(move |queue| queue.select(id, Transition::None))
+            .await
             .unwrap_or_else(|e| panic!("[SelectAt({bounded})] select failed: {e}"));
         wait_for_loaded(&self.queue, id, Duration::from_secs(20))
             .await
@@ -641,12 +645,12 @@ impl SimHarness {
         let _ = timeout(Duration::from_millis(100), settle).await;
     }
 
-    fn do_pause(&mut self) {
-        self.queue.pause();
+    async fn do_pause(&mut self) {
+        self.run(QueueControl::pause).await;
     }
 
-    fn do_resume(&mut self) {
-        self.queue.play();
+    async fn do_resume(&mut self) {
+        self.run(QueueControl::play).await;
     }
 
     async fn do_play_for(&mut self, at_least: Duration) {

--- a/tests/src/user_sim/harness.rs
+++ b/tests/src/user_sim/harness.rs
@@ -135,6 +135,7 @@ impl SimHarness {
                     .build(),
             ),
         )
+        .await
         .expect("create product offline queue");
         let queue = queue_owner.control();
         let queue_for_tick = queue.clone();
@@ -238,12 +239,21 @@ impl SimHarness {
     /// Wait for any in-flight seek to settle, then assert the queue is
     /// at a sane terminal state for the scenario. Used as the final
     /// step in scripted scenarios.
-    pub async fn shutdown(self) {
-        self.tick.abort();
-        let _ = self.tick.await;
-        drop(self.queue);
-        drop(self.queue_owner);
-        drop(self._downloader);
+    pub async fn close(self) {
+        let Self {
+            queue,
+            queue_owner,
+            tick,
+            _downloader,
+            _store,
+            ..
+        } = self;
+        tick.abort();
+        let _ = tick.await;
+        drop(queue);
+        queue_owner.close().await;
+        drop(_downloader);
+        drop(_store);
     }
 
     fn current_codec(&self) -> Option<String> {

--- a/tests/src/waits.rs
+++ b/tests/src/waits.rs
@@ -419,7 +419,7 @@ pub async fn render_until_position(
     loop {
         let this = max_blocks.saturating_sub(rendered).clamp(1, BATCH);
         for _ in 0..this {
-            let _ = player.render(block_frames);
+            drop(player.render(block_frames).await);
         }
         rendered = rendered.saturating_add(this);
         let position = player.position();

--- a/tests/tests/common/continuity.rs
+++ b/tests/tests/common/continuity.rs
@@ -93,7 +93,7 @@ impl PlaybackProgressProbe {
 }
 
 #[must_use]
-pub(crate) fn render_offline_window(
+pub(crate) async fn render_offline_window(
     player: &mut OfflinePlayer,
     blocks: u32,
     label: &str,
@@ -112,7 +112,7 @@ pub(crate) fn render_offline_window(
         // wall-clock contract (RTSan / block-budget). `Instant::now`/`elapsed`
         // here read real time because this helper runs with `active=false`.
         let started = Instant::now();
-        let out = player.render(block_frames);
+        let out = player.render(block_frames).await;
         let elapsed = started.elapsed();
         if elapsed > max_render {
             max_render = elapsed;

--- a/tests/tests/integration_regressions/cache_commit_grows.rs
+++ b/tests/tests/integration_regressions/cache_commit_grows.rs
@@ -166,6 +166,7 @@ async fn played_tracks_land_in_the_disk_cache(temp_dir: TestTempDir) {
                 .build(),
         ),
     )
+    .await
     .expect("create product offline queue");
     let mut rx = queue.subscribe();
 
@@ -231,4 +232,5 @@ async fn played_tracks_land_in_the_disk_cache(temp_dir: TestTempDir) {
     );
 
     queue.clear();
+    queue.close().await;
 }

--- a/tests/tests/integration_regressions/commands_survive_switch_storm.rs
+++ b/tests/tests/integration_regressions/commands_survive_switch_storm.rs
@@ -149,12 +149,16 @@ async fn commands_still_work_after_a_switch_storm(temp_dir: TestTempDir) {
         .iter()
         .enumerate()
         .map(|(index, handle)| {
-            queue.append(TrackSource::Config(Box::new(resource_config(
-                handle,
-                &downloader,
-                &store,
-                index,
-            ))))
+            queue
+                .run(move |q| {
+                    q.append(TrackSource::Config(Box::new(resource_config(
+                        handle,
+                        &downloader,
+                        &store,
+                        index,
+                    ))))
+                })
+                .await
         })
         .collect::<Result<Vec<_>, _>>()
         .expect("queue is open while fixtures are appended");
@@ -163,7 +167,7 @@ async fn commands_still_work_after_a_switch_storm(temp_dir: TestTempDir) {
     wait_for_loader_done_event(&mut status_rx, &queue, ids[0], Duration::from_secs(60))
         .await
         .unwrap_or_else(|error| panic!("precondition: first track: {error}"));
-    queue.play();
+    queue.run(move |q| q.play()).await;
 
     let mut active_gets = HashSet::new();
     drain_active_gets(&mut probe_rx, &mut active_gets);
@@ -176,7 +180,8 @@ async fn commands_still_work_after_a_switch_storm(temp_dir: TestTempDir) {
     for round in 0..STORM_ROUNDS {
         let target = ids[round % ids.len()];
         queue
-            .select(target, Transition::None)
+            .run(move |q| q.select(target, Transition::None))
+            .await
             .unwrap_or_else(|error| panic!("switch {round} was rejected: {error}"));
         if queue.current().is_some_and(|entry| entry.id == target) {
             continue;
@@ -227,7 +232,7 @@ async fn commands_still_work_after_a_switch_storm(temp_dir: TestTempDir) {
     wait_for_playing(&queue, false, Duration::from_secs(30))
         .await
         .unwrap_or_else(|error| panic!("pause was swallowed after the switch storm: {error}"));
-    queue.play();
+    queue.run(move |q| q.play()).await;
     wait_for_playing(&queue, true, Duration::from_secs(30))
         .await
         .unwrap_or_else(|error| panic!("play was swallowed after the switch storm: {error}"));

--- a/tests/tests/integration_regressions/commands_survive_switch_storm.rs
+++ b/tests/tests/integration_regressions/commands_survive_switch_storm.rs
@@ -139,6 +139,7 @@ async fn commands_still_work_after_a_switch_storm(temp_dir: TestTempDir) {
                 .build(),
         ),
     )
+    .await
     .expect("create product offline queue");
     let ticker = tokio::task::spawn(drive_queue_ticks(
         queue.control(),
@@ -257,4 +258,5 @@ async fn commands_still_work_after_a_switch_storm(temp_dir: TestTempDir) {
     queue.clear();
     ticker.abort();
     let _ = ticker.await;
+    queue.close().await;
 }

--- a/tests/tests/integration_regressions/commands_survive_switch_storm.rs
+++ b/tests/tests/integration_regressions/commands_survive_switch_storm.rs
@@ -21,7 +21,7 @@ use kithara_integration_tests::{
     BehaviorHandle, Content, Delivery, FixtureBehavior, TestServerHelper, TestTempDir,
     bufpool_ext::{TestPools, pools},
     kithara,
-    offline::{OfflineQueue, drive_queue_ticks},
+    offline::{OfflineQueue, QueueTicker},
     temp_dir,
     test_defaults::Consts as Shared,
     waits::{wait_for_event, wait_for_loader_done_event},
@@ -141,10 +141,7 @@ async fn commands_still_work_after_a_switch_storm(temp_dir: TestTempDir) {
     )
     .await
     .expect("create product offline queue");
-    let ticker = tokio::task::spawn(drive_queue_ticks(
-        queue.control(),
-        Duration::from_millis(20),
-    ));
+    let mut ticker = QueueTicker::spawn(queue.control(), Duration::from_millis(20));
     let mut status_rx = queue.subscribe();
     let mut probe_rx = queue.subscribe();
 
@@ -256,7 +253,6 @@ async fn commands_still_work_after_a_switch_storm(temp_dir: TestTempDir) {
     });
 
     queue.clear();
-    ticker.abort();
-    let _ = ticker.await;
+    ticker.stop().await;
     queue.close().await;
 }

--- a/tests/tests/integration_regressions/loaded_ranges_absolute.rs
+++ b/tests/tests/integration_regressions/loaded_ranges_absolute.rs
@@ -20,7 +20,7 @@ use kithara_integration_tests::{
     Content, Delivery, FixtureBehavior, TestServerHelper, TestTempDir,
     bufpool_ext::{TestPools, pools},
     kithara,
-    offline::{OfflineQueue, drive_queue_ticks},
+    offline::{OfflineQueue, QueueTicker},
     temp_dir,
     test_defaults::Consts as Shared,
     waits::{wait_for_event, wait_for_loader_done_event},
@@ -135,10 +135,7 @@ async fn progressive_download_fills_the_buffer_bar(temp_dir: TestTempDir) {
         .store(store)
         .build();
 
-    let ticker = tokio::task::spawn(drive_queue_ticks(
-        queue.control(),
-        Duration::from_millis(20),
-    ));
+    let mut ticker = QueueTicker::spawn(queue.control(), Duration::from_millis(20));
     let mut rx = queue.subscribe();
     // Separate subscriber: the warm-up below drains `rx`, and the body can
     // finish transferring before the pause — the completion must not be eaten
@@ -193,7 +190,6 @@ async fn progressive_download_fills_the_buffer_bar(temp_dir: TestTempDir) {
     );
 
     queue.clear();
-    ticker.abort();
-    let _ = ticker.await;
+    ticker.stop().await;
     queue.close().await;
 }

--- a/tests/tests/integration_regressions/loaded_ranges_absolute.rs
+++ b/tests/tests/integration_regressions/loaded_ranges_absolute.rs
@@ -142,15 +142,17 @@ async fn progressive_download_fills_the_buffer_bar(temp_dir: TestTempDir) {
     // by the wait that precedes it.
     let mut transfer_rx = queue.subscribe();
     let id = queue
-        .append(TrackSource::Config(Box::new(cfg)))
+        .run(move |q| q.append(TrackSource::Config(Box::new(cfg))))
+        .await
         .expect("append progressive track");
     queue
-        .select(id, Transition::None)
+        .run(move |q| q.select(id, Transition::None))
+        .await
         .expect("select progressive track");
     wait_for_loader_done_event(&mut rx, &queue, id, Duration::from_secs(30))
         .await
         .unwrap_or_else(|error| panic!("precondition: {error}"));
-    queue.play();
+    queue.run(move |q| q.play()).await;
 
     let mut transferred = 0;
     wait_for_event(

--- a/tests/tests/integration_regressions/loaded_ranges_absolute.rs
+++ b/tests/tests/integration_regressions/loaded_ranges_absolute.rs
@@ -125,6 +125,7 @@ async fn progressive_download_fills_the_buffer_bar(temp_dir: TestTempDir) {
                 .build(),
         ),
     )
+    .await
     .expect("create product offline queue");
     let mut file = FileConfigPatch::default();
     file.look_ahead_bytes = Some(LOOK_AHEAD_BYTES);
@@ -194,4 +195,5 @@ async fn progressive_download_fills_the_buffer_bar(temp_dir: TestTempDir) {
     queue.clear();
     ticker.abort();
     let _ = ticker.await;
+    queue.close().await;
 }

--- a/tests/tests/integration_regressions/offline_resume.rs
+++ b/tests/tests/integration_regressions/offline_resume.rs
@@ -202,6 +202,7 @@ async fn resumes_after_outage(
                 .build(),
         ),
     )
+    .await
     .expect("create product offline queue");
     let cfg = ResourceConfig::for_src(ResourceSrc::parse(url.as_str()).expect("valid HLS URL"))
         .downloader(downloader)
@@ -304,4 +305,5 @@ async fn resumes_after_outage(
     queue.clear();
     ticker.abort();
     let _ = ticker.await;
+    queue.close().await;
 }

--- a/tests/tests/integration_regressions/offline_resume.rs
+++ b/tests/tests/integration_regressions/offline_resume.rs
@@ -20,7 +20,7 @@ use kithara_integration_tests::{
     Content, Delivery, FixtureBehavior, PrivateTestServer, TestTempDir,
     bufpool_ext::{TestPools, pools},
     kithara,
-    offline::{OfflineQueue, drive_queue_ticks},
+    offline::{OfflineQueue, QueueTicker},
     temp_dir,
     test_defaults::Consts as Shared,
     waits::{wait_for_event, wait_for_loader_done_event, wait_for_position_event},
@@ -211,10 +211,7 @@ async fn resumes_after_outage(
         .store(store)
         .build();
 
-    let ticker = tokio::task::spawn(drive_queue_ticks(
-        queue.control(),
-        Duration::from_millis(20),
-    ));
+    let mut ticker = QueueTicker::spawn(queue.control(), Duration::from_millis(20));
     let mut rx = queue.subscribe();
     let id = queue
         .append(TrackSource::Config(Box::new(cfg)))
@@ -303,7 +300,6 @@ async fn resumes_after_outage(
     );
 
     queue.clear();
-    ticker.abort();
-    let _ = ticker.await;
+    ticker.stop().await;
     queue.close().await;
 }

--- a/tests/tests/integration_regressions/offline_resume.rs
+++ b/tests/tests/integration_regressions/offline_resume.rs
@@ -214,15 +214,17 @@ async fn resumes_after_outage(
     let mut ticker = QueueTicker::spawn(queue.control(), Duration::from_millis(20));
     let mut rx = queue.subscribe();
     let id = queue
-        .append(TrackSource::Config(Box::new(cfg)))
+        .run(move |q| q.append(TrackSource::Config(Box::new(cfg))))
+        .await
         .expect("append offline-resume track");
     queue
-        .select(id, Transition::None)
+        .run(move |q| q.select(id, Transition::None))
+        .await
         .expect("select HLS track");
     wait_for_loader_done_event(&mut rx, &queue, id, Duration::from_secs(30))
         .await
         .unwrap_or_else(|error| panic!("precondition: {error}"));
-    queue.play();
+    queue.run(move |q| q.play()).await;
 
     let before_outage = wait_for_position_event(
         &mut rx,

--- a/tests/tests/integration_regressions/rate_applies_while_playing.rs
+++ b/tests/tests/integration_regressions/rate_applies_while_playing.rs
@@ -28,9 +28,9 @@ fn make_resource(duration_secs: f64) -> Resource {
     ))
 }
 
-#[kithara::test]
-fn fixed_rate_reader_keeps_source_and_player_clock_at_unity() {
-    let oracle = loaded_harness();
+#[kithara::test(tokio)]
+async fn fixed_rate_reader_keeps_source_and_player_clock_at_unity() {
+    let oracle = loaded_harness().await;
     assert_eq!(oracle.player().rate(), 1.0);
     oracle.player().pause();
     assert_eq!(
@@ -38,7 +38,7 @@ fn fixed_rate_reader_keeps_source_and_player_clock_at_unity() {
         1.0,
         "the control thread must not publish pause before RT applies it"
     );
-    let _ = oracle.render(BLOCK_FRAMES);
+    let _ = oracle.render(BLOCK_FRAMES).await;
     let paused_rates = rate_events(oracle.tick_and_drain());
     assert_eq!(paused_rates, [0.0]);
     assert_eq!(oracle.player().rate(), 0.0);
@@ -51,15 +51,15 @@ fn fixed_rate_reader_keeps_source_and_player_clock_at_unity() {
         0.0,
         "the control thread must not publish the requested rate before RT applies it"
     );
-    let _ = oracle.render(BLOCK_FRAMES);
+    let _ = oracle.render(BLOCK_FRAMES).await;
     let resumed_rates = rate_events(oracle.tick_and_drain());
     assert_eq!(resumed_rates, [1.0]);
     assert_eq!(oracle.player().rate(), 1.0);
 
-    let baseline = blocks_until_silence(1.0);
-    let requested_fast = blocks_until_silence(FAST_RATE);
-    let baseline_advance = media_advance(1.0);
-    let requested_fast_advance = media_advance(FAST_RATE);
+    let baseline = blocks_until_silence(1.0).await;
+    let requested_fast = blocks_until_silence(FAST_RATE).await;
+    let baseline_advance = media_advance(1.0).await;
+    let requested_fast_advance = media_advance(FAST_RATE).await;
 
     assert!(
         baseline < MEASURE_BLOCKS,
@@ -75,8 +75,9 @@ fn fixed_rate_reader_keeps_source_and_player_clock_at_unity() {
     assert!(
         (requested_fast_advance - baseline_advance).abs() < f64::EPSILON,
         "a reader without a Warp control must not report a media clock that \
-         its PCM cannot follow: {requested_fast_advance}s vs {baseline_advance}s"
+        its PCM cannot follow: {requested_fast_advance}s vs {baseline_advance}s"
     );
+    oracle.close().await;
 }
 
 fn rate_events(events: Vec<PlayerEvent>) -> Vec<f32> {
@@ -89,48 +90,54 @@ fn rate_events(events: Vec<PlayerEvent>) -> Vec<f32> {
         .collect()
 }
 
-fn loaded_harness() -> OfflinePlayerHarness {
+async fn loaded_harness() -> OfflinePlayerHarness {
     let harness = OfflinePlayerHarness::with_sample_rate(
         OfflinePlayerOptions::builder().build(),
         SAMPLE_RATE,
-    );
-    harness.with_player(|player| {
-        player.insert(make_resource(1.0), TrackId::allocate(), None);
-        player
-            .select_item(0, true)
-            .expect("select first queue item");
-    });
+    )
+    .await;
+    harness
+        .with_player(|player| {
+            player.insert(make_resource(1.0), TrackId::allocate(), None);
+            player
+                .select_item(0, true)
+                .expect("select first queue item");
+        })
+        .await;
 
     for _ in 0..WARMUP_BLOCKS {
-        let _ = harness.render(BLOCK_FRAMES);
+        let _ = harness.render(BLOCK_FRAMES).await;
         let _ = harness.tick_and_drain();
     }
     harness
 }
 
-fn blocks_until_silence(rate: f32) -> usize {
-    let harness = loaded_harness();
+async fn blocks_until_silence(rate: f32) -> usize {
+    let harness = loaded_harness().await;
     harness.player().set_default_rate(rate);
 
     let mut blocks = 0usize;
     for _ in 0..MEASURE_BLOCKS {
-        let block = harness.render(BLOCK_FRAMES);
+        let block = harness.render(BLOCK_FRAMES).await;
         let _ = harness.tick_and_drain();
         blocks = blocks.saturating_add(1);
         if block.iter().all(|sample| sample.abs() == 0.0) {
             break;
         }
     }
+    harness.close().await;
     blocks
 }
 
-fn media_advance(rate: f32) -> f64 {
-    let harness = loaded_harness();
+async fn media_advance(rate: f32) -> f64 {
+    let harness = loaded_harness().await;
     let start = harness.player().position_seconds().unwrap_or(0.0);
     harness.player().set_default_rate(rate);
     for _ in 0..CLOCK_BLOCKS {
-        let _ = harness.render(BLOCK_FRAMES);
+        let _ = harness.render(BLOCK_FRAMES).await;
         let _ = harness.tick_and_drain();
     }
-    harness.player().position_seconds().unwrap_or(0.0) - start
+    let advance = harness.player().position_seconds().unwrap_or(0.0) - start;
+    harness.close().await;
+    advance
 }

--- a/tests/tests/integration_regressions/rate_applies_while_playing.rs
+++ b/tests/tests/integration_regressions/rate_applies_while_playing.rs
@@ -39,7 +39,7 @@ async fn fixed_rate_reader_keeps_source_and_player_clock_at_unity() {
         "the control thread must not publish pause before RT applies it"
     );
     let _ = oracle.render(BLOCK_FRAMES).await;
-    let paused_rates = rate_events(oracle.tick_and_drain());
+    let paused_rates = rate_events(oracle.tick_and_drain().await);
     assert_eq!(paused_rates, [0.0]);
     assert_eq!(oracle.player().rate(), 0.0);
 
@@ -52,7 +52,7 @@ async fn fixed_rate_reader_keeps_source_and_player_clock_at_unity() {
         "the control thread must not publish the requested rate before RT applies it"
     );
     let _ = oracle.render(BLOCK_FRAMES).await;
-    let resumed_rates = rate_events(oracle.tick_and_drain());
+    let resumed_rates = rate_events(oracle.tick_and_drain().await);
     assert_eq!(resumed_rates, [1.0]);
     assert_eq!(oracle.player().rate(), 1.0);
 
@@ -97,7 +97,7 @@ async fn loaded_harness() -> OfflinePlayerHarness {
     )
     .await;
     harness
-        .with_player(|player| {
+        .with_player(move |player| {
             player.insert(make_resource(1.0), TrackId::allocate(), None);
             player
                 .select_item(0, true)
@@ -107,7 +107,7 @@ async fn loaded_harness() -> OfflinePlayerHarness {
 
     for _ in 0..WARMUP_BLOCKS {
         let _ = harness.render(BLOCK_FRAMES).await;
-        let _ = harness.tick_and_drain();
+        let _ = harness.tick_and_drain().await;
     }
     harness
 }
@@ -119,7 +119,7 @@ async fn blocks_until_silence(rate: f32) -> usize {
     let mut blocks = 0usize;
     for _ in 0..MEASURE_BLOCKS {
         let block = harness.render(BLOCK_FRAMES).await;
-        let _ = harness.tick_and_drain();
+        let _ = harness.tick_and_drain().await;
         blocks = blocks.saturating_add(1);
         if block.iter().all(|sample| sample.abs() == 0.0) {
             break;
@@ -135,7 +135,7 @@ async fn media_advance(rate: f32) -> f64 {
     harness.player().set_default_rate(rate);
     for _ in 0..CLOCK_BLOCKS {
         let _ = harness.render(BLOCK_FRAMES).await;
-        let _ = harness.tick_and_drain();
+        let _ = harness.tick_and_drain().await;
     }
     let advance = harness.player().position_seconds().unwrap_or(0.0) - start;
     harness.close().await;

--- a/tests/tests/integration_regressions/rate_tracks_media_time.rs
+++ b/tests/tests/integration_regressions/rate_tracks_media_time.rs
@@ -54,7 +54,7 @@ async fn file_resource(harness: &OfflinePlayerHarness, path: &Path, store_dir: &
 async fn render_blocks(harness: &OfflinePlayerHarness, blocks: usize) {
     for _ in 0..blocks {
         let _ = harness.render(BLOCK_FRAMES).await;
-        let _ = harness.tick_and_drain();
+        let _ = harness.tick_and_drain().await;
         time::sleep(Duration::from_millis(1)).await;
     }
 }
@@ -85,7 +85,7 @@ async fn blocks_until_end(temp_dir: &TestTempDir, rate: f32) -> usize {
     )
     .await;
     harness
-        .with_player(|player| {
+        .with_player(move |player| {
             player.insert(resource, TrackId::allocate(), None);
             player
                 .select_item(0, true)
@@ -101,6 +101,7 @@ async fn blocks_until_end(temp_dir: &TestTempDir, rate: f32) -> usize {
         blocks += 1;
         let ended = harness
             .tick_and_drain()
+            .await
             .iter()
             .any(|event| matches!(event, PlayerEvent::ItemDidPlayToEnd { .. }));
         if ended {
@@ -129,7 +130,7 @@ async fn media_time_advances_with_the_playing_rate(temp_dir: TestTempDir) {
     std::fs::write(&path, signal_mp3_track_sine440_187s().bytes()).expect("write mp3 fixture");
     let resource = file_resource(&harness, &path, &temp_dir.path().join("store")).await;
     harness
-        .with_player(|player| {
+        .with_player(move |player| {
             player.insert(resource, TrackId::allocate(), None);
             player
                 .select_item(0, true)

--- a/tests/tests/integration_regressions/rate_tracks_media_time.rs
+++ b/tests/tests/integration_regressions/rate_tracks_media_time.rs
@@ -53,7 +53,7 @@ async fn file_resource(harness: &OfflinePlayerHarness, path: &Path, store_dir: &
 
 async fn render_blocks(harness: &OfflinePlayerHarness, blocks: usize) {
     for _ in 0..blocks {
-        let _ = harness.render(BLOCK_FRAMES);
+        let _ = harness.render(BLOCK_FRAMES).await;
         let _ = harness.tick_and_drain();
         time::sleep(Duration::from_millis(1)).await;
     }
@@ -71,7 +71,8 @@ async fn blocks_until_end(temp_dir: &TestTempDir, rate: f32) -> usize {
             .crossfade_duration(0.0)
             .build(),
         SAMPLE_RATE,
-    );
+    )
+    .await;
     let tag = format!("rate-{rate}");
     let path = temp_dir.path().join(format!("{tag}.wav"));
     let frames = DRAIN_FIXTURE_SECS * SAMPLE_RATE as usize;
@@ -83,28 +84,36 @@ async fn blocks_until_end(temp_dir: &TestTempDir, rate: f32) -> usize {
         &temp_dir.path().join(format!("store-{tag}")),
     )
     .await;
-    harness.with_player(|player| {
-        player.insert(resource, TrackId::allocate(), None);
-        player
-            .select_item(0, true)
-            .expect("select first queue item");
-    });
+    harness
+        .with_player(|player| {
+            player.insert(resource, TrackId::allocate(), None);
+            player
+                .select_item(0, true)
+                .expect("select first queue item");
+        })
+        .await;
     harness.player().set_default_rate(rate);
 
     let mut blocks = 0usize;
+    let mut ended_at = None;
     for _ in 0..DRAIN_BLOCK_BUDGET {
-        let _ = harness.render(BLOCK_FRAMES);
+        let _ = harness.render(BLOCK_FRAMES).await;
         blocks += 1;
         let ended = harness
             .tick_and_drain()
             .iter()
             .any(|event| matches!(event, PlayerEvent::ItemDidPlayToEnd { .. }));
         if ended {
-            return blocks;
+            ended_at = Some(blocks);
+            break;
         }
         time::sleep(Duration::from_millis(1)).await;
     }
-    panic!("the {rate}x track never reached end-of-stream within {DRAIN_BLOCK_BUDGET} blocks");
+    let blocks = ended_at.unwrap_or_else(|| {
+        panic!("the {rate}x track never reached end-of-stream within {DRAIN_BLOCK_BUDGET} blocks")
+    });
+    harness.close().await;
+    blocks
 }
 
 #[kithara::test(tokio, multi_thread, timeout(Duration::from_secs(120)))]
@@ -114,16 +123,19 @@ async fn media_time_advances_with_the_playing_rate(temp_dir: TestTempDir) {
             .crossfade_duration(0.0)
             .build(),
         SAMPLE_RATE,
-    );
+    )
+    .await;
     let path = temp_dir.path().join("rate.mp3");
     std::fs::write(&path, signal_mp3_track_sine440_187s().bytes()).expect("write mp3 fixture");
     let resource = file_resource(&harness, &path, &temp_dir.path().join("store")).await;
-    harness.with_player(|player| {
-        player.insert(resource, TrackId::allocate(), None);
-        player
-            .select_item(0, true)
-            .expect("select first queue item");
-    });
+    harness
+        .with_player(|player| {
+            player.insert(resource, TrackId::allocate(), None);
+            player
+                .select_item(0, true)
+                .expect("select first queue item");
+        })
+        .await;
 
     render_blocks(&harness, SETTLE_BLOCKS).await;
     let baseline = media_advance(&harness, MEASURE_BLOCKS).await;
@@ -142,6 +154,7 @@ async fn media_time_advances_with_the_playing_rate(temp_dir: TestTempDir) {
          {accelerated}s at rate {FAST_RATE} versus {baseline}s at rate 1.0 — \
          the reported clock is on the output scale, not the media scale"
     );
+    harness.close().await;
 }
 
 /// The other half of the same contract: the faster media clock has to be

--- a/tests/tests/integration_regressions/resume_from_saved_position.rs
+++ b/tests/tests/integration_regressions/resume_from_saved_position.rs
@@ -18,7 +18,7 @@ use kithara_integration_tests::{
     TestServerHelper, TestTempDir,
     bufpool_ext::{Pools, TestPools, pools},
     kithara,
-    offline::{OfflineQueue, drive_queue_ticks},
+    offline::{OfflineQueue, QueueTicker},
     temp_dir,
     test_defaults::Consts as Shared,
     waits::{wait_for_event, wait_for_loader_done_event, wait_for_position_event},
@@ -85,10 +85,7 @@ async fn playback_starts_from_the_seeked_position(temp_dir: TestTempDir) {
         .build();
     let first_queue = new_queue(&first_pools, first_store.clone()).await;
     let first_downloader = new_downloader(first_pools);
-    let first_tick = tokio::task::spawn(drive_queue_ticks(
-        first_queue.control(),
-        Duration::from_millis(50),
-    ));
+    let mut first_tick = QueueTicker::spawn(first_queue.control(), Duration::from_millis(50));
     let mut first_rx = first_queue.subscribe();
     let first_id = append_track(&first_queue, url.as_str(), &first_downloader, &first_store);
     first_queue
@@ -122,8 +119,7 @@ async fn playback_starts_from_the_seeked_position(temp_dir: TestTempDir) {
     first_queue.pause();
     let saved = played;
     first_queue.clear();
-    first_tick.abort();
-    let _ = first_tick.await;
+    first_tick.stop().await;
     first_queue.close().await;
     drop(first_downloader);
 
@@ -135,10 +131,7 @@ async fn playback_starts_from_the_seeked_position(temp_dir: TestTempDir) {
         .build();
     let second_queue = new_queue(&second_pools, second_store.clone()).await;
     let second_downloader = new_downloader(second_pools);
-    let second_tick = tokio::task::spawn(drive_queue_ticks(
-        second_queue.control(),
-        Duration::from_millis(50),
-    ));
+    let mut second_tick = QueueTicker::spawn(second_queue.control(), Duration::from_millis(50));
     let mut second_rx = second_queue.subscribe();
     let second_id = append_track(
         &second_queue,
@@ -205,7 +198,6 @@ async fn playback_starts_from_the_seeked_position(temp_dir: TestTempDir) {
          saved position {saved:.2}s"
     );
 
-    second_tick.abort();
-    let _ = second_tick.await;
+    second_tick.stop().await;
     second_queue.close().await;
 }

--- a/tests/tests/integration_regressions/resume_from_saved_position.rs
+++ b/tests/tests/integration_regressions/resume_from_saved_position.rs
@@ -27,7 +27,7 @@ use kithara_test_fixtures::SignalAsset;
 
 const SAVE_AFTER_SECS: f64 = 4.0;
 
-fn new_queue(pools: &Pools, store: AssetStore<TestPools>) -> OfflineQueue<TestPools> {
+async fn new_queue(pools: &Pools, store: AssetStore<TestPools>) -> OfflineQueue<TestPools> {
     let player = PlayerImpl::new(
         PlayerConfig::builder()
             .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
@@ -42,6 +42,7 @@ fn new_queue(pools: &Pools, store: AssetStore<TestPools>) -> OfflineQueue<TestPo
             .build(),
         Queue::new(QueueConfig::builder().player(player).store(store).build()),
     )
+    .await
     .expect("create product offline queue")
 }
 
@@ -82,7 +83,7 @@ async fn playback_starts_from_the_seeked_position(temp_dir: TestTempDir) {
             root: temp_dir.path().into(),
         })
         .build();
-    let first_queue = new_queue(&first_pools, first_store.clone());
+    let first_queue = new_queue(&first_pools, first_store.clone()).await;
     let first_downloader = new_downloader(first_pools);
     let first_tick = tokio::task::spawn(drive_queue_ticks(
         first_queue.control(),
@@ -123,7 +124,7 @@ async fn playback_starts_from_the_seeked_position(temp_dir: TestTempDir) {
     first_queue.clear();
     first_tick.abort();
     let _ = first_tick.await;
-    drop(first_queue);
+    first_queue.close().await;
     drop(first_downloader);
 
     let second_pools = pools();
@@ -132,7 +133,7 @@ async fn playback_starts_from_the_seeked_position(temp_dir: TestTempDir) {
             root: temp_dir.path().into(),
         })
         .build();
-    let second_queue = new_queue(&second_pools, second_store.clone());
+    let second_queue = new_queue(&second_pools, second_store.clone()).await;
     let second_downloader = new_downloader(second_pools);
     let second_tick = tokio::task::spawn(drive_queue_ticks(
         second_queue.control(),
@@ -206,4 +207,5 @@ async fn playback_starts_from_the_seeked_position(temp_dir: TestTempDir) {
 
     second_tick.abort();
     let _ = second_tick.await;
+    second_queue.close().await;
 }

--- a/tests/tests/integration_regressions/resume_from_saved_position.rs
+++ b/tests/tests/integration_regressions/resume_from_saved_position.rs
@@ -68,7 +68,8 @@ fn append_track(
         .store(store.clone())
         .build();
     queue
-        .append(TrackSource::Config(Box::new(cfg)))
+        .run(move |q| q.append(TrackSource::Config(Box::new(cfg))))
+        .await
         .expect("append resume track")
 }
 
@@ -89,7 +90,8 @@ async fn playback_starts_from_the_seeked_position(temp_dir: TestTempDir) {
     let mut first_rx = first_queue.subscribe();
     let first_id = append_track(&first_queue, url.as_str(), &first_downloader, &first_store);
     first_queue
-        .select(first_id, Transition::None)
+        .run(move |q| q.select(first_id, Transition::None))
+        .await
         .expect("select first session track");
     wait_for_loader_done_event(
         &mut first_rx,
@@ -102,7 +104,7 @@ async fn playback_starts_from_the_seeked_position(temp_dir: TestTempDir) {
 
     // Without this the first session never advances and no position worth
     // saving is ever reached.
-    first_queue.play();
+    first_queue.run(move |q| q.play()).await;
 
     let played = wait_for_position_event(
         &mut first_rx,
@@ -140,7 +142,8 @@ async fn playback_starts_from_the_seeked_position(temp_dir: TestTempDir) {
         &second_store,
     );
     second_queue
-        .select(second_id, Transition::None)
+        .run(move |q| q.select(second_id, Transition::None))
+        .await
         .expect("select second session track");
     wait_for_loader_done_event(
         &mut second_rx,
@@ -160,7 +163,7 @@ async fn playback_starts_from_the_seeked_position(temp_dir: TestTempDir) {
     );
     // `SeekComplete` is published by the decoder once it reads at the new
     // position, so it cannot arrive while the engine is still paused.
-    second_queue.play();
+    second_queue.run(move |q| q.play()).await;
     wait_for_event(
         &mut second_rx,
         "saved-position seek completion",

--- a/tests/tests/integration_regressions/seek_to_end_is_sane.rs
+++ b/tests/tests/integration_regressions/seek_to_end_is_sane.rs
@@ -126,6 +126,7 @@ async fn run_case(helper: &TestServerHelper, temp_dir: &TestTempDir, target_kind
                 .build(),
         ),
     )
+    .await
     .expect("create product offline queue");
     let cfg = ResourceConfig::for_src(
         ResourceSrc::parse(fixture.master_url().as_str()).expect("valid HLS URL"),
@@ -241,6 +242,7 @@ async fn run_case(helper: &TestServerHelper, temp_dir: &TestTempDir, target_kind
     );
 
     queue.clear();
+    queue.close().await;
 }
 
 #[kithara::test(tokio, multi_thread, timeout(Duration::from_secs(120)))]

--- a/tests/tests/integration_regressions/select_after_play_consumed_the_load.rs
+++ b/tests/tests/integration_regressions/select_after_play_consumed_the_load.rs
@@ -13,6 +13,7 @@
 //! rendezvous rather than a timing window.
 use std::{
     fs,
+    num::NonZeroU32,
     path::PathBuf,
     sync::atomic::{AtomicU64, Ordering},
 };
@@ -65,6 +66,9 @@ impl StartGatedSession {
 }
 
 impl SessionDispatcher<TestPools> for StartGatedSession {
+    fn requested_sample_rate(&self) -> NonZeroU32 {
+        Shared::NON_ZERO_SAMPLE_RATE
+    }
     fn exec(&self, cmd: Cmd<TestPools>) -> Result<Reply, PlayError> {
         let reply = match cmd {
             Cmd::StartPlayer { .. } => {

--- a/tests/tests/integration_regressions/select_after_play_consumed_the_load.rs
+++ b/tests/tests/integration_regressions/select_after_play_consumed_the_load.rs
@@ -99,15 +99,8 @@ impl SessionDispatcher<TestPools> for StartGatedSession {
     }
 }
 
-fn spawn_ticker(queue: Arc<Queue<TestPools>>) -> tokio::task::JoinHandle<()> {
-    tokio::task::spawn(async move {
-        loop {
-            time::sleep(Duration::from_millis(20)).await;
-            if queue.tick().is_err() {
-                break;
-            }
-        }
-    })
+fn spawn_ticker(queue: &Queue<TestPools>) -> QueueTicker {
+    QueueTicker::spawn(QueueControl::clone(queue), Duration::from_millis(20))
 }
 
 /// A local fixture per track: the load has to run and land asynchronously,
@@ -159,7 +152,7 @@ async fn a_track_play_consumed_mid_load_can_be_selected_again(temp_dir: TestTemp
             .store(store.clone())
             .build(),
     ));
-    let ticker = spawn_ticker(Arc::clone(&queue));
+    let mut ticker = spawn_ticker(&queue);
     let mut status_rx = queue.subscribe();
 
     let ids: Vec<_> = (0..TRACK_COUNT)
@@ -233,6 +226,5 @@ async fn a_track_play_consumed_mid_load_can_be_selected_again(temp_dir: TestTemp
         });
 
     queue.clear();
-    ticker.abort();
-    let _ = ticker.await;
+    ticker.stop().await;
 }

--- a/tests/tests/integration_regressions/select_after_play_consumed_the_load.rs
+++ b/tests/tests/integration_regressions/select_after_play_consumed_the_load.rs
@@ -157,9 +157,13 @@ async fn a_track_play_consumed_mid_load_can_be_selected_again(temp_dir: TestTemp
 
     let ids: Vec<_> = (0..TRACK_COUNT)
         .map(|index| {
-            queue.append(TrackSource::Config(Box::new(resource_config(
-                &temp_dir, &store, index,
-            ))))
+            queue
+                .run(move |q| {
+                    q.append(TrackSource::Config(Box::new(resource_config(
+                        &temp_dir, &store, index,
+                    ))))
+                })
+                .await
         })
         .collect::<Result<Vec<_>, _>>()
         .expect("queue is open while fixtures are appended");
@@ -168,7 +172,7 @@ async fn a_track_play_consumed_mid_load_can_be_selected_again(temp_dir: TestTemp
     // surface does, and parks inside the engine start.
     let playing = tokio::task::spawn_blocking({
         let queue = Arc::clone(&queue);
-        move || queue.play()
+        move || queue.run(move |q| q.play()).await
     });
     tokio::task::spawn_blocking(move || entered_rx.recv())
         .await
@@ -200,7 +204,11 @@ async fn a_track_play_consumed_mid_load_can_be_selected_again(temp_dir: TestTemp
     );
 
     queue
-        .select(ids[1], Transition::None)
+        .run({
+            let arg0 = ids[1];
+            move |q| q.select(arg0, Transition::None)
+        })
+        .await
         .expect("selecting the second track must be accepted");
     wait_for_event(
         &mut status_rx,
@@ -217,7 +225,11 @@ async fn a_track_play_consumed_mid_load_can_be_selected_again(temp_dir: TestTemp
     .unwrap_or_else(|error| panic!("precondition: {error}"));
 
     queue
-        .select(ids[0], Transition::None)
+        .run({
+            let arg0 = ids[0];
+            move |q| q.select(arg0, Transition::None)
+        })
+        .await
         .unwrap_or_else(|error| {
             panic!(
                 "switching back to the track `play` consumed was rejected: {error} — the \

--- a/tests/tests/integration_regressions/select_after_play_consumed_the_load.rs
+++ b/tests/tests/integration_regressions/select_after_play_consumed_the_load.rs
@@ -66,9 +66,6 @@ impl StartGatedSession {
 }
 
 impl SessionDispatcher<TestPools> for StartGatedSession {
-    fn requested_sample_rate(&self) -> NonZeroU32 {
-        Shared::NON_ZERO_SAMPLE_RATE
-    }
     fn exec(&self, cmd: Cmd<TestPools>) -> Result<Reply, PlayError> {
         let reply = match cmd {
             Cmd::StartPlayer { .. } => {
@@ -152,7 +149,7 @@ async fn a_track_play_consumed_mid_load_can_be_selected_again(temp_dir: TestTemp
             .worker(kithara::play::PlayWorker::new(
                 kithara::play::PlayWorkerConfig::builder(pools).build(),
             ))
-            .session(session)
+            .session(SessionBinding::new(session, Shared::NON_ZERO_SAMPLE_RATE))
             .build(),
     );
     let player_control = player.control();

--- a/tests/tests/integration_regressions/transient_failure_no_permanent_skip.rs
+++ b/tests/tests/integration_regressions/transient_failure_no_permanent_skip.rs
@@ -123,6 +123,7 @@ async fn transient_failure_does_not_kill_the_track(temp_dir: TestTempDir) {
                 .build(),
         ),
     )
+    .await
     .expect("create product offline queue");
 
     let target = queue
@@ -242,4 +243,5 @@ async fn transient_failure_does_not_kill_the_track(temp_dir: TestTempDir) {
     queue.clear();
     ticker.abort();
     let _ = ticker.await;
+    queue.close().await;
 }

--- a/tests/tests/integration_regressions/transient_failure_no_permanent_skip.rs
+++ b/tests/tests/integration_regressions/transient_failure_no_permanent_skip.rs
@@ -127,39 +127,46 @@ async fn transient_failure_does_not_kill_the_track(temp_dir: TestTempDir) {
     .expect("create product offline queue");
 
     let target = queue
-        .append(TrackSource::Config(Box::new(
-            ResourceConfig::for_src(
-                ResourceSrc::parse(target_url.as_str()).expect("valid HLS URL"),
-            )
-            .downloader(downloader.clone())
-            .initial_abr_mode(AbrMode::manual(0))
-            .hls(hls_look_ahead(LOOK_AHEAD_BYTES))
-            .store(store.clone())
-            .build(),
-        )))
+        .run(move |q| {
+            q.append(TrackSource::Config(Box::new(
+                ResourceConfig::for_src(
+                    ResourceSrc::parse(target_url.as_str()).expect("valid HLS URL"),
+                )
+                .downloader(downloader.clone())
+                .initial_abr_mode(AbrMode::manual(0))
+                .hls(hls_look_ahead(LOOK_AHEAD_BYTES))
+                .store(store.clone())
+                .build(),
+            )))
+        })
+        .await
         .expect("append target track");
     // A next track is what an auto-skip would move to. Without it the queue
     // has nowhere to go and the regression could not show itself.
     let fallback = queue
-        .append(TrackSource::Config(Box::new(
-            ResourceConfig::for_src(
-                ResourceSrc::parse(fallback_url.as_str()).expect("valid fallback URL"),
-            )
-            .downloader(downloader)
-            .store(store)
-            .build(),
-        )))
+        .run(move |q| {
+            q.append(TrackSource::Config(Box::new(
+                ResourceConfig::for_src(
+                    ResourceSrc::parse(fallback_url.as_str()).expect("valid fallback URL"),
+                )
+                .downloader(downloader)
+                .store(store)
+                .build(),
+            )))
+        })
+        .await
         .expect("append fallback track");
 
     let mut ticker = QueueTicker::spawn(queue.control(), Duration::from_millis(20));
     let mut rx = queue.subscribe();
     queue
-        .select(target, Transition::None)
+        .run(move |q| q.select(target, Transition::None))
+        .await
         .expect("select target track");
     wait_for_loader_done_event(&mut rx, &queue, target, Duration::from_secs(30))
         .await
         .unwrap_or_else(|error| panic!("precondition: target load failed: {error}"));
-    queue.play();
+    queue.run(move |q| q.play()).await;
 
     let before_failure = wait_for_position_event(
         &mut rx,

--- a/tests/tests/integration_regressions/transient_failure_no_permanent_skip.rs
+++ b/tests/tests/integration_regressions/transient_failure_no_permanent_skip.rs
@@ -20,7 +20,7 @@ use kithara_integration_tests::{
     Content, Delivery, FixtureBehavior, HlsFixtureBuilder, PrivateTestServer, TestTempDir,
     bufpool_ext::{TestPools, pools},
     kithara,
-    offline::{OfflineQueue, drive_queue_ticks},
+    offline::{OfflineQueue, QueueTicker},
     temp_dir,
     test_defaults::Consts as Shared,
     waits::{wait_for_event, wait_for_loader_done_event, wait_for_position_event},
@@ -151,10 +151,7 @@ async fn transient_failure_does_not_kill_the_track(temp_dir: TestTempDir) {
         )))
         .expect("append fallback track");
 
-    let ticker = tokio::task::spawn(drive_queue_ticks(
-        queue.control(),
-        Duration::from_millis(20),
-    ));
+    let mut ticker = QueueTicker::spawn(queue.control(), Duration::from_millis(20));
     let mut rx = queue.subscribe();
     queue
         .select(target, Transition::None)
@@ -241,7 +238,6 @@ async fn transient_failure_does_not_kill_the_track(temp_dir: TestTempDir) {
     });
 
     queue.clear();
-    ticker.abort();
-    let _ = ticker.await;
+    ticker.stop().await;
     queue.close().await;
 }

--- a/tests/tests/kithara_audio/no_sync_passthrough.rs
+++ b/tests/tests/kithara_audio/no_sync_passthrough.rs
@@ -411,19 +411,23 @@ async fn render_passthrough(
         HostConfig::offline(pools())
             .sample_rate(NonZeroU32::new(SAMPLE_RATE).expect("sample rate is non-zero"))
             .build(),
-    );
+    )
+    .await;
     target.set_fade_duration(0.0);
     target.load_and_fadein(resource_from_reader(target_audio));
-    let mut load = load_audio.take().map(|audio| {
+    let mut load = if let Some(audio) = load_audio.take() {
         let mut player = OfflinePlayer::new(
             HostConfig::offline(pools())
                 .sample_rate(NonZeroU32::new(SAMPLE_RATE).expect("sample rate is non-zero"))
                 .build(),
-        );
+        )
+        .await;
         player.set_fade_duration(0.0);
         player.load_and_fadein(resource_from_reader(audio));
-        player
-    });
+        Some(player)
+    } else {
+        None
+    };
     let block_period = Duration::from_secs_f64(
         f64::from(u32::try_from(BLOCK_FRAMES).expect("block size fits u32"))
             / f64::from(SAMPLE_RATE),
@@ -433,9 +437,9 @@ async fn render_passthrough(
     for _ in 0..WARMUP_BLOCKS {
         let started = Instant::now();
         if let Some(player) = load.as_mut() {
-            let _ = player.render(BLOCK_FRAMES);
+            let _ = player.render(BLOCK_FRAMES).await;
         }
-        let _ = target.render(BLOCK_FRAMES);
+        let _ = target.render(BLOCK_FRAMES).await;
         time::sleep(block_period.saturating_sub(started.elapsed())).await;
     }
     let metrics_before_capture = target.metrics();
@@ -450,15 +454,15 @@ async fn render_passthrough(
     for _ in 0..CAPTURE_BLOCKS {
         let started = Instant::now();
         if let Some(player) = load.as_mut() {
-            let _ = player.render(BLOCK_FRAMES);
+            let _ = player.render(BLOCK_FRAMES).await;
         }
-        pcm.extend(target.render(BLOCK_FRAMES));
+        pcm.extend(target.render(BLOCK_FRAMES).await);
         time::sleep(block_period.saturating_sub(started.elapsed())).await;
     }
     let load_observed_during_capture = load_probe.finish_capture();
     let metrics_after_capture = target.metrics();
 
-    RealtimeCapture {
+    let capture = RealtimeCapture {
         pcm,
         warmup_decode_errors,
         warmup_underruns,
@@ -469,7 +473,12 @@ async fn render_passthrough(
             .underruns()
             .saturating_sub(metrics_before_capture.underruns()),
         load_observed_during_capture,
+    };
+    if let Some(player) = load {
+        player.close().await;
     }
+    target.close().await;
+    capture
 }
 
 async fn render_queue_passthrough(source: &[u8], stretch: Option<(StretchKind, f32)>) -> Vec<f32> {
@@ -480,7 +489,8 @@ async fn render_queue_passthrough(source: &[u8], stretch: Option<(StretchKind, f
             .warp(WarpConfig::builder().stretch(Arc::clone(&stretch)).build())
             .build(),
         SAMPLE_RATE,
-    );
+    )
+    .await;
     let worker = harness.worker().clone();
     let mut audio = worker
         .open(audio_config(source, stretch, Vec::new()))
@@ -489,12 +499,14 @@ async fn render_queue_passthrough(source: &[u8], stretch: Option<(StretchKind, f
     wait_for_preload(&audio).await;
     audio.preload().expect("queue audio preload");
 
-    let queue = harness.insert_control(Queue::new(
-        QueueConfig::builder()
-            .player(harness.take_player())
-            .should_autoplay(false)
-            .build(),
-    ));
+    let queue = harness
+        .insert_control(Queue::new(
+            QueueConfig::builder()
+                .player(harness.take_player())
+                .should_autoplay(false)
+                .build(),
+        ))
+        .await;
     let id = queue.insert_loaded_for_test(resource_from_reader(audio));
     queue
         .select(id, Transition::None)
@@ -507,7 +519,7 @@ async fn render_queue_passthrough(source: &[u8], stretch: Option<(StretchKind, f
     for _ in 0..WARMUP_BLOCKS {
         let started = Instant::now();
         queue.tick().expect("tick queue during warmup");
-        let _ = harness.render(BLOCK_FRAMES);
+        let _ = harness.render(BLOCK_FRAMES).await;
         time::sleep(block_period.saturating_sub(started.elapsed())).await;
     }
 
@@ -515,9 +527,11 @@ async fn render_queue_passthrough(source: &[u8], stretch: Option<(StretchKind, f
     for _ in 0..CAPTURE_BLOCKS {
         let started = Instant::now();
         queue.tick().expect("tick queue during capture");
-        pcm.extend(harness.render(BLOCK_FRAMES));
+        pcm.extend(harness.render(BLOCK_FRAMES).await);
         time::sleep(block_period.saturating_sub(started.elapsed())).await;
     }
+    drop(queue);
+    harness.close().await;
     pcm
 }
 

--- a/tests/tests/kithara_audio/no_sync_passthrough.rs
+++ b/tests/tests/kithara_audio/no_sync_passthrough.rs
@@ -414,7 +414,9 @@ async fn render_passthrough(
     )
     .await;
     target.set_fade_duration(0.0);
-    target.load_and_fadein(resource_from_reader(target_audio));
+    target
+        .load_and_fadein(resource_from_reader(target_audio))
+        .await;
     let mut load = if let Some(audio) = load_audio.take() {
         let mut player = OfflinePlayer::new(
             HostConfig::offline(pools())
@@ -423,7 +425,7 @@ async fn render_passthrough(
         )
         .await;
         player.set_fade_duration(0.0);
-        player.load_and_fadein(resource_from_reader(audio));
+        player.load_and_fadein(resource_from_reader(audio)).await;
         Some(player)
     } else {
         None
@@ -507,9 +509,14 @@ async fn render_queue_passthrough(source: &[u8], stretch: Option<(StretchKind, f
                 .build(),
         ))
         .await;
-    let id = queue.insert_loaded_for_test(resource_from_reader(audio));
-    queue
-        .select(id, Transition::None)
+    let id = harness
+        .run(&queue, move |q| {
+            q.insert_loaded_for_test(resource_from_reader(audio))
+        })
+        .await;
+    harness
+        .run(&queue, move |q| q.select(id, Transition::None))
+        .await
         .expect("select queue passthrough track");
 
     let block_period = Duration::from_secs_f64(
@@ -518,7 +525,10 @@ async fn render_queue_passthrough(source: &[u8], stretch: Option<(StretchKind, f
     );
     for _ in 0..WARMUP_BLOCKS {
         let started = Instant::now();
-        queue.tick().expect("tick queue during warmup");
+        harness
+            .run(&queue, |q| q.tick())
+            .await
+            .expect("tick queue during warmup");
         let _ = harness.render(BLOCK_FRAMES).await;
         time::sleep(block_period.saturating_sub(started.elapsed())).await;
     }
@@ -526,7 +536,10 @@ async fn render_queue_passthrough(source: &[u8], stretch: Option<(StretchKind, f
     let mut pcm = Vec::with_capacity(CAPTURE_BLOCKS * BLOCK_FRAMES * usize::from(CHANNELS));
     for _ in 0..CAPTURE_BLOCKS {
         let started = Instant::now();
-        queue.tick().expect("tick queue during capture");
+        harness
+            .run(&queue, |q| q.tick())
+            .await
+            .expect("tick queue during capture");
         pcm.extend(harness.render(BLOCK_FRAMES).await);
         time::sleep(block_period.saturating_sub(started.elapsed())).await;
     }

--- a/tests/tests/kithara_broadcast/engine_e2e.rs
+++ b/tests/tests/kithara_broadcast/engine_e2e.rs
@@ -40,35 +40,38 @@ fn tone_resource() -> Resource {
     ))
 }
 
-fn playing_harness() -> OfflinePlayerHarness {
+async fn playing_harness() -> OfflinePlayerHarness {
     let harness = OfflinePlayerHarness::with_sample_rate(
         OfflinePlayerOptions::builder().build(),
         SESSION_RATE,
-    );
-    harness.with_player(|player| {
-        player.insert(tone_resource(), TrackId::allocate(), None);
-        player
-            .select_item(0, true)
-            .expect("select first queue item");
-    });
-    harness.render(BLOCK_FRAMES);
+    )
+    .await;
+    harness
+        .with_player(|player| {
+            player.insert(tone_resource(), TrackId::allocate(), None);
+            player
+                .select_item(0, true)
+                .expect("select first queue item");
+        })
+        .await;
+    harness.render(BLOCK_FRAMES).await;
     let _ = harness.tick_and_drain();
     harness
 }
 
-fn render_blocks(harness: &OfflinePlayerHarness, blocks: usize) -> Vec<f32> {
+async fn render_blocks(harness: &OfflinePlayerHarness, blocks: usize) -> Vec<f32> {
     let mut rendered = Vec::with_capacity(blocks * BLOCK_FRAMES * 2);
     for _ in 0..blocks {
-        rendered.extend_from_slice(&harness.render(BLOCK_FRAMES));
+        rendered.extend_from_slice(&harness.render(BLOCK_FRAMES).await);
         let _ = harness.tick_and_drain();
     }
     rendered
 }
 
-fn render_tone(harness: &OfflinePlayerHarness, frames: usize) {
+async fn render_tone(harness: &OfflinePlayerHarness, frames: usize) {
     let mut audible = 0;
     for _ in 0..MAX_BLOCKS {
-        let block = harness.render(BLOCK_FRAMES);
+        let block = harness.render(BLOCK_FRAMES).await;
         let _ = harness.tick_and_drain();
         audible += block.iter().step_by(2).filter(|s| s.abs() > 0.0).count();
         if audible >= frames {
@@ -138,7 +141,7 @@ impl OnAir {
         String::from_utf8(self.get("v/0/live.m3u8").await).expect("the playlist is text")
     }
 
-    fn start(
+    async fn start(
         harness: &OfflinePlayerHarness,
         ring_samples: usize,
         gap_after_writes: Option<usize>,
@@ -167,6 +170,7 @@ impl OnAir {
         harness
             .host()
             .enable_outputs(outputs)
+            .await
             .expect("enable the master output group");
         let base = Url::parse(handle.url()).expect("the handle reports a URL");
         let client = HttpClient::new(NetOptions::default(), pools, scope.token());
@@ -212,11 +216,11 @@ impl Drop for OnAir {
     }
 }
 
-#[kithara::test]
-fn the_session_renders_the_source_tone() {
-    let harness = playing_harness();
+#[kithara::test(tokio)]
+async fn the_session_renders_the_source_tone() {
+    let harness = playing_harness().await;
 
-    let rendered = render_blocks(&harness, 200);
+    let rendered = render_blocks(&harness, 200).await;
 
     assert_carries_the_tone(
         &left_channel(&rendered),
@@ -224,6 +228,7 @@ fn the_session_renders_the_source_tone() {
         SESSION_RATE,
         "the rendered mix",
     );
+    harness.close().await;
 }
 
 #[kithara::test(tokio, flash(false), timeout(Duration::from_secs(60)))]
@@ -231,10 +236,10 @@ async fn the_engine_mix_reaches_an_http_client_as_the_source_tone() {
     const ROOMY_RING: usize = MAX_BLOCKS * BLOCK_FRAMES * 2;
     const TONE_RENDER_FRAMES: usize = 110_250;
 
-    let harness = playing_harness();
-    let on_air = OnAir::start(&harness, ROOMY_RING, None);
+    let harness = playing_harness().await;
+    let on_air = OnAir::start(&harness, ROOMY_RING, None).await;
 
-    render_tone(&harness, TONE_RENDER_FRAMES);
+    render_tone(&harness, TONE_RENDER_FRAMES).await;
     on_air.handle.stop();
 
     let decoded = decode_adts_left(on_air.listed_stream().await);
@@ -256,6 +261,8 @@ async fn the_engine_mix_reaches_an_http_client_as_the_source_tone() {
         SESSION_RATE,
         "the fetched stream",
     );
+    drop(on_air);
+    harness.close().await;
 }
 
 #[kithara::test(tokio, flash(false), timeout(Duration::from_secs(60)))]
@@ -266,12 +273,12 @@ async fn an_intake_gap_breaks_the_served_playlist() {
     const TAIL_FRAMES: usize = 8_820;
     const TAIL_TONE_FRAMES: usize = 4_410;
 
-    let harness = playing_harness();
-    let on_air = OnAir::start(&harness, ROOMY_RING, Some(GAP_AFTER_WRITES));
+    let harness = playing_harness().await;
+    let on_air = OnAir::start(&harness, ROOMY_RING, Some(GAP_AFTER_WRITES)).await;
 
-    render_tone(&harness, OVERRUN_FRAMES);
+    render_tone(&harness, OVERRUN_FRAMES).await;
     on_air.wait_until_drained().await;
-    render_tone(&harness, TAIL_FRAMES);
+    render_tone(&harness, TAIL_FRAMES).await;
     on_air.handle.stop();
 
     let playlist = Playlist::parse(on_air.media_playlist().await);
@@ -303,4 +310,6 @@ async fn an_intake_gap_breaks_the_served_playlist() {
         SESSION_RATE,
         "the stream after the break",
     );
+    drop(on_air);
+    harness.close().await;
 }

--- a/tests/tests/kithara_broadcast/engine_e2e.rs
+++ b/tests/tests/kithara_broadcast/engine_e2e.rs
@@ -47,7 +47,7 @@ async fn playing_harness() -> OfflinePlayerHarness {
     )
     .await;
     harness
-        .with_player(|player| {
+        .with_player(move |player| {
             player.insert(tone_resource(), TrackId::allocate(), None);
             player
                 .select_item(0, true)
@@ -55,7 +55,7 @@ async fn playing_harness() -> OfflinePlayerHarness {
         })
         .await;
     harness.render(BLOCK_FRAMES).await;
-    let _ = harness.tick_and_drain();
+    let _ = harness.tick_and_drain().await;
     harness
 }
 
@@ -63,7 +63,7 @@ async fn render_blocks(harness: &OfflinePlayerHarness, blocks: usize) -> Vec<f32
     let mut rendered = Vec::with_capacity(blocks * BLOCK_FRAMES * 2);
     for _ in 0..blocks {
         rendered.extend_from_slice(&harness.render(BLOCK_FRAMES).await);
-        let _ = harness.tick_and_drain();
+        let _ = harness.tick_and_drain().await;
     }
     rendered
 }
@@ -72,7 +72,7 @@ async fn render_tone(harness: &OfflinePlayerHarness, frames: usize) {
     let mut audible = 0;
     for _ in 0..MAX_BLOCKS {
         let block = harness.render(BLOCK_FRAMES).await;
-        let _ = harness.tick_and_drain();
+        let _ = harness.tick_and_drain().await;
         audible += block.iter().step_by(2).filter(|s| s.abs() > 0.0).count();
         if audible >= frames {
             return;

--- a/tests/tests/kithara_broadcast/route_handover.rs
+++ b/tests/tests/kithara_broadcast/route_handover.rs
@@ -81,13 +81,13 @@ async fn playing_harness() -> OfflinePlayerHarness {
         OfflinePlayerHarness::with_sample_rate(OfflinePlayerOptions::builder().build(), OLD_RATE)
             .await;
     harness
-        .with_player(|player| {
+        .with_player(move |player| {
             player.insert(tone_resource(), TrackId::allocate(), None);
             player.select_item(0, true).expect("select tone");
         })
         .await;
     let _ = harness.render(BLOCK_FRAMES).await;
-    let _ = harness.tick_and_drain();
+    let _ = harness.tick_and_drain().await;
     harness
 }
 
@@ -95,7 +95,7 @@ async fn render_blocks(harness: &OfflinePlayerHarness) -> Vec<f32> {
     let mut rendered = Vec::with_capacity(BLOCKS_PER_RATE * BLOCK_FRAMES * usize::from(CHANNELS));
     for _ in 0..BLOCKS_PER_RATE {
         rendered.extend_from_slice(&harness.render(BLOCK_FRAMES).await);
-        let _ = harness.tick_and_drain();
+        let _ = harness.tick_and_drain().await;
     }
     rendered
 }

--- a/tests/tests/kithara_broadcast/route_handover.rs
+++ b/tests/tests/kithara_broadcast/route_handover.rs
@@ -76,22 +76,25 @@ fn tone_resource() -> Resource {
     resource_from_reader(TestPcmReader::with_signal(spec, 6.0, Wave::sine(TONE_HZ)))
 }
 
-fn playing_harness() -> OfflinePlayerHarness {
+async fn playing_harness() -> OfflinePlayerHarness {
     let harness =
-        OfflinePlayerHarness::with_sample_rate(OfflinePlayerOptions::builder().build(), OLD_RATE);
-    harness.with_player(|player| {
-        player.insert(tone_resource(), TrackId::allocate(), None);
-        player.select_item(0, true).expect("select tone");
-    });
-    let _ = harness.render(BLOCK_FRAMES);
+        OfflinePlayerHarness::with_sample_rate(OfflinePlayerOptions::builder().build(), OLD_RATE)
+            .await;
+    harness
+        .with_player(|player| {
+            player.insert(tone_resource(), TrackId::allocate(), None);
+            player.select_item(0, true).expect("select tone");
+        })
+        .await;
+    let _ = harness.render(BLOCK_FRAMES).await;
     let _ = harness.tick_and_drain();
     harness
 }
 
-fn render_blocks(harness: &OfflinePlayerHarness) -> Vec<f32> {
+async fn render_blocks(harness: &OfflinePlayerHarness) -> Vec<f32> {
     let mut rendered = Vec::with_capacity(BLOCKS_PER_RATE * BLOCK_FRAMES * usize::from(CHANNELS));
     for _ in 0..BLOCKS_PER_RATE {
-        rendered.extend_from_slice(&harness.render(BLOCK_FRAMES));
+        rendered.extend_from_slice(&harness.render(BLOCK_FRAMES).await);
         let _ = harness.tick_and_drain();
     }
     rendered
@@ -122,7 +125,7 @@ fn wav_rate(store: &AssetStore<TestPools>, key: &ResourceKey) -> u32 {
 
 #[kithara::test(tokio, flash(false), timeout(Duration::from_secs(60)))]
 async fn route_change_continues_recording_and_broadcast_in_new_segments() {
-    let harness = playing_harness();
+    let harness = playing_harness().await;
     let pools = pools();
     let worker = Worker::new(WorkerConfig::new());
     let store = memory_asset_store();
@@ -173,14 +176,16 @@ async fn route_change_continues_recording_and_broadcast_in_new_segments() {
     harness
         .host()
         .enable_outputs(outputs)
+        .await
         .expect("enable recorder and broadcast");
 
-    let before = render_blocks(&harness);
+    let before = render_blocks(&harness).await;
     harness
         .host()
         .restart_stream(NEW_RATE)
+        .await
         .expect("restart at the new device rate");
-    let after = render_blocks(&harness);
+    let after = render_blocks(&harness).await;
 
     assert_eq!(broadcast_handle.url(), url);
     assert!(before.iter().any(|sample| sample.abs() > 0.0));
@@ -188,6 +193,7 @@ async fn route_change_continues_recording_and_broadcast_in_new_segments() {
     harness
         .host()
         .disable_mix_tap()
+        .await
         .expect("release output group");
     let report = wait_recording(&recording_handle);
     broadcast_handle.stop();
@@ -218,4 +224,5 @@ async fn route_change_continues_recording_and_broadcast_in_new_segments() {
             .all(|pair| pair[0] < pair[1])
     );
     assert!(playlist.text.contains("#EXT-X-ENDLIST\n"));
+    harness.close().await;
 }

--- a/tests/tests/kithara_hls/abr_switch_playback.rs
+++ b/tests/tests/kithara_hls/abr_switch_playback.rs
@@ -414,7 +414,8 @@ async fn packaged_abr_switch_keeps_player_continuity(temp_dir: TestTempDir) {
         HostConfig::offline(pools.clone())
             .sample_rate(NonZeroU32::new(CONTINUITY_SAMPLE_RATE).expect("sample rate is non-zero"))
             .build(),
-    );
+    )
+    .await;
     player.load_and_fadein(resource);
     let _warmup = render_offline_window(
         &mut player,
@@ -422,14 +423,16 @@ async fn packaged_abr_switch_keeps_player_continuity(temp_dir: TestTempDir) {
         "packaged abr warmup",
         CONTINUITY_BLOCK_FRAMES,
         CONTINUITY_SAMPLE_RATE,
-    );
+    )
+    .await;
     let seam = render_offline_window(
         &mut player,
         220,
         "packaged abr seam window",
         CONTINUITY_BLOCK_FRAMES,
         CONTINUITY_SAMPLE_RATE,
-    );
+    )
+    .await;
     assert!(
         seam.max_silence_run <= 2,
         "packaged ABR switch produced {} silent blocks ({seam})",
@@ -440,6 +443,7 @@ async fn packaged_abr_switch_keeps_player_continuity(temp_dir: TestTempDir) {
         "packaged ABR switch exceeded render budget {} times ({seam})",
         seam.slow_renders
     );
+    player.close().await;
 }
 
 /// Stream must continue producing chunks after seek sequence.

--- a/tests/tests/kithara_hls/abr_switch_playback.rs
+++ b/tests/tests/kithara_hls/abr_switch_playback.rs
@@ -416,7 +416,7 @@ async fn packaged_abr_switch_keeps_player_continuity(temp_dir: TestTempDir) {
             .build(),
     )
     .await;
-    player.load_and_fadein(resource);
+    player.load_and_fadein(resource).await;
     let _warmup = render_offline_window(
         &mut player,
         24,

--- a/tests/tests/kithara_play/cochlea_continuity_oracle.rs
+++ b/tests/tests/kithara_play/cochlea_continuity_oracle.rs
@@ -31,7 +31,7 @@ async fn render_no_switch_control() -> Vec<f32> {
     )
     .await;
     harness
-        .with_player(|player| {
+        .with_player(move |player| {
             player.insert(
                 resource_from_reader(TestPcmReader::with_value(spec, 3.0, 0.5)),
                 TrackId::allocate(),
@@ -46,7 +46,7 @@ async fn render_no_switch_control() -> Vec<f32> {
     let mut rendered = Vec::with_capacity(CAPTURE_FRAMES * usize::from(CHANNELS));
     while rendered.len() / usize::from(CHANNELS) < CAPTURE_FRAMES {
         rendered.extend(harness.render(BLOCK_FRAMES).await);
-        let _ = harness.tick_and_drain();
+        let _ = harness.tick_and_drain().await;
     }
     rendered.truncate(CAPTURE_FRAMES * usize::from(CHANNELS));
     harness.close().await;

--- a/tests/tests/kithara_play/cochlea_continuity_oracle.rs
+++ b/tests/tests/kithara_play/cochlea_continuity_oracle.rs
@@ -18,7 +18,7 @@ const PAUSE_FRAMES: usize = SAMPLE_RATE as usize * 3 / 50;
 const SEGMENT_WINDOW_MS: f64 = 20.0;
 const SAMPLE_SILENCE_THRESHOLD: f32 = 1.0e-4;
 
-fn render_no_switch_control() -> Vec<f32> {
+async fn render_no_switch_control() -> Vec<f32> {
     let spec = AudioSpec::new(
         CHANNELS,
         NonZeroU32::new(SAMPLE_RATE).expect("test sample rate is non-zero"),
@@ -28,24 +28,28 @@ fn render_no_switch_control() -> Vec<f32> {
             .crossfade_duration(0.0)
             .build(),
         SAMPLE_RATE,
-    );
-    harness.with_player(|player| {
-        player.insert(
-            resource_from_reader(TestPcmReader::with_value(spec, 3.0, 0.5)),
-            TrackId::allocate(),
-            None,
-        );
-        player
-            .select_item(0, true)
-            .expect("select no-switch control item");
-    });
+    )
+    .await;
+    harness
+        .with_player(|player| {
+            player.insert(
+                resource_from_reader(TestPcmReader::with_value(spec, 3.0, 0.5)),
+                TrackId::allocate(),
+                None,
+            );
+            player
+                .select_item(0, true)
+                .expect("select no-switch control item");
+        })
+        .await;
 
     let mut rendered = Vec::with_capacity(CAPTURE_FRAMES * usize::from(CHANNELS));
     while rendered.len() / usize::from(CHANNELS) < CAPTURE_FRAMES {
-        rendered.extend(harness.render(BLOCK_FRAMES));
+        rendered.extend(harness.render(BLOCK_FRAMES).await);
         let _ = harness.tick_and_drain();
     }
     rendered.truncate(CAPTURE_FRAMES * usize::from(CHANNELS));
+    harness.close().await;
     rendered
 }
 
@@ -103,9 +107,9 @@ fn cochlea_silent_segments(samples: &[f32], start_frame: usize, end_frame: usize
         .count()
 }
 
-#[kithara::test]
-fn cochlea_oracle_rejects_click_and_pause_in_rendered_no_switch_control() {
-    let control = render_no_switch_control();
+#[kithara::test(tokio)]
+async fn cochlea_oracle_rejects_click_and_pause_in_rendered_no_switch_control() {
+    let control = render_no_switch_control().await;
     let pause_end = SEAM_FRAME + PAUSE_FRAMES;
     let channels = usize::from(CHANNELS);
 

--- a/tests/tests/kithara_play/engine_cpal_tests.rs
+++ b/tests/tests/kithara_play/engine_cpal_tests.rs
@@ -1,6 +1,8 @@
 //! The lifecycle contract runs through the same Host graph with a cpal backend.
 //! A test-only dispatcher owns that graph so the production Host never exposes
 //! its resident engine or raw session.
+use std::num::NonZeroU32;
+
 use firewheel::{FirewheelCtx, cpal::CpalBackend};
 use kithara::{
     audio::ConsumerWakeMode,
@@ -63,6 +65,9 @@ impl Drop for CpalGraphSession {
 }
 
 impl SessionDispatcher<TestPools> for CpalGraphSession {
+    fn requested_sample_rate(&self) -> NonZeroU32 {
+        Shared::NON_ZERO_SAMPLE_RATE
+    }
     #[kithara::allow_block]
     fn exec(&self, cmd: Cmd<TestPools>) -> Result<Reply, PlayError> {
         let (reply_tx, reply_rx) = mpsc::channel();

--- a/tests/tests/kithara_play/engine_cpal_tests.rs
+++ b/tests/tests/kithara_play/engine_cpal_tests.rs
@@ -65,9 +65,6 @@ impl Drop for CpalGraphSession {
 }
 
 impl SessionDispatcher<TestPools> for CpalGraphSession {
-    fn requested_sample_rate(&self) -> NonZeroU32 {
-        Shared::NON_ZERO_SAMPLE_RATE
-    }
     #[kithara::allow_block]
     fn exec(&self, cmd: Cmd<TestPools>) -> Result<Reply, PlayError> {
         let (reply_tx, reply_rx) = mpsc::channel();
@@ -105,7 +102,7 @@ fn run_contract(max_slots: usize, contract: impl FnOnce(&EngineImpl<TestPools>))
             .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .max_slots(max_slots)
             .worker(PlayWorker::new(PlayWorkerConfig::builder(pools()).build()))
-            .session(session)
+            .session(SessionBinding::new(session, Shared::NON_ZERO_SAMPLE_RATE))
             .build(),
     );
     contract(player.engine());

--- a/tests/tests/kithara_play/engine_tests.rs
+++ b/tests/tests/kithara_play/engine_tests.rs
@@ -19,6 +19,9 @@ use crate::bufpool_ext::{TestPools, pools};
 struct FixtureSession;
 
 impl SessionDispatcher<TestPools> for FixtureSession {
+    fn requested_sample_rate(&self) -> NonZeroU32 {
+        Shared::NON_ZERO_SAMPLE_RATE
+    }
     fn exec(&self, _cmd: Cmd<TestPools>) -> Result<Reply, PlayError> {
         Ok(Reply::Ok)
     }

--- a/tests/tests/kithara_play/engine_tests.rs
+++ b/tests/tests/kithara_play/engine_tests.rs
@@ -8,7 +8,7 @@ use kithara::{
     platform::sync::Arc,
     play::{
         Cmd, EngineConfig, EngineImpl, PlayError, PlayWorker, PlayWorkerConfig, PlayerConfig,
-        PlayerImpl, Reply, SessionDispatcher, SessionDuckingMode, SlotId,
+        PlayerImpl, Reply, SessionBinding, SessionDispatcher, SessionDuckingMode, SlotId,
     },
     warp::{BeatGrid, BeatGridId},
 };
@@ -19,9 +19,6 @@ use crate::bufpool_ext::{TestPools, pools};
 struct FixtureSession;
 
 impl SessionDispatcher<TestPools> for FixtureSession {
-    fn requested_sample_rate(&self) -> NonZeroU32 {
-        Shared::NON_ZERO_SAMPLE_RATE
-    }
     fn exec(&self, _cmd: Cmd<TestPools>) -> Result<Reply, PlayError> {
         Ok(Reply::Ok)
     }
@@ -44,7 +41,10 @@ fn make_engine() -> EngineImpl<TestPools> {
         EngineConfig::builder()
             .sample_rate(Shared::NON_ZERO_SAMPLE_RATE)
             .grid_id(BeatGridId::allocate().expect("fixture grid id"))
-            .session(Arc::new(FixtureSession))
+            .session(SessionBinding::new(
+                Arc::new(FixtureSession),
+                Shared::NON_ZERO_SAMPLE_RATE,
+            ))
             .pools(pools())
             .response_budget_frames(response_budget())
             .build(),
@@ -90,7 +90,10 @@ fn engine_config_defaults() {
 fn engine_config_builder() {
     let config = EngineConfig::builder()
         .grid_id(BeatGridId::allocate().expect("fixture grid id"))
-        .session(Arc::new(FixtureSession))
+        .session(SessionBinding::new(
+            Arc::new(FixtureSession),
+            Shared::NON_ZERO_SAMPLE_RATE,
+        ))
         .max_slots(8)
         .sample_rate(NonZeroU32::new(48_000).expect("fixture sample rate is non-zero"))
         .channels(1)
@@ -150,7 +153,10 @@ fn engine_not_running_operations_return_error(#[case] scenario: NotRunningErrorS
 fn engine_master_sample_rate_returns_config_when_stopped() {
     let config = EngineConfig::builder()
         .grid_id(BeatGridId::allocate().expect("fixture grid id"))
-        .session(Arc::new(FixtureSession))
+        .session(SessionBinding::new(
+            Arc::new(FixtureSession),
+            Shared::NON_ZERO_SAMPLE_RATE,
+        ))
         .sample_rate(NonZeroU32::new(48_000).expect("fixture sample rate is non-zero"))
         .pools(pools())
         .response_budget_frames(response_budget())

--- a/tests/tests/kithara_play/flac_realtime_player_continuity.rs
+++ b/tests/tests/kithara_play/flac_realtime_player_continuity.rs
@@ -166,7 +166,7 @@ async fn run_case(
             .build(),
     )
     .await;
-    player.load_and_fadein(resource);
+    player.load_and_fadein(resource).await;
 
     let chan = CHANNELS as usize;
     let wall_budget_ms = num_traits::cast::<f64, u64>(PLAY_SECS * 1000.0 / 4.0).unwrap_or(u64::MAX)

--- a/tests/tests/kithara_play/flac_realtime_player_continuity.rs
+++ b/tests/tests/kithara_play/flac_realtime_player_continuity.rs
@@ -100,7 +100,7 @@ async fn render_into(
     let mut rendered = 0u32;
     while rendered < target_blocks {
         for _ in 0..BATCH {
-            out.extend_from_slice(&player.render(BLOCK_FRAMES));
+            out.extend_from_slice(&player.render(BLOCK_FRAMES).await);
             rendered += 1;
         }
         if Instant::now() >= deadline {
@@ -164,7 +164,8 @@ async fn run_case(
         HostConfig::offline(pools())
             .sample_rate(NonZeroU32::new(out_rate).expect("output rate is non-zero"))
             .build(),
-    );
+    )
+    .await;
     player.load_and_fadein(resource);
 
     let chan = CHANNELS as usize;
@@ -235,6 +236,7 @@ async fn run_case(
         "rendered FLAC playback has {} phase discontinuit(ies) (scenario={scenario:?} backend={backend:?} delay_ms={delay_ms:?}): {drifts:?}",
         drifts.len(),
     );
+    player.close().await;
 }
 
 /// Phase-continuity guard for the real player loop (`PlayerProcessor` /

--- a/tests/tests/kithara_play/gapless_offline_e2e.rs
+++ b/tests/tests/kithara_play/gapless_offline_e2e.rs
@@ -120,7 +120,7 @@ async fn single_track_silence_trim_strips_leading_priming(temp_dir: TestTempDir)
     .await;
 
     let resource = create_resource(
-        harness.player(),
+        &harness,
         &server,
         temp_dir.path(),
         Some(AAC_GAPLESS_ENCODER_DELAY),
@@ -182,7 +182,7 @@ async fn two_tracks_gapless_no_click_with_silence_trim_zero_crossfade(temp_dir: 
     .await;
 
     let first = create_resource(
-        harness.player(),
+        &harness,
         &server,
         temp_dir.path(),
         Some(AAC_GAPLESS_ENCODER_DELAY),
@@ -191,7 +191,7 @@ async fn two_tracks_gapless_no_click_with_silence_trim_zero_crossfade(temp_dir: 
     )
     .await;
     let second = create_resource(
-        harness.player(),
+        &harness,
         &server,
         temp_dir.path(),
         Some(AAC_GAPLESS_ENCODER_DELAY),
@@ -266,7 +266,7 @@ async fn two_tracks_gapless_stitch_continuity_metric(temp_dir: TestTempDir) {
     .await;
 
     let first = create_resource(
-        harness.player(),
+        &harness,
         &server,
         temp_dir.path(),
         Some(AAC_GAPLESS_ENCODER_DELAY),
@@ -275,7 +275,7 @@ async fn two_tracks_gapless_stitch_continuity_metric(temp_dir: TestTempDir) {
     )
     .await;
     let second = create_resource(
-        harness.player(),
+        &harness,
         &server,
         temp_dir.path(),
         Some(AAC_GAPLESS_ENCODER_DELAY),
@@ -384,7 +384,7 @@ async fn apple_fused_gapless_fixture_keeps_device_rate_seam_metric(temp_dir: Tes
     )
     .await;
     let probe = create_apple_fused_resource(
-        probe_harness.player(),
+        probe_harness,
         &server,
         temp_dir.path(),
         Some(AAC_GAPLESS_ENCODER_DELAY),
@@ -446,7 +446,7 @@ async fn render_apple_fused_deficit_seam(
     .await;
 
     let first = create_apple_fused_resource(
-        harness.player(),
+        harness,
         server,
         cache_dir,
         Some(AAC_GAPLESS_ENCODER_DELAY),
@@ -455,7 +455,7 @@ async fn render_apple_fused_deficit_seam(
     )
     .await;
     let second = create_apple_fused_resource(
-        harness.player(),
+        harness,
         server,
         cache_dir,
         Some(AAC_GAPLESS_ENCODER_DELAY),
@@ -519,7 +519,7 @@ async fn disabled_gapless_mode_keeps_full_decoded_length(temp_dir: TestTempDir) 
     .await;
 
     let resource = create_resource(
-        harness.player(),
+        &harness,
         &server,
         temp_dir.path(),
         Some(AAC_GAPLESS_ENCODER_DELAY),
@@ -569,7 +569,7 @@ async fn single_track_silence_trim_heuristic_strips_leading_when_no_gapless_meta
     .await;
 
     let resource = create_resource_with_encoding(
-        harness.player(),
+        &harness,
         &server,
         temp_dir.path(),
         Some(AAC_GAPLESS_ENCODER_DELAY),
@@ -611,7 +611,7 @@ async fn two_tracks_silence_trim_heuristic_no_click_when_no_gapless_metadata(
     let visible = expected_visible_frames(AAC_GAPLESS_ENCODER_DELAY, AAC_GAPLESS_TRAILING_DELAY);
 
     let first = create_resource_with_encoding(
-        harness.player(),
+        &harness,
         &server,
         temp_dir.path(),
         Some(AAC_GAPLESS_ENCODER_DELAY),
@@ -621,7 +621,7 @@ async fn two_tracks_silence_trim_heuristic_no_click_when_no_gapless_metadata(
     )
     .await;
     let second = create_resource_with_encoding(
-        harness.player(),
+        &harness,
         &server,
         temp_dir.path(),
         Some(AAC_GAPLESS_ENCODER_DELAY),
@@ -702,7 +702,7 @@ async fn single_track_silence_trim_heuristic_fade_out_smooths_trailing_edge(temp
     .await;
 
     let resource = create_resource_with_encoding(
-        harness.player(),
+        &harness,
         &server,
         temp_dir.path(),
         Some(AAC_GAPLESS_ENCODER_DELAY),
@@ -755,7 +755,7 @@ async fn single_track_silence_trim_heuristic_fade_out_smooths_trailing_edge(temp
 }
 
 async fn create_resource(
-    player: &kithara::play::player::PlayerControl<TestPools>,
+    harness: &OfflinePlayerHarness,
     server: &TestServerHelper,
     cache_dir: &std::path::Path,
     encoder_delay: Option<u32>,
@@ -763,7 +763,7 @@ async fn create_resource(
     start_frame: u64,
 ) -> Resource {
     create_resource_with_encoding(
-        player,
+        harness,
         server,
         cache_dir,
         encoder_delay,
@@ -779,7 +779,7 @@ async fn create_resource(
     reason = "fixture builder: each parameter pins one HLS-fixture knob"
 )]
 async fn create_resource_with_encoding(
-    player: &kithara::play::player::PlayerControl<TestPools>,
+    harness: &OfflinePlayerHarness,
     server: &TestServerHelper,
     cache_dir: &std::path::Path,
     encoder_delay: Option<u32>,
@@ -818,8 +818,9 @@ async fn create_resource_with_encoding(
     )
     .store(store)
     .build();
-    config = player
-        .prepare_config(config)
+    config = harness
+        .with_player(move |player| player.prepare_config(config))
+        .await
         .expect("prepare gapless e2e HLS resource config");
     let mut resource = Resource::new(config)
         .await
@@ -837,7 +838,7 @@ async fn create_resource_with_encoding(
     reason = "fixture builder: each parameter pins one HLS-fixture knob"
 )]
 async fn create_apple_fused_resource(
-    player: &kithara::play::player::PlayerControl<TestPools>,
+    harness: &OfflinePlayerHarness,
     server: &TestServerHelper,
     cache_dir: &std::path::Path,
     encoder_delay: Option<u32>,
@@ -888,8 +889,9 @@ async fn create_apple_fused_resource(
             .build(),
     )
     .build();
-    let config = player
-        .prepare_config(config)
+    let config = harness
+        .with_player(move |player| player.prepare_config(config))
+        .await
         .expect("prepare Apple fused HLS resource config");
     let mut resource = Resource::new(config)
         .await
@@ -1028,7 +1030,7 @@ async fn load_tagged_queue<const N: usize>(
 ) -> [TrackId; N] {
     let ids = [(); N].map(|()| TrackId::allocate());
     harness
-        .with_player(|player| {
+        .with_player(move |player| {
             player.reserve_slots(items.len());
             for (index, (resource, id)) in items.into_iter().zip(ids.iter().copied()).enumerate() {
                 player
@@ -1260,6 +1262,7 @@ async fn render_until_item_end_with_post_roll(
         events.extend(
             harness
                 .tick_and_drain()
+                .await
                 .into_iter()
                 .map(|event| TimedPlayerEvent::new(rendered_frames, event)),
         );
@@ -1277,6 +1280,7 @@ async fn render_until_item_end_with_post_roll(
                 events.extend(
                     harness
                         .tick_and_drain()
+                        .await
                         .into_iter()
                         .map(|event| TimedPlayerEvent::new(rendered_frames, event)),
                 );

--- a/tests/tests/kithara_play/gapless_offline_e2e.rs
+++ b/tests/tests/kithara_play/gapless_offline_e2e.rs
@@ -116,7 +116,8 @@ async fn single_track_silence_trim_strips_leading_priming(temp_dir: TestTempDir)
             .gapless_mode(silence_trim_with_trailing())
             .build(),
         GAPLESS_SAMPLE_RATE,
-    );
+    )
+    .await;
 
     let resource = create_resource(
         harness.player(),
@@ -128,7 +129,7 @@ async fn single_track_silence_trim_strips_leading_priming(temp_dir: TestTempDir)
     )
     .await;
 
-    let [single] = load_tagged_queue(&harness, [resource]);
+    let [single] = load_tagged_queue(&harness, [resource]).await;
 
     let (rendered, events) = render_until_item_end(&harness, single).await;
     let left = deinterleave_left(&rendered, usize::from(GAPLESS_CHANNELS));
@@ -157,6 +158,7 @@ async fn single_track_silence_trim_strips_leading_priming(temp_dir: TestTempDir)
         "head RMS too low — leading priming likely not trimmed: head_rms={head_rms:.4}, \
          events={events:?}"
     );
+    harness.close().await;
 }
 
 #[kithara::test(
@@ -176,7 +178,8 @@ async fn two_tracks_gapless_no_click_with_silence_trim_zero_crossfade(temp_dir: 
             .gapless_mode(silence_trim_with_trailing())
             .build(),
         GAPLESS_SAMPLE_RATE,
-    );
+    )
+    .await;
 
     let first = create_resource(
         harness.player(),
@@ -197,7 +200,7 @@ async fn two_tracks_gapless_no_click_with_silence_trim_zero_crossfade(temp_dir: 
     )
     .await;
 
-    let [first_id, second_id] = load_tagged_queue(&harness, [first, second]);
+    let [first_id, second_id] = load_tagged_queue(&harness, [first, second]).await;
 
     let (rendered, events) = render_until_item_end(&harness, second_id).await;
     let left = deinterleave_left(&rendered, usize::from(GAPLESS_CHANNELS));
@@ -245,6 +248,7 @@ async fn two_tracks_gapless_no_click_with_silence_trim_zero_crossfade(temp_dir: 
              item1_end={item1_end}, events={events:?}"
         );
     }
+    harness.close().await;
 }
 
 #[kithara::test(native, tokio, timeout(Duration::from_secs(30)), hang_timeout_secs(1))]
@@ -258,7 +262,8 @@ async fn two_tracks_gapless_stitch_continuity_metric(temp_dir: TestTempDir) {
             .gapless_mode(silence_trim_with_trailing())
             .build(),
         GAPLESS_SAMPLE_RATE,
-    );
+    )
+    .await;
 
     let first = create_resource(
         harness.player(),
@@ -279,7 +284,7 @@ async fn two_tracks_gapless_stitch_continuity_metric(temp_dir: TestTempDir) {
     )
     .await;
 
-    let [first_id, second_id] = load_tagged_queue(&harness, [first, second]);
+    let [first_id, second_id] = load_tagged_queue(&harness, [first, second]).await;
 
     let (rendered, events) = render_until_item_end(&harness, second_id).await;
     let left = deinterleave_left(&rendered, usize::from(GAPLESS_CHANNELS));
@@ -306,6 +311,7 @@ async fn two_tracks_gapless_stitch_continuity_metric(temp_dir: TestTempDir) {
         ratio < ContinuityMetric::MAX_RATIO,
         "gapless stitch discontinuity {switch_peak:.6} is {ratio:.1}x the worst same-track control window {control_peak:.6}",
     );
+    harness.close().await;
 }
 
 #[kithara::test(native, tokio, timeout(Duration::from_secs(30)), hang_timeout_secs(1))]
@@ -375,7 +381,8 @@ async fn apple_fused_gapless_fixture_keeps_device_rate_seam_metric(temp_dir: Tes
             .gapless_mode(silence_trim_with_trailing())
             .build(),
         FUSED_FIXTURE_DEVICE_RATE,
-    );
+    )
+    .await;
     let probe = create_apple_fused_resource(
         probe_harness.player(),
         &server,
@@ -391,6 +398,7 @@ async fn apple_fused_gapless_fixture_keeps_device_rate_seam_metric(temp_dir: Tes
         "visible length must be the scaled ratio rounded either way: got {}, expected {floor_frames} or {ceil_frames}",
         probe.output_frames
     );
+    probe_harness.close().await;
 
     let pending_decision =
         render_apple_fused_deficit_seam(&server, temp_dir.path(), probe.output_frames).await;
@@ -434,7 +442,8 @@ async fn render_apple_fused_deficit_seam(
             .gapless_mode(silence_trim_with_trailing())
             .build(),
         FUSED_FIXTURE_DEVICE_RATE,
-    );
+    )
+    .await;
 
     let first = create_apple_fused_resource(
         harness.player(),
@@ -455,7 +464,7 @@ async fn render_apple_fused_deficit_seam(
     )
     .await;
 
-    let [first_id, _second_id] = load_tagged_queue(&harness, [first, second]);
+    let [first_id, _second_id] = load_tagged_queue(&harness, [first, second]).await;
 
     let control_post_roll_blocks =
         (ContinuityMetric::CONTROL_STRIDE_FRAMES / BLOCK_FRAMES) + POST_ROLL_BLOCKS;
@@ -485,13 +494,15 @@ async fn render_apple_fused_deficit_seam(
         "Apple fused seam metric needs at least {} same-track control windows, got {control_count}",
         ContinuityMetric::MIN_CONTROL_WINDOWS
     );
-    AppleFusedSeamRender {
+    let result = AppleFusedSeamRender {
         control_db,
         head_db: seam_step_db(&left, stitch_frame.saturating_add(1)),
         nearby_db: nearby_seam_step_db(&left, stitch_frame),
         seam_db,
         stitch_frame,
-    }
+    };
+    harness.close().await;
+    result
 }
 
 #[kithara::test(native, tokio, timeout(Duration::from_secs(30)), hang_timeout_secs(1))]
@@ -504,7 +515,8 @@ async fn disabled_gapless_mode_keeps_full_decoded_length(temp_dir: TestTempDir) 
             .gapless_mode(GaplessMode::Disabled)
             .build(),
         GAPLESS_SAMPLE_RATE,
-    );
+    )
+    .await;
 
     let resource = create_resource(
         harness.player(),
@@ -516,7 +528,7 @@ async fn disabled_gapless_mode_keeps_full_decoded_length(temp_dir: TestTempDir) 
     )
     .await;
 
-    let [only] = load_tagged_queue(&harness, [resource]);
+    let [only] = load_tagged_queue(&harness, [resource]).await;
 
     let (rendered, events) = render_until_item_end(&harness, only).await;
     let left = deinterleave_left(&rendered, usize::from(GAPLESS_CHANNELS));
@@ -538,6 +550,7 @@ async fn disabled_gapless_mode_keeps_full_decoded_length(temp_dir: TestTempDir) 
         "Disabled mode must pass through full decoded PCM (no leading/trailing trim)",
         &events,
     );
+    harness.close().await;
 }
 
 #[kithara::test(native, tokio, timeout(Duration::from_secs(30)), hang_timeout_secs(1))]
@@ -552,7 +565,8 @@ async fn single_track_silence_trim_heuristic_strips_leading_when_no_gapless_meta
             .gapless_mode(silence_trim_with_trailing())
             .build(),
         GAPLESS_SAMPLE_RATE,
-    );
+    )
+    .await;
 
     let resource = create_resource_with_encoding(
         harness.player(),
@@ -565,7 +579,7 @@ async fn single_track_silence_trim_heuristic_strips_leading_when_no_gapless_meta
     )
     .await;
 
-    let [only] = load_tagged_queue(&harness, [resource]);
+    let [only] = load_tagged_queue(&harness, [resource]).await;
 
     let (rendered, events) = render_until_item_end(&harness, only).await;
     let left = deinterleave_left(&rendered, usize::from(GAPLESS_CHANNELS));
@@ -576,6 +590,7 @@ async fn single_track_silence_trim_heuristic_strips_leading_when_no_gapless_meta
         "head RMS too low — heuristic SilenceTrim did not strip leading silence: \
          head_rms={head_rms:.4}, events={events:?}"
     );
+    harness.close().await;
 }
 
 #[kithara::test(native, tokio, timeout(Duration::from_secs(30)), hang_timeout_secs(1))]
@@ -590,7 +605,8 @@ async fn two_tracks_silence_trim_heuristic_no_click_when_no_gapless_metadata(
             .gapless_mode(silence_trim_with_trailing())
             .build(),
         GAPLESS_SAMPLE_RATE,
-    );
+    )
+    .await;
 
     let visible = expected_visible_frames(AAC_GAPLESS_ENCODER_DELAY, AAC_GAPLESS_TRAILING_DELAY);
 
@@ -615,7 +631,7 @@ async fn two_tracks_silence_trim_heuristic_no_click_when_no_gapless_metadata(
     )
     .await;
 
-    let [first_id, second_id] = load_tagged_queue(&harness, [first, second]);
+    let [first_id, second_id] = load_tagged_queue(&harness, [first, second]).await;
 
     let (rendered, events) = render_until_item_end(&harness, second_id).await;
     let left = deinterleave_left(&rendered, usize::from(GAPLESS_CHANNELS));
@@ -669,6 +685,7 @@ async fn two_tracks_silence_trim_heuristic_no_click_when_no_gapless_metadata(
              events={events:?}"
         );
     }
+    harness.close().await;
 }
 
 #[kithara::test(native, tokio, timeout(Duration::from_secs(30)), hang_timeout_secs(1))]
@@ -681,7 +698,8 @@ async fn single_track_silence_trim_heuristic_fade_out_smooths_trailing_edge(temp
             .gapless_mode(silence_trim_with_trailing())
             .build(),
         GAPLESS_SAMPLE_RATE,
-    );
+    )
+    .await;
 
     let resource = create_resource_with_encoding(
         harness.player(),
@@ -693,7 +711,7 @@ async fn single_track_silence_trim_heuristic_fade_out_smooths_trailing_edge(temp
         GaplessEncoding::None,
     )
     .await;
-    let [only] = load_tagged_queue(&harness, [resource]);
+    let [only] = load_tagged_queue(&harness, [resource]).await;
 
     let (rendered, events) = render_until_item_end(&harness, only).await;
     let left = deinterleave_left(&rendered, usize::from(GAPLESS_CHANNELS));
@@ -733,6 +751,7 @@ async fn single_track_silence_trim_heuristic_fade_out_smooths_trailing_edge(temp
          tail_peak={tail_peak:.4}, body_peak={body_peak:.4}, ratio={:.2}",
         tail_peak / body_peak.max(f32::MIN_POSITIVE),
     );
+    harness.close().await;
 }
 
 async fn create_resource(
@@ -902,7 +921,8 @@ async fn render_synthetic_fused_deficit_seam(tail_compensation: bool) -> Synthet
             .gapless_mode(GaplessMode::Disabled)
             .build(),
         FUSED_FIXTURE_DEVICE_RATE,
-    );
+    )
+    .await;
     harness.set_host_level(FUSED_FIXTURE_MASTER_LEVEL);
     let first_frames = synthetic_tail_trimmed_first_frames(tail_compensation);
     let first_frame_count = first_frames.len();
@@ -918,7 +938,7 @@ async fn render_synthetic_fused_deficit_seam(tail_compensation: bool) -> Synthet
         Some(Arc::from("fused-deficit-2")),
     );
 
-    let [first_id, second_id] = load_tagged_queue(&harness, [first, second]);
+    let [first_id, second_id] = load_tagged_queue(&harness, [first, second]).await;
 
     let (rendered, events) = render_until_item_end(&harness, second_id).await;
     let left = deinterleave_left(&rendered, usize::from(GAPLESS_CHANNELS));
@@ -927,12 +947,14 @@ async fn render_synthetic_fused_deficit_seam(tail_compensation: bool) -> Synthet
         (peak - FUSED_FIXTURE_MASTER_LEVEL).abs() <= 1.0e-3,
         "fused seam fixture must preserve its explicit headroom; peak={peak}"
     );
-    SyntheticSeamRender {
+    let result = SyntheticSeamRender {
         left,
         events,
         first_frames: first_frame_count,
         first_id,
-    }
+    };
+    harness.close().await;
+    result
 }
 
 fn synthetic_tail_trimmed_first_frames(tail_compensation: bool) -> Vec<f32> {
@@ -1000,22 +1022,24 @@ fn left_frames_from_chunks(chunks: impl IntoIterator<Item = AudioChunk>) -> Vec<
 
 /// Loads the queue and returns the identity the player will report back
 /// for each item, in the order they were given.
-fn load_tagged_queue<const N: usize>(
+async fn load_tagged_queue<const N: usize>(
     harness: &OfflinePlayerHarness,
     items: [Resource; N],
 ) -> [TrackId; N] {
     let ids = [(); N].map(|()| TrackId::allocate());
-    harness.with_player(|player| {
-        player.reserve_slots(items.len());
-        for (index, (resource, id)) in items.into_iter().zip(ids.iter().copied()).enumerate() {
+    harness
+        .with_player(|player| {
+            player.reserve_slots(items.len());
+            for (index, (resource, id)) in items.into_iter().zip(ids.iter().copied()).enumerate() {
+                player
+                    .replace_item(index, resource, id)
+                    .expect("replace gapless fixture item");
+            }
             player
-                .replace_item(index, resource, id)
-                .expect("replace gapless fixture item");
-        }
-        player
-            .select_item(0, true)
-            .expect("select first queue item");
-    });
+                .select_item(0, true)
+                .expect("select first queue item");
+        })
+        .await;
     ids
 }
 
@@ -1230,7 +1254,7 @@ async fn render_until_item_end_with_post_roll(
     let mut events = Vec::new();
 
     loop {
-        let block = harness.render(BLOCK_FRAMES);
+        let block = harness.render(BLOCK_FRAMES).await;
         rendered.extend_from_slice(&block);
         rendered_frames = rendered_frames.saturating_add(BLOCK_FRAMES);
         events.extend(
@@ -1247,7 +1271,7 @@ async fn render_until_item_end_with_post_roll(
             )
         }) {
             for _ in 0..post_roll_blocks {
-                let block = harness.render(BLOCK_FRAMES);
+                let block = harness.render(BLOCK_FRAMES).await;
                 rendered.extend_from_slice(&block);
                 rendered_frames = rendered_frames.saturating_add(BLOCK_FRAMES);
                 events.extend(

--- a/tests/tests/kithara_play/gapless_startup_regressions.rs
+++ b/tests/tests/kithara_play/gapless_startup_regressions.rs
@@ -6,7 +6,7 @@ use kithara::{
     decode::{GaplessMode, SilenceTrimParams},
     events::TrackId,
     platform::time::{Duration, Instant},
-    play::{Resource, ResourceConfig, ResourceSrc},
+    play::{Resource, ResourceConfig, ResourceSrc, player::PlayerControl},
     stream::AudioCodec,
 };
 use kithara_integration_tests::{
@@ -50,23 +50,22 @@ async fn gapless_modes_do_not_block_network_startup_until_full_cache(
         GAPLESS_SAMPLE_RATE,
     )
     .await;
-    let resource =
-        create_delayed_gapless_hls_resource(harness.player(), &server, temp_dir.path()).await;
+    let resource = create_delayed_gapless_hls_resource(&harness, &server, temp_dir.path()).await;
 
     harness
-        .with_player(|player| player.insert(resource, TrackId::allocate(), None))
+        .with_player(move |player| player.insert(resource, TrackId::allocate(), None))
         .await;
 
     let started_at = Instant::now();
-    harness.player().play();
-    let _ = harness.tick_and_drain();
+    harness.with_player(PlayerControl::play).await;
+    let _ = harness.tick_and_drain().await;
 
     let deadline = started_at + STARTUP_TIMEOUT;
     let mut rendered = Vec::new();
 
     loop {
         let block = harness.render(BLOCK_FRAMES).await;
-        let _ = harness.tick_and_drain();
+        let _ = harness.tick_and_drain().await;
         rendered.extend_from_slice(&block);
 
         let position = harness.player().position_seconds().unwrap_or(0.0);
@@ -96,7 +95,7 @@ async fn gapless_modes_do_not_block_network_startup_until_full_cache(
 }
 
 async fn create_delayed_gapless_hls_resource(
-    player: &kithara::play::player::PlayerControl<TestPools>,
+    harness: &OfflinePlayerHarness,
     server: &TestServerHelper,
     cache_dir: &Path,
 ) -> Resource {
@@ -135,8 +134,9 @@ async fn create_delayed_gapless_hls_resource(
     )
     .store(store)
     .build();
-    config = player
-        .prepare_config(config)
+    config = harness
+        .with_player(move |player| player.prepare_config(config))
+        .await
         .expect("prepare delayed gapless HLS resource config");
 
     Resource::new(config)

--- a/tests/tests/kithara_play/gapless_startup_regressions.rs
+++ b/tests/tests/kithara_play/gapless_startup_regressions.rs
@@ -48,11 +48,14 @@ async fn gapless_modes_do_not_block_network_startup_until_full_cache(
             .gapless_mode(gapless_mode)
             .build(),
         GAPLESS_SAMPLE_RATE,
-    );
+    )
+    .await;
     let resource =
         create_delayed_gapless_hls_resource(harness.player(), &server, temp_dir.path()).await;
 
-    harness.with_player(|player| player.insert(resource, TrackId::allocate(), None));
+    harness
+        .with_player(|player| player.insert(resource, TrackId::allocate(), None))
+        .await;
 
     let started_at = Instant::now();
     harness.player().play();
@@ -62,7 +65,7 @@ async fn gapless_modes_do_not_block_network_startup_until_full_cache(
     let mut rendered = Vec::new();
 
     loop {
-        let block = harness.render(BLOCK_FRAMES);
+        let block = harness.render(BLOCK_FRAMES).await;
         let _ = harness.tick_and_drain();
         rendered.extend_from_slice(&block);
 
@@ -76,8 +79,9 @@ async fn gapless_modes_do_not_block_network_startup_until_full_cache(
             assert!(
                 elapsed < Duration::from_millis(DELAY_MS),
                 "gapless mode {gapless_mode:?} must start before delayed tail segments \
-                 could fully cache; elapsed={elapsed:?}, position={position:.3}s"
+                could fully cache; elapsed={elapsed:?}, position={position:.3}s"
             );
+            harness.close().await;
             return;
         }
 

--- a/tests/tests/kithara_play/hls_seek_middle_no_queue.rs
+++ b/tests/tests/kithara_play/hls_seek_middle_no_queue.rs
@@ -93,7 +93,7 @@ async fn render_until_position(player: &mut OfflinePlayer, min_blocks: u32, unti
     loop {
         let this = min_blocks.saturating_sub(rendered).clamp(1, BATCH);
         for _ in 0..this {
-            let _ = player.render(Consts::BLOCK_FRAMES);
+            let _ = player.render(Consts::BLOCK_FRAMES).await;
         }
         rendered = rendered.saturating_add(this);
         if player.position() >= until_position && rendered >= min_blocks {
@@ -125,7 +125,7 @@ async fn render_until_gate_requested(
         if gate.requested() > 0 {
             for _ in 0..hold_ticks {
                 for _ in 0..BATCH {
-                    let _ = player.render(Consts::BLOCK_FRAMES);
+                    let _ = player.render(Consts::BLOCK_FRAMES).await;
                 }
                 let held_position = player.position();
                 assert!(
@@ -223,7 +223,8 @@ async fn hls_seek_middle_lands_under_simulated_slow_connection(#[case] scenario:
         HostConfig::offline(pools())
             .sample_rate(NonZeroU32::new(Consts::SAMPLE_RATE).expect("sample rate is non-zero"))
             .build(),
-    );
+    )
+    .await;
     player.load_and_fadein(resource);
 
     let warmup_target = player.position() + Consts::PRE_SEEK_RENDER_SECS;
@@ -280,7 +281,7 @@ async fn hls_seek_middle_lands_under_simulated_slow_connection(#[case] scenario:
         Consts::MIN_POSITION_ADVANCE_POST_SEEK_SECS,
     );
 
-    drop(player);
+    player.close().await;
     drop(downloader);
     drop(temp);
 }

--- a/tests/tests/kithara_play/hls_seek_middle_no_queue.rs
+++ b/tests/tests/kithara_play/hls_seek_middle_no_queue.rs
@@ -225,7 +225,7 @@ async fn hls_seek_middle_lands_under_simulated_slow_connection(#[case] scenario:
             .build(),
     )
     .await;
-    player.load_and_fadein(resource);
+    player.load_and_fadein(resource).await;
 
     let warmup_target = player.position() + Consts::PRE_SEEK_RENDER_SECS;
     render_until_position(

--- a/tests/tests/kithara_play/hls_seek_middle_stress.rs
+++ b/tests/tests/kithara_play/hls_seek_middle_stress.rs
@@ -96,7 +96,8 @@ async fn hls_seek_middle_repeated_seeks_stress(
         HostConfig::offline(pools())
             .sample_rate(NonZeroU32::new(Consts::SAMPLE_RATE).expect("sample rate is non-zero"))
             .build(),
-    );
+    )
+    .await;
     player.load_and_fadein(resource);
 
     let warmup_target = player.position() + Consts::PRE_SEEK_RENDER_SECS;
@@ -139,7 +140,7 @@ async fn hls_seek_middle_repeated_seeks_stress(
         }
     }
 
-    drop(player);
+    player.close().await;
     drop(downloader);
     drop(temp);
 

--- a/tests/tests/kithara_play/hls_seek_middle_stress.rs
+++ b/tests/tests/kithara_play/hls_seek_middle_stress.rs
@@ -98,7 +98,7 @@ async fn hls_seek_middle_repeated_seeks_stress(
             .build(),
     )
     .await;
-    player.load_and_fadein(resource);
+    player.load_and_fadein(resource).await;
 
     let warmup_target = player.position() + Consts::PRE_SEEK_RENDER_SECS;
     render_until_position(

--- a/tests/tests/kithara_play/hls_seek_middle_stress_long.rs
+++ b/tests/tests/kithara_play/hls_seek_middle_stress_long.rs
@@ -26,7 +26,7 @@ use kithara::{
 };
 use kithara_integration_tests::{
     HlsFixtureBuilder, PackagedTestServer, SegmentGateHandle, TestServerHelper, Xorshift64,
-    offline::{OfflinePlayer, OfflineQueue, drive_queue_ticks},
+    offline::{OfflinePlayer, OfflineQueue, QueueTicker},
     temp_dir,
     waits::{
         render_until_position as raw_render_until_position, wait_for_loader_done_event,
@@ -450,10 +450,7 @@ async fn hls_rate_seek_stress_keeps_playback_live(#[case] backend: DecoderBacken
     )
     .await
     .expect("create product offline queue");
-    let tick_handle = task::spawn(drive_queue_ticks(
-        queue.control(),
-        Duration::from_millis(50),
-    ));
+    let mut tick_handle = QueueTicker::spawn(queue.control(), Duration::from_millis(50));
 
     let hls_config = ResourceConfig::for_src(
         ResourceSrc::parse(master.as_str()).expect("valid packaged HLS URL"),
@@ -579,8 +576,7 @@ async fn hls_rate_seek_stress_keeps_playback_live(#[case] backend: DecoderBacken
     );
 
     shutdown.cancel();
-    tick_handle.abort();
-    let _tick_result = tick_handle.await;
+    tick_handle.stop().await;
     queue.close().await;
     drop(downloader);
     drop(temp);

--- a/tests/tests/kithara_play/hls_seek_middle_stress_long.rs
+++ b/tests/tests/kithara_play/hls_seek_middle_stress_long.rs
@@ -227,12 +227,12 @@ async fn wait_for_gate_request(player: &mut OfflinePlayer, gate: &SegmentGateHan
     const BATCH: u32 = 16;
     for _ in 0..Consts::GATE_REQUEST_TICKS {
         for _ in 0..BATCH {
-            let _ = player.render(Consts::BLOCK_FRAMES);
+            let _ = player.render(Consts::BLOCK_FRAMES).await;
         }
         if gate.requested() > 0 {
             for _ in 0..Consts::GATE_HOLD_TICKS {
                 for _ in 0..BATCH {
-                    let _ = player.render(Consts::BLOCK_FRAMES);
+                    let _ = player.render(Consts::BLOCK_FRAMES).await;
                 }
                 sleep(Duration::from_millis(1)).await;
             }
@@ -300,7 +300,8 @@ async fn hls_seek_middle_repeated_seeks_long_stress(#[case] backend: DecoderBack
         HostConfig::offline(pools())
             .sample_rate(NonZeroU32::new(Consts::SAMPLE_RATE).expect("sample rate is non-zero"))
             .build(),
-    );
+    )
+    .await;
     player.load_and_fadein(resource);
 
     let warmup_target = player.position() + Consts::PRE_SEEK_RENDER_SECS;
@@ -353,7 +354,7 @@ async fn hls_seek_middle_repeated_seeks_long_stress(#[case] backend: DecoderBack
         }
     }
 
-    drop(player);
+    player.close().await;
     drop(downloader);
     drop(temp);
 
@@ -447,6 +448,7 @@ async fn hls_rate_seek_stress_keeps_playback_live(#[case] backend: DecoderBacken
                 .build(),
         ),
     )
+    .await
     .expect("create product offline queue");
     let tick_handle = task::spawn(drive_queue_ticks(
         queue.control(),
@@ -579,7 +581,7 @@ async fn hls_rate_seek_stress_keeps_playback_live(#[case] backend: DecoderBacken
     shutdown.cancel();
     tick_handle.abort();
     let _tick_result = tick_handle.await;
-    drop(queue);
+    queue.close().await;
     drop(downloader);
     drop(temp);
 }

--- a/tests/tests/kithara_play/hls_seek_middle_stress_long.rs
+++ b/tests/tests/kithara_play/hls_seek_middle_stress_long.rs
@@ -302,7 +302,7 @@ async fn hls_seek_middle_repeated_seeks_long_stress(#[case] backend: DecoderBack
             .build(),
     )
     .await;
-    player.load_and_fadein(resource);
+    player.load_and_fadein(resource).await;
 
     let warmup_target = player.position() + Consts::PRE_SEEK_RENDER_SECS;
     render_until_position(
@@ -468,15 +468,17 @@ async fn hls_rate_seek_stress_keeps_playback_live(#[case] backend: DecoderBacken
 
     let mut rx = queue.subscribe();
     let hls_id = queue
-        .append(TrackSource::Config(Box::new(hls_config)))
+        .run(move |q| q.append(TrackSource::Config(Box::new(hls_config))))
+        .await
         .expect("append packaged HLS track");
     wait_for_loader_done_event(&mut rx, &queue, hls_id, Duration::from_secs(20))
         .await
         .expect("packaged HLS track must load");
     queue
-        .select(hls_id, Transition::None)
+        .run(move |q| q.select(hls_id, Transition::None))
+        .await
         .expect("loaded HLS track must select");
-    queue.play();
+    queue.run(move |q| q.play()).await;
 
     let _ = wait_for_position_event(&mut rx, &queue, 0.75, Duration::from_secs(15))
         .await

--- a/tests/tests/kithara_play/hls_seek_past_end_terminates.rs
+++ b/tests/tests/kithara_play/hls_seek_past_end_terminates.rs
@@ -47,7 +47,7 @@ async fn render_burst(player: &mut OfflinePlayer, blocks: u32) {
     while remaining > 0 {
         let this = remaining.min(BATCH);
         for _ in 0..this {
-            let _ = player.render(Consts::BLOCK_FRAMES);
+            let _ = player.render(Consts::BLOCK_FRAMES).await;
         }
         remaining -= this;
         sleep(Duration::from_millis(1)).await;
@@ -86,7 +86,8 @@ async fn hls_seek_past_end_terminates_in_bounded_time() {
         HostConfig::offline(pools())
             .sample_rate(NonZeroU32::new(Consts::SAMPLE_RATE).expect("sample rate is non-zero"))
             .build(),
-    );
+    )
+    .await;
     player.load_and_fadein(resource);
 
     // Warm-up is state-driven, not a fixed-size burst: the render races the
@@ -136,7 +137,7 @@ async fn hls_seek_past_end_terminates_in_bounded_time() {
         wall_secs = Consts::POST_SEEK_RENDER_SECS,
     );
 
-    drop(player);
+    player.close().await;
     drop(downloader);
     drop(temp);
 }

--- a/tests/tests/kithara_play/hls_seek_past_end_terminates.rs
+++ b/tests/tests/kithara_play/hls_seek_past_end_terminates.rs
@@ -88,7 +88,7 @@ async fn hls_seek_past_end_terminates_in_bounded_time() {
             .build(),
     )
     .await;
-    player.load_and_fadein(resource);
+    player.load_and_fadein(resource).await;
 
     // Warm-up is state-driven, not a fixed-size burst: the render races the
     // REAL network + decode pipeline, and under flash the burst's virtual

--- a/tests/tests/kithara_play/local_seek_hang_iters.rs
+++ b/tests/tests/kithara_play/local_seek_hang_iters.rs
@@ -92,7 +92,7 @@ async fn render_and_collect(
         // frames for it; a silent block is an underrun, so we let virtual time
         // advance and re-pull rather than counting ring-empty silence.
         let out = loop {
-            let out = player.render(Consts::BLOCK_FRAMES);
+            let out = player.render(Consts::BLOCK_FRAMES).await;
             // Drain progress/lifecycle events so the bounded bus cannot lag and
             // so polling them rides the virtual clock alongside the sleep below.
             drain_events(events);
@@ -161,7 +161,7 @@ async fn render_until_audio(
     let min_position_ms = Duration::from_secs_f64(min_position_secs).as_millis();
 
     loop {
-        let _ = player.render(Consts::BLOCK_FRAMES);
+        let _ = player.render(Consts::BLOCK_FRAMES).await;
 
         let mut advanced = false;
         loop {
@@ -279,7 +279,8 @@ async fn local_seek_middle_hang_iters(#[case] backend: DecoderBackend, #[case] a
             HostConfig::offline(pools())
                 .sample_rate(NonZeroU32::new(Consts::SAMPLE_RATE).expect("sample rate is non-zero"))
                 .build(),
-        );
+        )
+        .await;
         let mut iteration_samples: Vec<f32> = Vec::new();
 
         let resource = build_resource(&master, &downloader, &iter_label, store, backend, abr).await;
@@ -393,7 +394,7 @@ async fn local_seek_middle_hang_iters(#[case] backend: DecoderBackend, #[case] a
             Consts::MIN_WINDOW_RMS,
         );
 
-        drop(player);
+        player.close().await;
         drop(downloader);
         drop(temp);
     }

--- a/tests/tests/kithara_play/local_seek_hang_iters.rs
+++ b/tests/tests/kithara_play/local_seek_hang_iters.rs
@@ -287,7 +287,7 @@ async fn local_seek_middle_hang_iters(#[case] backend: DecoderBackend, #[case] a
         // Subscribe before the resource moves into the player so no
         // `PlaybackProgress` event is missed once the render pull starts.
         let mut events = resource.subscribe();
-        player.load_and_fadein(resource);
+        player.load_and_fadein(resource).await;
 
         // Event-driven warmup: drive the render pull until the worker has
         // actually produced PCM (position advances past the warmup horizon),

--- a/tests/tests/kithara_play/mix_tap.rs
+++ b/tests/tests/kithara_play/mix_tap.rs
@@ -32,7 +32,7 @@ async fn playing_harness() -> OfflinePlayerHarness {
     )
     .await;
     harness
-        .with_player(|player| {
+        .with_player(move |player| {
             player.insert(make_resource(), TrackId::allocate(), None);
             player
                 .select_item(0, true)
@@ -40,7 +40,7 @@ async fn playing_harness() -> OfflinePlayerHarness {
         })
         .await;
     harness.render(BLOCK_FRAMES).await;
-    let _ = harness.tick_and_drain();
+    let _ = harness.tick_and_drain().await;
     harness
 }
 
@@ -48,7 +48,7 @@ async fn render_blocks(harness: &OfflinePlayerHarness, blocks: usize) -> Vec<f32
     let mut rendered = Vec::with_capacity(blocks * BLOCK_FRAMES * 2);
     for _ in 0..blocks {
         rendered.extend_from_slice(&harness.render(BLOCK_FRAMES).await);
-        let _ = harness.tick_and_drain();
+        let _ = harness.tick_and_drain().await;
     }
     rendered
 }
@@ -114,7 +114,7 @@ async fn a_tap_armed_before_playback_reaches_the_graph_it_waits_for() {
     assert!(tap.drain().is_empty(), "an idle session feeds nothing");
 
     harness
-        .with_player(|player| {
+        .with_player(move |player| {
             player.insert(make_resource(), TrackId::allocate(), None);
             player
                 .select_item(0, true)

--- a/tests/tests/kithara_play/mix_tap.rs
+++ b/tests/tests/kithara_play/mix_tap.rs
@@ -25,45 +25,51 @@ fn make_resource() -> Resource {
     ))
 }
 
-fn playing_harness() -> OfflinePlayerHarness {
+async fn playing_harness() -> OfflinePlayerHarness {
     let harness = OfflinePlayerHarness::with_sample_rate(
         OfflinePlayerOptions::builder().build(),
         SAMPLE_RATE,
-    );
-    harness.with_player(|player| {
-        player.insert(make_resource(), TrackId::allocate(), None);
-        player
-            .select_item(0, true)
-            .expect("select first queue item");
-    });
-    harness.render(BLOCK_FRAMES);
+    )
+    .await;
+    harness
+        .with_player(|player| {
+            player.insert(make_resource(), TrackId::allocate(), None);
+            player
+                .select_item(0, true)
+                .expect("select first queue item");
+        })
+        .await;
+    harness.render(BLOCK_FRAMES).await;
     let _ = harness.tick_and_drain();
     harness
 }
 
-fn render_blocks(harness: &OfflinePlayerHarness, blocks: usize) -> Vec<f32> {
+async fn render_blocks(harness: &OfflinePlayerHarness, blocks: usize) -> Vec<f32> {
     let mut rendered = Vec::with_capacity(blocks * BLOCK_FRAMES * 2);
     for _ in 0..blocks {
-        rendered.extend_from_slice(&harness.render(BLOCK_FRAMES));
+        rendered.extend_from_slice(&harness.render(BLOCK_FRAMES).await);
         let _ = harness.tick_and_drain();
     }
     rendered
 }
 
-fn render_with_tap() -> (Vec<f32>, Vec<f32>, u64) {
-    let harness = playing_harness();
+async fn render_with_tap() -> (Vec<f32>, Vec<f32>, u64) {
+    let harness = playing_harness().await;
     let mut tap = harness
         .host()
         .enable_mix_tap(ROOMY_CAPACITY)
+        .await
         .expect("enable mix tap");
-    let rendered = render_blocks(&harness, BLOCKS);
+    let rendered = render_blocks(&harness, BLOCKS).await;
     let tapped = tap.drain();
-    (rendered, tapped, tap.drops())
+    let drops = tap.drops();
+    harness.close().await;
+    (rendered, tapped, drops)
 }
 
-#[kithara::test]
-fn zero_output_sink_is_processed_beside_graph_out() {
-    let (rendered, tapped, drops) = render_with_tap();
+#[kithara::test(tokio)]
+async fn zero_output_sink_is_processed_beside_graph_out() {
+    let (rendered, tapped, drops) = render_with_tap().await;
 
     assert_eq!(
         rendered.len(),
@@ -78,9 +84,9 @@ fn zero_output_sink_is_processed_beside_graph_out() {
     assert_eq!(drops, 0);
 }
 
-#[kithara::test]
-fn mix_tap_matches_graph_out_bit_exactly() {
-    let (rendered, tapped, _) = render_with_tap();
+#[kithara::test(tokio)]
+async fn mix_tap_matches_graph_out_bit_exactly() {
+    let (rendered, tapped, _) = render_with_tap().await;
 
     assert!(
         rendered.iter().any(|sample| sample.abs() > 0.0),
@@ -93,49 +99,56 @@ fn mix_tap_matches_graph_out_bit_exactly() {
     assert_eq!(tapped, rendered, "mix tap must be bit-exact with graph_out");
 }
 
-#[kithara::test]
-fn a_tap_armed_before_playback_reaches_the_graph_it_waits_for() {
+#[kithara::test(tokio)]
+async fn a_tap_armed_before_playback_reaches_the_graph_it_waits_for() {
     let harness = OfflinePlayerHarness::with_sample_rate(
         OfflinePlayerOptions::builder().build(),
         SAMPLE_RATE,
-    );
+    )
+    .await;
     let mut tap = harness
         .host()
         .enable_mix_tap(ROOMY_CAPACITY)
+        .await
         .expect("arm the mix tap before a session output exists");
     assert!(tap.drain().is_empty(), "an idle session feeds nothing");
 
-    harness.with_player(|player| {
-        player.insert(make_resource(), TrackId::allocate(), None);
-        player
-            .select_item(0, true)
-            .expect("select first queue item");
-    });
+    harness
+        .with_player(|player| {
+            player.insert(make_resource(), TrackId::allocate(), None);
+            player
+                .select_item(0, true)
+                .expect("select first queue item");
+        })
+        .await;
 
-    let rendered = render_blocks(&harness, BLOCKS);
+    let rendered = render_blocks(&harness, BLOCKS).await;
     assert_eq!(
         tap.drain(),
         rendered,
         "the waiting tap catches the mix from the first block the graph renders"
     );
+    harness.close().await;
 }
 
-#[kithara::test]
-fn the_tap_keeps_feeding_across_a_device_route_restart() {
-    let harness = playing_harness();
+#[kithara::test(tokio)]
+async fn the_tap_keeps_feeding_across_a_device_route_restart() {
+    let harness = playing_harness().await;
     let mut tap = harness
         .host()
         .enable_mix_tap(ROOMY_CAPACITY)
+        .await
         .expect("enable mix tap");
-    render_blocks(&harness, 2);
+    render_blocks(&harness, 2).await;
     assert!(!tap.drain().is_empty(), "the feed runs before the restart");
 
     harness
         .host()
         .invalidate_audio_route("mix tap route restart")
+        .await
         .expect("invalidate the audio route");
 
-    let rendered = render_blocks(&harness, 4);
+    let rendered = render_blocks(&harness, 4).await;
     assert!(
         tap.writer_alive(),
         "a stream restart at the same rate keeps the producer"
@@ -145,19 +158,21 @@ fn the_tap_keeps_feeding_across_a_device_route_restart() {
         rendered,
         "the same producer carries the mix rendered after the restart"
     );
+    harness.close().await;
 }
 
-#[kithara::test]
-fn mix_tap_overflow_drops_exactly_the_capacity_deficit() {
+#[kithara::test(tokio)]
+async fn mix_tap_overflow_drops_exactly_the_capacity_deficit() {
     const TIGHT_CAPACITY: usize = 2_048;
 
-    let harness = playing_harness();
+    let harness = playing_harness().await;
     let mut tap = harness
         .host()
         .enable_mix_tap(TIGHT_CAPACITY)
+        .await
         .expect("enable mix tap");
 
-    let rendered = render_blocks(&harness, BLOCKS);
+    let rendered = render_blocks(&harness, BLOCKS).await;
     let tapped = tap.drain();
 
     assert_eq!(tapped.len(), TIGHT_CAPACITY, "the ring fills to capacity");
@@ -171,24 +186,35 @@ fn mix_tap_overflow_drops_exactly_the_capacity_deficit() {
         (rendered.len() - TIGHT_CAPACITY) as u64,
         "every sample the ring had no room for is counted"
     );
+    harness.close().await;
 }
 
-#[kithara::test]
-fn second_enable_is_rejected_and_disable_releases_the_writer() {
-    let harness = playing_harness();
+#[kithara::test(tokio)]
+async fn second_enable_is_rejected_and_disable_releases_the_writer() {
+    let harness = playing_harness().await;
     let tap = harness
         .host()
         .enable_mix_tap(ROOMY_CAPACITY)
+        .await
         .expect("enable mix tap");
 
-    match harness.host().enable_mix_tap(ROOMY_CAPACITY).map(|_| ()) {
+    match harness
+        .host()
+        .enable_mix_tap(ROOMY_CAPACITY)
+        .await
+        .map(|_| ())
+    {
         Err(PlayError::Session(SessionError::MixTapActive)) => {}
         other => panic!("a second consumer must be rejected, got {other:?}"),
     }
     assert!(tap.writer_alive());
 
-    harness.host().disable_mix_tap().expect("disable mix tap");
-    render_blocks(&harness, 2);
+    harness
+        .host()
+        .disable_mix_tap()
+        .await
+        .expect("disable mix tap");
+    render_blocks(&harness, 2).await;
     assert!(
         !tap.writer_alive(),
         "disabling the tap must drop the producer so the consumer sees the feed end"
@@ -197,6 +223,8 @@ fn second_enable_is_rejected_and_disable_releases_the_writer() {
     let re_enabled = harness
         .host()
         .enable_mix_tap(ROOMY_CAPACITY)
+        .await
         .expect("re-enable mix tap after disable");
     assert!(re_enabled.writer_alive());
+    harness.close().await;
 }

--- a/tests/tests/kithara_play/mixing.rs
+++ b/tests/tests/kithara_play/mixing.rs
@@ -32,7 +32,7 @@ struct MixHarness {
 impl MixHarness {
     // Players are built but not started, so a mix applied before `play` takes the
     // never-started path and each node is created at its level, unramped.
-    fn new(count: usize) -> Self {
+    async fn new(count: usize) -> Self {
         let pools = pools();
         let sample_rate = NonZeroU32::new(SAMPLE_RATE).expect("fixture sample rate is non-zero");
         let host = OfflineHostHarness::new(
@@ -40,20 +40,23 @@ impl MixHarness {
                 .sample_rate(sample_rate)
                 .build(),
         )
+        .await
         .expect("create product offline Host");
-        let players = (0..count)
-            .map(|_| {
-                let config = PlayerConfig::builder()
-                    .worker(PlayWorker::new(
-                        PlayWorkerConfig::builder(pools.clone()).build(),
-                    ))
-                    .sample_rate(sample_rate)
-                    .crossfade_duration(0.0)
-                    .build();
+        let mut players = Vec::with_capacity(count);
+        for _ in 0..count {
+            let config = PlayerConfig::builder()
+                .worker(PlayWorker::new(
+                    PlayWorkerConfig::builder(pools.clone()).build(),
+                ))
+                .sample_rate(sample_rate)
+                .crossfade_duration(0.0)
+                .build();
+            players.push(
                 host.insert(PlayerImpl::new(config))
-                    .expect("insert player into product offline Host")
-            })
-            .collect();
+                    .await
+                    .expect("insert player into product offline Host"),
+            );
+        }
         Self { host, players }
     }
 
@@ -80,13 +83,15 @@ impl MixHarness {
         }
     }
 
-    fn apply(&self, levels: &[f32]) -> Result<(), PlayError> {
-        self.host.apply_mix(
-            self.players
-                .iter()
-                .zip(levels)
-                .map(|(player, &level)| player.level(level)),
-        )
+    async fn apply(&self, levels: &[f32]) -> Result<(), PlayError> {
+        self.host
+            .apply_mix(
+                self.players
+                    .iter()
+                    .zip(levels)
+                    .map(|(player, &level)| player.level(level)),
+            )
+            .await
     }
 
     // Paced at the block's real audio duration, or the render outruns the decode
@@ -95,7 +100,7 @@ impl MixHarness {
         for player in &self.players {
             player.process_notifications();
         }
-        let block = self.host.render(BLOCK_FRAMES);
+        let block = self.host.render(BLOCK_FRAMES).await;
         let budget = Duration::from_secs_f64(BLOCK_FRAMES as f64 / f64::from(SAMPLE_RATE));
         time::sleep(budget).await;
         block
@@ -114,6 +119,12 @@ impl MixHarness {
 
     async fn steady_peak(&self) -> f32 {
         peak(&self.steady().await)
+    }
+
+    async fn close(self) {
+        let Self { host, players } = self;
+        drop(players);
+        host.close().await;
     }
 }
 
@@ -136,12 +147,13 @@ async fn players_render_exact_weighted_sum(
     #[case] levels: &[f32],
     #[case] label: &str,
 ) {
-    let harness = MixHarness::new(values.len());
-    harness.apply(levels).expect("apply mix");
+    let harness = MixHarness::new(values.len()).await;
+    harness.apply(levels).await.expect("apply mix");
     harness.play(values);
 
     let expected = values.iter().zip(levels).map(|(v, l)| v * l).sum();
     assert_near(harness.steady_peak().await, expected, label);
+    harness.close().await;
 }
 
 #[kithara::test(native, tokio, timeout(Duration::from_secs(60)))]
@@ -149,11 +161,12 @@ async fn zeroed_players_are_silent_and_gains_are_independent() {
     let values = [0.4, 0.3, 0.2, 0.1];
     let levels = [1.0, 0.0, 0.0, 0.0];
 
-    let harness = MixHarness::new(values.len());
-    harness.apply(&levels).expect("apply mix");
+    let harness = MixHarness::new(values.len()).await;
+    harness.apply(&levels).await.expect("apply mix");
     harness.play(&values);
 
     assert_near(harness.steady_peak().await, 0.4, "independent gains");
+    harness.close().await;
 }
 
 #[kithara::test(native, tokio, timeout(Duration::from_secs(60)))]
@@ -167,8 +180,8 @@ async fn limiter_holds_the_ceiling_when_players_overload_the_sum() {
         "test is vacuous: unlimited sum {raw} does not reach the ceiling {CEILING}"
     );
 
-    let harness = MixHarness::new(values.len());
-    harness.apply(&levels).expect("apply mix");
+    let harness = MixHarness::new(values.len()).await;
+    harness.apply(&levels).await.expect("apply mix");
     harness.play(&values);
 
     let rendered = harness.steady().await;
@@ -179,12 +192,13 @@ async fn limiter_holds_the_ceiling_when_players_overload_the_sum() {
         );
     }
     assert_near(peak(&rendered), CEILING, "limiter holds the ceiling");
+    harness.close().await;
 }
 
 #[kithara::test(native, tokio, timeout(Duration::from_secs(60)))]
 async fn sub_threshold_mix_passes_through_untouched() {
-    let harness = MixHarness::new(1);
-    harness.apply(&[1.0]).expect("apply mix");
+    let harness = MixHarness::new(1).await;
+    harness.apply(&[1.0]).await.expect("apply mix");
     harness.play(&[0.4]);
 
     let rendered = harness.steady().await;
@@ -199,24 +213,26 @@ async fn sub_threshold_mix_passes_through_untouched() {
     for &s in &rendered {
         assert_near(s.abs(), expected, "sub-threshold sample is unmodulated");
     }
+    harness.close().await;
 }
 
 #[kithara::test(native, tokio, timeout(Duration::from_secs(60)))]
 async fn single_player_without_a_mix_is_unchanged() {
-    let harness = MixHarness::new(1);
+    let harness = MixHarness::new(1).await;
     harness.play(&[0.4]);
     assert_near(
         harness.steady_peak().await,
         0.4,
         "single-player playback regressed",
     );
+    harness.close().await;
 }
 
 #[kithara::test(native, tokio, timeout(Duration::from_secs(60)))]
 async fn rejected_mix_changes_no_rendered_gain() {
     let values = [0.4, 0.2];
-    let harness = MixHarness::new(values.len());
-    harness.apply(&[0.5, 0.25]).expect("apply mix");
+    let harness = MixHarness::new(values.len()).await;
+    harness.apply(&[0.5, 0.25]).await.expect("apply mix");
     harness.play(&values);
 
     let expected = 0.4 * 0.5 + 0.2 * 0.25;
@@ -224,6 +240,7 @@ async fn rejected_mix_changes_no_rendered_gain() {
 
     let err = harness
         .apply(&[0.5, 2.0])
+        .await
         .expect_err("invalid level must be rejected");
     assert!(matches!(err, PlayError::MixLevel { .. }));
     assert_near(
@@ -231,17 +248,19 @@ async fn rejected_mix_changes_no_rendered_gain() {
         expected,
         "rejected mix changed a gain",
     );
+    harness.close().await;
 }
 
-#[kithara::test]
-fn session_mix_does_not_mirror_player_content_volume() {
-    let harness = MixHarness::new(1);
+#[kithara::test(tokio)]
+async fn session_mix_does_not_mirror_player_content_volume() {
+    let harness = MixHarness::new(1).await;
     harness.play(&[0.4]);
-    harness.apply(&[0.5]).expect("apply mix");
+    harness.apply(&[0.5]).await.expect("apply mix");
 
     assert_eq!(
         harness.players[0].volume(),
         1.0,
         "session mix must not mirror player content volume"
     );
+    harness.close().await;
 }

--- a/tests/tests/kithara_play/mixing.rs
+++ b/tests/tests/kithara_play/mixing.rs
@@ -60,27 +60,39 @@ impl MixHarness {
         Self { host, players }
     }
 
-    fn play(&self, values: &[f32]) {
+    async fn play(&self, values: &[f32]) {
         let spec = AudioSpec::new(2, NonZeroU32::new(SAMPLE_RATE).expect("sample rate"));
-        for (player, &value) in self.players.iter().zip(values) {
-            player.reserve_slots(1);
-            player
-                .replace_item(
-                    0,
-                    resource_from_reader(TestPcmReader::with_value(spec, TRACK_SECS, value)),
-                    TrackId::allocate(),
-                )
-                .expect("replace player item");
-            player
-                .select_item_with_crossfade(
-                    0,
-                    SelectTransition {
-                        autoplay: true,
-                        crossfade_seconds: 0.0,
-                    },
-                )
-                .expect("select item");
-        }
+        let players: Vec<_> = self
+            .players
+            .iter()
+            .map(|player| player.control().clone())
+            .collect();
+        let values = values.to_vec();
+        self.host
+            .run(move || {
+                for (player, value) in players.iter().zip(values) {
+                    player.reserve_slots(1);
+                    player
+                        .replace_item(
+                            0,
+                            resource_from_reader(TestPcmReader::with_value(
+                                spec, TRACK_SECS, value,
+                            )),
+                            TrackId::allocate(),
+                        )
+                        .expect("replace player item");
+                    player
+                        .select_item_with_crossfade(
+                            0,
+                            SelectTransition {
+                                autoplay: true,
+                                crossfade_seconds: 0.0,
+                            },
+                        )
+                        .expect("select item");
+                }
+            })
+            .await;
     }
 
     async fn apply(&self, levels: &[f32]) -> Result<(), PlayError> {
@@ -149,7 +161,7 @@ async fn players_render_exact_weighted_sum(
 ) {
     let harness = MixHarness::new(values.len()).await;
     harness.apply(levels).await.expect("apply mix");
-    harness.play(values);
+    harness.play(values).await;
 
     let expected = values.iter().zip(levels).map(|(v, l)| v * l).sum();
     assert_near(harness.steady_peak().await, expected, label);
@@ -163,7 +175,7 @@ async fn zeroed_players_are_silent_and_gains_are_independent() {
 
     let harness = MixHarness::new(values.len()).await;
     harness.apply(&levels).await.expect("apply mix");
-    harness.play(&values);
+    harness.play(&values).await;
 
     assert_near(harness.steady_peak().await, 0.4, "independent gains");
     harness.close().await;
@@ -182,7 +194,7 @@ async fn limiter_holds_the_ceiling_when_players_overload_the_sum() {
 
     let harness = MixHarness::new(values.len()).await;
     harness.apply(&levels).await.expect("apply mix");
-    harness.play(&values);
+    harness.play(&values).await;
 
     let rendered = harness.steady().await;
     for &s in &rendered {
@@ -199,7 +211,7 @@ async fn limiter_holds_the_ceiling_when_players_overload_the_sum() {
 async fn sub_threshold_mix_passes_through_untouched() {
     let harness = MixHarness::new(1).await;
     harness.apply(&[1.0]).await.expect("apply mix");
-    harness.play(&[0.4]);
+    harness.play(&[0.4]).await;
 
     let rendered = harness.steady().await;
     let expected = 0.4;
@@ -219,7 +231,7 @@ async fn sub_threshold_mix_passes_through_untouched() {
 #[kithara::test(native, tokio, timeout(Duration::from_secs(60)))]
 async fn single_player_without_a_mix_is_unchanged() {
     let harness = MixHarness::new(1).await;
-    harness.play(&[0.4]);
+    harness.play(&[0.4]).await;
     assert_near(
         harness.steady_peak().await,
         0.4,
@@ -233,7 +245,7 @@ async fn rejected_mix_changes_no_rendered_gain() {
     let values = [0.4, 0.2];
     let harness = MixHarness::new(values.len()).await;
     harness.apply(&[0.5, 0.25]).await.expect("apply mix");
-    harness.play(&values);
+    harness.play(&values).await;
 
     let expected = 0.4 * 0.5 + 0.2 * 0.25;
     assert_near(harness.steady_peak().await, expected, "baseline mix");
@@ -254,7 +266,7 @@ async fn rejected_mix_changes_no_rendered_gain() {
 #[kithara::test(tokio)]
 async fn session_mix_does_not_mirror_player_content_volume() {
     let harness = MixHarness::new(1).await;
-    harness.play(&[0.4]);
+    harness.play(&[0.4]).await;
     harness.apply(&[0.5]).await.expect("apply mix");
 
     assert_eq!(

--- a/tests/tests/kithara_play/no_sync_real_media.rs
+++ b/tests/tests/kithara_play/no_sync_real_media.rs
@@ -274,6 +274,7 @@ async fn run_case(case: &Case, hls: &Url, record_artifacts: bool) -> Vec<String>
             .max_block_frames(max_block_frames)
             .build(),
     )
+    .await
     .unwrap_or_else(|error| panic!("{}: create product offline Host: {error}", case.label));
     let mut failures = Vec::new();
 
@@ -295,7 +296,7 @@ async fn run_case(case: &Case, hls: &Url, record_artifacts: bool) -> Vec<String>
     }
 
     load_decks(case, &decks, &mut failures);
-    runtime::record_transport_state(&host, "before first render", &mut failures);
+    runtime::record_transport_state(&host, "before first render", &mut failures).await;
     runtime::drain_all_events(
         &mut decks,
         "startup",
@@ -331,7 +332,7 @@ async fn run_case(case: &Case, hls: &Url, record_artifacts: bool) -> Vec<String>
         runtime::validate_deck(case, deck_index, deck, &mut failures);
         runtime::record_control_state(case, deck_index, deck, "after capture", &mut failures);
     }
-    runtime::record_transport_state(&host, "after capture", &mut failures);
+    runtime::record_transport_state(&host, "after capture", &mut failures).await;
     let oracles = oracle::assess_audio(case.label, case.host_rate, &final_mix.pcm, &mut failures);
 
     let mut audio_levels = direct_references
@@ -431,6 +432,7 @@ async fn run_case(case: &Case, hls: &Url, record_artifacts: bool) -> Vec<String>
             "KITHARA_AUDIO_ARTIFACT_DIR must be set for the artifact recorder"
         );
     }
+    host.close().await;
     failures
 }
 
@@ -458,6 +460,7 @@ async fn capture_pass(
 
     let mut tap = host
         .enable_mix_tap(requested_frames * usize::from(CHANNELS) + BLOCK_FRAMES)
+        .await
         .unwrap_or_else(|error| panic!("{} {label}: enable mix tap: {error}", case.label));
     let positions_before = decks
         .iter()
@@ -500,7 +503,7 @@ async fn capture_pass(
         &zero_blocks,
         failures,
     );
-    disable_mix_tap(case.label, label, host, failures);
+    disable_mix_tap(case.label, label, host, failures).await;
     assess_position_advance(
         case,
         label,
@@ -550,7 +553,10 @@ async fn reset_for_capture(
         failures,
     )
     .await;
-    if let Err(error) = host.apply_mix(decks.iter().map(|deck| deck.player.level(0.0))) {
+    if let Err(error) = host
+        .apply_mix(decks.iter().map(|deck| deck.player.level(0.0)))
+        .await
+    {
         failures.push(format!(
             "{} {label}: mute before seek failed: {error}",
             case.label,
@@ -726,12 +732,15 @@ async fn reset_for_capture(
         ));
         return false;
     }
-    if let Err(error) = host.apply_mix(
-        decks
-            .iter()
-            .zip(levels.iter().copied())
-            .map(|(deck, level)| deck.player.level(level)),
-    ) {
+    if let Err(error) = host
+        .apply_mix(
+            decks
+                .iter()
+                .zip(levels.iter().copied())
+                .map(|(deck, level)| deck.player.level(level)),
+        )
+        .await
+    {
         failures.push(format!(
             "{} {label}: apply capture levels failed: {error}",
             case.label,
@@ -774,13 +783,13 @@ async fn settle_controls(
     }
 }
 
-fn disable_mix_tap(
+async fn disable_mix_tap(
     case: &str,
     label: &str,
     host: &OfflineHostHarness<TestPools>,
     failures: &mut Vec<String>,
 ) {
-    if let Err(error) = host.disable_mix_tap() {
+    if let Err(error) = host.disable_mix_tap().await {
         failures.push(format!(
             "{case} {label}: disable mix tap dispatch failed: {error}",
         ));
@@ -940,7 +949,7 @@ async fn prepare_deck(
     let reference = open_resource(case, deck_index, "reference", reference_config).await;
     let reference_events = reference.subscribe();
     player.insert(resource, TrackId::allocate(), None);
-    let player = host.insert(player).unwrap_or_else(|error| {
+    let player = host.insert(player).await.unwrap_or_else(|error| {
         panic!(
             "{} deck {deck_index}: insert player into product Host: {error}",
             case.label
@@ -1007,7 +1016,7 @@ async fn render_paced(
     for deck in decks {
         deck.player.process_notifications();
     }
-    let block = host.render(BLOCK_FRAMES);
+    let block = host.render(BLOCK_FRAMES).await;
     time::sleep(Duration::from_secs_f64(
         f64::from(u32::try_from(BLOCK_FRAMES).expect("block frames fit u32"))
             / f64::from(sample_rate),

--- a/tests/tests/kithara_play/no_sync_real_media.rs
+++ b/tests/tests/kithara_play/no_sync_real_media.rs
@@ -295,7 +295,7 @@ async fn run_case(case: &Case, hls: &Url, record_artifacts: bool) -> Vec<String>
         );
     }
 
-    load_decks(case, &decks, &mut failures);
+    load_decks(case, &host, &decks, &mut failures).await;
     runtime::record_transport_state(&host, "before first render", &mut failures).await;
     runtime::drain_all_events(
         &mut decks,
@@ -623,9 +623,7 @@ async fn reset_for_capture(
         return false;
     }
 
-    for deck in &*decks {
-        deck.player.play();
-    }
+    play_decks(host, decks).await;
     let mut completed = false;
     let mut seek_blocks = 0_u32;
     for _ in 0..oracle::blocks_for_secs(case.host_rate, MAX_SEEK_SECS) {
@@ -747,9 +745,7 @@ async fn reset_for_capture(
         ));
         return false;
     }
-    for deck in &*decks {
-        deck.player.play();
-    }
+    play_decks(host, decks).await;
     settle_controls(
         case,
         host,
@@ -861,21 +857,42 @@ fn assess_position_advance(
     }
 }
 
-fn load_decks(case: &Case, decks: &[Deck], failures: &mut Vec<String>) {
+async fn load_decks(
+    case: &Case,
+    host: &OfflineHostHarness<TestPools>,
+    decks: &[Deck],
+    failures: &mut Vec<String>,
+) {
     for (deck_index, deck) in decks.iter().enumerate() {
         runtime::record_control_state(case, deck_index, deck, "before playback", failures);
-        deck.player
-            .select_item_with_crossfade(
+        let player = deck.player.control().clone();
+        host.run(move || {
+            player.select_item_with_crossfade(
                 0,
                 SelectTransition {
                     autoplay: false,
                     crossfade_seconds: 0.0,
                 },
             )
-            .unwrap_or_else(|error| {
-                panic!("{} deck {deck_index}: select resource: {error}", case.label)
-            });
+        })
+        .await
+        .unwrap_or_else(|error| {
+            panic!("{} deck {deck_index}: select resource: {error}", case.label)
+        });
     }
+}
+
+async fn play_decks(host: &OfflineHostHarness<TestPools>, decks: &[Deck]) {
+    let players: Vec<_> = decks
+        .iter()
+        .map(|deck| deck.player.control().clone())
+        .collect();
+    host.run(move || {
+        for player in &players {
+            player.play();
+        }
+    })
+    .await;
 }
 
 async fn prepare_deck(

--- a/tests/tests/kithara_play/no_sync_real_media/runtime.rs
+++ b/tests/tests/kithara_play/no_sync_real_media/runtime.rs
@@ -342,12 +342,12 @@ pub(super) fn record_control_state(
     }
 }
 
-pub(super) fn record_transport_state(
+pub(super) async fn record_transport_state(
     host: &OfflineHostHarness<TestPools>,
     phase: &str,
     failures: &mut Vec<String>,
 ) {
-    match host.transport_revision() {
+    match host.transport_revision().await {
         Err(PlayError::Session(SessionError::TransportNotProcessed)) => {}
         Err(error) => failures.push(format!(
             "session transport returned {error} {phase}, expected unconfigured",

--- a/tests/tests/kithara_play/offline_harness_smoke.rs
+++ b/tests/tests/kithara_play/offline_harness_smoke.rs
@@ -18,24 +18,27 @@ fn make_resource(duration_secs: f64) -> Resource {
     ))
 }
 
-#[kithara::test]
-fn offline_harness_smoke() {
+#[kithara::test(tokio)]
+async fn offline_harness_smoke() {
     let harness = OfflinePlayerHarness::with_sample_rate(
         OfflinePlayerOptions::builder().build(),
         Consts::SAMPLE_RATE,
-    );
-    harness.with_player(|player| {
-        player.insert(make_resource(0.1), TrackId::allocate(), None);
-        player.insert(make_resource(0.1), TrackId::allocate(), None);
-        player
-            .select_item(0, true)
-            .expect("select first queue item");
-    });
+    )
+    .await;
+    harness
+        .with_player(|player| {
+            player.insert(make_resource(0.1), TrackId::allocate(), None);
+            player.insert(make_resource(0.1), TrackId::allocate(), None);
+            player
+                .select_item(0, true)
+                .expect("select first queue item");
+        })
+        .await;
 
     let mut rendered: Vec<f32> = Vec::new();
     let mut total_frames: usize = 0;
     while rendered.len() < TARGET_SAMPLES && total_frames < MAX_RENDERED_FRAMES {
-        let block = harness.render(BLOCK_FRAMES);
+        let block = harness.render(BLOCK_FRAMES).await;
         rendered.extend_from_slice(&block);
         total_frames = total_frames.saturating_add(BLOCK_FRAMES);
         let _ = harness.tick_and_drain();
@@ -43,4 +46,5 @@ fn offline_harness_smoke() {
 
     assert!(!rendered.is_empty());
     assert!(rendered.iter().any(|sample| sample.abs() > 0.0));
+    harness.close().await;
 }

--- a/tests/tests/kithara_play/offline_harness_smoke.rs
+++ b/tests/tests/kithara_play/offline_harness_smoke.rs
@@ -26,7 +26,7 @@ async fn offline_harness_smoke() {
     )
     .await;
     harness
-        .with_player(|player| {
+        .with_player(move |player| {
             player.insert(make_resource(0.1), TrackId::allocate(), None);
             player.insert(make_resource(0.1), TrackId::allocate(), None);
             player
@@ -41,7 +41,7 @@ async fn offline_harness_smoke() {
         let block = harness.render(BLOCK_FRAMES).await;
         rendered.extend_from_slice(&block);
         total_frames = total_frames.saturating_add(BLOCK_FRAMES);
-        let _ = harness.tick_and_drain();
+        let _ = harness.tick_and_drain().await;
     }
 
     assert!(!rendered.is_empty());

--- a/tests/tests/kithara_play/player_internal.rs
+++ b/tests/tests/kithara_play/player_internal.rs
@@ -7,7 +7,10 @@
     reason = "test fixture values are small positive integers/floats"
 )]
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::{
+    num::NonZeroU32,
+    sync::atomic::{AtomicU64, Ordering},
+};
 
 use kithara::{
     self,
@@ -70,6 +73,9 @@ impl FixtureSession {
 }
 
 impl SessionDispatcher<TestPools> for FixtureSession {
+    fn requested_sample_rate(&self) -> NonZeroU32 {
+        Consts::NON_ZERO_SAMPLE_RATE
+    }
     fn exec(&self, cmd: Cmd<TestPools>) -> Result<Reply, PlayError> {
         let reply = match cmd {
             Cmd::RegisterPlayer { .. } => {

--- a/tests/tests/kithara_play/player_internal.rs
+++ b/tests/tests/kithara_play/player_internal.rs
@@ -7,10 +7,7 @@
     reason = "test fixture values are small positive integers/floats"
 )]
 
-use std::{
-    num::NonZeroU32,
-    sync::atomic::{AtomicU64, Ordering},
-};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use kithara::{
     self,
@@ -19,8 +16,9 @@ use kithara::{
     platform::sync::{Arc, Mutex},
     play::{
         AllocatedSlot, Cmd, NodeInputs, PlayError, PlayWorker, PlayWorkerConfig, PlayerConfig,
-        PlayerEvent, PlayerImpl, PlayerStatus, Reply, Resource, SeekOutcome, SessionDispatcher,
-        SessionDuckingMode, SessionSampleRate, SharedEq, SlotId, bridge::slot_channels,
+        PlayerEvent, PlayerImpl, PlayerStatus, Reply, Resource, SeekOutcome, SessionBinding,
+        SessionDispatcher, SessionDuckingMode, SessionSampleRate, SharedEq, SlotId,
+        bridge::slot_channels,
     },
 };
 use kithara_integration_tests::{audio_mock::TestPcmReader, test_defaults::Consts};
@@ -73,9 +71,6 @@ impl FixtureSession {
 }
 
 impl SessionDispatcher<TestPools> for FixtureSession {
-    fn requested_sample_rate(&self) -> NonZeroU32 {
-        Consts::NON_ZERO_SAMPLE_RATE
-    }
     fn exec(&self, cmd: Cmd<TestPools>) -> Result<Reply, PlayError> {
         let reply = match cmd {
             Cmd::RegisterPlayer { .. } => {
@@ -114,7 +109,10 @@ fn make_fixture_player(crossfade_duration: f32) -> (PlayerImpl<TestPools>, Arc<F
         .crossfade_duration(crossfade_duration)
         .sample_rate(Consts::NON_ZERO_SAMPLE_RATE)
         .worker(PlayWorker::new(PlayWorkerConfig::builder(pools()).build()))
-        .session(Arc::clone(&session) as Arc<dyn SessionDispatcher<TestPools>>)
+        .session(SessionBinding::new(
+            Arc::clone(&session) as Arc<dyn SessionDispatcher<TestPools>>,
+            Consts::NON_ZERO_SAMPLE_RATE,
+        ))
         .build();
     let player = PlayerImpl::new(player_config);
     (player, session)
@@ -138,7 +136,10 @@ fn default_player_config() -> PlayerConfig<TestPools> {
     PlayerConfig::builder()
         .sample_rate(Consts::NON_ZERO_SAMPLE_RATE)
         .worker(PlayWorker::new(PlayWorkerConfig::builder(pools()).build()))
-        .session(fixture_session())
+        .session(SessionBinding::new(
+            fixture_session(),
+            Consts::NON_ZERO_SAMPLE_RATE,
+        ))
         .build()
 }
 

--- a/tests/tests/kithara_play/player_queue_api_regressions.rs
+++ b/tests/tests/kithara_play/player_queue_api_regressions.rs
@@ -34,28 +34,28 @@ async fn auto_advance_starts_next_track_without_explicit_play(temp_dir: TestTemp
     let second_id = TrackId::allocate();
 
     let first = make_signal_resource(
-        harness.player(),
+        &harness,
         &server,
         temp_dir.path(),
         SignalAsset::WAV_SINE440_120MS,
     )
     .await;
     let second = make_signal_resource(
-        harness.player(),
+        &harness,
         &server,
         temp_dir.path(),
         SignalAsset::WAV_SINE880_240MS,
     )
     .await;
     harness
-        .with_player(|player| {
+        .with_player(move |player| {
             player.insert(first, first_id, None);
             player.insert(second, second_id, None);
         })
         .await;
 
-    harness.player().play();
-    let _ = harness.tick_and_drain();
+    harness.with_player(PlayerControl::play).await;
+    let _ = harness.tick_and_drain().await;
 
     let deadline = Instant::now() + STARTUP_CLEAR_TIMEOUT;
     let block_budget = Duration::from_secs_f64(BLOCK_FRAMES as f64 / f64::from(SAMPLE_RATE));
@@ -66,7 +66,7 @@ async fn auto_advance_starts_next_track_without_explicit_play(temp_dir: TestTemp
 
     while Instant::now() <= deadline {
         let block = harness.render(BLOCK_FRAMES).await;
-        let drained = harness.tick_and_drain();
+        let drained = harness.tick_and_drain().await;
         rendered_frames = rendered_frames.saturating_add(block.len() / 2);
         events.extend(
             drained
@@ -128,7 +128,7 @@ async fn auto_advance_starts_next_track_without_explicit_play(temp_dir: TestTemp
 }
 
 async fn make_signal_resource(
-    player: &PlayerControl<TestPools>,
+    harness: &OfflinePlayerHarness,
     server: &TestServerHelper,
     cache_dir: &Path,
     asset: SignalAsset,
@@ -139,8 +139,9 @@ async fn make_signal_resource(
     )
     .store(kithara_integration_tests::disk_asset_store(cache_dir))
     .build();
-    config = player
-        .prepare_config(config)
+    config = harness
+        .with_player(move |player| player.prepare_config(config))
+        .await
         .expect("prepare queue regression resource config");
 
     Resource::new(config)

--- a/tests/tests/kithara_play/player_queue_api_regressions.rs
+++ b/tests/tests/kithara_play/player_queue_api_regressions.rs
@@ -28,7 +28,8 @@ async fn auto_advance_starts_next_track_without_explicit_play(temp_dir: TestTemp
             .crossfade_duration(0.0)
             .build(),
         SAMPLE_RATE,
-    );
+    )
+    .await;
     let first_id = TrackId::allocate();
     let second_id = TrackId::allocate();
 
@@ -46,10 +47,12 @@ async fn auto_advance_starts_next_track_without_explicit_play(temp_dir: TestTemp
         SignalAsset::WAV_SINE880_240MS,
     )
     .await;
-    harness.with_player(|player| {
-        player.insert(first, first_id, None);
-        player.insert(second, second_id, None);
-    });
+    harness
+        .with_player(|player| {
+            player.insert(first, first_id, None);
+            player.insert(second, second_id, None);
+        })
+        .await;
 
     harness.player().play();
     let _ = harness.tick_and_drain();
@@ -62,7 +65,7 @@ async fn auto_advance_starts_next_track_without_explicit_play(temp_dir: TestTemp
     let mut first_item_finished = None;
 
     while Instant::now() <= deadline {
-        let block = harness.render(BLOCK_FRAMES);
+        let block = harness.render(BLOCK_FRAMES).await;
         let drained = harness.tick_and_drain();
         rendered_frames = rendered_frames.saturating_add(block.len() / 2);
         events.extend(
@@ -121,6 +124,7 @@ async fn auto_advance_starts_next_track_without_explicit_play(temp_dir: TestTemp
         "first track must reach terminal playback before or at the second-track takeover \
          in the zero-crossfade API path; events={events:?}"
     );
+    harness.close().await;
 }
 
 async fn make_signal_resource(

--- a/tests/tests/kithara_play/quality_switch_continuity.rs
+++ b/tests/tests/kithara_play/quality_switch_continuity.rs
@@ -107,6 +107,22 @@ struct PreparedPlayer {
     capture_frame: i64,
 }
 
+impl PreparedPlayer {
+    async fn close(self) {
+        let Self {
+            _temp,
+            player,
+            abr,
+            events,
+            capture_frame: _,
+        } = self;
+        drop(abr);
+        drop(events);
+        player.close().await;
+        drop(_temp);
+    }
+}
+
 #[derive(Debug)]
 struct SwitchRender {
     samples: Vec<f32>,
@@ -320,7 +336,8 @@ async fn prepare_player(
         HostConfig::offline(pools())
             .sample_rate(NonZeroU32::new(SAMPLE_RATE).expect("sample rate is non-zero"))
             .build(),
-    );
+    )
+    .await;
     player.load_and_fadein(resource);
 
     // Render to a capture point fixed in *frames*, not to whichever frame the
@@ -394,7 +411,7 @@ async fn prepare_player(
 /// rather than of the pipeline under test.
 #[kithara::flash(true)]
 async fn render_paced(player: &mut OfflinePlayer, frames: usize) -> Vec<f32> {
-    let block = player.render(frames);
+    let block = player.render(frames).await;
     sleep(Duration::from_secs_f64(
         frames.to_f64().expect("render frame count fits f64") / f64::from(SAMPLE_RATE),
     ))
@@ -501,12 +518,14 @@ async fn render_switch(
         "{} target decoder did not deliver enough post-event PCM: active={active_after_target}, required={target_pcm_frames}, target_event_frame={target_decoder_frame}",
         transition.label,
     );
-    SwitchRender {
+    let result = SwitchRender {
         samples,
         capture_frame: prepared.capture_frame,
         applied_frame,
         target_decoder_frame,
-    }
+    };
+    prepared.close().await;
+    result
 }
 
 async fn render_no_switch_control(
@@ -547,8 +566,10 @@ async fn render_no_switch_control(
         decoder_events.is_empty(),
         "{label} no-switch control must not recreate its decoder after Initial: {decoder_events:?}",
     );
-    ControlRender {
+    let result = ControlRender {
         samples,
         capture_frame: prepared.capture_frame,
-    }
+    };
+    prepared.close().await;
+    result
 }

--- a/tests/tests/kithara_play/quality_switch_continuity.rs
+++ b/tests/tests/kithara_play/quality_switch_continuity.rs
@@ -338,7 +338,7 @@ async fn prepare_player(
             .build(),
     )
     .await;
-    player.load_and_fadein(resource);
+    player.load_and_fadein(resource).await;
 
     // Render to a capture point fixed in *frames*, not to whichever frame the
     // warm-up happens to stop on. A cold start can hand back a short block, and

--- a/tests/tests/kithara_play/quality_switch_continuity/desktop.rs
+++ b/tests/tests/kithara_play/quality_switch_continuity/desktop.rs
@@ -46,6 +46,22 @@ struct DesktopPrepared {
     capture_frame: i64,
 }
 
+impl DesktopPrepared {
+    async fn close(self) {
+        let Self {
+            _temp,
+            harness,
+            abr,
+            events,
+            capture_frame: _,
+        } = self;
+        drop(abr);
+        drop(events);
+        harness.close().await;
+        drop(_temp);
+    }
+}
+
 #[derive(Debug)]
 struct DesktopRender {
     capture_frame: i64,
@@ -153,7 +169,7 @@ fn host_frame(position: f64, label: &str) -> i64 {
 /// the decode worker.
 #[kithara::flash(true)]
 async fn render_paced(harness: &OfflinePlayerHarness, frames: usize) -> Vec<f32> {
-    let block = harness.render(frames);
+    let block = harness.render(frames).await;
     let _ = harness.tick_and_drain();
     sleep(Duration::from_secs_f64(
         frames.to_f64().expect("render frame count fits f64") / f64::from(HOST_SAMPLE_RATE),
@@ -176,7 +192,8 @@ async fn prepare_desktop_player(master_url: &url::Url, label: &str) -> DesktopPr
             )
             .build(),
         HOST_SAMPLE_RATE,
-    );
+    )
+    .await;
     let temp = TestTempDir::new();
     let bus = EventBus::new(4_096);
     let mut events = bus.subscribe();
@@ -215,15 +232,17 @@ async fn prepare_desktop_player(master_url: &url::Url, label: &str) -> DesktopPr
     let abr = resource
         .abr_handle()
         .unwrap_or_else(|| panic!("{label} HLS resource must expose an ABR handle"));
-    harness.with_player(|player| {
-        player.reserve_slots(1);
-        player
-            .replace_item(0, resource, TrackId::allocate())
-            .expect("replace quality-switch fixture item");
-        player
-            .select_item(0, true)
-            .unwrap_or_else(|error| panic!("select {label} Kithara App resource: {error}"));
-    });
+    harness
+        .with_player(|player| {
+            player.reserve_slots(1);
+            player
+                .replace_item(0, resource, TrackId::allocate())
+                .expect("replace quality-switch fixture item");
+            player
+                .select_item(0, true)
+                .unwrap_or_else(|error| panic!("select {label} Kithara App resource: {error}"));
+        })
+        .await;
 
     let deadline = Instant::now() + Duration::from_secs(20);
     let mut active_blocks = 0usize;
@@ -340,10 +359,12 @@ async fn render_desktop(master_url: &url::Url, switch: bool) -> DesktopRender {
         );
     }
 
-    DesktopRender {
+    let result = DesktopRender {
         capture_frame: prepared.capture_frame,
         samples,
-    }
+    };
+    prepared.close().await;
+    result
 }
 
 fn desktop_silent_buckets(samples: &[f32]) -> usize {

--- a/tests/tests/kithara_play/quality_switch_continuity/desktop.rs
+++ b/tests/tests/kithara_play/quality_switch_continuity/desktop.rs
@@ -170,7 +170,7 @@ fn host_frame(position: f64, label: &str) -> i64 {
 #[kithara::flash(true)]
 async fn render_paced(harness: &OfflinePlayerHarness, frames: usize) -> Vec<f32> {
     let block = harness.render(frames).await;
-    let _ = harness.tick_and_drain();
+    let _ = harness.tick_and_drain().await;
     sleep(Duration::from_secs_f64(
         frames.to_f64().expect("render frame count fits f64") / f64::from(HOST_SAMPLE_RATE),
     ))
@@ -232,15 +232,16 @@ async fn prepare_desktop_player(master_url: &url::Url, label: &str) -> DesktopPr
     let abr = resource
         .abr_handle()
         .unwrap_or_else(|| panic!("{label} HLS resource must expose an ABR handle"));
+    let select_label = label.to_owned();
     harness
-        .with_player(|player| {
+        .with_player(move |player| {
             player.reserve_slots(1);
             player
                 .replace_item(0, resource, TrackId::allocate())
                 .expect("replace quality-switch fixture item");
-            player
-                .select_item(0, true)
-                .unwrap_or_else(|error| panic!("select {label} Kithara App resource: {error}"));
+            player.select_item(0, true).unwrap_or_else(|error| {
+                panic!("select {select_label} Kithara App resource: {error}")
+            });
         })
         .await;
 

--- a/tests/tests/kithara_play/quality_switch_continuity/underrun.rs
+++ b/tests/tests/kithara_play/quality_switch_continuity/underrun.rs
@@ -98,7 +98,8 @@ async fn prepare_tiny_ring_player(
         HostConfig::offline(pools)
             .sample_rate(NonZeroU32::new(SAMPLE_RATE).expect("sample rate is non-zero"))
             .build(),
-    );
+    )
+    .await;
     player.load_and_fadein(resource_from_reader(audio));
 
     let deadline = Instant::now() + Duration::from_secs(15);
@@ -188,10 +189,12 @@ async fn render_tiny_ring_control(
         decoder_events.is_empty(),
         "{label} must not recreate its decoder: {decoder_events:?}",
     );
-    Render {
+    let result = Render {
         capture_frame: prepared.capture_frame,
         samples,
-    }
+    };
+    prepared.close().await;
+    result
 }
 
 async fn render_tiny_ring_switch(
@@ -229,10 +232,12 @@ async fn render_tiny_ring_switch(
         Some(expected_variant),
         "{label} target variant"
     );
-    Render {
+    let result = Render {
         capture_frame: prepared.capture_frame,
         samples,
-    }
+    };
+    prepared.close().await;
+    result
 }
 
 fn cochlea_silent_buckets(samples: &[f32]) -> usize {

--- a/tests/tests/kithara_play/quality_switch_continuity/underrun.rs
+++ b/tests/tests/kithara_play/quality_switch_continuity/underrun.rs
@@ -100,7 +100,7 @@ async fn prepare_tiny_ring_player(
             .build(),
     )
     .await;
-    player.load_and_fadein(resource_from_reader(audio));
+    player.load_and_fadein(resource_from_reader(audio)).await;
 
     let deadline = Instant::now() + Duration::from_secs(15);
     let mut active_blocks = 0usize;

--- a/tests/tests/kithara_play/rate_response.rs
+++ b/tests/tests/kithara_play/rate_response.rs
@@ -155,7 +155,7 @@ async fn capture_frames(
         let remaining = frames - samples.len() / usize::from(CHANNELS);
         let block_frames = remaining.min(callback_frames);
         samples.extend(harness.render(block_frames).await);
-        let _ = harness.tick_and_drain();
+        let _ = harness.tick_and_drain().await;
         time::sleep(frame_period(block_frames)).await;
     }
     samples
@@ -277,12 +277,16 @@ async fn playing_queue(
     ))
     .build();
     let mut events = queue.subscribe();
-    let id = queue.append(config).expect("append sine fixture");
+    let id = harness
+        .run(queue.control(), move |q| q.append(config))
+        .await
+        .expect("append sine fixture");
     wait_for_loader_done_event(&mut events, &queue, id, Duration::from_secs(30))
         .await
         .expect("load sine fixture through resident queue");
-    queue
-        .select(id, Transition::None)
+    harness
+        .run(queue.control(), move |q| q.select(id, Transition::None))
+        .await
         .expect("select live-rate fixture");
     (harness, queue)
 }

--- a/tests/tests/kithara_play/rate_response.rs
+++ b/tests/tests/kithara_play/rate_response.rs
@@ -154,7 +154,7 @@ async fn capture_frames(
     while samples.len() / usize::from(CHANNELS) < frames {
         let remaining = frames - samples.len() / usize::from(CHANNELS);
         let block_frames = remaining.min(callback_frames);
-        samples.extend(harness.render(block_frames));
+        samples.extend(harness.render(block_frames).await);
         let _ = harness.tick_and_drain();
         time::sleep(frame_period(block_frames)).await;
     }
@@ -255,14 +255,15 @@ async fn playing_queue(
             )
             .build(),
         SAMPLE_RATE,
-    );
+    )
+    .await;
     let queue = Queue::new(
         QueueConfig::builder()
             .player(harness.take_player())
             .should_autoplay(false)
             .build(),
     );
-    let queue = harness.insert(queue);
+    let queue = harness.insert(queue).await;
     queue.set_default_rate(case.initial_rate);
     let path = signal_mp3_sine880_30s()
         .path()
@@ -506,6 +507,8 @@ async fn run_case(
         "{backend} already contained the target tone before set_rate"
     );
     assert_response(backend, case, command_frame, &samples, &events);
+    drop(queue);
+    harness.close().await;
 }
 
 #[kithara::test(

--- a/tests/tests/kithara_play/red_crossfade_hls_to_mp3_blocks_render.rs
+++ b/tests/tests/kithara_play/red_crossfade_hls_to_mp3_blocks_render.rs
@@ -130,7 +130,7 @@ async fn red_hls_to_mp3_crossfade_no_render_budget_violations() {
 
     for iter in 0..10 {
         let hls = make_hls(worker.clone(), store.clone()).await;
-        player.load_and_fadein(hls);
+        player.load_and_fadein(hls).await;
         let _hls_warmup = render_offline_window(
             &mut player,
             40,
@@ -146,7 +146,7 @@ async fn red_hls_to_mp3_crossfade_no_render_budget_violations() {
             .expect("MP3 preload")
             .expect("MP3 preload result");
         let before_fade = Instant::now();
-        player.load_and_fadein(mp3);
+        player.load_and_fadein(mp3).await;
         let fade_stats = render_offline_window(
             &mut player,
             60,

--- a/tests/tests/kithara_play/red_crossfade_hls_to_mp3_blocks_render.rs
+++ b/tests/tests/kithara_play/red_crossfade_hls_to_mp3_blocks_render.rs
@@ -78,7 +78,8 @@ async fn red_hls_to_mp3_crossfade_no_render_budget_violations() {
         HostConfig::offline(pools.clone())
             .sample_rate(NonZeroU32::new(Consts::SR).expect("sample rate is non-zero"))
             .build(),
-    );
+    )
+    .await;
 
     let media_dir = temp_dir();
     let local_mp3 = media_dir.write("track.mp3", signal_mp3_track_sine440_187s().bytes());
@@ -136,7 +137,8 @@ async fn red_hls_to_mp3_crossfade_no_render_budget_violations() {
             &format!("HLS warmup #{iter}"),
             Consts::BLOCK,
             Consts::SR,
-        );
+        )
+        .await;
 
         let mut mp3 = make_mp3(worker.clone()).await;
         time::timeout(Consts::READ_TIMEOUT, mp3.preload())
@@ -151,7 +153,8 @@ async fn red_hls_to_mp3_crossfade_no_render_budget_violations() {
             &format!("HLS→MP3 red #{iter}"),
             Consts::BLOCK,
             Consts::SR,
-        );
+        )
+        .await;
         info!(
             "iter {iter}: {fade_stats}, wall={:?}",
             before_fade.elapsed()
@@ -172,4 +175,5 @@ async fn red_hls_to_mp3_crossfade_no_render_budget_violations() {
          while the shared worker was busy on HLS",
         worst_slow_renders,
     );
+    player.close().await;
 }

--- a/tests/tests/kithara_play/resource_regressions.rs
+++ b/tests/tests/kithara_play/resource_regressions.rs
@@ -914,7 +914,7 @@ async fn packaged_hls_single_variant_continuity_is_stable(
             .build(),
     )
     .await;
-    player.load_and_fadein(resource);
+    player.load_and_fadein(resource).await;
     let _warmup = render_offline_window(
         &mut player,
         24,
@@ -1128,7 +1128,7 @@ async fn stress_offline_crossfade_no_gaps() {
         .await
         .expect("mp3_1 preload deadline")
         .expect("mp3_1 preload");
-    player.load_and_fadein(mp3_1);
+    player.load_and_fadein(mp3_1).await;
     let s1a = render_offline_window(&mut player, 40, "MP3 solo", BLOCK, SR).await;
 
     let mut hls_1 = make_hls(worker.clone(), store.clone(), master_cancel.child()).await;
@@ -1136,7 +1136,7 @@ async fn stress_offline_crossfade_no_gaps() {
         .await
         .expect("hls_1 preload deadline")
         .expect("hls_1 preload");
-    player.load_and_fadein(hls_1);
+    player.load_and_fadein(hls_1).await;
     let s1b = render_offline_window(&mut player, 80, "MP3→HLS fade", BLOCK, SR).await;
 
     let mut mp3_2 = make_mp3(worker.clone(), store.clone(), master_cancel.child()).await;
@@ -1144,7 +1144,7 @@ async fn stress_offline_crossfade_no_gaps() {
         .await
         .expect("mp3_2 preload deadline")
         .expect("mp3_2 preload");
-    player.load_and_fadein(mp3_2);
+    player.load_and_fadein(mp3_2).await;
     let s2 = render_offline_window(&mut player, 80, "HLS→MP3 fade", BLOCK, SR).await;
 
     let mut mp3_3 = make_mp3(worker.clone(), store.clone(), master_cancel.child()).await;
@@ -1152,7 +1152,7 @@ async fn stress_offline_crossfade_no_gaps() {
         .await
         .expect("mp3_3 preload deadline")
         .expect("mp3_3 preload");
-    player.load_and_fadein(mp3_3);
+    player.load_and_fadein(mp3_3).await;
     let s3 = render_offline_window(&mut player, 80, "MP3→MP3 fade", BLOCK, SR).await;
 
     info!("\n=== Stress crossfade results (budget={block_budget:?}) ===");
@@ -1171,7 +1171,7 @@ async fn stress_offline_crossfade_no_gaps() {
             .await
             .expect("hls_n preload deadline")
             .expect("hls_n preload");
-        player.load_and_fadein(hls_n);
+        player.load_and_fadein(hls_n).await;
         let _sh =
             render_offline_window(&mut player, 40, &format!("HLS solo #{iter}"), BLOCK, SR).await;
 
@@ -1180,7 +1180,7 @@ async fn stress_offline_crossfade_no_gaps() {
             .await
             .expect("mp3_n preload deadline")
             .expect("mp3_n preload");
-        player.load_and_fadein(mp3_n);
+        player.load_and_fadein(mp3_n).await;
         let sm =
             render_offline_window(&mut player, 60, &format!("HLS→MP3 #{iter}"), BLOCK, SR).await;
 

--- a/tests/tests/kithara_play/resource_regressions.rs
+++ b/tests/tests/kithara_play/resource_regressions.rs
@@ -912,7 +912,8 @@ async fn packaged_hls_single_variant_continuity_is_stable(
         HostConfig::offline(region.clone())
             .sample_rate(NonZeroU32::new(CONTINUITY_SAMPLE_RATE).expect("sample rate is non-zero"))
             .build(),
-    );
+    )
+    .await;
     player.load_and_fadein(resource);
     let _warmup = render_offline_window(
         &mut player,
@@ -920,14 +921,16 @@ async fn packaged_hls_single_variant_continuity_is_stable(
         "packaged warmup",
         CONTINUITY_BLOCK_FRAMES,
         CONTINUITY_SAMPLE_RATE,
-    );
+    )
+    .await;
     let steady = render_offline_window(
         &mut player,
         80,
         "packaged steady-state",
         CONTINUITY_BLOCK_FRAMES,
         CONTINUITY_SAMPLE_RATE,
-    );
+    )
+    .await;
     assert!(
         steady.max_silence_run <= 1,
         "{codec:?}: offline output produced {} silent blocks ({steady})",
@@ -938,6 +941,7 @@ async fn packaged_hls_single_variant_continuity_is_stable(
         "{codec:?}: offline output exceeded render budget {} times ({steady})",
         steady.slow_renders
     );
+    player.close().await;
 }
 
 #[kithara::test(tokio, browser, timeout(Duration::from_secs(10)), hang_timeout_secs(5))]
@@ -1068,7 +1072,8 @@ async fn stress_offline_crossfade_no_gaps() {
         HostConfig::offline(region.clone())
             .sample_rate(NonZeroU32::new(SR).expect("sample rate is non-zero"))
             .build(),
-    );
+    )
+    .await;
 
     let media_dir = temp_dir();
     let local_mp3 = media_dir.write("track.mp3", signal_mp3_track_sine440_187s().bytes());
@@ -1124,7 +1129,7 @@ async fn stress_offline_crossfade_no_gaps() {
         .expect("mp3_1 preload deadline")
         .expect("mp3_1 preload");
     player.load_and_fadein(mp3_1);
-    let s1a = render_offline_window(&mut player, 40, "MP3 solo", BLOCK, SR);
+    let s1a = render_offline_window(&mut player, 40, "MP3 solo", BLOCK, SR).await;
 
     let mut hls_1 = make_hls(worker.clone(), store.clone(), master_cancel.child()).await;
     time::timeout(Consts::READ_TIMEOUT, hls_1.preload())
@@ -1132,7 +1137,7 @@ async fn stress_offline_crossfade_no_gaps() {
         .expect("hls_1 preload deadline")
         .expect("hls_1 preload");
     player.load_and_fadein(hls_1);
-    let s1b = render_offline_window(&mut player, 80, "MP3→HLS fade", BLOCK, SR);
+    let s1b = render_offline_window(&mut player, 80, "MP3→HLS fade", BLOCK, SR).await;
 
     let mut mp3_2 = make_mp3(worker.clone(), store.clone(), master_cancel.child()).await;
     time::timeout(Consts::READ_TIMEOUT, mp3_2.preload())
@@ -1140,7 +1145,7 @@ async fn stress_offline_crossfade_no_gaps() {
         .expect("mp3_2 preload deadline")
         .expect("mp3_2 preload");
     player.load_and_fadein(mp3_2);
-    let s2 = render_offline_window(&mut player, 80, "HLS→MP3 fade", BLOCK, SR);
+    let s2 = render_offline_window(&mut player, 80, "HLS→MP3 fade", BLOCK, SR).await;
 
     let mut mp3_3 = make_mp3(worker.clone(), store.clone(), master_cancel.child()).await;
     time::timeout(Consts::READ_TIMEOUT, mp3_3.preload())
@@ -1148,7 +1153,7 @@ async fn stress_offline_crossfade_no_gaps() {
         .expect("mp3_3 preload deadline")
         .expect("mp3_3 preload");
     player.load_and_fadein(mp3_3);
-    let s3 = render_offline_window(&mut player, 80, "MP3→MP3 fade", BLOCK, SR);
+    let s3 = render_offline_window(&mut player, 80, "MP3→MP3 fade", BLOCK, SR).await;
 
     info!("\n=== Stress crossfade results (budget={block_budget:?}) ===");
     for s in [&s1a, &s1b, &s2, &s3] {
@@ -1167,7 +1172,8 @@ async fn stress_offline_crossfade_no_gaps() {
             .expect("hls_n preload deadline")
             .expect("hls_n preload");
         player.load_and_fadein(hls_n);
-        let _sh = render_offline_window(&mut player, 40, &format!("HLS solo #{iter}"), BLOCK, SR);
+        let _sh =
+            render_offline_window(&mut player, 40, &format!("HLS solo #{iter}"), BLOCK, SR).await;
 
         let mut mp3_n = make_mp3(worker.clone(), store.clone(), master_cancel.child()).await;
         time::timeout(Consts::READ_TIMEOUT, mp3_n.preload())
@@ -1175,7 +1181,8 @@ async fn stress_offline_crossfade_no_gaps() {
             .expect("mp3_n preload deadline")
             .expect("mp3_n preload");
         player.load_and_fadein(mp3_n);
-        let sm = render_offline_window(&mut player, 60, &format!("HLS→MP3 #{iter}"), BLOCK, SR);
+        let sm =
+            render_offline_window(&mut player, 60, &format!("HLS→MP3 #{iter}"), BLOCK, SR).await;
 
         info!("  {sm}");
         if sm.max_silence_run > worst_silence {
@@ -1231,6 +1238,7 @@ async fn stress_offline_crossfade_no_gaps() {
         "HLS→MP3 repeated: {worst_slow} blocks exceeded budget, \
          max_render={worst_render:?} — sustained blocking during crossfade"
     );
+    player.close().await;
 }
 
 /// MP3 through `ResourceConfig` (same path as kithara-app) must probe, decode,

--- a/tests/tests/kithara_play/ring_admission.rs
+++ b/tests/tests/kithara_play/ring_admission.rs
@@ -16,7 +16,7 @@ use kithara::{
     platform::sync::Arc,
     play::{
         Cmd, PlayWorker, PlayWorkerConfig, PlayerConfig, PlayerId, PlayerImpl, Reply,
-        SessionDispatcher,
+        SessionBinding, SessionDispatcher,
     },
 };
 use kithara_integration_tests::ring::{
@@ -104,7 +104,7 @@ fn empty_player(session: &Arc<ManualRingSession>) -> PlayerImpl<TestPools> {
             .worker(PlayWorker::new(PlayWorkerConfig::builder(pools()).build()))
             .crossfade_duration(0.0)
             .sample_rate(session_rate())
-            .session(dispatcher)
+            .session(SessionBinding::new(dispatcher, session_rate()))
             .build(),
     )
 }

--- a/tests/tests/kithara_play/seamless_queue_advance.rs
+++ b/tests/tests/kithara_play/seamless_queue_advance.rs
@@ -67,7 +67,7 @@ async fn seamless_queue_advance_gapless_when_crossfade_is_zero(temp_dir: TestTem
         .crossfade_duration(0.0)
         .gapless_mode(GaplessMode::SilenceTrim(gapless_params))
         .build();
-    let harness = OfflinePlayerHarness::with_sample_rate(player_config, GAPLESS_SAMPLE_RATE);
+    let harness = OfflinePlayerHarness::with_sample_rate(player_config, GAPLESS_SAMPLE_RATE).await;
     let first = create_gapless_hls_resource(
         harness.player(),
         &server,
@@ -89,7 +89,7 @@ async fn seamless_queue_advance_gapless_when_crossfade_is_zero(temp_dir: TestTem
     )
     .await;
 
-    load_queue(&harness, [first, second]);
+    load_queue(&harness, [first, second]).await;
 
     let (rendered, events) = render_until_second_item_end(&harness).await;
     let left = deinterleave_left(&rendered, usize::from(GAPLESS_CHANNELS));
@@ -142,6 +142,7 @@ async fn seamless_queue_advance_gapless_when_crossfade_is_zero(temp_dir: TestTem
         ms_int = max_silence_ms_x10 / 10,
         ms_frac = max_silence_ms_x10 % 10
     );
+    harness.close().await;
 }
 
 #[kithara::test(native, tokio, timeout(Duration::from_secs(30)), hang_timeout_secs(1))]
@@ -155,7 +156,7 @@ async fn seamless_queue_advance_overlaps_tracks_when_crossfade_is_non_zero(temp_
         .crossfade_duration(1.0)
         .gapless_mode(GaplessMode::SilenceTrim(gapless_params))
         .build();
-    let harness = OfflinePlayerHarness::with_sample_rate(player_config, GAPLESS_SAMPLE_RATE);
+    let harness = OfflinePlayerHarness::with_sample_rate(player_config, GAPLESS_SAMPLE_RATE).await;
     let first = create_gapless_hls_resource(
         harness.player(),
         &server,
@@ -173,7 +174,7 @@ async fn seamless_queue_advance_overlaps_tracks_when_crossfade_is_non_zero(temp_
     )
     .await;
 
-    load_queue(&harness, [first, second]);
+    load_queue(&harness, [first, second]).await;
 
     let (rendered, events) = render_until_second_item_end(&harness).await;
     let left = deinterleave_left(&rendered, usize::from(GAPLESS_CHANNELS));
@@ -259,8 +260,9 @@ async fn seamless_queue_advance_overlaps_tracks_when_crossfade_is_non_zero(temp_
         max_silence < BLOCK_FRAMES as usize,
         "no extended silence allowed inside the overlap; \
          max_silence={max_silence} frames, overlap=[{overlap_start}..{overlap_end}), \
-         events={events:?}"
+        events={events:?}"
     );
+    harness.close().await;
 }
 
 async fn create_gapless_hls_resource(
@@ -312,18 +314,20 @@ async fn create_gapless_hls_resource(
     resource
 }
 
-fn load_queue<const N: usize>(harness: &OfflinePlayerHarness, items: [Resource; N]) {
-    harness.with_player(|player| {
-        player.reserve_slots(items.len());
-        for (index, resource) in items.into_iter().enumerate() {
+async fn load_queue<const N: usize>(harness: &OfflinePlayerHarness, items: [Resource; N]) {
+    harness
+        .with_player(|player| {
+            player.reserve_slots(items.len());
+            for (index, resource) in items.into_iter().enumerate() {
+                player
+                    .replace_item(index, resource, TrackId::allocate())
+                    .expect("replace seamless fixture item");
+            }
             player
-                .replace_item(index, resource, TrackId::allocate())
-                .expect("replace seamless fixture item");
-        }
-        player
-            .select_item(0, true)
-            .expect("select first queue item");
-    });
+                .select_item(0, true)
+                .expect("select first queue item");
+        })
+        .await;
 }
 
 async fn render_until_second_item_end(
@@ -342,7 +346,7 @@ async fn render_until_second_item_end(
     let mut events = Vec::new();
 
     loop {
-        let block = harness.render(BLOCK_FRAMES as usize);
+        let block = harness.render(BLOCK_FRAMES as usize).await;
         rendered.extend_from_slice(&block);
         rendered_frames = rendered_frames.saturating_add(BLOCK_FRAMES as usize);
         events.extend(
@@ -354,7 +358,7 @@ async fn render_until_second_item_end(
 
         if count_item_end(&events) >= 2 {
             for _ in 0..POST_ROLL_BLOCKS {
-                let block = harness.render(BLOCK_FRAMES as usize);
+                let block = harness.render(BLOCK_FRAMES as usize).await;
                 rendered.extend_from_slice(&block);
                 rendered_frames = rendered_frames.saturating_add(BLOCK_FRAMES as usize);
                 events.extend(

--- a/tests/tests/kithara_play/seamless_queue_advance.rs
+++ b/tests/tests/kithara_play/seamless_queue_advance.rs
@@ -316,7 +316,7 @@ async fn create_gapless_hls_resource(
 
 async fn load_queue<const N: usize>(harness: &OfflinePlayerHarness, items: [Resource; N]) {
     harness
-        .with_player(|player| {
+        .with_player(move |player| {
             player.reserve_slots(items.len());
             for (index, resource) in items.into_iter().enumerate() {
                 player
@@ -352,6 +352,7 @@ async fn render_until_second_item_end(
         events.extend(
             harness
                 .tick_and_drain()
+                .await
                 .into_iter()
                 .map(|event| TimedPlayerEvent::new(rendered_frames, event)),
         );
@@ -364,6 +365,7 @@ async fn render_until_second_item_end(
                 events.extend(
                     harness
                         .tick_and_drain()
+                        .await
                         .into_iter()
                         .map(|event| TimedPlayerEvent::new(rendered_frames, event)),
                 );

--- a/tests/tests/kithara_play/silvercomet_seek_hang.rs
+++ b/tests/tests/kithara_play/silvercomet_seek_hang.rs
@@ -225,7 +225,7 @@ async fn silvercomet_3tracks_seek_middle_hang_10x(
             let resource =
                 build_resource(url, &downloader, &iter_label, store.clone(), backend, abr).await;
             eprintln!("[iter {iter}][t{track_idx}] resource built, load_and_fadein");
-            player.load_and_fadein(resource);
+            player.load_and_fadein(resource).await;
 
             eprintln!("[iter {iter}][t{track_idx}] warmup ({warmup_blocks} blocks)");
             let _ = render_and_collect(&mut player, warmup_blocks, &mut iteration_samples);

--- a/tests/tests/kithara_play/silvercomet_seek_hang.rs
+++ b/tests/tests/kithara_play/silvercomet_seek_hang.rs
@@ -51,7 +51,7 @@ const SILVERCOMET_URLS: &[&str] = &["https://stream.silvercomet.top/hls/master.m
 
 /// Render `blocks` audio blocks, collect the raw interleaved samples,
 /// and return statistics covering exactly this window.
-fn render_and_collect(
+async fn render_and_collect(
     player: &mut OfflinePlayer,
     blocks: u32,
     samples_out: &mut Vec<f32>,
@@ -228,13 +228,14 @@ async fn silvercomet_3tracks_seek_middle_hang_10x(
             player.load_and_fadein(resource).await;
 
             eprintln!("[iter {iter}][t{track_idx}] warmup ({warmup_blocks} blocks)");
-            let _ = render_and_collect(&mut player, warmup_blocks, &mut iteration_samples);
+            let _ = render_and_collect(&mut player, warmup_blocks, &mut iteration_samples).await;
             eprintln!(
                 "[iter {iter}][t{track_idx}] warmup done, position={:.2}",
                 player.position()
             );
 
-            let initial = render_and_collect(&mut player, window_blocks, &mut iteration_samples);
+            let initial =
+                render_and_collect(&mut player, window_blocks, &mut iteration_samples).await;
             let initial_samples = &iteration_samples[initial.window_start_sample..];
             let initial_rms = rms(initial_samples);
             let initial_silence_fraction =
@@ -272,7 +273,8 @@ async fn silvercomet_3tracks_seek_middle_hang_10x(
             eprintln!("[iter {iter}][t{track_idx}] seek to {seek_target:.2}s epoch={seek_epoch}");
             player.seek(seek_target, seek_epoch);
 
-            let after = render_and_collect(&mut player, window_blocks, &mut iteration_samples);
+            let after =
+                render_and_collect(&mut player, window_blocks, &mut iteration_samples).await;
             let after_samples = &iteration_samples[after.window_start_sample..];
             let after_rms = rms(after_samples);
             let after_silence_fraction =

--- a/tests/tests/kithara_play/silvercomet_seek_hang.rs
+++ b/tests/tests/kithara_play/silvercomet_seek_hang.rs
@@ -65,7 +65,7 @@ fn render_and_collect(
 
     for _ in 0..blocks {
         let started = Instant::now();
-        let out = player.render(Consts::BLOCK_FRAMES);
+        let out = player.render(Consts::BLOCK_FRAMES).await;
         let elapsed = started.elapsed();
 
         if !out.iter().any(|s| s.abs() > ACTIVE_THRESHOLD) {
@@ -216,7 +216,8 @@ async fn silvercomet_3tracks_seek_middle_hang_10x(
             HostConfig::offline(pools())
                 .sample_rate(NonZeroU32::new(Consts::SAMPLE_RATE).expect("sample rate is non-zero"))
                 .build(),
-        );
+        )
+        .await;
         let mut iteration_samples: Vec<f32> = Vec::new();
 
         for (track_idx, url) in SILVERCOMET_URLS.iter().enumerate() {
@@ -322,7 +323,7 @@ async fn silvercomet_3tracks_seek_middle_hang_10x(
             wav_path.display(),
         );
 
-        drop(player);
+        player.close().await;
         drop(downloader);
         drop(temp);
         let _ = iter_label;

--- a/tests/tests/kithara_play/sync_listening.rs
+++ b/tests/tests/kithara_play/sync_listening.rs
@@ -36,7 +36,8 @@ async fn render_solo(case: SyncCase, provider: Provider, audible_deck: usize) ->
 async fn render_mix(case: SyncCase, provider: Provider, target_bpm: Option<f64>) -> Capture {
     let mut harness = ProductHarness::new(case, provider, 0).await;
     for deck in &harness.decks {
-        deck.set_muted(false);
+        let control = deck.control().clone();
+        harness.host.run(move || control.set_muted(false)).await;
     }
     harness.request_sync(case).await;
 
@@ -45,7 +46,9 @@ async fn render_mix(case: SyncCase, provider: Provider, target_bpm: Option<f64>)
         let mut rendered = 0;
         for step in 1..=RIDE_STEPS {
             let progress = step as f64 / RIDE_STEPS as f64;
-            harness.set_tempo(case, (target_bpm - 120.0).mul_add(progress, 120.0), false);
+            harness
+                .set_tempo(case, (target_bpm - 120.0).mul_add(progress, 120.0), false)
+                .await;
             let deadline = CAPTURE_FRAMES * step / RIDE_STEPS;
             pcm.extend(render_frames(&mut harness, case, deadline - rendered).await);
             rendered = deadline;

--- a/tests/tests/kithara_play/sync_product_matrix.rs
+++ b/tests/tests/kithara_play/sync_product_matrix.rs
@@ -7,8 +7,8 @@ use kithara::{
     encode::EncodeConfig,
     events::TrackStatus,
     hls::AbrMode,
-    host::{Host, HostConfig, HostOwned, testing::HostProbe},
-    output::{OfflineRenderRequest, OfflineRenderer, RenderSink, RenderSinkError},
+    host::{Host, HostConfig, HostOwned},
+    output::{OfflineRenderRequest, OfflineRenderer},
     platform::{
         CancelScope,
         sync::Arc,
@@ -33,6 +33,7 @@ use kithara_integration_tests::{
     fixture_protocol::EncryptionRequest,
     hls_fixture::{aes128_iv, aes128_key_bytes},
     kithara, memory_asset_store,
+    offline::OfflineHostHarness,
 };
 use kithara_test_fixtures::{
     asset::Asset,
@@ -315,22 +316,9 @@ pub(super) struct ProductHarness {
     pub(super) decks: Vec<HostOwned<Queue<TestPools>>>,
     pub(super) failures: Vec<String>,
     block_frames: usize,
-    host: Host<TestPools>,
-    spec: AudioSpec,
+    pub(super) host: OfflineHostHarness<TestPools>,
     output_frames: u64,
     paced: bool,
-}
-
-#[derive(Default)]
-struct VecRenderSink {
-    samples: Vec<f32>,
-}
-
-impl RenderSink for VecRenderSink {
-    fn write(&mut self, samples: &[f32]) -> Result<(), RenderSinkError> {
-        self.samples.extend_from_slice(samples);
-        Ok(())
-    }
 }
 
 struct FailingPartSink(AssetPartSink<TestPools>);
@@ -424,12 +412,12 @@ impl ProductHarness {
             u32::try_from(block_frames).expect("offline render block count fits u32"),
         )
         .expect("offline render block count is non-zero");
-        let spec = AudioSpec::new(CHANNELS, sample_rate);
         let session = HostConfig::offline(pools)
             .sample_rate(sample_rate)
             .max_block_frames(render_block_frames)
             .build();
-        let mut host = Host::new(session)
+        let host = OfflineHostHarness::new(session)
+            .await
             .unwrap_or_else(|error| panic!("{}: create offline Host: {error}", case.id));
         let mut decks = Vec::with_capacity(sources.len());
         let mut ids = Vec::with_capacity(sources.len());
@@ -445,6 +433,7 @@ impl ProductHarness {
             queue.set_muted(index != audible_deck);
             let deck = host
                 .insert(queue)
+                .await
                 .unwrap_or_else(|error| panic!("{}: insert deck {index}: {error}", case.id));
             let config = ResourceConfig::for_src(
                 ResourceSrc::parse(&source)
@@ -454,8 +443,10 @@ impl ProductHarness {
             .initial_abr_mode(AbrMode::manual(0))
             .discriminator(format!("{}-{provider:?}-{index}", case.id))
             .build();
-            let id = deck
-                .append(TrackSource::Config(Box::new(config)))
+            let control = deck.control().clone();
+            let id = host
+                .run(move || control.append(TrackSource::Config(Box::new(config))))
+                .await
                 .unwrap_or_else(|error| panic!("{}: append deck {index}: {error}", case.id));
             decks.push(deck);
             ids.push(id);
@@ -467,14 +458,17 @@ impl ProductHarness {
             host,
             output_frames: 0,
             paced,
-            spec,
         };
         harness.wait_loaded(case, &ids).await;
         for (index, (deck, id)) in harness.decks.iter().zip(ids).enumerate() {
-            deck.select(id, Transition::None)
+            let control = deck.control().clone();
+            harness
+                .host
+                .run(move || control.select(id, Transition::None))
+                .await
                 .unwrap_or_else(|error| panic!("{}: select deck {index}: {error}", case.id));
         }
-        harness.set_tempo(case, case.start_bpm(), true);
+        harness.set_tempo(case, case.start_bpm(), true).await;
         let _ = harness.render(case, harness.block_frames).await;
         if !case.paused {
             harness.start_staggered(case).await;
@@ -485,7 +479,7 @@ impl ProductHarness {
     async fn wait_loaded(&mut self, case: SyncCase, ids: &[kithara::events::TrackId]) {
         let deadline = Instant::now() + LOAD_TIMEOUT;
         loop {
-            self.tick_all(case);
+            self.tick_all(case).await;
             let mut loaded = true;
             for (index, (deck, id)) in self.decks.iter().zip(ids).enumerate() {
                 match deck.track(*id).map(|track| track.status) {
@@ -508,35 +502,35 @@ impl ProductHarness {
         }
     }
 
-    fn tick_all(&self, case: SyncCase) {
-        for (index, deck) in self.decks.iter().enumerate() {
-            deck.tick()
-                .unwrap_or_else(|error| panic!("{}: tick deck {index}: {error}", case.id));
-        }
+    /// Ticks every deck from the host owner thread, as the app update loop
+    /// would.
+    async fn tick_all(&self, case: SyncCase) {
+        let controls: Vec<_> = self
+            .decks
+            .iter()
+            .map(|deck| deck.control().clone())
+            .collect();
+        self.host
+            .run(move || {
+                for (index, control) in controls.iter().enumerate() {
+                    control
+                        .tick()
+                        .unwrap_or_else(|error| panic!("{}: tick deck {index}: {error}", case.id));
+                }
+            })
+            .await;
     }
 
     pub(super) async fn render(&mut self, case: SyncCase, frames: usize) -> Vec<f32> {
         let started = Instant::now();
-        self.tick_all(case);
+        self.tick_all(case).await;
         let start = self.output_frames;
         let end = start
             .checked_add(u64::try_from(frames).expect("render frame count fits u64"))
             .expect("offline render timeline fits u64");
-        let request = OfflineRenderRequest::builder()
-            .spec(self.spec)
-            .frames(start..end)
-            .build();
-        let cancel = CancelScope::new(None);
-        let mut sink = VecRenderSink::default();
-        let report = self
-            .host
-            .render(&request, &cancel.token(), &mut sink)
-            .unwrap_or_else(|error| panic!("{}: render offline Host: {error}", case.id));
-        assert_eq!(
-            report.frames,
-            u64::try_from(frames).expect("frame count fits u64")
-        );
-        self.tick_all(case);
+        let samples = self.host.render(frames).await;
+        assert_eq!(self.host.position(), end);
+        self.tick_all(case).await;
         self.output_frames = end;
         let delay = if self.paced {
             Duration::from_secs_f64(frames as f64 / f64::from(case.sample_rate))
@@ -545,7 +539,7 @@ impl ProductHarness {
             Duration::from_millis(1)
         };
         time::sleep(delay).await;
-        sink.samples
+        samples
     }
 
     pub(super) async fn settle(&mut self, case: SyncCase, blocks: usize) {
@@ -554,17 +548,27 @@ impl ProductHarness {
         }
     }
 
-    fn play_all(&self) {
-        for deck in &self.decks {
-            deck.play();
-        }
+    async fn play_all(&self) {
+        let controls: Vec<_> = self
+            .decks
+            .iter()
+            .map(|deck| deck.control().clone())
+            .collect();
+        self.host
+            .run(move || {
+                for control in &controls {
+                    control.play();
+                }
+            })
+            .await;
     }
 
     async fn start_staggered(&mut self, case: SyncCase) {
         let stagger_frames =
             (f64::from(case.sample_rate) * 3.0 / 8.0 * 60.0 / case.start_bpm()).round() as usize;
         for index in 0..self.decks.len() {
-            self.decks[index].play();
+            let control = self.decks[index].control().clone();
+            self.host.run(move || control.play()).await;
             if index + 1 < self.decks.len() {
                 let _ = self.render(case, stagger_frames).await;
             }
@@ -581,9 +585,9 @@ impl ProductHarness {
         self.settle(case, 96).await;
     }
 
-    pub(super) fn set_tempo(&mut self, case: SyncCase, bpm: f64, required: bool) {
+    pub(super) async fn set_tempo(&mut self, case: SyncCase, bpm: f64, required: bool) {
         let tempo = Tempo::new(bpm).expect("fixture tempo");
-        match self.host.set_tempo(tempo) {
+        match self.host.with(move |host| host.set_tempo(tempo)).await {
             Ok(()) => {}
             Err(error) if !required => self.record_tempo_failure(format!(
                 "tempo request {bpm:.6} BPM could not reach Host: {error}"
@@ -602,9 +606,10 @@ impl ProductHarness {
         }
     }
 
-    fn transport_revision(&self, case: SyncCase) -> kithara::warp::TransportRevision {
+    async fn transport_revision(&self, case: SyncCase) -> kithara::warp::TransportRevision {
         self.host
             .transport_revision()
+            .await
             .unwrap_or_else(|error| panic!("{}: query Host transport: {error}", case.id))
     }
 
@@ -613,7 +618,7 @@ impl ProductHarness {
     }
 
     pub(super) async fn request_sync_intent(&mut self, case: SyncCase, intent: SyncIntent) {
-        let transport = self.transport_revision(case);
+        let transport = self.transport_revision(case).await;
         for index in 0..self.decks.len() {
             {
                 let deck = &self.decks[index];
@@ -631,18 +636,22 @@ impl ProductHarness {
                 } else {
                     AlignmentSource::Prepared
                 };
+                let target = deck.id();
+                let activation =
+                    SessionFrame::new(i64::try_from(self.output_frames).unwrap_or(i64::MAX));
                 let admission = self
                     .host
-                    .transact(SyncOperation::Sync {
-                        target: deck.id(),
-                        load: LoadGeneration::first(),
-                        transport,
-                        source,
-                        activation: SessionFrame::new(
-                            i64::try_from(self.output_frames).unwrap_or(i64::MAX),
-                        ),
-                        intent,
+                    .with(move |host| {
+                        host.transact(SyncOperation::Sync {
+                            target,
+                            load: LoadGeneration::first(),
+                            transport,
+                            source,
+                            activation,
+                            intent,
+                        })
                     })
+                    .await
                     .unwrap_or_else(|rejected| {
                         panic!("{}: sync deck {index}: {rejected}", case.id)
                     });
@@ -662,7 +671,7 @@ impl ProductHarness {
         for operation in case.order.operations() {
             match operation {
                 Operation::Play => {
-                    self.play_all();
+                    self.play_all().await;
                     self.settle(case, 2).await;
                 }
                 Operation::Seek => self.seek_staggered(case).await,
@@ -680,7 +689,7 @@ impl ProductHarness {
             for step in 1..=steps_per_leg {
                 let fraction = f64::from(step) / f64::from(steps_per_leg);
                 let bpm = start + (target - start) * fraction;
-                self.set_tempo(case, bpm, false);
+                self.set_tempo(case, bpm, false).await;
                 update += 1;
                 let deadline = update * u64::from(case.sample_rate) / u64::from(case.updates_hz);
                 let frames = deadline.saturating_sub(rendered);
@@ -696,7 +705,7 @@ impl ProductHarness {
     }
 
     async fn capture(&mut self, case: SyncCase) -> Vec<f32> {
-        self.play_all();
+        self.play_all().await;
         self.settle(case, 4).await;
         let capture_frames =
             (f64::from(case.sample_rate) * 60.0 / case.ride.final_bpm() * 6.0).round() as usize;

--- a/tests/tests/kithara_play/sync_runtime_oracles.rs
+++ b/tests/tests/kithara_play/sync_runtime_oracles.rs
@@ -40,7 +40,7 @@ async fn tempo_retarget_run(block_frames: usize, warm_blocks: usize, retarget: b
         .await;
     let command_index = samples.len() / usize::from(CHANNELS);
     if retarget {
-        harness.set_tempo(ONE_DECK, 132.0, false);
+        harness.set_tempo(ONE_DECK, 132.0, false).await;
     }
     samples.extend(
         harness

--- a/tests/tests/kithara_queue/advance_boundary_provenance.rs
+++ b/tests/tests/kithara_queue/advance_boundary_provenance.rs
@@ -10,10 +10,7 @@ use kithara::{
         time::{self, Duration},
         tokio::sync::broadcast::error::TryRecvError,
     },
-    play::{
-        Resource, ResourceConfig, ResourceSrc, effects::eq::generate_log_spaced_bands,
-        player::PlayerControl,
-    },
+    play::{Resource, ResourceConfig, ResourceSrc, effects::eq::generate_log_spaced_bands},
     queue::{Queue, QueueConfig, QueueControl, Transition, test_utils::QueueProbe},
     warp::{StretchControls, WarpConfig},
 };
@@ -1096,7 +1093,7 @@ async fn setup_queue_with_sample_rate(
         .await;
 
     let resource_a = hls_resource(
-        harness.player(),
+        &harness,
         server,
         &temp_dir.path().join("a"),
         PcmPattern::Ascending,
@@ -1104,7 +1101,7 @@ async fn setup_queue_with_sample_rate(
     )
     .await;
     let resource_b = hls_resource(
-        harness.player(),
+        &harness,
         server,
         &temp_dir.path().join("b"),
         PcmPattern::Descending,
@@ -1112,10 +1109,15 @@ async fn setup_queue_with_sample_rate(
     )
     .await;
 
-    let id_a = queue.insert_loaded_for_test(resource_a);
-    let _ = queue.insert_loaded_for_test(resource_b);
-    queue
-        .select(id_a, Transition::None)
+    let id_a = harness
+        .run(&queue, move |q| q.insert_loaded_for_test(resource_a))
+        .await;
+    let _ = harness
+        .run(&queue, move |q| q.insert_loaded_for_test(resource_b))
+        .await;
+    harness
+        .run(&queue, move |q| q.select(id_a, Transition::None))
+        .await
         .expect("select track A");
 
     QueueSetup { harness, queue }
@@ -1142,24 +1144,29 @@ async fn setup_multivariant_flac_queue(
         .await;
 
     let resource_a = hls_multivariant_flac_resource(
-        harness.player(),
+        &harness,
         server,
         &temp_dir.path().join("a"),
         PcmPattern::Ascending,
     )
     .await;
     let resource_b = hls_multivariant_flac_resource(
-        harness.player(),
+        &harness,
         server,
         &temp_dir.path().join("b"),
         PcmPattern::Descending,
     )
     .await;
 
-    let id_a = queue.insert_loaded_for_test(resource_a);
-    let _ = queue.insert_loaded_for_test(resource_b);
-    queue
-        .select(id_a, Transition::None)
+    let id_a = harness
+        .run(&queue, move |q| q.insert_loaded_for_test(resource_a))
+        .await;
+    let _ = harness
+        .run(&queue, move |q| q.insert_loaded_for_test(resource_b))
+        .await;
+    harness
+        .run(&queue, move |q| q.select(id_a, Transition::None))
+        .await
         .expect("select track A");
 
     QueueSetup { harness, queue }
@@ -1231,7 +1238,7 @@ async fn setup_flac_queue_with_player_config_autoplay_geometry(
         .await;
 
     let resource_a = hls_resource_with_segments_and_duration(
-        harness.player(),
+        &harness,
         server,
         &temp_dir.path().join("a"),
         PcmPattern::Ascending,
@@ -1241,7 +1248,7 @@ async fn setup_flac_queue_with_player_config_autoplay_geometry(
     )
     .await;
     let resource_b = hls_resource_with_segments_and_duration(
-        harness.player(),
+        &harness,
         server,
         &temp_dir.path().join("b"),
         PcmPattern::Descending,
@@ -1254,13 +1261,22 @@ async fn setup_flac_queue_with_player_config_autoplay_geometry(
     if should_autoplay {
         let id_a = queue.register_for_test();
         let id_b = queue.register_for_test();
-        queue.complete_load_for_test(id_b, resource_b);
-        queue.complete_load_for_test(id_a, resource_a);
+        harness
+            .run(&queue, move |q| q.complete_load_for_test(id_b, resource_b))
+            .await;
+        harness
+            .run(&queue, move |q| q.complete_load_for_test(id_a, resource_a))
+            .await;
     } else {
-        let id_a = queue.insert_loaded_for_test(resource_a);
-        let _ = queue.insert_loaded_for_test(resource_b);
-        queue
-            .select(id_a, Transition::None)
+        let id_a = harness
+            .run(&queue, move |q| q.insert_loaded_for_test(resource_a))
+            .await;
+        let _ = harness
+            .run(&queue, move |q| q.insert_loaded_for_test(resource_b))
+            .await;
+        harness
+            .run(&queue, move |q| q.select(id_a, Transition::None))
+            .await
             .expect("select track A");
     }
 
@@ -1282,42 +1298,37 @@ async fn setup_sine_aac_queue(server: &TestServerHelper, temp_dir: &TestTempDir)
         )))
         .await;
 
-    let resource_a = hls_sine_aac_resource(
-        harness.player(),
-        server,
-        &temp_dir.path().join("a"),
-        TONE_A_FREQ_HZ,
-    )
-    .await;
-    let resource_b = hls_sine_aac_resource(
-        harness.player(),
-        server,
-        &temp_dir.path().join("b"),
-        TONE_B_FREQ_HZ,
-    )
-    .await;
+    let resource_a =
+        hls_sine_aac_resource(&harness, server, &temp_dir.path().join("a"), TONE_A_FREQ_HZ).await;
+    let resource_b =
+        hls_sine_aac_resource(&harness, server, &temp_dir.path().join("b"), TONE_B_FREQ_HZ).await;
 
-    let id_a = queue.insert_loaded_for_test(resource_a);
-    let _ = queue.insert_loaded_for_test(resource_b);
-    queue
-        .select(id_a, Transition::None)
+    let id_a = harness
+        .run(&queue, move |q| q.insert_loaded_for_test(resource_a))
+        .await;
+    let _ = harness
+        .run(&queue, move |q| q.insert_loaded_for_test(resource_b))
+        .await;
+    harness
+        .run(&queue, move |q| q.select(id_a, Transition::None))
+        .await
         .expect("select track A");
 
     QueueSetup { harness, queue }
 }
 
 async fn hls_resource(
-    player: &PlayerControl<TestPools>,
+    harness: &OfflinePlayerHarness,
     server: &TestServerHelper,
     cache_dir: &Path,
     pattern: PcmPattern,
     flac: bool,
 ) -> Resource {
-    hls_resource_with_segments(player, server, cache_dir, pattern, flac, SEGMENTS).await
+    hls_resource_with_segments(harness, server, cache_dir, pattern, flac, SEGMENTS).await
 }
 
 async fn hls_resource_with_segments(
-    player: &PlayerControl<TestPools>,
+    harness: &OfflinePlayerHarness,
     server: &TestServerHelper,
     cache_dir: &Path,
     pattern: PcmPattern,
@@ -1325,7 +1336,7 @@ async fn hls_resource_with_segments(
     segments: usize,
 ) -> Resource {
     hls_resource_with_segments_and_duration(
-        player,
+        harness,
         server,
         cache_dir,
         pattern,
@@ -1337,7 +1348,7 @@ async fn hls_resource_with_segments(
 }
 
 async fn hls_resource_with_segments_and_duration(
-    player: &PlayerControl<TestPools>,
+    harness: &OfflinePlayerHarness,
     server: &TestServerHelper,
     cache_dir: &Path,
     pattern: PcmPattern,
@@ -1364,8 +1375,9 @@ async fn hls_resource_with_segments_and_duration(
     )
     .store(store)
     .build();
-    config = player
-        .prepare_config(config)
+    config = harness
+        .with_player(move |player| player.prepare_config(config))
+        .await
         .expect("prepare advance-boundary HLS resource");
     let mut resource = Resource::new(config)
         .await
@@ -1375,7 +1387,7 @@ async fn hls_resource_with_segments_and_duration(
 }
 
 async fn hls_multivariant_flac_resource(
-    player: &PlayerControl<TestPools>,
+    harness: &OfflinePlayerHarness,
     server: &TestServerHelper,
     cache_dir: &Path,
     pattern: PcmPattern,
@@ -1400,8 +1412,9 @@ async fn hls_multivariant_flac_resource(
     )
     .store(store)
     .build();
-    config = player
-        .prepare_config(config)
+    config = harness
+        .with_player(move |player| player.prepare_config(config))
+        .await
         .expect("prepare advance-boundary multivariant FLAC resource");
     let mut resource = Resource::new(config)
         .await
@@ -1411,7 +1424,7 @@ async fn hls_multivariant_flac_resource(
 }
 
 async fn hls_sine_aac_resource(
-    player: &PlayerControl<TestPools>,
+    harness: &OfflinePlayerHarness,
     server: &TestServerHelper,
     cache_dir: &Path,
     freq_hz: f64,
@@ -1432,8 +1445,9 @@ async fn hls_sine_aac_resource(
     )
     .store(store)
     .build();
-    config = player
-        .prepare_config(config)
+    config = harness
+        .with_player(move |player| player.prepare_config(config))
+        .await
         .expect("prepare advance-boundary sine AAC resource");
     let mut resource = Resource::new(config)
         .await
@@ -1454,7 +1468,7 @@ async fn render_until_b_with_postroll(
     let mut expected_a_frames: Option<usize> = None;
 
     for _ in 0..BLOCK_BUDGET {
-        let _ = queue.tick();
+        let _ = harness.run(queue, |q| q.tick()).await;
         let block = harness.render(BLOCK_FRAMES).await;
         progress.push_block(&block, class_tolerance, Some(0));
 
@@ -1491,7 +1505,7 @@ async fn render_until_b_with_late_variant_switch(
     let mut committed_variant: Option<usize> = None;
 
     for _ in 0..BLOCK_BUDGET {
-        let _ = queue.tick();
+        let _ = harness.run(queue, |q| q.tick()).await;
         let block = harness.render(BLOCK_FRAMES).await;
         progress.push_block(&block, ASCENDING_TOL, Some(0));
 
@@ -1562,7 +1576,7 @@ async fn render_crossfade_until_b_with_postroll(
     let mut expected_a_end_frame: Option<usize> = None;
 
     for _ in 0..CROSSFADE_BLOCK_BUDGET {
-        let _ = queue.tick();
+        let _ = harness.run(queue, |q| q.tick()).await;
         let block = harness.render(BLOCK_FRAMES).await;
         progress.push_block(&block, ASCENDING_TOL, Some(0));
 
@@ -1615,8 +1629,8 @@ async fn render_app_layer_crossfade_until_b_with_postroll_config(
     let mut auto_advanced_index: Option<usize> = None;
 
     for _ in 0..block_budget {
-        let _ = queue.tick();
-        drive_app_layer_crossfade_advance(queue, &mut auto_advanced_index);
+        let _ = harness.run(queue, |q| q.tick()).await;
+        drive_app_layer_crossfade_advance(harness, queue, &mut auto_advanced_index).await;
 
         let block = harness.render(BLOCK_FRAMES).await;
         progress.push_block(&block, ASCENDING_TOL, Some(0));
@@ -1641,7 +1655,8 @@ async fn render_app_layer_crossfade_until_b_with_postroll_config(
     )
 }
 
-fn drive_app_layer_crossfade_advance(
+async fn drive_app_layer_crossfade_advance(
+    harness: &OfflinePlayerHarness,
     queue: &QueueControl<TestPools>,
     auto_advanced_index: &mut Option<usize>,
 ) {
@@ -1653,8 +1668,11 @@ fn drive_app_layer_crossfade_advance(
         let current = queue.current_index().unwrap_or(0);
         if *auto_advanced_index != Some(current) && current + 1 < queue.len() {
             *auto_advanced_index = Some(current);
-            queue
-                .advance_to_next(Transition::Crossfade, AdvanceReason::UserNext)
+            harness
+                .run(queue, move |q| {
+                    q.advance_to_next(Transition::Crossfade, AdvanceReason::UserNext)
+                })
+                .await
                 .expect("advance provenance crossfade");
         }
     }
@@ -1694,7 +1712,7 @@ async fn render_seek_near_end_until_b_with_postroll(
     let mut seek_duration: Option<f64> = None;
 
     for _ in 0..BLOCK_BUDGET {
-        let _ = queue.tick();
+        let _ = harness.run(queue, |q| q.tick()).await;
 
         loop {
             match events.try_recv().map(|envelope| envelope.event) {
@@ -1747,7 +1765,7 @@ async fn render_until_tone_b_with_postroll(
     let mut track_duration: Option<f64> = None;
 
     for _ in 0..BLOCK_BUDGET {
-        let _ = queue.tick();
+        let _ = harness.run(queue, |q| q.tick()).await;
         let block = harness.render(BLOCK_FRAMES).await;
         progress.push_block(&block, render_sample_rate);
 

--- a/tests/tests/kithara_queue/advance_boundary_provenance.rs
+++ b/tests/tests/kithara_queue/advance_boundary_provenance.rs
@@ -317,6 +317,7 @@ async fn natural_eof_advance_emits_only_b_after_a_flac(temp_dir: TestTempDir) {
             setup.queue.current_index()
         )
     );
+    setup.close().await;
 }
 
 #[kithara::test(native, tokio, timeout(Duration::from_secs(120)), hang_timeout_secs(5))]
@@ -457,6 +458,7 @@ async fn natural_eof_advance_with_late_variant_switch_flac(temp_dir: TestTempDir
             setup.queue.current_index(),
         )
     );
+    setup.close().await;
 }
 
 #[kithara::test(native, tokio, timeout(Duration::from_secs(120)), hang_timeout_secs(5))]
@@ -498,6 +500,7 @@ async fn natural_eof_advance_app_layer_crossfade_advance_flac_resampled_48k(temp
         "app-layer crossfade resampled FLAC queue.current_index must advance to track B at end; {}",
         context.dump()
     );
+    setup.close().await;
 }
 
 #[kithara::test(native, tokio, timeout(Duration::from_secs(240)), hang_timeout_secs(5))]
@@ -550,6 +553,7 @@ async fn natural_eof_advance_app_layer_crossfade_advance_flac_resampled_48k_real
         "app-layer crossfade resampled FLAC real geometry queue.current_index must advance to track B at end; {}",
         context.dump()
     );
+    setup.close().await;
 }
 
 #[kithara::test(native, tokio, timeout(Duration::from_secs(120)), hang_timeout_secs(5))]
@@ -690,6 +694,7 @@ async fn natural_eof_advance_emits_only_b_flac_resampled_48k(temp_dir: TestTempD
             setup.queue.current_index()
         )
     );
+    setup.close().await;
 }
 
 #[kithara::test(native, tokio, timeout(Duration::from_secs(120)), hang_timeout_secs(5))]
@@ -764,6 +769,7 @@ async fn natural_eof_advance_app_layer_crossfade_advance_flac(temp_dir: TestTemp
         "app-layer crossfade FLAC queue.current_index must advance to track B at end; {}",
         context.dump()
     );
+    setup.close().await;
 }
 
 #[kithara::test(native, tokio, timeout(Duration::from_secs(120)), hang_timeout_secs(5))]
@@ -877,6 +883,7 @@ async fn seek_near_end_then_eof_advance_emits_only_b_flac(temp_dir: TestTempDir)
             setup.queue.current_index()
         )
     );
+    setup.close().await;
 }
 
 /// AAC cannot preserve the 0.67 Hz sawtooth slope/phase provenance reliably;
@@ -981,11 +988,20 @@ async fn natural_eof_advance_emits_only_b_aac(temp_dir: TestTempDir) {
         "queue.current_index must advance to track B for AAC; {}",
         diagnostics()
     );
+    setup.close().await;
 }
 
 struct QueueSetup {
     harness: OfflinePlayerHarness,
     queue: QueueControl<TestPools>,
+}
+
+impl QueueSetup {
+    async fn close(self) {
+        let Self { harness, queue } = self;
+        drop(queue);
+        harness.close().await;
+    }
 }
 
 struct RenderProgress {
@@ -1038,6 +1054,7 @@ async fn run_crossfade_flac_case(
         collapse_runs,
         label,
     );
+    setup.close().await;
 }
 
 fn crossfade_eq_stretch_player_config(timestretch: &Arc<StretchControls>) -> OfflinePlayerOptions {
@@ -1062,16 +1079,21 @@ async fn setup_queue_with_sample_rate(
     flac: bool,
     render_sample_rate: u32,
 ) -> QueueSetup {
-    let harness = with_provenance_headroom(OfflinePlayerHarness::with_sample_rate(
-        OfflinePlayerOptions::builder()
-            .crossfade_duration(0.0)
-            .build(),
-        render_sample_rate,
-    ));
-    let queue = harness.insert_control(Queue::new(with_autoplay(
-        QueueConfig::builder().player(harness.take_player()).build(),
-        false,
-    )));
+    let harness = with_provenance_headroom(
+        OfflinePlayerHarness::with_sample_rate(
+            OfflinePlayerOptions::builder()
+                .crossfade_duration(0.0)
+                .build(),
+            render_sample_rate,
+        )
+        .await,
+    );
+    let queue = harness
+        .insert_control(Queue::new(with_autoplay(
+            QueueConfig::builder().player(harness.take_player()).build(),
+            false,
+        )))
+        .await;
 
     let resource_a = hls_resource(
         harness.player(),
@@ -1103,16 +1125,21 @@ async fn setup_multivariant_flac_queue(
     server: &TestServerHelper,
     temp_dir: &TestTempDir,
 ) -> QueueSetup {
-    let harness = with_provenance_headroom(OfflinePlayerHarness::with_sample_rate(
-        OfflinePlayerOptions::builder()
-            .crossfade_duration(0.0)
-            .build(),
-        SAMPLE_RATE,
-    ));
-    let queue = harness.insert_control(Queue::new(with_autoplay(
-        QueueConfig::builder().player(harness.take_player()).build(),
-        false,
-    )));
+    let harness = with_provenance_headroom(
+        OfflinePlayerHarness::with_sample_rate(
+            OfflinePlayerOptions::builder()
+                .crossfade_duration(0.0)
+                .build(),
+            SAMPLE_RATE,
+        )
+        .await,
+    );
+    let queue = harness
+        .insert_control(Queue::new(with_autoplay(
+            QueueConfig::builder().player(harness.take_player()).build(),
+            false,
+        )))
+        .await;
 
     let resource_a = hls_multivariant_flac_resource(
         harness.player(),
@@ -1190,16 +1217,18 @@ async fn setup_flac_queue_with_player_config_autoplay_geometry(
     should_autoplay: bool,
     provenance_headroom: bool,
 ) -> QueueSetup {
-    let harness = OfflinePlayerHarness::with_sample_rate(player_config, render_sample_rate);
+    let harness = OfflinePlayerHarness::with_sample_rate(player_config, render_sample_rate).await;
     let harness = if provenance_headroom {
         with_provenance_headroom(harness)
     } else {
         harness
     };
-    let queue = harness.insert_control(Queue::new(with_autoplay(
-        QueueConfig::builder().player(harness.take_player()).build(),
-        should_autoplay,
-    )));
+    let queue = harness
+        .insert_control(Queue::new(with_autoplay(
+            QueueConfig::builder().player(harness.take_player()).build(),
+            should_autoplay,
+        )))
+        .await;
 
     let resource_a = hls_resource_with_segments_and_duration(
         harness.player(),
@@ -1244,11 +1273,14 @@ async fn setup_sine_aac_queue(server: &TestServerHelper, temp_dir: &TestTempDir)
             .crossfade_duration(0.0)
             .build(),
         SAMPLE_RATE,
-    );
-    let queue = harness.insert_control(Queue::new(with_autoplay(
-        QueueConfig::builder().player(harness.take_player()).build(),
-        false,
-    )));
+    )
+    .await;
+    let queue = harness
+        .insert_control(Queue::new(with_autoplay(
+            QueueConfig::builder().player(harness.take_player()).build(),
+            false,
+        )))
+        .await;
 
     let resource_a = hls_sine_aac_resource(
         harness.player(),
@@ -1423,7 +1455,7 @@ async fn render_until_b_with_postroll(
 
     for _ in 0..BLOCK_BUDGET {
         let _ = queue.tick();
-        let block = harness.render(BLOCK_FRAMES);
+        let block = harness.render(BLOCK_FRAMES).await;
         progress.push_block(&block, class_tolerance, Some(0));
 
         if expected_a_frames.is_none()
@@ -1460,7 +1492,7 @@ async fn render_until_b_with_late_variant_switch(
 
     for _ in 0..BLOCK_BUDGET {
         let _ = queue.tick();
-        let block = harness.render(BLOCK_FRAMES);
+        let block = harness.render(BLOCK_FRAMES).await;
         progress.push_block(&block, ASCENDING_TOL, Some(0));
 
         if expected_a_frames.is_none()
@@ -1531,7 +1563,7 @@ async fn render_crossfade_until_b_with_postroll(
 
     for _ in 0..CROSSFADE_BLOCK_BUDGET {
         let _ = queue.tick();
-        let block = harness.render(BLOCK_FRAMES);
+        let block = harness.render(BLOCK_FRAMES).await;
         progress.push_block(&block, ASCENDING_TOL, Some(0));
 
         if expected_a_end_frame.is_none()
@@ -1586,7 +1618,7 @@ async fn render_app_layer_crossfade_until_b_with_postroll_config(
         let _ = queue.tick();
         drive_app_layer_crossfade_advance(queue, &mut auto_advanced_index);
 
-        let block = harness.render(BLOCK_FRAMES);
+        let block = harness.render(BLOCK_FRAMES).await;
         progress.push_block(&block, ASCENDING_TOL, Some(0));
 
         if expected_a_end_frame.is_none()
@@ -1675,7 +1707,7 @@ async fn render_seek_near_end_until_b_with_postroll(
             }
         }
 
-        let block = harness.render(BLOCK_FRAMES);
+        let block = harness.render(BLOCK_FRAMES).await;
         progress.push_block(&block, ASCENDING_TOL, seek_issue_frame);
 
         if seek_issue_frame.is_none()
@@ -1716,7 +1748,7 @@ async fn render_until_tone_b_with_postroll(
 
     for _ in 0..BLOCK_BUDGET {
         let _ = queue.tick();
-        let block = harness.render(BLOCK_FRAMES);
+        let block = harness.render(BLOCK_FRAMES).await;
         progress.push_block(&block, render_sample_rate);
 
         if track_duration.is_none()

--- a/tests/tests/kithara_queue/app_fixture_ticks.rs
+++ b/tests/tests/kithara_queue/app_fixture_ticks.rs
@@ -1,0 +1,52 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::fs;
+
+use kithara::{
+    decode::DecoderBackend,
+    events::AbrMode,
+    platform::{time::Duration, tokio::task::spawn_blocking},
+    queue::Transition,
+};
+use kithara_app::document::Config;
+use kithara_integration_tests::{
+    TestServerHelper, kithara, offline::app_queue, temp_dir, waits::wait_for_position_at_least,
+};
+use kithara_test_fixtures::SignalAsset;
+
+use super::{app_disk_asset_store, app_track_source};
+
+/// The native ticker uses a real timed channel receive, so its lifetime needs a real clock.
+#[kithara::test(tokio, flash(false))]
+async fn app_fixture_updates_position_without_manual_ticks() {
+    let server = TestServerHelper::new().await;
+    let url = server.signal(SignalAsset::MP3_SINE880_48K_162S);
+    let document = spawn_blocking(|| {
+        let temp = temp_dir();
+        let path = temp.path().join("app.yaml");
+        fs::write(&path, "drm:\n  providers: []\n").expect("write local configuration");
+        Config::load(Some(&path), None).expect("load configuration without DRM credentials")
+    })
+    .await
+    .expect("load local configuration off the runtime worker");
+    let fixture = app_queue(document).await;
+    let source = app_track_source(
+        url.as_str(),
+        &fixture.config,
+        app_disk_asset_store(&fixture.config, fixture.cache.path()),
+        DecoderBackend::Symphonia,
+        AbrMode::Auto(None),
+        None,
+    );
+    fixture
+        .queue
+        .run(move |queue| {
+            let id = queue.append(source).expect("append local track");
+            queue.select(id, Transition::None).expect("select track");
+        })
+        .await;
+
+    let advanced = wait_for_position_at_least(&fixture.queue, 0.1, Duration::from_secs(10)).await;
+    fixture.close().await;
+    advanced.expect("the fixture ticker must publish playback progress");
+}

--- a/tests/tests/kithara_queue/architecture_flow.rs
+++ b/tests/tests/kithara_queue/architecture_flow.rs
@@ -44,13 +44,16 @@ async fn queue_playback_architecture() {
             .crossfade_duration(0.0)
             .build(),
         SAMPLE_RATE,
-    );
-    let queue = harness.insert_control(Queue::new(
-        QueueConfig::builder()
-            .player(harness.take_player())
-            .store(store.clone())
-            .build(),
-    ));
+    )
+    .await;
+    let queue = harness
+        .insert_control(Queue::new(
+            QueueConfig::builder()
+                .player(harness.take_player())
+                .store(store.clone())
+                .build(),
+        ))
+        .await;
     let downloader = create_test_downloader();
     let config = resource_config(url.as_str(), downloader, store);
     let mut events = queue.subscribe();
@@ -68,7 +71,7 @@ async fn queue_playback_architecture() {
     let peak = kithara::platform::time::timeout(Duration::from_secs(30), async {
         for _ in 0..RENDER_BLOCK_BUDGET {
             let _ = queue.tick();
-            let block = harness.render(BLOCK_FRAMES);
+            let block = harness.render(BLOCK_FRAMES).await;
             let peak = block.iter().copied().map(f32::abs).fold(0.0, f32::max);
             if peak > 0.005 {
                 return Some(peak);
@@ -114,6 +117,7 @@ async fn queue_playback_architecture() {
     ];
     architecture_trace::write(trace_path.as_ref(), records, &probes)
         .expect("write queue architecture trace");
+    harness.close().await;
 }
 
 fn resource_config(

--- a/tests/tests/kithara_queue/auto_advance.rs
+++ b/tests/tests/kithara_queue/auto_advance.rs
@@ -70,7 +70,7 @@ async fn render_loop(
 ) -> Vec<f32> {
     let mut pcm = Vec::new();
     for _ in 0..block_budget {
-        let _ = queue.tick();
+        let _ = harness.run(queue, |q| q.tick()).await;
         let block = harness.render(BLOCK_FRAMES).await;
         pcm.extend(block);
     }
@@ -94,11 +94,16 @@ async fn crossfade_started_requires_a_live_predecessor() {
             false,
         )))
         .await;
-    let id = queue.insert_loaded_for_test(make_resource("initial", 0.2, 0.3));
+    let id = harness
+        .run(&queue, move |q| {
+            q.insert_loaded_for_test(make_resource("initial", 0.2, 0.3))
+        })
+        .await;
     let mut receiver = queue.subscribe();
 
-    queue
-        .select(id, Transition::Crossfade)
+    harness
+        .run(&queue, move |q| q.select(id, Transition::Crossfade))
+        .await
         .expect("select initial track");
 
     while let Ok(envelope) = receiver.try_recv() {
@@ -113,7 +118,7 @@ async fn crossfade_started_requires_a_live_predecessor() {
 
     let mut saw_playing = false;
     for _ in 0..MAX_BLOCKS {
-        let _ = queue.tick();
+        let _ = harness.run(&queue, |q| q.tick()).await;
         let _ = harness.render(BLOCK_FRAMES).await;
         let is_playing = queue.is_playing();
         saw_playing |= is_playing;
@@ -126,12 +131,20 @@ async fn crossfade_started_requires_a_live_predecessor() {
         "the predecessor must start before reaching EOF"
     );
     assert!(!queue.is_playing(), "the predecessor must reach EOF");
-    queue.tick().expect("process predecessor EOF");
+    harness
+        .run(&queue, |q| q.tick())
+        .await
+        .expect("process predecessor EOF");
 
-    let successor = queue.insert_loaded_for_test(make_resource("successor", 1.0, 0.3));
+    let successor = harness
+        .run(&queue, move |q| {
+            q.insert_loaded_for_test(make_resource("successor", 1.0, 0.3))
+        })
+        .await;
     let mut receiver = queue.subscribe();
-    queue
-        .select(successor, Transition::Crossfade)
+    harness
+        .run(&queue, move |q| q.select(successor, Transition::Crossfade))
+        .await
         .expect("select successor after EOF");
 
     while let Ok(envelope) = receiver.try_recv() {
@@ -162,9 +175,14 @@ async fn repeat_one_natural_advance_keeps_current_track() {
             false,
         )))
         .await;
-    let id = queue.insert_loaded_for_test(make_resource("one", 1.0, 0.3));
-    queue
-        .select(id, Transition::None)
+    let id = harness
+        .run(&queue, move |q| {
+            q.insert_loaded_for_test(make_resource("one", 1.0, 0.3))
+        })
+        .await;
+    harness
+        .run(&queue, move |q| q.select(id, Transition::None))
+        .await
         .expect("select repeat-one track");
     let mut receiver = queue.subscribe();
     queue.set_repeat(RepeatMode::One);
@@ -176,8 +194,12 @@ async fn repeat_one_natural_advance_keeps_current_track() {
         }))
     ));
     assert_eq!(
-        queue
-            .advance_to_next(Transition::Crossfade, AdvanceReason::NaturalEof)
+        harness
+            .run(&queue, move |q| q.advance_to_next(
+                Transition::Crossfade,
+                AdvanceReason::NaturalEof
+            ))
+            .await
             .expect("advance repeat-one queue"),
         Some(id)
     );
@@ -201,10 +223,19 @@ async fn repeat_all_natural_advance_wraps_last_track_to_first() {
             false,
         )))
         .await;
-    let first = queue.insert_loaded_for_test(make_resource("first", 1.0, 0.2));
-    let last = queue.insert_loaded_for_test(make_resource("last", 1.0, 0.8));
-    queue
-        .select(last, Transition::None)
+    let first = harness
+        .run(&queue, move |q| {
+            q.insert_loaded_for_test(make_resource("first", 1.0, 0.2))
+        })
+        .await;
+    let last = harness
+        .run(&queue, move |q| {
+            q.insert_loaded_for_test(make_resource("last", 1.0, 0.8))
+        })
+        .await;
+    harness
+        .run(&queue, move |q| q.select(last, Transition::None))
+        .await
         .expect("select last repeat-all track");
     let mut receiver = queue.subscribe();
     queue.set_repeat(RepeatMode::All);
@@ -216,8 +247,12 @@ async fn repeat_all_natural_advance_wraps_last_track_to_first() {
         }))
     ));
     assert_eq!(
-        queue
-            .advance_to_next(Transition::Crossfade, AdvanceReason::NaturalEof)
+        harness
+            .run(&queue, move |q| q.advance_to_next(
+                Transition::Crossfade,
+                AdvanceReason::NaturalEof
+            ))
+            .await
             .expect("advance repeat-all queue"),
         Some(first)
     );
@@ -249,10 +284,19 @@ async fn cf_zero_queue_tick_advances_to_second_track_audio() {
         )))
         .await;
 
-    let id_a = queue.insert_loaded_for_test(make_resource("a", TRACK_SECS, TRACK_A_VALUE));
-    let _ = queue.insert_loaded_for_test(make_resource("b", TRACK_SECS, TRACK_B_VALUE));
-    queue
-        .select(id_a, Transition::None)
+    let id_a = harness
+        .run(&queue, move |q| {
+            q.insert_loaded_for_test(make_resource("a", TRACK_SECS, TRACK_A_VALUE))
+        })
+        .await;
+    let _ = harness
+        .run(&queue, move |q| {
+            q.insert_loaded_for_test(make_resource("b", TRACK_SECS, TRACK_B_VALUE))
+        })
+        .await;
+    harness
+        .run(&queue, move |q| q.select(id_a, Transition::None))
+        .await
         .expect("select track A");
 
     let pcm = render_loop(&queue, &harness, MAX_BLOCKS).await;
@@ -321,10 +365,19 @@ async fn cf_nonzero_queue_tick_crossfades_to_second_track_audio() {
         )))
         .await;
 
-    let id_a = queue.insert_loaded_for_test(make_resource("a", TRACK_SECS, TRACK_A_VALUE));
-    let _ = queue.insert_loaded_for_test(make_resource("b", TRACK_SECS, TRACK_B_VALUE));
-    queue
-        .select(id_a, Transition::None)
+    let id_a = harness
+        .run(&queue, move |q| {
+            q.insert_loaded_for_test(make_resource("a", TRACK_SECS, TRACK_A_VALUE))
+        })
+        .await;
+    let _ = harness
+        .run(&queue, move |q| {
+            q.insert_loaded_for_test(make_resource("b", TRACK_SECS, TRACK_B_VALUE))
+        })
+        .await;
+    harness
+        .run(&queue, move |q| q.select(id_a, Transition::None))
+        .await
         .expect("select track A");
 
     let pcm = render_loop(&queue, &harness, MAX_BLOCKS).await;
@@ -402,10 +455,19 @@ async fn queue_tick_pumps_audio_thread_notifications_to_bus() {
         .await;
     let mut rx = queue.subscribe();
 
-    let id_a = queue.insert_loaded_for_test(make_resource("a", TRACK_SECS, 0.10));
-    let _ = queue.insert_loaded_for_test(make_resource("b", TRACK_SECS, 0.80));
-    queue
-        .select(id_a, Transition::None)
+    let id_a = harness
+        .run(&queue, move |q| {
+            q.insert_loaded_for_test(make_resource("a", TRACK_SECS, 0.10))
+        })
+        .await;
+    let _ = harness
+        .run(&queue, move |q| {
+            q.insert_loaded_for_test(make_resource("b", TRACK_SECS, 0.80))
+        })
+        .await;
+    harness
+        .run(&queue, move |q| q.select(id_a, Transition::None))
+        .await
         .expect("select track A");
 
     let mut prefetch_seen = false;
@@ -413,7 +475,7 @@ async fn queue_tick_pumps_audio_thread_notifications_to_bus() {
     let mut item_end_seen = false;
 
     for _ in 0..MAX_BLOCKS {
-        let _ = queue.tick();
+        let _ = harness.run(&queue, |q| q.tick()).await;
         let _ = harness.render(BLOCK_FRAMES).await;
 
         loop {
@@ -480,8 +542,16 @@ async fn autoplay_first_registered_track_plays_first_even_when_loaded_last() {
     let id_a = queue.register_for_test();
     let id_b = queue.register_for_test();
 
-    queue.complete_load_for_test(id_b, make_resource("b", TRACK_SECS, LOUD_VALUE));
-    queue.complete_load_for_test(id_a, make_resource("a", TRACK_SECS, QUIET_VALUE));
+    harness
+        .run(&queue, move |q| {
+            q.complete_load_for_test(id_b, make_resource("b", TRACK_SECS, LOUD_VALUE))
+        })
+        .await;
+    harness
+        .run(&queue, move |q| {
+            q.complete_load_for_test(id_a, make_resource("a", TRACK_SECS, QUIET_VALUE))
+        })
+        .await;
 
     let pcm = render_loop(&queue, &harness, MAX_BLOCKS).await;
 
@@ -547,11 +617,20 @@ async fn cf_zero_replay_after_full_playthrough_still_advances() {
         )))
         .await;
 
-    let id_a = queue.insert_loaded_for_test(make_resource("a", TRACK_SECS, TRACK_A_VALUE));
-    let id_b = queue.insert_loaded_for_test(make_resource("b", TRACK_SECS, TRACK_B_VALUE));
+    let id_a = harness
+        .run(&queue, move |q| {
+            q.insert_loaded_for_test(make_resource("a", TRACK_SECS, TRACK_A_VALUE))
+        })
+        .await;
+    let id_b = harness
+        .run(&queue, move |q| {
+            q.insert_loaded_for_test(make_resource("b", TRACK_SECS, TRACK_B_VALUE))
+        })
+        .await;
 
-    queue
-        .select(id_a, Transition::None)
+    harness
+        .run(&queue, move |q| q.select(id_a, Transition::None))
+        .await
         .expect("first select track A");
     let _first_pcm = render_loop(&queue, &harness, MAX_BLOCKS).await;
     assert_eq!(
@@ -563,8 +642,9 @@ async fn cf_zero_replay_after_full_playthrough_still_advances() {
     queue.supply_test_resource_for_respawn(id_a, make_resource("a2", TRACK_SECS, TRACK_A_VALUE));
     queue.supply_test_resource_for_respawn(id_b, make_resource("b2", TRACK_SECS, TRACK_B_VALUE));
 
-    queue
-        .select(id_a, Transition::None)
+    harness
+        .run(&queue, move |q| q.select(id_a, Transition::None))
+        .await
         .expect("second select track A");
 
     let pcm = render_loop(&queue, &harness, MAX_BLOCKS).await;
@@ -621,14 +701,19 @@ async fn queue_stops_live_playback_when_last_track_ends() {
         .await;
     let mut rx = queue.subscribe();
 
-    let id_a = queue.insert_loaded_for_test(make_resource("a", TRACK_SECS, 0.30));
-    queue
-        .select(id_a, Transition::None)
+    let id_a = harness
+        .run(&queue, move |q| {
+            q.insert_loaded_for_test(make_resource("a", TRACK_SECS, 0.30))
+        })
+        .await;
+    harness
+        .run(&queue, move |q| q.select(id_a, Transition::None))
+        .await
         .expect("select track A");
 
     let mut saw_queue_ended = false;
     for _ in 0..MAX_BLOCKS {
-        let _ = queue.tick();
+        let _ = harness.run(&queue, |q| q.tick()).await;
         let _ = harness.render(BLOCK_FRAMES).await;
         loop {
             match rx.try_recv().map(|env| env.event) {
@@ -640,7 +725,7 @@ async fn queue_stops_live_playback_when_last_track_ends() {
         }
         if saw_queue_ended {
             for _ in 0..4 {
-                let _ = queue.tick();
+                let _ = harness.run(&queue, |q| q.tick()).await;
                 let _ = harness.render(BLOCK_FRAMES).await;
             }
             break;
@@ -681,7 +766,11 @@ async fn autoplay_first_track_does_not_self_arm_and_kill_its_own_decoder() {
         )))
         .await;
 
-    let _id = queue.insert_loaded_for_test(make_resource("solo", TRACK_SECS, TRACK_VALUE));
+    let _id = harness
+        .run(&queue, move |q| {
+            q.insert_loaded_for_test(make_resource("solo", TRACK_SECS, TRACK_VALUE))
+        })
+        .await;
 
     let pcm = render_loop(&queue, &harness, MAX_BLOCKS).await;
 
@@ -739,14 +828,27 @@ async fn a_middle_track_is_heard_in_the_middle_of_its_own_span() {
         )))
         .await;
 
-    let id_a = queue.insert_loaded_for_test(make_resource("a", TRACK_SECS, LEVEL_A));
-    let _ = queue.insert_loaded_for_test(make_resource("b", TRACK_SECS, LEVEL_B));
-    let _ = queue.insert_loaded_for_test(make_resource("c", TRACK_SECS, LEVEL_C));
+    let id_a = harness
+        .run(&queue, move |q| {
+            q.insert_loaded_for_test(make_resource("a", TRACK_SECS, LEVEL_A))
+        })
+        .await;
+    let _ = harness
+        .run(&queue, move |q| {
+            q.insert_loaded_for_test(make_resource("b", TRACK_SECS, LEVEL_B))
+        })
+        .await;
+    let _ = harness
+        .run(&queue, move |q| {
+            q.insert_loaded_for_test(make_resource("c", TRACK_SECS, LEVEL_C))
+        })
+        .await;
     // The app starts a catalog row exactly this way, with no fade into the
     // first track, and it is the arrangement that leaves the engine's own
     // handover trigger disarmed for that track.
-    queue
-        .select(id_a, Transition::None)
+    harness
+        .run(&queue, move |q| q.select(id_a, Transition::None))
+        .await
         .expect("select track A");
 
     let pcm = render_loop(&queue, &harness, MAX_BLOCKS).await;

--- a/tests/tests/kithara_queue/auto_advance.rs
+++ b/tests/tests/kithara_queue/auto_advance.rs
@@ -63,7 +63,7 @@ fn first_onset_frame(pcm: &[f32], threshold: f32) -> Option<usize> {
 
 /// Render until either EOF count or block budget is reached. Returns the
 /// concatenated stereo-interleaved PCM.
-fn render_loop(
+async fn render_loop(
     queue: &QueueControl<TestPools>,
     harness: &OfflinePlayerHarness,
     block_budget: usize,
@@ -71,14 +71,14 @@ fn render_loop(
     let mut pcm = Vec::new();
     for _ in 0..block_budget {
         let _ = queue.tick();
-        let block = harness.render(BLOCK_FRAMES);
+        let block = harness.render(BLOCK_FRAMES).await;
         pcm.extend(block);
     }
     pcm
 }
 
-#[kithara::test]
-fn crossfade_started_requires_a_live_predecessor() {
+#[kithara::test(tokio)]
+async fn crossfade_started_requires_a_live_predecessor() {
     const CROSSFADE_SECS: f32 = 0.2;
 
     let harness = OfflinePlayerHarness::with_sample_rate(
@@ -86,11 +86,14 @@ fn crossfade_started_requires_a_live_predecessor() {
             .crossfade_duration(CROSSFADE_SECS)
             .build(),
         SAMPLE_RATE,
-    );
-    let queue = harness.insert_control(Queue::new(with_autoplay(
-        QueueConfig::builder().player(harness.take_player()).build(),
-        false,
-    )));
+    )
+    .await;
+    let queue = harness
+        .insert_control(Queue::new(with_autoplay(
+            QueueConfig::builder().player(harness.take_player()).build(),
+            false,
+        )))
+        .await;
     let id = queue.insert_loaded_for_test(make_resource("initial", 0.2, 0.3));
     let mut receiver = queue.subscribe();
 
@@ -111,7 +114,7 @@ fn crossfade_started_requires_a_live_predecessor() {
     let mut saw_playing = false;
     for _ in 0..MAX_BLOCKS {
         let _ = queue.tick();
-        let _ = harness.render(BLOCK_FRAMES);
+        let _ = harness.render(BLOCK_FRAMES).await;
         let is_playing = queue.is_playing();
         saw_playing |= is_playing;
         if saw_playing && !is_playing {
@@ -140,6 +143,8 @@ fn crossfade_started_requires_a_live_predecessor() {
             "a completed predecessor cannot start a crossfade"
         );
     }
+    drop(queue);
+    harness.close().await;
 }
 
 #[kithara::test(tokio)]
@@ -149,11 +154,14 @@ async fn repeat_one_natural_advance_keeps_current_track() {
             .crossfade_duration(0.0)
             .build(),
         SAMPLE_RATE,
-    );
-    let queue = harness.insert_control(Queue::new(with_autoplay(
-        QueueConfig::builder().player(harness.take_player()).build(),
-        false,
-    )));
+    )
+    .await;
+    let queue = harness
+        .insert_control(Queue::new(with_autoplay(
+            QueueConfig::builder().player(harness.take_player()).build(),
+            false,
+        )))
+        .await;
     let id = queue.insert_loaded_for_test(make_resource("one", 1.0, 0.3));
     queue
         .select(id, Transition::None)
@@ -174,6 +182,8 @@ async fn repeat_one_natural_advance_keeps_current_track() {
         Some(id)
     );
     assert_eq!(queue.current().map(|entry| entry.id), Some(id));
+    drop(queue);
+    harness.close().await;
 }
 
 #[kithara::test(tokio)]
@@ -183,11 +193,14 @@ async fn repeat_all_natural_advance_wraps_last_track_to_first() {
             .crossfade_duration(0.0)
             .build(),
         SAMPLE_RATE,
-    );
-    let queue = harness.insert_control(Queue::new(with_autoplay(
-        QueueConfig::builder().player(harness.take_player()).build(),
-        false,
-    )));
+    )
+    .await;
+    let queue = harness
+        .insert_control(Queue::new(with_autoplay(
+            QueueConfig::builder().player(harness.take_player()).build(),
+            false,
+        )))
+        .await;
     let first = queue.insert_loaded_for_test(make_resource("first", 1.0, 0.2));
     let last = queue.insert_loaded_for_test(make_resource("last", 1.0, 0.8));
     queue
@@ -209,6 +222,8 @@ async fn repeat_all_natural_advance_wraps_last_track_to_first() {
         Some(first)
     );
     assert_eq!(queue.current().map(|entry| entry.id), Some(first));
+    drop(queue);
+    harness.close().await;
 }
 
 /// cf=0: queue.tick must drive `process_notifications`, the audio thread
@@ -225,11 +240,14 @@ async fn cf_zero_queue_tick_advances_to_second_track_audio() {
             .crossfade_duration(0.0)
             .build(),
         SAMPLE_RATE,
-    );
-    let queue = harness.insert_control(Queue::new(with_autoplay(
-        QueueConfig::builder().player(harness.take_player()).build(),
-        false,
-    )));
+    )
+    .await;
+    let queue = harness
+        .insert_control(Queue::new(with_autoplay(
+            QueueConfig::builder().player(harness.take_player()).build(),
+            false,
+        )))
+        .await;
 
     let id_a = queue.insert_loaded_for_test(make_resource("a", TRACK_SECS, TRACK_A_VALUE));
     let _ = queue.insert_loaded_for_test(make_resource("b", TRACK_SECS, TRACK_B_VALUE));
@@ -237,7 +255,7 @@ async fn cf_zero_queue_tick_advances_to_second_track_audio() {
         .select(id_a, Transition::None)
         .expect("select track A");
 
-    let pcm = render_loop(&queue, &harness, MAX_BLOCKS);
+    let pcm = render_loop(&queue, &harness, MAX_BLOCKS).await;
 
     let onset = first_onset_frame(&pcm, 0.005)
         .expect("track A must produce non-silence within the render budget");
@@ -275,6 +293,8 @@ async fn cf_zero_queue_tick_advances_to_second_track_audio() {
         Some(1),
         "queue.current_index must follow the audio thread to track B"
     );
+    drop(queue);
+    harness.close().await;
 }
 
 /// cf>0: queue.tick observes `HandoverRequested`, calls `commit_next`,
@@ -292,11 +312,14 @@ async fn cf_nonzero_queue_tick_crossfades_to_second_track_audio() {
             .crossfade_duration(CROSSFADE_SECS)
             .build(),
         SAMPLE_RATE,
-    );
-    let queue = harness.insert_control(Queue::new(with_autoplay(
-        QueueConfig::builder().player(harness.take_player()).build(),
-        false,
-    )));
+    )
+    .await;
+    let queue = harness
+        .insert_control(Queue::new(with_autoplay(
+            QueueConfig::builder().player(harness.take_player()).build(),
+            false,
+        )))
+        .await;
 
     let id_a = queue.insert_loaded_for_test(make_resource("a", TRACK_SECS, TRACK_A_VALUE));
     let _ = queue.insert_loaded_for_test(make_resource("b", TRACK_SECS, TRACK_B_VALUE));
@@ -304,7 +327,7 @@ async fn cf_nonzero_queue_tick_crossfades_to_second_track_audio() {
         .select(id_a, Transition::None)
         .expect("select track A");
 
-    let pcm = render_loop(&queue, &harness, MAX_BLOCKS);
+    let pcm = render_loop(&queue, &harness, MAX_BLOCKS).await;
 
     let onset = first_onset_frame(&pcm, 0.005)
         .expect("track A must produce non-silence within the render budget");
@@ -345,6 +368,8 @@ async fn cf_nonzero_queue_tick_crossfades_to_second_track_audio() {
         Some(1),
         "queue.current_index must advance to track B after crossfade commit"
     );
+    drop(queue);
+    harness.close().await;
 }
 
 /// Sanity guard: if `Queue::tick` regresses to skipping
@@ -367,11 +392,14 @@ async fn queue_tick_pumps_audio_thread_notifications_to_bus() {
             .crossfade_duration(CROSSFADE_SECS)
             .build(),
         SAMPLE_RATE,
-    );
-    let queue = harness.insert_control(Queue::new(with_autoplay(
-        QueueConfig::builder().player(harness.take_player()).build(),
-        false,
-    )));
+    )
+    .await;
+    let queue = harness
+        .insert_control(Queue::new(with_autoplay(
+            QueueConfig::builder().player(harness.take_player()).build(),
+            false,
+        )))
+        .await;
     let mut rx = queue.subscribe();
 
     let id_a = queue.insert_loaded_for_test(make_resource("a", TRACK_SECS, 0.10));
@@ -386,7 +414,7 @@ async fn queue_tick_pumps_audio_thread_notifications_to_bus() {
 
     for _ in 0..MAX_BLOCKS {
         let _ = queue.tick();
-        let _ = harness.render(BLOCK_FRAMES);
+        let _ = harness.render(BLOCK_FRAMES).await;
 
         loop {
             match rx.try_recv().map(|env| env.event) {
@@ -415,6 +443,8 @@ async fn queue_tick_pumps_audio_thread_notifications_to_bus() {
         item_end_seen,
         "ItemDidPlayToEnd must reach the bus via Queue::tick → process_notifications"
     );
+    drop(queue);
+    harness.close().await;
 }
 
 /// Behavioural autoplay test that **simulates the actual race** that
@@ -438,11 +468,14 @@ async fn autoplay_first_registered_track_plays_first_even_when_loaded_last() {
             .crossfade_duration(0.0)
             .build(),
         SAMPLE_RATE,
-    );
-    let queue = harness.insert_control(Queue::new(with_autoplay(
-        QueueConfig::builder().player(harness.take_player()).build(),
-        true,
-    )));
+    )
+    .await;
+    let queue = harness
+        .insert_control(Queue::new(with_autoplay(
+            QueueConfig::builder().player(harness.take_player()).build(),
+            true,
+        )))
+        .await;
 
     let id_a = queue.register_for_test();
     let id_b = queue.register_for_test();
@@ -450,7 +483,7 @@ async fn autoplay_first_registered_track_plays_first_even_when_loaded_last() {
     queue.complete_load_for_test(id_b, make_resource("b", TRACK_SECS, LOUD_VALUE));
     queue.complete_load_for_test(id_a, make_resource("a", TRACK_SECS, QUIET_VALUE));
 
-    let pcm = render_loop(&queue, &harness, MAX_BLOCKS);
+    let pcm = render_loop(&queue, &harness, MAX_BLOCKS).await;
 
     let onset = first_onset_frame(&pcm, 0.005)
         .expect("autoplay must start producing audio without an explicit select");
@@ -477,6 +510,8 @@ async fn autoplay_first_registered_track_plays_first_even_when_loaded_last() {
         Some(1),
         "after track A finishes, queue must auto-advance to track B"
     );
+    drop(queue);
+    harness.close().await;
 }
 
 /// Replay regression: after a full cf=0 playthrough every track is
@@ -503,11 +538,14 @@ async fn cf_zero_replay_after_full_playthrough_still_advances() {
             .crossfade_duration(0.0)
             .build(),
         SAMPLE_RATE,
-    );
-    let queue = harness.insert_control(Queue::new(with_autoplay(
-        QueueConfig::builder().player(harness.take_player()).build(),
-        false,
-    )));
+    )
+    .await;
+    let queue = harness
+        .insert_control(Queue::new(with_autoplay(
+            QueueConfig::builder().player(harness.take_player()).build(),
+            false,
+        )))
+        .await;
 
     let id_a = queue.insert_loaded_for_test(make_resource("a", TRACK_SECS, TRACK_A_VALUE));
     let id_b = queue.insert_loaded_for_test(make_resource("b", TRACK_SECS, TRACK_B_VALUE));
@@ -515,7 +553,7 @@ async fn cf_zero_replay_after_full_playthrough_still_advances() {
     queue
         .select(id_a, Transition::None)
         .expect("first select track A");
-    let _first_pcm = render_loop(&queue, &harness, MAX_BLOCKS);
+    let _first_pcm = render_loop(&queue, &harness, MAX_BLOCKS).await;
     assert_eq!(
         queue.current_index(),
         Some(1),
@@ -529,7 +567,7 @@ async fn cf_zero_replay_after_full_playthrough_still_advances() {
         .select(id_a, Transition::None)
         .expect("second select track A");
 
-    let pcm = render_loop(&queue, &harness, MAX_BLOCKS);
+    let pcm = render_loop(&queue, &harness, MAX_BLOCKS).await;
 
     let onset = first_onset_frame(&pcm, 0.005).expect("track A must produce non-silence on replay");
     let track_a_frames =
@@ -553,6 +591,8 @@ async fn cf_zero_replay_after_full_playthrough_still_advances() {
         Some(1),
         "second playthrough must also reach track B"
     );
+    drop(queue);
+    harness.close().await;
 }
 
 /// When the last track finishes, the live playback snapshot must become inactive
@@ -571,11 +611,14 @@ async fn queue_stops_live_playback_when_last_track_ends() {
             .crossfade_duration(0.0)
             .build(),
         SAMPLE_RATE,
-    );
-    let queue = harness.insert_control(Queue::new(with_autoplay(
-        QueueConfig::builder().player(harness.take_player()).build(),
-        false,
-    )));
+    )
+    .await;
+    let queue = harness
+        .insert_control(Queue::new(with_autoplay(
+            QueueConfig::builder().player(harness.take_player()).build(),
+            false,
+        )))
+        .await;
     let mut rx = queue.subscribe();
 
     let id_a = queue.insert_loaded_for_test(make_resource("a", TRACK_SECS, 0.30));
@@ -586,7 +629,7 @@ async fn queue_stops_live_playback_when_last_track_ends() {
     let mut saw_queue_ended = false;
     for _ in 0..MAX_BLOCKS {
         let _ = queue.tick();
-        let _ = harness.render(BLOCK_FRAMES);
+        let _ = harness.render(BLOCK_FRAMES).await;
         loop {
             match rx.try_recv().map(|env| env.event) {
                 Ok(Event::Queue(QueueEvent::QueueEnded)) => saw_queue_ended = true,
@@ -598,7 +641,7 @@ async fn queue_stops_live_playback_when_last_track_ends() {
         if saw_queue_ended {
             for _ in 0..4 {
                 let _ = queue.tick();
-                let _ = harness.render(BLOCK_FRAMES);
+                let _ = harness.render(BLOCK_FRAMES).await;
             }
             break;
         }
@@ -612,6 +655,8 @@ async fn queue_stops_live_playback_when_last_track_ends() {
         !queue.is_playing(),
         "live playback must stop after the last EOF"
     );
+    drop(queue);
+    harness.close().await;
 }
 
 /// Regression: `PrefetchRequested` can arrive before `current_index` is
@@ -627,15 +672,18 @@ async fn autoplay_first_track_does_not_self_arm_and_kill_its_own_decoder() {
             .crossfade_duration(0.0)
             .build(),
         SAMPLE_RATE,
-    );
-    let queue = harness.insert_control(Queue::new(with_autoplay(
-        QueueConfig::builder().player(harness.take_player()).build(),
-        true,
-    )));
+    )
+    .await;
+    let queue = harness
+        .insert_control(Queue::new(with_autoplay(
+            QueueConfig::builder().player(harness.take_player()).build(),
+            true,
+        )))
+        .await;
 
     let _id = queue.insert_loaded_for_test(make_resource("solo", TRACK_SECS, TRACK_VALUE));
 
-    let pcm = render_loop(&queue, &harness, MAX_BLOCKS);
+    let pcm = render_loop(&queue, &harness, MAX_BLOCKS).await;
 
     let onset =
         first_onset_frame(&pcm, 0.005).expect("autoplay'd track must produce audible samples");
@@ -656,6 +704,8 @@ async fn autoplay_first_track_does_not_self_arm_and_kill_its_own_decoder() {
         Some(0),
         "current_index must stay on the only track"
     );
+    drop(queue);
+    harness.close().await;
 }
 
 /// A queue played straight through has to let its middle track be heard.
@@ -680,11 +730,14 @@ async fn a_middle_track_is_heard_in_the_middle_of_its_own_span() {
             .crossfade_duration(CROSSFADE_SECS)
             .build(),
         SAMPLE_RATE,
-    );
-    let queue = harness.insert_control(Queue::new(with_autoplay(
-        QueueConfig::builder().player(harness.take_player()).build(),
-        false,
-    )));
+    )
+    .await;
+    let queue = harness
+        .insert_control(Queue::new(with_autoplay(
+            QueueConfig::builder().player(harness.take_player()).build(),
+            false,
+        )))
+        .await;
 
     let id_a = queue.insert_loaded_for_test(make_resource("a", TRACK_SECS, LEVEL_A));
     let _ = queue.insert_loaded_for_test(make_resource("b", TRACK_SECS, LEVEL_B));
@@ -696,7 +749,7 @@ async fn a_middle_track_is_heard_in_the_middle_of_its_own_span() {
         .select(id_a, Transition::None)
         .expect("select track A");
 
-    let pcm = render_loop(&queue, &harness, MAX_BLOCKS);
+    let pcm = render_loop(&queue, &harness, MAX_BLOCKS).await;
 
     let onset = first_onset_frame(&pcm, 0.005)
         .expect("track A must produce non-silence within the render budget");
@@ -741,4 +794,6 @@ async fn a_middle_track_is_heard_in_the_middle_of_its_own_span() {
          ratio={ratio_c}, C={expected_c}, B={expected_b} \
          (mean_a={mean_a}, mean_c={mean_c})"
     );
+    drop(queue);
+    harness.close().await;
 }

--- a/tests/tests/kithara_queue/cold_seek_cpal.rs
+++ b/tests/tests/kithara_queue/cold_seek_cpal.rs
@@ -15,7 +15,7 @@ use kithara::{
     queue::{Queue, QueueConfig, QueueControl, TrackSource, Transition},
     stream::dl::{Downloader, DownloaderConfig},
 };
-use kithara_integration_tests::{kithara, temp_dir};
+use kithara_integration_tests::{kithara, offline::QueueTicker, temp_dir};
 
 use crate::bufpool_ext::{TestPools, pools};
 
@@ -130,14 +130,7 @@ async fn cpal_cold_seek_silvercomet_hls(#[case] backend: DecoderBackend) {
     queue.set_volume(kithara_integration_tests::e2e::volume());
 
     let queue_for_tick = Arc::clone(&queue);
-    let tick_handle = tokio::task::spawn(async move {
-        loop {
-            time::sleep(Duration::from_millis(16)).await;
-            if queue_for_tick.tick().is_err() {
-                break;
-            }
-        }
-    });
+    let mut tick_handle = QueueTicker::spawn(queue_for_tick, Duration::from_millis(16));
 
     let cfg = ResourceConfig::for_src(ResourceSrc::parse(URL).expect("valid silvercomet URL"))
         .downloader(downloader.clone())
@@ -199,7 +192,7 @@ async fn cpal_cold_seek_silvercomet_hls(#[case] backend: DecoderBackend) {
     }
 
     if tick_handle.is_finished() {
-        match tick_handle.await {
+        match tick_handle.join().await {
             Ok(()) => panic!("tick task exited without panic"),
             Err(e) => panic!("SEEK HANG REPRODUCED on silvercomet: {e}"),
         }
@@ -243,7 +236,7 @@ async fn cpal_cold_seek_silvercomet_hls(#[case] backend: DecoderBackend) {
     }
 
     if tick_handle.is_finished() {
-        match tick_handle.await {
+        match tick_handle.join().await {
             Ok(()) => panic!("tick task exited without panic"),
             Err(e) => panic!("BACKWARD SEEK HANG REPRODUCED on silvercomet: {e}"),
         }
@@ -256,8 +249,7 @@ async fn cpal_cold_seek_silvercomet_hls(#[case] backend: DecoderBackend) {
         queue.position_seconds(),
     );
 
-    tick_handle.abort();
-    let _ = tick_handle.await;
+    tick_handle.stop().await;
     host.remove(queue.as_ref())
         .expect("detach queue from playback host");
     drop(queue);

--- a/tests/tests/kithara_queue/cold_seek_cpal.rs
+++ b/tests/tests/kithara_queue/cold_seek_cpal.rs
@@ -7,15 +7,17 @@ use kithara::{
     net::{HttpClient, NetOptions},
     platform::{
         CancelToken,
-        sync::Arc,
         time::{self, Duration, Instant, timeout},
-        tokio,
     },
-    play::{PlayWorker, PlayWorkerConfig, PlayerConfig, PlayerImpl, ResourceConfig, ResourceSrc},
+    play::{
+        PlayError, PlayWorker, PlayWorkerConfig, PlayerConfig, PlayerImpl, ResourceConfig,
+        ResourceSrc,
+    },
     queue::{Queue, QueueConfig, QueueControl, TrackSource, Transition},
     stream::dl::{Downloader, DownloaderConfig},
 };
 use kithara_integration_tests::{kithara, offline::QueueTicker, temp_dir};
+use kithara_test_utils::off_thread::OffThread;
 
 use crate::bufpool_ext::{TestPools, pools};
 
@@ -118,18 +120,24 @@ async fn cpal_cold_seek_silvercomet_hls(#[case] backend: DecoderBackend) {
     );
 
     let worker = PlayWorker::new(PlayWorkerConfig::builder(pools()).build());
-    let mut host = Host::new(HostConfig::builder().build()).expect("create playback host");
-    let player = PlayerImpl::new(
-        PlayerConfig::builder()
-            .sample_rate(host.requested_sample_rate())
-            .worker(worker)
-            .build(),
-    );
-    let queue = Queue::new(QueueConfig::builder().player(player).build());
-    let queue = Arc::new(host.insert(queue).expect("attach queue to playback host"));
+    let owner = OffThread::spawn("cpal-seek-host", move || {
+        let mut host = Host::new(HostConfig::builder().build())?;
+        let player = PlayerImpl::new(
+            PlayerConfig::builder()
+                .sample_rate(host.requested_sample_rate())
+                .worker(worker)
+                .build(),
+        );
+        let queue = Queue::new(QueueConfig::builder().player(player).build());
+        let queue = host.insert(queue)?;
+        Ok::<_, PlayError>((queue, host))
+    })
+    .await
+    .expect("create playback host");
+    let queue = owner.call(|(queue, _)| queue.control().clone()).await;
     queue.set_volume(kithara_integration_tests::e2e::volume());
 
-    let queue_for_tick = Arc::clone(&queue);
+    let queue_for_tick = queue.clone();
     let mut tick_handle = QueueTicker::spawn(queue_for_tick, Duration::from_millis(16));
 
     let cfg = ResourceConfig::for_src(ResourceSrc::parse(URL).expect("valid silvercomet URL"))
@@ -144,13 +152,13 @@ async fn cpal_cold_seek_silvercomet_hls(#[case] backend: DecoderBackend) {
     let source = TrackSource::Config(Box::new(cfg));
 
     let mut rx = queue.subscribe();
-    let id = queue
-        .run(move |q| q.append(source))
+    let id = owner
+        .call(move |(q, _)| q.append(source))
         .await
         .expect("append silvercomet HLS track");
     wait_for_status(
         &mut rx,
-        queue.control(),
+        &queue,
         id,
         TrackStatus::Loaded,
         Duration::from_secs(30),
@@ -158,13 +166,13 @@ async fn cpal_cold_seek_silvercomet_hls(#[case] backend: DecoderBackend) {
     .await
     .unwrap_or_else(|e| panic!("silvercomet track load failed: {e}"));
 
-    queue
-        .run(move |q| q.select(id, Transition::None))
+    owner
+        .call(move |(q, _)| q.select(id, Transition::None))
         .await
         .expect("select");
-    queue.run(move |q| q.play()).await;
+    owner.call(move |(q, _)| q.play()).await;
 
-    let pos_before = wait_for_position_at_least(queue.control(), 2.0, Duration::from_secs(45))
+    let pos_before = wait_for_position_at_least(&queue, 2.0, Duration::from_secs(45))
         .await
         .expect("silvercomet track never played past 2s");
     eprintln!("[silvercomet] pre-seek pos={pos_before:.3}s");
@@ -172,7 +180,10 @@ async fn cpal_cold_seek_silvercomet_hls(#[case] backend: DecoderBackend) {
     let duration = queue.duration_seconds().unwrap_or(240.0);
     let seek_target = duration * 0.5;
     eprintln!("[silvercomet] duration={duration:.1}s, seeking to {seek_target:.1}s (50%)");
-    queue.seek(seek_target).expect("seek accepted");
+    owner
+        .call(move |(q, _)| q.seek(seek_target))
+        .await
+        .expect("seek accepted");
 
     let observation_deadline = Instant::now() + Duration::from_secs(90);
     let mut confirmed = false;
@@ -216,7 +227,10 @@ async fn cpal_cold_seek_silvercomet_hls(#[case] backend: DecoderBackend) {
         "[silvercomet] backward seek: from {:?} to {backward_target:.1}s (25%)",
         queue.position_seconds()
     );
-    queue.seek(backward_target).expect("backward seek accepted");
+    owner
+        .call(move |(q, _)| q.seek(backward_target))
+        .await
+        .expect("backward seek accepted");
 
     let observation_deadline = Instant::now() + Duration::from_secs(90);
     let mut backward_confirmed = false;
@@ -256,9 +270,8 @@ async fn cpal_cold_seek_silvercomet_hls(#[case] backend: DecoderBackend) {
     );
 
     tick_handle.stop().await;
-    host.remove(queue.as_ref())
-        .expect("detach queue from playback host");
     drop(queue);
+    owner.close().await;
     drop(downloader);
     drop(temp);
 }

--- a/tests/tests/kithara_queue/cold_seek_cpal.rs
+++ b/tests/tests/kithara_queue/cold_seek_cpal.rs
@@ -144,7 +144,10 @@ async fn cpal_cold_seek_silvercomet_hls(#[case] backend: DecoderBackend) {
     let source = TrackSource::Config(Box::new(cfg));
 
     let mut rx = queue.subscribe();
-    let id = queue.append(source).expect("append silvercomet HLS track");
+    let id = queue
+        .run(move |q| q.append(source))
+        .await
+        .expect("append silvercomet HLS track");
     wait_for_status(
         &mut rx,
         queue.control(),
@@ -155,8 +158,11 @@ async fn cpal_cold_seek_silvercomet_hls(#[case] backend: DecoderBackend) {
     .await
     .unwrap_or_else(|e| panic!("silvercomet track load failed: {e}"));
 
-    queue.select(id, Transition::None).expect("select");
-    queue.play();
+    queue
+        .run(move |q| q.select(id, Transition::None))
+        .await
+        .expect("select");
+    queue.run(move |q| q.play()).await;
 
     let pos_before = wait_for_position_at_least(queue.control(), 2.0, Duration::from_secs(45))
         .await

--- a/tests/tests/kithara_queue/cold_seek_middle.rs
+++ b/tests/tests/kithara_queue/cold_seek_middle.rs
@@ -67,7 +67,7 @@ async fn wait_for_status(
     Err(format!("timeout waiting for {target:?}"))
 }
 
-fn build_queue_with_tick(
+async fn build_queue_with_tick(
     temp_dir: &TestTempDir,
 ) -> (
     OfflineQueue<TestPools>,
@@ -91,6 +91,7 @@ fn build_queue_with_tick(
         session,
         Queue::new(QueueConfig::builder().player(player).build()),
     )
+    .await
     .expect("create product offline queue");
     let queue_for_tick = queue.control();
     let tick_handle = tokio::task::spawn(async move {
@@ -221,6 +222,7 @@ async fn observe_seek_advance_or_panic(
     }
 
     tick_handle.abort();
+    let _ = tick_handle.await;
 }
 
 async fn run_seek_scenario(urls: &[&str], select_index: usize, temp: TestTempDir) {
@@ -258,6 +260,7 @@ async fn run_seek_scenario(urls: &[&str], select_index: usize, temp: TestTempDir
         session,
         Queue::new(QueueConfig::builder().player(player).build()),
     )
+    .await
     .expect("create product offline queue");
 
     let queue_for_tick = queue.control();
@@ -349,7 +352,8 @@ async fn run_seek_scenario(urls: &[&str], select_index: usize, temp: TestTempDir
     }
 
     tick_handle.abort();
-    drop(queue);
+    let _ = tick_handle.await;
+    queue.close().await;
     let _ = ids;
 }
 
@@ -404,7 +408,7 @@ async fn queue_seek_long_cold_cache_far_segment(temp_dir: TestTempDir) {
         .expect("create long HLS fixture");
     let master = created.master_url();
 
-    let (queue, downloader, store, tick_handle) = build_queue_with_tick(&temp_dir);
+    let (queue, downloader, store, tick_handle) = build_queue_with_tick(&temp_dir).await;
     let track_source = |url: &str| -> TrackSource<TestPools> {
         let cfg = ResourceConfig::for_src(ResourceSrc::parse(url).expect("valid URL"))
             .downloader(downloader.clone())
@@ -448,7 +452,7 @@ async fn queue_seek_long_cold_cache_far_segment(temp_dir: TestTempDir) {
         "long-cold",
     )
     .await;
-    drop(queue);
+    queue.close().await;
 }
 
 /// Multi-variant ABR variant: 3 variants × 30 segments × 4s = 120s each,
@@ -494,7 +498,7 @@ async fn queue_seek_multi_variant_cold_far(temp_dir: TestTempDir) {
         .expect("create multi-variant HLS fixture");
     let master = created.master_url();
 
-    let (queue, downloader, store, tick_handle) = build_queue_with_tick(&temp_dir);
+    let (queue, downloader, store, tick_handle) = build_queue_with_tick(&temp_dir).await;
     let track_source = |url: &str| -> TrackSource<TestPools> {
         let cfg = ResourceConfig::for_src(ResourceSrc::parse(url).expect("valid URL"))
             .downloader(downloader.clone())
@@ -538,5 +542,5 @@ async fn queue_seek_multi_variant_cold_far(temp_dir: TestTempDir) {
         "multi-variant-cold",
     )
     .await;
-    drop(queue);
+    queue.close().await;
 }

--- a/tests/tests/kithara_queue/cold_seek_middle.rs
+++ b/tests/tests/kithara_queue/cold_seek_middle.rs
@@ -7,8 +7,7 @@ use kithara::{
     net::{HttpClient, NetOptions},
     platform::{
         CancelToken,
-        time::{Duration, Instant, sleep, timeout},
-        tokio,
+        time::{Duration, Instant, timeout},
         tokio::sync::broadcast::error::RecvError,
     },
     play::{PlayWorker, PlayWorkerConfig, PlayerConfig, PlayerImpl, ResourceConfig, ResourceSrc},
@@ -17,7 +16,10 @@ use kithara::{
 };
 use kithara_integration_tests::{
     HlsFixtureBuilder, PackagedTestServer, TestServerHelper, TestTempDir,
-    fixture_protocol::DelayRule, kithara, offline::OfflineQueue, temp_dir,
+    fixture_protocol::DelayRule,
+    kithara,
+    offline::{OfflineQueue, QueueTicker},
+    temp_dir,
     waits::wait_for_position_event,
 };
 
@@ -73,7 +75,7 @@ async fn build_queue_with_tick(
     OfflineQueue<TestPools>,
     Downloader,
     AssetStore<TestPools>,
-    tokio::task::JoinHandle<()>,
+    QueueTicker,
 ) {
     let pools = pools();
     let session = HostConfig::offline(pools.clone())
@@ -94,14 +96,7 @@ async fn build_queue_with_tick(
     .await
     .expect("create product offline queue");
     let queue_for_tick = queue.control();
-    let tick_handle = tokio::task::spawn(async move {
-        loop {
-            sleep(Duration::from_millis(50)).await;
-            if queue_for_tick.tick().is_err() {
-                break;
-            }
-        }
-    });
+    let tick_handle = QueueTicker::spawn(queue_for_tick, Duration::from_millis(50));
     let downloader = Downloader::new(
         DownloaderConfig::for_client(HttpClient::new(
             NetOptions::default(),
@@ -198,7 +193,7 @@ async fn wait_for_post_seek_progress(
 async fn observe_seek_advance_or_panic(
     rx: &mut EventReceiver,
     queue: &QueueControl<TestPools>,
-    tick_handle: tokio::task::JoinHandle<()>,
+    mut tick_handle: QueueTicker,
     seek_target: f64,
     observation_window: Duration,
     pos_before: f64,
@@ -207,7 +202,7 @@ async fn observe_seek_advance_or_panic(
     let progress = wait_for_post_seek_progress(rx, queue, pos_before, observation_window).await;
 
     if tick_handle.is_finished() {
-        match tick_handle.await {
+        match tick_handle.join().await {
             Ok(()) => panic!("[{label}] tick task exited unexpectedly"),
             Err(e) => panic!("[{label}] seek watchdog panicked — hang reproduced: {e}"),
         }
@@ -221,8 +216,7 @@ async fn observe_seek_advance_or_panic(
         ),
     }
 
-    tick_handle.abort();
-    let _ = tick_handle.await;
+    tick_handle.stop().await;
 }
 
 async fn run_seek_scenario(urls: &[&str], select_index: usize, temp: TestTempDir) {
@@ -264,14 +258,7 @@ async fn run_seek_scenario(urls: &[&str], select_index: usize, temp: TestTempDir
     .expect("create product offline queue");
 
     let queue_for_tick = queue.control();
-    let tick_handle = tokio::task::spawn(async move {
-        loop {
-            sleep(Duration::from_millis(50)).await;
-            if queue_for_tick.tick().is_err() {
-                break;
-            }
-        }
-    });
+    let mut tick_handle = QueueTicker::spawn(queue_for_tick, Duration::from_millis(50));
 
     let mut rx = queue.subscribe();
     let ids: Vec<TrackId> = resolved
@@ -329,7 +316,7 @@ async fn run_seek_scenario(urls: &[&str], select_index: usize, temp: TestTempDir
             .await;
 
     if tick_handle.is_finished() {
-        match tick_handle.await {
+        match tick_handle.join().await {
             Ok(()) => panic!("tick task exited unexpectedly without panic"),
             Err(e) => panic!("seek watchdog panicked (expected on bug reproduction): {e}"),
         }
@@ -351,8 +338,7 @@ async fn run_seek_scenario(urls: &[&str], select_index: usize, temp: TestTempDir
         ),
     }
 
-    tick_handle.abort();
-    let _ = tick_handle.await;
+    tick_handle.stop().await;
     queue.close().await;
     let _ = ids;
 }

--- a/tests/tests/kithara_queue/cold_seek_middle.rs
+++ b/tests/tests/kithara_queue/cold_seek_middle.rs
@@ -261,18 +261,19 @@ async fn run_seek_scenario(urls: &[&str], select_index: usize, temp: TestTempDir
     let mut tick_handle = QueueTicker::spawn(queue_for_tick, Duration::from_millis(50));
 
     let mut rx = queue.subscribe();
-    let ids: Vec<TrackId> = resolved
-        .iter()
-        .map(|u| {
-            let cfg = ResourceConfig::for_src(ResourceSrc::parse(u).expect("valid URL"))
-                .downloader(downloader.clone())
-                .store(store.clone())
-                .build();
+    let mut ids: Vec<TrackId> = Vec::with_capacity(resolved.len());
+    for u in &resolved {
+        let cfg = ResourceConfig::for_src(ResourceSrc::parse(u).expect("valid URL"))
+            .downloader(downloader.clone())
+            .store(store.clone())
+            .build();
+        ids.push(
             queue
-                .append(TrackSource::Config(Box::new(cfg)))
-                .expect("append cold-seek track")
-        })
-        .collect();
+                .run(move |q| q.append(TrackSource::Config(Box::new(cfg))))
+                .await
+                .expect("append cold-seek track"),
+        );
+    }
     let selected_id = ids[select_index];
 
     wait_for_status(
@@ -285,8 +286,11 @@ async fn run_seek_scenario(urls: &[&str], select_index: usize, temp: TestTempDir
     .await
     .unwrap_or_else(|e| panic!("selected track never reached Loaded: {e}"));
 
-    queue.select(selected_id, Transition::None).expect("select");
-    queue.play();
+    queue
+        .run(move |q| q.select(selected_id, Transition::None))
+        .await
+        .expect("select");
+    queue.run(move |q| q.play()).await;
 
     let pos_before_seek = wait_for_position_event(&mut rx, &queue, 1.0, Duration::from_secs(15))
         .await
@@ -405,7 +409,11 @@ async fn queue_seek_long_cold_cache_far_segment(temp_dir: TestTempDir) {
 
     let mut rx = queue.subscribe();
     let id = queue
-        .append(track_source(master.as_str()))
+        .run({
+            let arg0 = track_source(master.as_str());
+            move |q| q.append(arg0)
+        })
+        .await
         .expect("append long cold-seek track");
     wait_for_status(
         &mut rx,
@@ -416,8 +424,11 @@ async fn queue_seek_long_cold_cache_far_segment(temp_dir: TestTempDir) {
     )
     .await
     .unwrap_or_else(|e| panic!("load: {e}"));
-    queue.select(id, Transition::None).expect("select");
-    queue.play();
+    queue
+        .run(move |q| q.select(id, Transition::None))
+        .await
+        .expect("select");
+    queue.run(move |q| q.play()).await;
 
     let pos_before = wait_for_position_event(&mut rx, &queue, 2.0, Duration::from_secs(30))
         .await
@@ -495,7 +506,11 @@ async fn queue_seek_multi_variant_cold_far(temp_dir: TestTempDir) {
 
     let mut rx = queue.subscribe();
     let id = queue
-        .append(track_source(master.as_str()))
+        .run({
+            let arg0 = track_source(master.as_str());
+            move |q| q.append(arg0)
+        })
+        .await
         .expect("append multivariant cold-seek track");
     wait_for_status(
         &mut rx,
@@ -506,8 +521,11 @@ async fn queue_seek_multi_variant_cold_far(temp_dir: TestTempDir) {
     )
     .await
     .unwrap_or_else(|e| panic!("load: {e}"));
-    queue.select(id, Transition::None).expect("select");
-    queue.play();
+    queue
+        .run(move |q| q.select(id, Transition::None))
+        .await
+        .expect("select");
+    queue.run(move |q| q.play()).await;
 
     let pos_before = wait_for_position_event(&mut rx, &queue, 2.0, Duration::from_secs(30))
         .await

--- a/tests/tests/kithara_queue/cpal_cold_seek_synthetic.rs
+++ b/tests/tests/kithara_queue/cpal_cold_seek_synthetic.rs
@@ -74,6 +74,7 @@ async fn cold_seek_far_segment_hls_offline(#[case] backend: DecoderBackend) {
             .build(),
         Queue::new(QueueConfig::builder().player(player).build()),
     )
+    .await
     .expect("create product offline queue");
 
     let queue_for_tick = queue.control();
@@ -157,7 +158,7 @@ async fn cold_seek_far_segment_hls_offline(#[case] backend: DecoderBackend) {
     );
 
     tick_handle.abort();
-    drop(queue);
+    queue.close().await;
     drop(downloader);
     drop(temp);
 }

--- a/tests/tests/kithara_queue/cpal_cold_seek_synthetic.rs
+++ b/tests/tests/kithara_queue/cpal_cold_seek_synthetic.rs
@@ -5,7 +5,7 @@ use kithara::{
     events::{AudioEvent, Event},
     host::HostConfig,
     net::{HttpClient, NetOptions},
-    platform::{CancelToken, time::Duration, tokio},
+    platform::{CancelToken, time::Duration},
     play::{PlayWorker, PlayWorkerConfig, PlayerConfig, PlayerImpl, ResourceConfig, ResourceSrc},
     queue::{Queue, QueueConfig, TrackSource, Transition},
     stream::dl::{Downloader, DownloaderConfig},
@@ -14,7 +14,7 @@ use kithara_integration_tests::{
     HlsFixtureBuilder, TestServerHelper,
     fixture_protocol::DelayRule,
     kithara,
-    offline::OfflineQueue,
+    offline::{OfflineQueue, QueueTicker},
     temp_dir,
     test_defaults::Consts as Shared,
     waits::{wait_for_loader_done, wait_for_position_at_least},
@@ -78,14 +78,7 @@ async fn cold_seek_far_segment_hls_offline(#[case] backend: DecoderBackend) {
     .expect("create product offline queue");
 
     let queue_for_tick = queue.control();
-    let tick_handle = tokio::task::spawn(async move {
-        loop {
-            time::sleep(Duration::from_millis(16)).await;
-            if queue_for_tick.tick().is_err() {
-                break;
-            }
-        }
-    });
+    let mut tick_handle = QueueTicker::spawn(queue_for_tick, Duration::from_millis(16));
 
     let cfg =
         ResourceConfig::for_src(ResourceSrc::parse(master.as_str()).expect("valid master URL"))
@@ -144,7 +137,7 @@ async fn cold_seek_far_segment_hls_offline(#[case] backend: DecoderBackend) {
     }
 
     if tick_handle.is_finished() {
-        match tick_handle.await {
+        match tick_handle.join().await {
             Ok(()) => panic!("tick task exited without panic"),
             Err(e) => panic!("seek watchdog panicked — HANG REPRODUCED: {e}"),
         }
@@ -157,7 +150,7 @@ async fn cold_seek_far_segment_hls_offline(#[case] backend: DecoderBackend) {
         queue.position_seconds(),
     );
 
-    tick_handle.abort();
+    tick_handle.stop().await;
     queue.close().await;
     drop(downloader);
     drop(temp);

--- a/tests/tests/kithara_queue/cpal_cold_seek_synthetic.rs
+++ b/tests/tests/kithara_queue/cpal_cold_seek_synthetic.rs
@@ -92,13 +92,19 @@ async fn cold_seek_far_segment_hls_offline(#[case] backend: DecoderBackend) {
             .build();
     let source = TrackSource::Config(Box::new(cfg));
 
-    let id = queue.append(source).expect("append synthetic HLS track");
+    let id = queue
+        .run(move |q| q.append(source))
+        .await
+        .expect("append synthetic HLS track");
     wait_for_loader_done(&queue, id, Duration::from_secs(30))
         .await
         .unwrap_or_else(|e| panic!("load: {e}"));
 
-    queue.select(id, Transition::None).expect("select");
-    queue.play();
+    queue
+        .run(move |q| q.select(id, Transition::None))
+        .await
+        .expect("select");
+    queue.run(move |q| q.play()).await;
 
     let pos_before = wait_for_position_at_least(&queue, 1.5, Duration::from_secs(20))
         .await

--- a/tests/tests/kithara_queue/duplicate_src_in_queue.rs
+++ b/tests/tests/kithara_queue/duplicate_src_in_queue.rs
@@ -31,18 +31,22 @@ const TRACK_SECS: f64 = 30.0;
 const LOUD: f32 = 0.80;
 const REPEATED_SRC: &str = "https://example.com/repeat.mp3";
 
-fn load(queue: &QueueControl<TestPools>, id: TrackId) {
+async fn load(harness: &OfflinePlayerHarness, queue: &QueueControl<TestPools>, id: TrackId) {
     let spec = AudioSpec::new(
         CHANNELS,
         NonZero::new(SAMPLE_RATE).expect("sample rate is non-zero"),
     );
-    queue.complete_load_for_test(
-        id,
-        resource_from_reader_with_src(
-            TestPcmReader::with_value(spec, TRACK_SECS, LOUD),
-            Arc::from(REPEATED_SRC),
-        ),
-    );
+    harness
+        .run(queue, move |q| {
+            q.complete_load_for_test(
+                id,
+                resource_from_reader_with_src(
+                    TestPcmReader::with_value(spec, TRACK_SECS, LOUD),
+                    Arc::from(REPEATED_SRC),
+                ),
+            )
+        })
+        .await;
 }
 
 async fn render_loop(
@@ -51,7 +55,7 @@ async fn render_loop(
     block_budget: usize,
 ) {
     for _ in 0..block_budget {
-        let _ = queue.tick();
+        let _ = harness.run(queue, |q| q.tick()).await;
         let _ = harness.render(BLOCK_FRAMES).await;
     }
 }
@@ -73,13 +77,20 @@ async fn fixture_playing_the_second_copy() -> (
     TrackId,
 ) {
     let (harness, queue) = offline_queue_fixture(SAMPLE_RATE).await;
-    let first = queue.append(REPEATED_SRC).expect("append first copy");
-    let playing = queue.append(REPEATED_SRC).expect("append second copy");
-    load(&queue, first);
-    load(&queue, playing);
+    let first = harness
+        .run(&queue, move |q| q.append(REPEATED_SRC))
+        .await
+        .expect("append first copy");
+    let playing = harness
+        .run(&queue, move |q| q.append(REPEATED_SRC))
+        .await
+        .expect("append second copy");
+    load(&harness, &queue, first).await;
+    load(&harness, &queue, playing).await;
 
-    queue
-        .select(playing, Transition::None)
+    harness
+        .run(&queue, move |q| q.select(playing, Transition::None))
+        .await
         .expect("select the second copy");
     render_loop(&queue, &harness, WARMUP_BLOCKS).await;
 

--- a/tests/tests/kithara_queue/duplicate_src_in_queue.rs
+++ b/tests/tests/kithara_queue/duplicate_src_in_queue.rs
@@ -45,14 +45,14 @@ fn load(queue: &QueueControl<TestPools>, id: TrackId) {
     );
 }
 
-fn render_loop(
+async fn render_loop(
     queue: &QueueControl<TestPools>,
     harness: &OfflinePlayerHarness,
     block_budget: usize,
 ) {
     for _ in 0..block_budget {
         let _ = queue.tick();
-        let _ = harness.render(BLOCK_FRAMES);
+        let _ = harness.render(BLOCK_FRAMES).await;
     }
 }
 
@@ -66,13 +66,13 @@ fn status_of(queue: &QueueControl<TestPools>, id: TrackId) -> TrackStatus {
 }
 
 /// The failing track is the *second* entry carrying this URL.
-fn fixture_playing_the_second_copy() -> (
+async fn fixture_playing_the_second_copy() -> (
     OfflinePlayerHarness,
     QueueControl<TestPools>,
     TrackId,
     TrackId,
 ) {
-    let (harness, queue) = offline_queue_fixture(SAMPLE_RATE);
+    let (harness, queue) = offline_queue_fixture(SAMPLE_RATE).await;
     let first = queue.append(REPEATED_SRC).expect("append first copy");
     let playing = queue.append(REPEATED_SRC).expect("append second copy");
     load(&queue, first);
@@ -81,7 +81,7 @@ fn fixture_playing_the_second_copy() -> (
     queue
         .select(playing, Transition::None)
         .expect("select the second copy");
-    render_loop(&queue, &harness, WARMUP_BLOCKS);
+    render_loop(&queue, &harness, WARMUP_BLOCKS).await;
 
     (harness, queue, first, playing)
 }
@@ -99,10 +99,10 @@ fn publish_leading_failure(harness: &OfflinePlayerHarness, id: TrackId) {
 #[case::played_entry(true)]
 #[case::same_url_entry(false)]
 async fn a_failure_only_flags_the_entry_that_played(#[case] played_entry: bool) {
-    let (harness, queue, first, playing) = fixture_playing_the_second_copy();
+    let (harness, queue, first, playing) = fixture_playing_the_second_copy().await;
 
     publish_leading_failure(&harness, playing);
-    render_loop(&queue, &harness, WARMUP_BLOCKS);
+    render_loop(&queue, &harness, WARMUP_BLOCKS).await;
 
     let id = if played_entry { playing } else { first };
     let status = status_of(&queue, id);
@@ -111,4 +111,6 @@ async fn a_failure_only_flags_the_entry_that_played(#[case] played_entry: bool) 
         played_entry,
         "only the entry that played may be flagged: {status:?}"
     );
+    drop(queue);
+    harness.close().await;
 }

--- a/tests/tests/kithara_queue/early_seek_size_withheld_advance.rs
+++ b/tests/tests/kithara_queue/early_seek_size_withheld_advance.rs
@@ -29,7 +29,7 @@ use kithara::{
         PlayWorker, PlayWorkerConfig, PlayerConfig, PlayerImpl, Resource, ResourceConfig,
         ResourceSrc,
     },
-    queue::{Queue, QueueConfig, Transition, test_utils::QueueProbe},
+    queue::{Queue, QueueConfig, QueueControl, Transition, test_utils::QueueProbe},
     stream::dl::{Downloader, DownloaderConfig},
 };
 use kithara_integration_tests::{
@@ -111,6 +111,19 @@ impl Harness {
 
     async fn render(&self, frames: usize) -> Vec<f32> {
         self.host.render(frames).await
+    }
+
+    /// Issues a queue control call from the host owner thread, as the app would.
+    async fn run<R>(
+        &self,
+        queue: &QueueControl<TestPools>,
+        f: impl FnOnce(&QueueControl<TestPools>) -> R + Send + 'static,
+    ) -> R
+    where
+        R: Send + 'static,
+    {
+        let queue = queue.clone();
+        self.host.run(move || f(&queue)).await
     }
 
     async fn close(self) {
@@ -250,17 +263,24 @@ async fn run_case(mode: GateMode) {
         ))
         .await
         .expect("insert queue into product offline Host");
-    let id0 = queue.insert_loaded_for_test(target);
-    let _id1 = queue.insert_loaded_for_test(next);
+    let id0 = harness
+        .run(&queue, move |q| q.insert_loaded_for_test(target))
+        .await;
+    let _id1 = harness
+        .run(&queue, move |q| q.insert_loaded_for_test(next))
+        .await;
 
-    queue.select(id0, Transition::None).expect("select track 0");
-    queue.play();
+    harness
+        .run(&queue, move |q| q.select(id0, Transition::None))
+        .await
+        .expect("select track 0");
+    harness.run(&queue, move |q| q.play()).await;
     assert_eq!(queue.current_index(), Some(0), "starts on track 0");
 
     // Warm up: render some blocks so segment 0 decodes and the track is
     // genuinely playing before the seek arrives.
     for _ in 0..WARMUP_BLOCKS {
-        let _ = queue.tick();
+        let _ = harness.run(&queue, |q| q.tick()).await;
         let _ = harness.render(BLOCK_FRAMES).await;
     }
     assert_eq!(
@@ -279,7 +299,7 @@ async fn run_case(mode: GateMode) {
     let mut trigger = Trigger::NoTerminal;
     let mut outcome = Outcome::HeldOnTrack;
     for _ in 0..OBSERVE_BLOCKS {
-        let _ = queue.tick();
+        let _ = harness.run(&queue, |q| q.tick()).await;
         let _ = harness.render(BLOCK_FRAMES).await;
         while let Ok(ev) = rx.try_recv().map(|env| env.event) {
             if let kithara::events::Event::Player(pe) = ev {

--- a/tests/tests/kithara_queue/early_seek_size_withheld_advance.rs
+++ b/tests/tests/kithara_queue/early_seek_size_withheld_advance.rs
@@ -80,11 +80,13 @@ struct Harness {
 }
 
 impl Harness {
-    fn new(pools: Pools) -> Self {
+    async fn new(pools: Pools) -> Self {
         let session = HostConfig::offline(pools.clone())
             .sample_rate(NonZeroU32::new(SAMPLE_RATE).expect("sample rate must be non-zero"))
             .build();
-        let host = OfflineHostHarness::new(session).expect("create product offline Host");
+        let host = OfflineHostHarness::new(session)
+            .await
+            .expect("create product offline Host");
         let worker = PlayWorker::new(PlayWorkerConfig::builder(pools).build());
         let config = PlayerConfig::builder()
             .crossfade_duration(0.0)
@@ -107,8 +109,19 @@ impl Harness {
         self.player.take().expect("harness player was transferred")
     }
 
-    fn render(&self, frames: usize) -> Vec<f32> {
-        self.host.render(frames)
+    async fn render(&self, frames: usize) -> Vec<f32> {
+        self.host.render(frames).await
+    }
+
+    async fn close(self) {
+        let Self {
+            player,
+            worker,
+            host,
+        } = self;
+        drop(player);
+        drop(worker);
+        host.close().await;
     }
 }
 
@@ -218,7 +231,7 @@ async fn run_case(mode: GateMode) {
         .build(),
     );
 
-    let mut harness = Harness::new(pools);
+    let mut harness = Harness::new(pools).await;
     let mut rx = harness.player().subscribe();
 
     // Track 0 = the gated HLS track. Track 1 = a second HLS track so a forward
@@ -235,6 +248,7 @@ async fn run_case(mode: GateMode) {
                 .player(player)
                 .build(),
         ))
+        .await
         .expect("insert queue into product offline Host");
     let id0 = queue.insert_loaded_for_test(target);
     let _id1 = queue.insert_loaded_for_test(next);
@@ -247,7 +261,7 @@ async fn run_case(mode: GateMode) {
     // genuinely playing before the seek arrives.
     for _ in 0..WARMUP_BLOCKS {
         let _ = queue.tick();
-        let _ = harness.render(BLOCK_FRAMES);
+        let _ = harness.render(BLOCK_FRAMES).await;
     }
     assert_eq!(
         gate.head_requested(),
@@ -266,7 +280,7 @@ async fn run_case(mode: GateMode) {
     let mut outcome = Outcome::HeldOnTrack;
     for _ in 0..OBSERVE_BLOCKS {
         let _ = queue.tick();
-        let _ = harness.render(BLOCK_FRAMES);
+        let _ = harness.render(BLOCK_FRAMES).await;
         while let Ok(ev) = rx.try_recv().map(|env| env.event) {
             if let kithara::events::Event::Player(pe) = ev {
                 match pe {
@@ -328,4 +342,5 @@ async fn run_case(mode: GateMode) {
     queue.clear();
     drop(queue);
     drop(server);
+    harness.close().await;
 }

--- a/tests/tests/kithara_queue/false_eof_rapid_scrub.rs
+++ b/tests/tests/kithara_queue/false_eof_rapid_scrub.rs
@@ -3,6 +3,7 @@
 use kithara::{
     decode::DecoderBackend,
     events::{Event, EventReceiver, PlayerEvent},
+    hls::AbrMode,
     platform::time::{Duration, Instant, timeout},
     queue::{QueueControl, Transition},
 };
@@ -293,26 +294,35 @@ async fn rapid_scrub_does_not_silently_advance(#[case] backend: DecoderBackend) 
 
     let _before_id = ctx
         .queue
-        .append(super::source_helper::app_drm_track_source(
+        .append(super::source_helper::app_track_source(
             SENTINEL_BEFORE,
-            &ctx,
+            &ctx.config,
+            super::source_helper::app_disk_asset_store(&ctx.config, ctx.cache.path()),
             backend,
+            AbrMode::Auto(None),
+            None,
         ))
         .expect("append leading sentinel");
     let target_id = ctx
         .queue
-        .append(super::source_helper::app_drm_track_source(
+        .append(super::source_helper::app_track_source(
             TARGET_TRACK,
-            &ctx,
+            &ctx.config,
+            super::source_helper::app_disk_asset_store(&ctx.config, ctx.cache.path()),
             backend,
+            AbrMode::Auto(None),
+            None,
         ))
         .expect("append scrub target");
     let _after_id = ctx
         .queue
-        .append(super::source_helper::app_drm_track_source(
+        .append(super::source_helper::app_track_source(
             SENTINEL_AFTER,
-            &ctx,
+            &ctx.config,
+            super::source_helper::app_disk_asset_store(&ctx.config, ctx.cache.path()),
             backend,
+            AbrMode::Auto(None),
+            None,
         ))
         .expect("append trailing sentinel");
 

--- a/tests/tests/kithara_queue/false_eof_rapid_scrub.rs
+++ b/tests/tests/kithara_queue/false_eof_rapid_scrub.rs
@@ -48,7 +48,7 @@ const OUTCOME_BUDGET: Duration = Duration::from_secs(45);
 const MIN_POST_SEEK_GROWTH_SECS: f64 = 1.0;
 
 async fn build_ctx() -> AppQueueFixture {
-    insecure_app_queue()
+    insecure_app_queue().await
 }
 
 /// Wait until the decoder has produced at least one PCM chunk for the
@@ -294,36 +294,48 @@ async fn rapid_scrub_does_not_silently_advance(#[case] backend: DecoderBackend) 
 
     let _before_id = ctx
         .queue
-        .append(super::source_helper::app_track_source(
-            SENTINEL_BEFORE,
-            &ctx.config,
-            super::source_helper::app_disk_asset_store(&ctx.config, ctx.cache.path()),
-            backend,
-            AbrMode::Auto(None),
-            None,
-        ))
+        .run({
+            let source = super::source_helper::app_track_source(
+                SENTINEL_BEFORE,
+                &ctx.config,
+                super::source_helper::app_disk_asset_store(&ctx.config, ctx.cache.path()),
+                backend,
+                AbrMode::Auto(None),
+                None,
+            );
+            move |q| q.append(source)
+        })
+        .await
         .expect("append leading sentinel");
     let target_id = ctx
         .queue
-        .append(super::source_helper::app_track_source(
-            TARGET_TRACK,
-            &ctx.config,
-            super::source_helper::app_disk_asset_store(&ctx.config, ctx.cache.path()),
-            backend,
-            AbrMode::Auto(None),
-            None,
-        ))
+        .run({
+            let source = super::source_helper::app_track_source(
+                TARGET_TRACK,
+                &ctx.config,
+                super::source_helper::app_disk_asset_store(&ctx.config, ctx.cache.path()),
+                backend,
+                AbrMode::Auto(None),
+                None,
+            );
+            move |q| q.append(source)
+        })
+        .await
         .expect("append scrub target");
     let _after_id = ctx
         .queue
-        .append(super::source_helper::app_track_source(
-            SENTINEL_AFTER,
-            &ctx.config,
-            super::source_helper::app_disk_asset_store(&ctx.config, ctx.cache.path()),
-            backend,
-            AbrMode::Auto(None),
-            None,
-        ))
+        .run({
+            let source = super::source_helper::app_track_source(
+                SENTINEL_AFTER,
+                &ctx.config,
+                super::source_helper::app_disk_asset_store(&ctx.config, ctx.cache.path()),
+                backend,
+                AbrMode::Auto(None),
+                None,
+            );
+            move |q| q.append(source)
+        })
+        .await
         .expect("append trailing sentinel");
 
     wait_for_loader_done_event(&mut rx, &ctx.queue, target_id, LOAD_BUDGET)
@@ -331,7 +343,8 @@ async fn rapid_scrub_does_not_silently_advance(#[case] backend: DecoderBackend) 
         .unwrap_or_else(|e| panic!("Loaded never arrived for {TARGET_TRACK}: {e}"));
 
     ctx.queue
-        .select(target_id, Transition::None)
+        .run(move |q| q.select(target_id, Transition::None))
+        .await
         .expect("select target");
 
     // Production-truth warmup signal: the first PCM chunk has been
@@ -352,7 +365,10 @@ async fn rapid_scrub_does_not_silently_advance(#[case] backend: DecoderBackend) 
     let chunks_at_seek = count_build_chunks(&recorder);
     eprintln!("[harness] chunks_at_seek={chunks_at_seek}");
 
-    ctx.queue.seek(SCRUB_TARGET_SECS).expect("seek");
+    ctx.queue
+        .run(move |q| q.seek(SCRUB_TARGET_SECS))
+        .await
+        .expect("seek");
     let started_at = Instant::now();
     let mut event_log: Vec<TimedEvent> = Vec::new();
 

--- a/tests/tests/kithara_queue/file_replay_from_warm_cache.rs
+++ b/tests/tests/kithara_queue/file_replay_from_warm_cache.rs
@@ -9,14 +9,14 @@ use kithara::{
     events::AbrMode,
     host::HostConfig,
     net::{HttpClient, NetOptions},
-    platform::{CancelToken, sync::Arc, time::Duration, tokio},
+    platform::{CancelToken, sync::Arc, time::Duration},
     play::{PlayWorker, PlayWorkerConfig, PlayerConfig, PlayerImpl, ResourceConfig, ResourceSrc},
     queue::{Queue, QueueConfig, TrackSource, Transition},
     stream::dl::{Downloader, DownloaderConfig},
 };
 use kithara_integration_tests::{
     TestServerHelper, TestTempDir, kithara,
-    offline::{OfflineQueue, drive_queue_ticks},
+    offline::{OfflineQueue, QueueTicker},
     temp_dir,
     test_defaults::Consts as Shared,
     waits::{wait_for_loader_done, wait_for_position_at_least},
@@ -31,7 +31,7 @@ struct Session {
     downloader: Downloader,
     store: AssetStore<TestPools>,
     flush_hub: Arc<FlushHub>,
-    tick: tokio::task::JoinHandle<()>,
+    tick: QueueTicker,
 }
 
 impl Session {
@@ -41,10 +41,9 @@ impl Session {
             downloader,
             store,
             flush_hub,
-            tick,
+            mut tick,
         } = self;
-        tick.abort();
-        let _ = tick.await;
+        tick.stop().await;
         drop(downloader);
         drop(store);
         drop(flush_hub);
@@ -85,10 +84,7 @@ async fn build_session(cache_path: &Path) -> Session {
     )
     .await
     .expect("create product offline queue");
-    let tick = tokio::task::spawn(drive_queue_ticks(
-        queue.control(),
-        Duration::from_millis(50),
-    ));
+    let tick = QueueTicker::spawn(queue.control(), Duration::from_millis(50));
     let downloader = Downloader::new(
         DownloaderConfig::for_client(HttpClient::new(
             NetOptions::default(),
@@ -121,7 +117,7 @@ fn track_source(url: &Url, session: &Session) -> TrackSource<TestPools> {
 }
 
 async fn play_one_session(url: &Url, cache_path: &Path, min_play_secs: f64, label: &str) {
-    let session = build_session(cache_path).await;
+    let mut session = build_session(cache_path).await;
     let id = session
         .queue
         .append(track_source(url, &session))
@@ -136,7 +132,7 @@ async fn play_one_session(url: &Url, cache_path: &Path, min_play_secs: f64, labe
     wait_for_position_at_least(&session.queue, min_play_secs, Duration::from_secs(15))
         .await
         .unwrap_or_else(|e| panic!("[{label}] play: {e}"));
-    session.tick.abort();
+    session.tick.stop().await;
     // Durable checkpoint: returns only once the on-disk indexes
     // (availability / lru / pins) are committed, so the next warm-cache
     // session observes a fully-written cache. This is a state-completion

--- a/tests/tests/kithara_queue/file_replay_from_warm_cache.rs
+++ b/tests/tests/kithara_queue/file_replay_from_warm_cache.rs
@@ -34,7 +34,25 @@ struct Session {
     tick: tokio::task::JoinHandle<()>,
 }
 
-fn build_session(cache_path: &Path) -> Session {
+impl Session {
+    async fn close(self) {
+        let Self {
+            queue,
+            downloader,
+            store,
+            flush_hub,
+            tick,
+        } = self;
+        tick.abort();
+        let _ = tick.await;
+        drop(downloader);
+        drop(store);
+        drop(flush_hub);
+        queue.close().await;
+    }
+}
+
+async fn build_session(cache_path: &Path) -> Session {
     // Own the flush hub so the test can drive a synchronous durable
     // checkpoint (`flush_now`) instead of guessing at the background
     // worker's debounce with a timer.
@@ -65,6 +83,7 @@ fn build_session(cache_path: &Path) -> Session {
                 .build(),
         ),
     )
+    .await
     .expect("create product offline queue");
     let tick = tokio::task::spawn(drive_queue_ticks(
         queue.control(),
@@ -102,7 +121,7 @@ fn track_source(url: &Url, session: &Session) -> TrackSource<TestPools> {
 }
 
 async fn play_one_session(url: &Url, cache_path: &Path, min_play_secs: f64, label: &str) {
-    let session = build_session(cache_path);
+    let session = build_session(cache_path).await;
     let id = session
         .queue
         .append(track_source(url, &session))
@@ -118,7 +137,6 @@ async fn play_one_session(url: &Url, cache_path: &Path, min_play_secs: f64, labe
         .await
         .unwrap_or_else(|e| panic!("[{label}] play: {e}"));
     session.tick.abort();
-    let _ = session.tick.await;
     // Durable checkpoint: returns only once the on-disk indexes
     // (availability / lru / pins) are committed, so the next warm-cache
     // session observes a fully-written cache. This is a state-completion
@@ -127,8 +145,7 @@ async fn play_one_session(url: &Url, cache_path: &Path, min_play_secs: f64, labe
         .flush_hub
         .flush_now()
         .unwrap_or_else(|e| panic!("[{label}] flush: {e}"));
-    drop(session.queue);
-    drop(session.downloader);
+    session.close().await;
 }
 
 /// Drives the player through the production restart sequence: download

--- a/tests/tests/kithara_queue/file_replay_from_warm_cache.rs
+++ b/tests/tests/kithara_queue/file_replay_from_warm_cache.rs
@@ -120,14 +120,19 @@ async fn play_one_session(url: &Url, cache_path: &Path, min_play_secs: f64, labe
     let mut session = build_session(cache_path).await;
     let id = session
         .queue
-        .append(track_source(url, &session))
+        .run({
+            let source = track_source(url, &session);
+            move |q| q.append(source)
+        })
+        .await
         .expect("append replay track");
     wait_for_loader_done(&session.queue, id, Duration::from_secs(30))
         .await
         .unwrap_or_else(|e| panic!("[{label}] load: {e}"));
     session
         .queue
-        .select(id, Transition::None)
+        .run(move |q| q.select(id, Transition::None))
+        .await
         .expect("select after load");
     wait_for_position_at_least(&session.queue, min_play_secs, Duration::from_secs(15))
         .await

--- a/tests/tests/kithara_queue/flac_swallow_fixture.rs
+++ b/tests/tests/kithara_queue/flac_swallow_fixture.rs
@@ -170,7 +170,7 @@ async fn flac_swallow_fixture(#[case] backend: DecoderBackend) {
             .build(),
     )
     .await;
-    player.load_and_fadein(resource);
+    player.load_and_fadein(resource).await;
 
     let window_secs = (BLOCKS_PER_WINDOW * BLOCK_FRAMES) as f64 / f64::from(OUT_RATE);
     let windows =

--- a/tests/tests/kithara_queue/flac_swallow_fixture.rs
+++ b/tests/tests/kithara_queue/flac_swallow_fixture.rs
@@ -97,7 +97,7 @@ async fn play_realtime(player: &mut OfflinePlayer, windows: u64, window_secs: f6
     for _ in 0..windows {
         let started = Instant::now();
         for _ in 0..BLOCKS_PER_WINDOW {
-            let _ = player.render(BLOCK_FRAMES);
+            let _ = player.render(BLOCK_FRAMES).await;
         }
         let elapsed = started.elapsed().as_secs_f64();
         if window_secs > elapsed {
@@ -168,7 +168,8 @@ async fn flac_swallow_fixture(#[case] backend: DecoderBackend) {
         HostConfig::offline(pools())
             .sample_rate(NonZeroU32::new(OUT_RATE).expect("output rate is non-zero"))
             .build(),
-    );
+    )
+    .await;
     player.load_and_fadein(resource);
 
     let window_secs = (BLOCKS_PER_WINDOW * BLOCK_FRAMES) as f64 / f64::from(OUT_RATE);
@@ -186,4 +187,5 @@ async fn flac_swallow_fixture(#[case] backend: DecoderBackend) {
 
     assert_committed_reached(&recorder, MIN_DELAYED_PLAYHEAD_SECS);
     assert_no_committed_swallow(&recorder, MAX_COMMITTED_STEP_SECS);
+    player.close().await;
 }

--- a/tests/tests/kithara_queue/full_playthrough_census.rs
+++ b/tests/tests/kithara_queue/full_playthrough_census.rs
@@ -640,6 +640,12 @@ async fn census_provenance(origins: &[Origin], seam: Seam, temp_dir: &TestTempDi
 /// quantisation, and a seam that fades rather than sums. A lossy container
 /// carries none of these, so a census over one runs the provenance half
 /// alone.
+///
+/// `no_block`: seconds of frame classification over the whole take, after the
+/// last await and over captured samples only. It occupies the poll it runs in
+/// the way the budget is meant to catch, but there is no product work left to
+/// starve.
+#[kithara::allow_block]
 fn census_acoustics(take: &Take) {
     let rendered = take.rendered.as_slice();
     let ordered = take.ordered.as_slice();

--- a/tests/tests/kithara_queue/full_playthrough_census.rs
+++ b/tests/tests/kithara_queue/full_playthrough_census.rs
@@ -284,6 +284,19 @@ struct Census {
     tracks: Vec<TrackId>,
 }
 
+impl Census {
+    async fn close(self) {
+        let Self {
+            harness,
+            queue,
+            tracks,
+        } = self;
+        drop(queue);
+        drop(tracks);
+        harness.close().await;
+    }
+}
+
 async fn build_queue(
     origins: &[Origin],
     server: Option<&TestServerHelper>,
@@ -297,11 +310,12 @@ async fn build_queue(
             .block_on_underrun(true)
             .build(),
         SAMPLE_RATE,
-    );
+    )
+    .await;
     harness.set_host_level(CENSUS_LEVEL);
     let mut config = QueueConfig::builder().player(harness.take_player()).build();
     config.should_autoplay = false;
-    let queue: QueueControl<TestPools> = harness.insert_control(Queue::new(config));
+    let queue: QueueControl<TestPools> = harness.insert_control(Queue::new(config)).await;
 
     let mut tracks = Vec::with_capacity(patterns.len());
     for (index, (origin, pattern)) in origins.iter().zip(patterns).enumerate() {
@@ -354,7 +368,7 @@ async fn play_to_the_end(census: &Census) -> (Vec<f32>, QueueLog) {
 
     for _ in 0..BLOCK_BUDGET {
         let _ = census.queue.tick();
-        rendered.extend(census.harness.render(BLOCK_FRAMES));
+        rendered.extend(census.harness.render(BLOCK_FRAMES).await);
 
         if let (Some(index), Some(duration)) = (
             census.queue.current_index(),
@@ -632,6 +646,7 @@ async fn census_provenance(origins: &[Origin], seam: Seam, temp_dir: &TestTempDi
         "a crossfade must be announced exactly at the configured boundaries"
     );
 
+    census.close().await;
     Take { rendered, ordered }
 }
 

--- a/tests/tests/kithara_queue/full_playthrough_census.rs
+++ b/tests/tests/kithara_queue/full_playthrough_census.rs
@@ -31,7 +31,7 @@ use kithara::{
         sync::Arc,
         time::{self, Duration},
     },
-    play::{Resource, ResourceConfig, ResourceSrc, player::PlayerControl},
+    play::{Resource, ResourceConfig, ResourceSrc},
     queue::{Queue, QueueConfig, QueueControl, Transition, test_utils::QueueProbe},
     stream::AudioCodec,
 };
@@ -263,15 +263,16 @@ async fn track_src(
 }
 
 async fn open_resource(
-    player: &PlayerControl<TestPools>,
+    harness: &OfflinePlayerHarness,
     src: ResourceSrc,
     cache_dir: &Path,
 ) -> Resource {
     let config = ResourceConfig::<TestPools>::for_src(src)
         .store(kithara_integration_tests::disk_asset_store(cache_dir))
         .build();
-    let config = player
-        .prepare_config(config)
+    let config = harness
+        .with_player(move |player| player.prepare_config(config))
+        .await
         .expect("prepare census resource");
     let mut resource = Resource::new(config).await.expect("open census resource");
     let _ = resource.preload().await;
@@ -321,15 +322,24 @@ async fn build_queue(
     for (index, (origin, pattern)) in origins.iter().zip(patterns).enumerate() {
         let src = track_src(*origin, server, *pattern).await;
         let resource = open_resource(
-            harness.player(),
+            &harness,
             src,
             &temp_dir.path().join(format!("track{index}")),
         )
         .await;
-        tracks.push(queue.insert_loaded_for_test(resource));
+        tracks.push(
+            harness
+                .run(&queue, move |q| q.insert_loaded_for_test(resource))
+                .await,
+        );
     }
-    queue
-        .select(tracks[0], seam.transition())
+    harness
+        .run(&queue, {
+            let arg0 = tracks[0];
+            let arg1 = seam.transition();
+            move |q| q.select(arg0, arg1)
+        })
+        .await
         .expect("select the first track");
 
     Census {
@@ -367,7 +377,7 @@ async fn play_to_the_end(census: &Census) -> (Vec<f32>, QueueLog) {
     let mut rendered = Vec::new();
 
     for _ in 0..BLOCK_BUDGET {
-        let _ = census.queue.tick();
+        let _ = census.harness.run(&census.queue, |q| q.tick()).await;
         rendered.extend(census.harness.render(BLOCK_FRAMES).await);
 
         if let (Some(index), Some(duration)) = (

--- a/tests/tests/kithara_queue/hls_seek_cancels_stale_fetches.rs
+++ b/tests/tests/kithara_queue/hls_seek_cancels_stale_fetches.rs
@@ -204,9 +204,13 @@ async fn hls_seek_near_end_skips_prefix(#[case] backend: DecoderBackend) {
             .build();
 
     let track_id = queue
-        .append(TrackSource::Config(Box::new(cfg)))
+        .run(move |q| q.append(TrackSource::Config(Box::new(cfg))))
+        .await
         .expect("append stale-fetch seek track");
-    queue.select(track_id, Transition::None).expect("select");
+    queue
+        .run(move |q| q.select(track_id, Transition::None))
+        .await
+        .expect("select");
 
     wait_for_loader_done(&queue, track_id, Consts::LOAD_DEADLINE)
         .await

--- a/tests/tests/kithara_queue/hls_seek_cancels_stale_fetches.rs
+++ b/tests/tests/kithara_queue/hls_seek_cancels_stale_fetches.rs
@@ -23,7 +23,7 @@ use kithara_integration_tests::{
     HlsFixtureBuilder, TestServerHelper, TestTempDir,
     fixture_protocol::DelayRule,
     kithara,
-    offline::{OfflineQueue, drive_queue_ticks},
+    offline::{OfflineQueue, QueueTicker},
     temp_dir,
     waits::wait_for_loader_done,
 };
@@ -101,7 +101,7 @@ async fn build_queue_with_tick(
     OfflineQueue<TestPools>,
     Downloader,
     AssetStore<TestPools>,
-    tokio::task::JoinHandle<()>,
+    QueueTicker,
 ) {
     let store = kithara_integration_tests::disk_asset_store(temp_dir.path());
     let pools = pools();
@@ -127,10 +127,7 @@ async fn build_queue_with_tick(
     )
     .await
     .expect("create product offline queue");
-    let tick_handle = tokio::task::spawn(drive_queue_ticks(
-        queue.control(),
-        Duration::from_millis(50),
-    ));
+    let tick_handle = QueueTicker::spawn(queue.control(), Duration::from_millis(50));
     let downloader = Downloader::new(
         DownloaderConfig::for_client(HttpClient::new(
             NetOptions::default(),
@@ -190,7 +187,7 @@ async fn hls_seek_near_end_skips_prefix(#[case] backend: DecoderBackend) {
     let url = build_hls_with_delay(&helper).await;
 
     let temp = temp_dir();
-    let (queue, downloader, store, tick_handle) = build_queue_with_tick(&temp).await;
+    let (queue, downloader, store, mut tick_handle) = build_queue_with_tick(&temp).await;
 
     let mut rx = queue.subscribe();
 
@@ -309,7 +306,7 @@ async fn hls_seek_near_end_skips_prefix(#[case] backend: DecoderBackend) {
         ),
     );
 
-    tick_handle.abort();
+    tick_handle.stop().await;
 
     let probe_events = probe_recorder.snapshot();
     let total_probes = probe_events.len();
@@ -455,7 +452,6 @@ async fn hls_seek_near_end_skips_prefix(#[case] backend: DecoderBackend) {
          (seek dropped silently, or the target starved behind stale fetches)",
         Consts::POST_SEEK_OBSERVATION,
     );
-    let _ = tick_handle.await;
     queue.close().await;
 }
 

--- a/tests/tests/kithara_queue/hls_seek_cancels_stale_fetches.rs
+++ b/tests/tests/kithara_queue/hls_seek_cancels_stale_fetches.rs
@@ -95,7 +95,7 @@ async fn build_hls_with_delay(helper: &TestServerHelper) -> Url {
         .master_url()
 }
 
-fn build_queue_with_tick(
+async fn build_queue_with_tick(
     temp_dir: &TestTempDir,
 ) -> (
     OfflineQueue<TestPools>,
@@ -125,6 +125,7 @@ fn build_queue_with_tick(
                 .build(),
         ),
     )
+    .await
     .expect("create product offline queue");
     let tick_handle = tokio::task::spawn(drive_queue_ticks(
         queue.control(),
@@ -189,7 +190,7 @@ async fn hls_seek_near_end_skips_prefix(#[case] backend: DecoderBackend) {
     let url = build_hls_with_delay(&helper).await;
 
     let temp = temp_dir();
-    let (queue, downloader, store, tick_handle) = build_queue_with_tick(&temp);
+    let (queue, downloader, store, tick_handle) = build_queue_with_tick(&temp).await;
 
     let mut rx = queue.subscribe();
 
@@ -454,6 +455,8 @@ async fn hls_seek_near_end_skips_prefix(#[case] backend: DecoderBackend) {
          (seek dropped silently, or the target starved behind stale fetches)",
         Consts::POST_SEEK_OBSERVATION,
     );
+    let _ = tick_handle.await;
+    queue.close().await;
 }
 
 async fn observe_post_seek(

--- a/tests/tests/kithara_queue/hls_seek_near_end_stress.rs
+++ b/tests/tests/kithara_queue/hls_seek_near_end_stress.rs
@@ -10,7 +10,6 @@ use kithara::{
     platform::{
         CancelToken,
         time::{Duration, timeout},
-        tokio,
         tokio::sync::broadcast::error::RecvError,
     },
     play::{PlayWorker, PlayWorkerConfig, PlayerConfig, PlayerImpl, ResourceConfig, ResourceSrc},
@@ -19,7 +18,7 @@ use kithara::{
 };
 use kithara_integration_tests::{
     HlsFixtureBuilder, TestServerHelper, TestTempDir, kithara,
-    offline::{OfflineQueue, drive_queue_ticks},
+    offline::{OfflineQueue, QueueTicker},
     temp_dir,
     waits::{wait_for_loader_done_event, wait_for_position_event},
 };
@@ -112,7 +111,7 @@ async fn build_queue_with_tick(
     OfflineQueue<TestPools>,
     Downloader,
     AssetStore<TestPools>,
-    tokio::task::JoinHandle<()>,
+    QueueTicker,
 ) {
     let store = kithara_integration_tests::disk_asset_store(temp_dir.path());
     let pools = pools();
@@ -138,10 +137,7 @@ async fn build_queue_with_tick(
     )
     .await
     .expect("create product offline queue");
-    let tick_handle = tokio::task::spawn(drive_queue_ticks(
-        queue.control(),
-        Duration::from_millis(50),
-    ));
+    let tick_handle = QueueTicker::spawn(queue.control(), Duration::from_millis(50));
     let downloader = Downloader::new(
         DownloaderConfig::for_client(HttpClient::new(
             NetOptions::default(),
@@ -165,12 +161,12 @@ async fn run_one_attempt(
     backend: DecoderBackend,
 ) -> IterOutcome {
     let temp = temp_dir();
-    let (queue, downloader, store, tick_handle) = build_queue_with_tick(&temp).await;
+    let (queue, downloader, store, mut tick_handle) = build_queue_with_tick(&temp).await;
 
     let src = match ResourceSrc::parse(url.as_str()) {
         Ok(src) => src,
         Err(e) => {
-            tick_handle.abort();
+            drop(tick_handle);
             return IterOutcome::Errored {
                 iter,
                 target: f64::NAN,
@@ -192,7 +188,7 @@ async fn run_one_attempt(
     let track_id = match queue.append(TrackSource::Config(Box::new(cfg))) {
         Ok(track_id) => track_id,
         Err(error) => {
-            tick_handle.abort();
+            drop(tick_handle);
             return IterOutcome::Errored {
                 iter,
                 target: f64::NAN,
@@ -208,7 +204,7 @@ async fn run_one_attempt(
     let mut rx = queue.subscribe();
 
     if let Err(e) = queue.select(track_id, Transition::None) {
-        tick_handle.abort();
+        drop(tick_handle);
         return IterOutcome::Errored {
             iter,
             target: f64::NAN,
@@ -219,7 +215,7 @@ async fn run_one_attempt(
     if let Err(e) =
         wait_for_loader_done_event(&mut rx, &queue, track_id, Consts::LOAD_DEADLINE).await
     {
-        tick_handle.abort();
+        drop(tick_handle);
         return IterOutcome::Errored {
             iter,
             target: f64::NAN,
@@ -235,7 +231,7 @@ async fn run_one_attempt(
     )
     .await
     {
-        tick_handle.abort();
+        drop(tick_handle);
         return IterOutcome::Errored {
             iter,
             target: f64::NAN,
@@ -246,7 +242,7 @@ async fn run_one_attempt(
     let duration = if let Some(d) = queue.duration_seconds() {
         d
     } else {
-        tick_handle.abort();
+        drop(tick_handle);
         return IterOutcome::Errored {
             iter,
             target: f64::NAN,
@@ -258,7 +254,7 @@ async fn run_one_attempt(
     let pos_before = queue.position_seconds().unwrap_or(0.0);
 
     if let Err(e) = queue.seek(target) {
-        tick_handle.abort();
+        drop(tick_handle);
         return IterOutcome::Errored {
             iter,
             target,
@@ -274,7 +270,7 @@ async fn run_one_attempt(
     match wait_for_seek_landed(&mut rx, &queue, track_id, target, Consts::SEEK_BUDGET).await {
         SeekLanded::Landed => {}
         SeekLanded::Failed(err) => {
-            tick_handle.abort();
+            drop(tick_handle);
             return IterOutcome::Errored {
                 iter,
                 target,
@@ -283,7 +279,7 @@ async fn run_one_attempt(
         }
         SeekLanded::Timeout => {
             let pos_after = queue.position_seconds().unwrap_or(0.0);
-            tick_handle.abort();
+            drop(tick_handle);
             return IterOutcome::Hung {
                 iter,
                 target,
@@ -308,13 +304,12 @@ async fn run_one_attempt(
     .await
     {
         PostSeekAdvance::Advanced => {
-            tick_handle.abort();
-            let _ = tick_handle.await;
+            tick_handle.stop().await;
             queue.close().await;
             IterOutcome::Ok
         }
         PostSeekAdvance::Failed(err) => {
-            tick_handle.abort();
+            drop(tick_handle);
             IterOutcome::Errored {
                 iter,
                 target,
@@ -322,7 +317,7 @@ async fn run_one_attempt(
             }
         }
         PostSeekAdvance::Timeout(pos_after) => {
-            tick_handle.abort();
+            drop(tick_handle);
             IterOutcome::Hung {
                 iter,
                 target,

--- a/tests/tests/kithara_queue/hls_seek_near_end_stress.rs
+++ b/tests/tests/kithara_queue/hls_seek_near_end_stress.rs
@@ -185,7 +185,10 @@ async fn run_one_attempt(
                 .build(),
         )
         .build();
-    let track_id = match queue.append(TrackSource::Config(Box::new(cfg))) {
+    let track_id = match queue
+        .run(move |q| q.append(TrackSource::Config(Box::new(cfg))))
+        .await
+    {
         Ok(track_id) => track_id,
         Err(error) => {
             drop(tick_handle);
@@ -203,7 +206,10 @@ async fn run_one_attempt(
     // `player.bus()`), so audio sink-truth events arrive here too.
     let mut rx = queue.subscribe();
 
-    if let Err(e) = queue.select(track_id, Transition::None) {
+    if let Err(e) = queue
+        .run(move |q| q.select(track_id, Transition::None))
+        .await
+    {
         drop(tick_handle);
         return IterOutcome::Errored {
             iter,

--- a/tests/tests/kithara_queue/hls_seek_near_end_stress.rs
+++ b/tests/tests/kithara_queue/hls_seek_near_end_stress.rs
@@ -106,7 +106,7 @@ async fn build_hls(helper: &TestServerHelper, include_sidx: bool) -> Url {
         .master_url()
 }
 
-fn build_queue_with_tick(
+async fn build_queue_with_tick(
     temp_dir: &TestTempDir,
 ) -> (
     OfflineQueue<TestPools>,
@@ -136,6 +136,7 @@ fn build_queue_with_tick(
                 .build(),
         ),
     )
+    .await
     .expect("create product offline queue");
     let tick_handle = tokio::task::spawn(drive_queue_ticks(
         queue.control(),
@@ -164,7 +165,7 @@ async fn run_one_attempt(
     backend: DecoderBackend,
 ) -> IterOutcome {
     let temp = temp_dir();
-    let (queue, downloader, store, tick_handle) = build_queue_with_tick(&temp);
+    let (queue, downloader, store, tick_handle) = build_queue_with_tick(&temp).await;
 
     let src = match ResourceSrc::parse(url.as_str()) {
         Ok(src) => src,
@@ -308,6 +309,8 @@ async fn run_one_attempt(
     {
         PostSeekAdvance::Advanced => {
             tick_handle.abort();
+            let _ = tick_handle.await;
+            queue.close().await;
             IterOutcome::Ok
         }
         PostSeekAdvance::Failed(err) => {

--- a/tests/tests/kithara_queue/hls_variant_playlists_concurrent.rs
+++ b/tests/tests/kithara_queue/hls_variant_playlists_concurrent.rs
@@ -12,7 +12,6 @@ use kithara::{
     platform::{
         CancelToken,
         time::{Duration, timeout},
-        tokio,
         tokio::sync::broadcast::error::RecvError,
     },
     play::{PlayWorker, PlayWorkerConfig, PlayerConfig, PlayerImpl, ResourceConfig, ResourceSrc},
@@ -21,7 +20,7 @@ use kithara::{
 };
 use kithara_integration_tests::{
     HlsFixtureBuilder, TestServerHelper, TestTempDir, kithara,
-    offline::{OfflineQueue, drive_queue_ticks},
+    offline::{OfflineQueue, QueueTicker},
     temp_dir,
 };
 use kithara_test_utils::probe::capture as probe_capture;
@@ -61,7 +60,7 @@ async fn build_queue_with_tick(
     OfflineQueue<TestPools>,
     Downloader,
     AssetStore<TestPools>,
-    tokio::task::JoinHandle<()>,
+    QueueTicker,
 ) {
     let store = kithara_integration_tests::disk_asset_store(temp_dir.path());
     let pools = pools();
@@ -87,10 +86,7 @@ async fn build_queue_with_tick(
     )
     .await
     .expect("create product offline queue");
-    let tick_handle = tokio::task::spawn(drive_queue_ticks(
-        queue.control(),
-        Duration::from_millis(50),
-    ));
+    let tick_handle = QueueTicker::spawn(queue.control(), Duration::from_millis(50));
     let downloader = Downloader::new(
         DownloaderConfig::for_client(HttpClient::new(
             NetOptions::default(),
@@ -239,7 +235,7 @@ async fn variant_media_playlists_load_concurrently(#[case] decoder: DecoderBacke
     let url = build_hls(&helper).await;
 
     let temp = temp_dir();
-    let (queue, downloader, store, tick_handle) = build_queue_with_tick(&temp).await;
+    let (queue, downloader, store, mut tick_handle) = build_queue_with_tick(&temp).await;
 
     let mut rx = queue.subscribe();
 
@@ -263,14 +259,12 @@ async fn variant_media_playlists_load_concurrently(#[case] decoder: DecoderBacke
     let variant_request_ids = match observe_until_loaded(&mut rx, &queue, track_id, &url).await {
         Ok(request_ids) => request_ids,
         Err(error) => {
-            tick_handle.abort();
-            let _ = tick_handle.await;
+            tick_handle.stop().await;
             panic!("{error}");
         }
     };
     let probes = recorder.snapshot();
-    tick_handle.abort();
-    let _ = tick_handle.await;
+    tick_handle.stop().await;
 
     let process_dump = format_process_probes(&probes);
     let max_batch = max_playlist_batch_size(&probes, &variant_request_ids);

--- a/tests/tests/kithara_queue/hls_variant_playlists_concurrent.rs
+++ b/tests/tests/kithara_queue/hls_variant_playlists_concurrent.rs
@@ -252,9 +252,13 @@ async fn variant_media_playlists_load_concurrently(#[case] decoder: DecoderBacke
             .build();
 
     let track_id = queue
-        .append(TrackSource::Config(Box::new(cfg)))
+        .run(move |q| q.append(TrackSource::Config(Box::new(cfg))))
+        .await
         .expect("append multivariant HLS track");
-    queue.select(track_id, Transition::None).expect("select");
+    queue
+        .run(move |q| q.select(track_id, Transition::None))
+        .await
+        .expect("select");
 
     let variant_request_ids = match observe_until_loaded(&mut rx, &queue, track_id, &url).await {
         Ok(request_ids) => request_ids,

--- a/tests/tests/kithara_queue/hls_variant_playlists_concurrent.rs
+++ b/tests/tests/kithara_queue/hls_variant_playlists_concurrent.rs
@@ -55,7 +55,7 @@ async fn build_hls(helper: &TestServerHelper) -> Url {
         .master_url()
 }
 
-fn build_queue_with_tick(
+async fn build_queue_with_tick(
     temp_dir: &TestTempDir,
 ) -> (
     OfflineQueue<TestPools>,
@@ -85,6 +85,7 @@ fn build_queue_with_tick(
                 .build(),
         ),
     )
+    .await
     .expect("create product offline queue");
     let tick_handle = tokio::task::spawn(drive_queue_ticks(
         queue.control(),
@@ -238,7 +239,7 @@ async fn variant_media_playlists_load_concurrently(#[case] decoder: DecoderBacke
     let url = build_hls(&helper).await;
 
     let temp = temp_dir();
-    let (queue, downloader, store, tick_handle) = build_queue_with_tick(&temp);
+    let (queue, downloader, store, tick_handle) = build_queue_with_tick(&temp).await;
 
     let mut rx = queue.subscribe();
 
@@ -295,4 +296,5 @@ async fn variant_media_playlists_load_concurrently(#[case] decoder: DecoderBacke
         Consts::VARIANT_COUNT,
         format_variant_request_ids(&variant_request_ids),
     );
+    queue.close().await;
 }

--- a/tests/tests/kithara_queue/loader_lanes.rs
+++ b/tests/tests/kithara_queue/loader_lanes.rs
@@ -175,11 +175,11 @@ async fn select_pending_track_parked_behind_hung_load_promotes() {
         build_queue_with_tick(&temp, Consts::BG_CAP).await;
 
     let hung_id = queue
-        .append(TrackSource::Config(Box::new(mk_cfg(
-            &hung.url(),
-            &downloader,
-            &store,
-        ))))
+        .run({
+            let source = TrackSource::Config(Box::new(mk_cfg(&hung.url(), &downloader, &store)));
+            move |q| q.append(source)
+        })
+        .await
         .expect("append hung track");
     wait_for_status_matching(&queue, hung_id, Consts::GATE_DEADLINE, "Loading", |s| {
         matches!(s, TrackStatus::Loading)
@@ -189,15 +189,17 @@ async fn select_pending_track_parked_behind_hung_load_promotes() {
 
     // Parked: the background lane is saturated by the hung load.
     let fast_id = queue
-        .append(TrackSource::Config(Box::new(mk_cfg(
-            &fast_url(&fast),
-            &downloader,
-            &store,
-        ))))
+        .run({
+            let source =
+                TrackSource::Config(Box::new(mk_cfg(&fast_url(&fast), &downloader, &store)));
+            move |q| q.append(source)
+        })
+        .await
         .expect("append fast track");
 
     queue
-        .select(fast_id, Transition::None)
+        .run(move |q| q.select(fast_id, Transition::None))
+        .await
         .expect("select fast");
 
     let load_result = wait_for_loader_done(&queue, fast_id, Consts::FAST_DEADLINE).await;
@@ -233,11 +235,11 @@ async fn superseded_hung_selection_frees_lane_for_next_select() {
     let mut events = queue.subscribe();
 
     let hung_id = queue
-        .append(TrackSource::Config(Box::new(mk_cfg(
-            &hung.url(),
-            &downloader,
-            &store,
-        ))))
+        .run({
+            let source = TrackSource::Config(Box::new(mk_cfg(&hung.url(), &downloader, &store)));
+            move |q| q.append(source)
+        })
+        .await
         .expect("append hung track");
     wait_for_status_matching(&queue, hung_id, Consts::GATE_DEADLINE, "Loading", |s| {
         matches!(s, TrackStatus::Loading)
@@ -246,19 +248,22 @@ async fn superseded_hung_selection_frees_lane_for_next_select() {
     .unwrap_or_else(|e| panic!("hung track gate: {e}"));
 
     let fast_id = queue
-        .append(TrackSource::Config(Box::new(mk_cfg(
-            &fast_url(&fast),
-            &downloader,
-            &store,
-        ))))
+        .run({
+            let source =
+                TrackSource::Config(Box::new(mk_cfg(&fast_url(&fast), &downloader, &store)));
+            move |q| q.append(source)
+        })
+        .await
         .expect("append fast track");
 
     // The user clicks the stuck track, then gives up and clicks another.
     queue
-        .select(hung_id, Transition::None)
+        .run(move |q| q.select(hung_id, Transition::None))
+        .await
         .expect("select hung");
     queue
-        .select(fast_id, Transition::None)
+        .run(move |q| q.select(fast_id, Transition::None))
+        .await
         .expect("select fast");
 
     wait_for_loader_done(&queue, fast_id, Consts::FAST_DEADLINE)

--- a/tests/tests/kithara_queue/loader_lanes.rs
+++ b/tests/tests/kithara_queue/loader_lanes.rs
@@ -78,7 +78,7 @@ fn fast_url(handle: &BehaviorHandle) -> Url {
     handle.child_url("track.mp3")
 }
 
-fn build_queue_with_tick(
+async fn build_queue_with_tick(
     temp_dir: &TestTempDir,
     cap: usize,
 ) -> (
@@ -111,6 +111,7 @@ fn build_queue_with_tick(
                 .build(),
         ),
     )
+    .await
     .expect("create product offline queue");
     let tick_handle = tokio::task::spawn(drive_queue_ticks(
         queue.control(),
@@ -174,7 +175,8 @@ async fn select_pending_track_parked_behind_hung_load_promotes() {
     let (hung, fast) = register_sources(&helper);
 
     let temp = temp_dir();
-    let (queue, downloader, store, tick_handle) = build_queue_with_tick(&temp, Consts::BG_CAP);
+    let (queue, downloader, store, tick_handle) =
+        build_queue_with_tick(&temp, Consts::BG_CAP).await;
 
     let hung_id = queue
         .append(TrackSource::Config(Box::new(mk_cfg(
@@ -219,6 +221,8 @@ async fn select_pending_track_parked_behind_hung_load_promotes() {
     );
 
     tick_handle.abort();
+    let _ = tick_handle.await;
+    queue.close().await;
 }
 
 /// A follow-up selection is not blocked by a superseded hung one, and
@@ -229,7 +233,8 @@ async fn superseded_hung_selection_frees_lane_for_next_select() {
     let (hung, fast) = register_sources(&helper);
 
     let temp = temp_dir();
-    let (queue, downloader, store, tick_handle) = build_queue_with_tick(&temp, Consts::BG_CAP);
+    let (queue, downloader, store, tick_handle) =
+        build_queue_with_tick(&temp, Consts::BG_CAP).await;
     let mut events = queue.subscribe();
 
     let hung_id = queue
@@ -285,6 +290,8 @@ async fn superseded_hung_selection_frees_lane_for_next_select() {
     );
 
     tick_handle.abort();
+    let _ = tick_handle.await;
+    queue.close().await;
 }
 
 /// Setup invariant: the hung track must still be mid-load when the fast

--- a/tests/tests/kithara_queue/loader_lanes.rs
+++ b/tests/tests/kithara_queue/loader_lanes.rs
@@ -14,7 +14,6 @@ use kithara::{
     platform::{
         CancelToken,
         time::{Duration, Instant, sleep},
-        tokio,
     },
     play::{PlayWorker, PlayWorkerConfig, PlayerConfig, PlayerImpl, ResourceConfig, ResourceSrc},
     queue::{Queue, QueueConfig, QueueControl, TrackSource, Transition},
@@ -22,7 +21,7 @@ use kithara::{
 };
 use kithara_integration_tests::{
     BehaviorHandle, Content, Delivery, FixtureBehavior, TestServerHelper, TestTempDir, kithara,
-    offline::{OfflineQueue, drive_queue_ticks},
+    offline::{OfflineQueue, QueueTicker},
     temp_dir,
     waits::{wait_for_loader_done, wait_for_position_at_least, wait_for_position_event},
 };
@@ -85,7 +84,7 @@ async fn build_queue_with_tick(
     OfflineQueue<TestPools>,
     Downloader,
     AssetStore<TestPools>,
-    tokio::task::JoinHandle<()>,
+    QueueTicker,
 ) {
     let store = kithara_integration_tests::disk_asset_store(temp_dir.path());
     let pools = pools();
@@ -113,10 +112,7 @@ async fn build_queue_with_tick(
     )
     .await
     .expect("create product offline queue");
-    let tick_handle = tokio::task::spawn(drive_queue_ticks(
-        queue.control(),
-        Duration::from_millis(50),
-    ));
+    let tick_handle = QueueTicker::spawn(queue.control(), Duration::from_millis(50));
     let downloader = Downloader::new(
         DownloaderConfig::for_client(HttpClient::new(
             NetOptions::default(),
@@ -175,7 +171,7 @@ async fn select_pending_track_parked_behind_hung_load_promotes() {
     let (hung, fast) = register_sources(&helper);
 
     let temp = temp_dir();
-    let (queue, downloader, store, tick_handle) =
+    let (queue, downloader, store, mut tick_handle) =
         build_queue_with_tick(&temp, Consts::BG_CAP).await;
 
     let hung_id = queue
@@ -220,8 +216,7 @@ async fn select_pending_track_parked_behind_hung_load_promotes() {
         "promotion must not spawn a second download session for the same track"
     );
 
-    tick_handle.abort();
-    let _ = tick_handle.await;
+    tick_handle.stop().await;
     queue.close().await;
 }
 
@@ -233,7 +228,7 @@ async fn superseded_hung_selection_frees_lane_for_next_select() {
     let (hung, fast) = register_sources(&helper);
 
     let temp = temp_dir();
-    let (queue, downloader, store, tick_handle) =
+    let (queue, downloader, store, mut tick_handle) =
         build_queue_with_tick(&temp, Consts::BG_CAP).await;
     let mut events = queue.subscribe();
 
@@ -289,8 +284,7 @@ async fn superseded_hung_selection_frees_lane_for_next_select() {
         status_of(&queue, hung_id)
     );
 
-    tick_handle.abort();
-    let _ = tick_handle.await;
+    tick_handle.stop().await;
     queue.close().await;
 }
 

--- a/tests/tests/kithara_queue/loader_starvation.rs
+++ b/tests/tests/kithara_queue/loader_starvation.rs
@@ -185,7 +185,11 @@ async fn hung_loads_must_not_starve_user_selected_track() {
     for url in &hung_urls {
         hung_ids.push(
             queue
-                .append(TrackSource::Config(Box::new(mk_cfg(url))))
+                .run({
+                    let source = TrackSource::Config(Box::new(mk_cfg(url)));
+                    move |q| q.append(source)
+                })
+                .await
                 .expect("append hung track"),
         );
     }
@@ -199,10 +203,15 @@ async fn hung_loads_must_not_starve_user_selected_track() {
 
     // Reachable track: its load queues behind the saturated semaphore.
     let fast_id = queue
-        .append(TrackSource::Config(Box::new(mk_cfg(&fast_url))))
+        .run({
+            let source = TrackSource::Config(Box::new(mk_cfg(&fast_url)));
+            move |q| q.append(source)
+        })
+        .await
         .expect("append fast track");
     queue
-        .select(fast_id, Transition::None)
+        .run(move |q| q.select(fast_id, Transition::None))
+        .await
         .expect("select fast");
 
     let load_result = wait_for_loader_done(&queue, fast_id, Consts::FAST_DEADLINE).await;

--- a/tests/tests/kithara_queue/loader_starvation.rs
+++ b/tests/tests/kithara_queue/loader_starvation.rs
@@ -19,7 +19,6 @@ use kithara::{
         CancelToken,
         sync::Arc,
         time::{Duration, sleep},
-        tokio,
     },
     play::{PlayWorker, PlayWorkerConfig, PlayerConfig, PlayerImpl, ResourceConfig, ResourceSrc},
     queue::{Queue, QueueConfig, QueueControl, TrackSource, Transition},
@@ -27,7 +26,9 @@ use kithara::{
 };
 use kithara_integration_tests::{
     Content, Delivery, FixtureBehavior, HlsFixtureBuilder, TestServerHelper, TestTempDir, kithara,
-    offline::OfflineQueue, temp_dir, waits::wait_for_loader_done,
+    offline::{OfflineQueue, QueueTicker},
+    temp_dir,
+    waits::wait_for_loader_done,
 };
 use url::Url;
 
@@ -91,7 +92,7 @@ async fn build_queue_with_tick(
     OfflineQueue<TestPools>,
     Downloader,
     AssetStore<TestPools>,
-    tokio::task::JoinHandle<()>,
+    QueueTicker,
 ) {
     let store = kithara_integration_tests::disk_asset_store(temp_dir.path());
     let pools = pools();
@@ -120,14 +121,7 @@ async fn build_queue_with_tick(
     .await
     .expect("create product offline queue");
     let queue_for_tick = queue.control();
-    let tick_handle = tokio::task::spawn(async move {
-        loop {
-            sleep(Duration::from_millis(50)).await;
-            if queue_for_tick.tick().is_err() {
-                break;
-            }
-        }
-    });
+    let tick_handle = QueueTicker::spawn(queue_for_tick, Duration::from_millis(50));
     let downloader = Downloader::new(
         DownloaderConfig::for_client(HttpClient::new(
             NetOptions::default(),
@@ -175,7 +169,8 @@ async fn hung_loads_must_not_starve_user_selected_track() {
     let fast_url = build_fast_hls(&helper).await;
 
     let temp = temp_dir();
-    let (queue, downloader, store, tick_handle) = build_queue_with_tick(&temp, Consts::CAP).await;
+    let (queue, downloader, store, mut tick_handle) =
+        build_queue_with_tick(&temp, Consts::CAP).await;
 
     let mk_cfg = |url: &Url| {
         ResourceConfig::for_src(ResourceSrc::parse(url.as_str()).expect("valid fixture URL"))
@@ -219,7 +214,7 @@ async fn hung_loads_must_not_starve_user_selected_track() {
         .filter(|&id| is_loading(&queue, id))
         .collect();
 
-    tick_handle.abort();
+    tick_handle.stop().await;
 
     assert_eq!(
         hung_still_loading.len(),
@@ -238,6 +233,5 @@ async fn hung_loads_must_not_starve_user_selected_track() {
             Consts::CAP
         )
     });
-    let _ = tick_handle.await;
     queue.close().await;
 }

--- a/tests/tests/kithara_queue/loader_starvation.rs
+++ b/tests/tests/kithara_queue/loader_starvation.rs
@@ -84,7 +84,7 @@ async fn build_fast_hls(helper: &TestServerHelper) -> Url {
         .master_url()
 }
 
-fn build_queue_with_tick(
+async fn build_queue_with_tick(
     temp_dir: &TestTempDir,
     cap: usize,
 ) -> (
@@ -117,6 +117,7 @@ fn build_queue_with_tick(
                 .build(),
         ),
     )
+    .await
     .expect("create product offline queue");
     let queue_for_tick = queue.control();
     let tick_handle = tokio::task::spawn(async move {
@@ -174,7 +175,7 @@ async fn hung_loads_must_not_starve_user_selected_track() {
     let fast_url = build_fast_hls(&helper).await;
 
     let temp = temp_dir();
-    let (queue, downloader, store, tick_handle) = build_queue_with_tick(&temp, Consts::CAP);
+    let (queue, downloader, store, tick_handle) = build_queue_with_tick(&temp, Consts::CAP).await;
 
     let mk_cfg = |url: &Url| {
         ResourceConfig::for_src(ResourceSrc::parse(url.as_str()).expect("valid fixture URL"))
@@ -237,4 +238,6 @@ async fn hung_loads_must_not_starve_user_selected_track() {
             Consts::CAP
         )
     });
+    let _ = tick_handle.await;
+    queue.close().await;
 }

--- a/tests/tests/kithara_queue/local_track_plays.rs
+++ b/tests/tests/kithara_queue/local_track_plays.rs
@@ -9,8 +9,7 @@ use kithara::{
     net::{HttpClient, NetOptions},
     platform::{
         CancelToken,
-        time::{Duration, sleep, timeout},
-        tokio,
+        time::{Duration, timeout},
         tokio::sync::broadcast::error::{RecvError, TryRecvError},
     },
     play::{PlayWorker, PlayWorkerConfig, PlayerConfig, PlayerImpl, ResourceConfig, ResourceSrc},
@@ -21,7 +20,7 @@ use kithara_integration_tests::{
     HlsFixtureBuilder, TestServerHelper, TestTempDir, Xorshift64,
     fixture_protocol::EncryptionRequest,
     kithara,
-    offline::{OfflineQueue, offline_gain_window},
+    offline::{OfflineQueue, QueueTicker, offline_gain_window},
     temp_dir,
     waits::{wait_for_loader_done_event, wait_for_position_event, wait_for_position_near_event},
 };
@@ -183,7 +182,7 @@ async fn build_queue_with_tick(
     OfflineQueue<TestPools>,
     Downloader,
     AssetStore<TestPools>,
-    tokio::task::JoinHandle<()>,
+    QueueTicker,
 ) {
     let store = kithara_integration_tests::disk_asset_store(temp_dir.path());
     let pools = pools();
@@ -210,14 +209,7 @@ async fn build_queue_with_tick(
     .await
     .expect("create product offline queue");
     let queue_for_tick = queue.control();
-    let tick_handle = tokio::task::spawn(async move {
-        loop {
-            sleep(Duration::from_millis(50)).await;
-            if queue_for_tick.tick().is_err() {
-                break;
-            }
-        }
-    });
+    let tick_handle = QueueTicker::spawn(queue_for_tick, Duration::from_millis(50));
     let downloader = Downloader::new(
         DownloaderConfig::for_client(HttpClient::new(
             NetOptions::default(),
@@ -291,7 +283,7 @@ async fn local_track_plays_end_to_end(
     let label = format!("{kind:?}/{backend:?}");
 
     let temp = temp_dir();
-    let (queue, downloader, store, tick_handle) = build_queue_with_tick(&temp).await;
+    let (queue, downloader, store, mut tick_handle) = build_queue_with_tick(&temp).await;
 
     let cfg = ResourceConfig::for_src(ResourceSrc::parse(url.as_str()).expect("valid fixture URL"))
         .downloader(downloader.clone())
@@ -406,8 +398,7 @@ async fn local_track_plays_end_to_end(
     );
 
     queue.remove(track_id).expect("remove");
-    tick_handle.abort();
-    let _ = tick_handle.await;
+    tick_handle.stop().await;
     queue.close().await;
 }
 
@@ -504,7 +495,7 @@ async fn local_queue_playlist_behavior(#[case] backend: DecoderBackend) {
     }
 
     let temp = temp_dir();
-    let (queue, downloader, store, tick_handle) = build_queue_with_tick(&temp).await;
+    let (queue, downloader, store, mut tick_handle) = build_queue_with_tick(&temp).await;
 
     queue.set_crossfade_duration(2.0);
 
@@ -684,7 +675,6 @@ async fn local_queue_playlist_behavior(#[case] backend: DecoderBackend) {
         );
     }
 
-    tick_handle.abort();
-    let _ = tick_handle.await;
+    tick_handle.stop().await;
     queue.close().await;
 }

--- a/tests/tests/kithara_queue/local_track_plays.rs
+++ b/tests/tests/kithara_queue/local_track_plays.rs
@@ -303,13 +303,19 @@ async fn local_track_plays_end_to_end(
     // so audio sink-truth events arrive here too.
     let mut rx = queue.subscribe();
 
-    let track_id = queue.append(source).expect("append local track");
+    let track_id = queue
+        .run(move |q| q.append(source))
+        .await
+        .expect("append local track");
 
     wait_for_loader_done_event(&mut rx, &queue, track_id, Duration::from_secs(30))
         .await
         .unwrap_or_else(|e| panic!("load fail [{label}]: {e}"));
 
-    queue.select(track_id, Transition::None).expect("select");
+    queue
+        .run(move |q| q.select(track_id, Transition::None))
+        .await
+        .expect("select");
     wait_for_position_event(&mut rx, &queue, 0.5, Duration::from_secs(15))
         .await
         .unwrap_or_else(|e| panic!("play fail [{label}]: {e}"));
@@ -500,28 +506,33 @@ async fn local_queue_playlist_behavior(#[case] backend: DecoderBackend) {
     queue.set_crossfade_duration(2.0);
 
     let mut rx = queue.subscribe();
-    let ids: Vec<TrackId> = urls
-        .iter()
-        .map(|u| {
-            let cfg =
-                ResourceConfig::for_src(ResourceSrc::parse(u.as_str()).expect("valid fixture URL"))
-                    .downloader(downloader.clone())
-                    .store(store.clone())
-                    .decoder(
-                        kithara::audio::AudioDecoderConfig::builder()
-                            .backend(backend)
-                            .build(),
-                    )
-                    .initial_abr_mode(AbrMode::Auto(None))
-                    .build();
+    let mut ids: Vec<TrackId> = Vec::with_capacity(urls.len());
+    for u in &urls {
+        let cfg =
+            ResourceConfig::for_src(ResourceSrc::parse(u.as_str()).expect("valid fixture URL"))
+                .downloader(downloader.clone())
+                .store(store.clone())
+                .decoder(
+                    kithara::audio::AudioDecoderConfig::builder()
+                        .backend(backend)
+                        .build(),
+                )
+                .initial_abr_mode(AbrMode::Auto(None))
+                .build();
+        ids.push(
             queue
-                .append(TrackSource::Config(Box::new(cfg)))
-                .expect("append crossfade fixture track")
-        })
-        .collect();
+                .run(move |q| q.append(TrackSource::Config(Box::new(cfg))))
+                .await
+                .expect("append crossfade fixture track"),
+        );
+    }
 
     queue
-        .select(ids[0], Transition::None)
+        .run({
+            let arg0 = ids[0];
+            move |q| q.select(arg0, Transition::None)
+        })
+        .await
         .expect("select first");
     wait_for_loader_done_event(&mut rx, &queue, ids[0], Duration::from_secs(30))
         .await
@@ -543,7 +554,7 @@ async fn local_queue_playlist_behavior(#[case] backend: DecoderBackend) {
         (during_pause - before_pause).abs() < 0.5,
         "position drifted during pause: {before_pause:.2} → {during_pause:.2}"
     );
-    queue.play();
+    queue.run(move |q| q.play()).await;
     let after_resume = wait_for_position_event(
         &mut rx,
         &queue,
@@ -573,7 +584,8 @@ async fn local_queue_playlist_behavior(#[case] backend: DecoderBackend) {
         .unwrap_or_else(|e| panic!("pre-crossfade: next track load [{}]: {e}", urls[1]));
     let xf_duration = queue.crossfade_duration();
     queue
-        .advance_to_next(Transition::Crossfade, AdvanceReason::UserNext)
+        .run(move |q| q.advance_to_next(Transition::Crossfade, AdvanceReason::UserNext))
+        .await
         .expect("advance local-track crossfade");
     let started = wait_for_queue_event(
         &mut rx,

--- a/tests/tests/kithara_queue/local_track_plays.rs
+++ b/tests/tests/kithara_queue/local_track_plays.rs
@@ -177,7 +177,7 @@ fn assert_monotonic_nondecreasing(samples: &[f64], label: &str) {
     }
 }
 
-fn build_queue_with_tick(
+async fn build_queue_with_tick(
     temp_dir: &TestTempDir,
 ) -> (
     OfflineQueue<TestPools>,
@@ -207,6 +207,7 @@ fn build_queue_with_tick(
                 .build(),
         ),
     )
+    .await
     .expect("create product offline queue");
     let queue_for_tick = queue.control();
     let tick_handle = tokio::task::spawn(async move {
@@ -290,7 +291,7 @@ async fn local_track_plays_end_to_end(
     let label = format!("{kind:?}/{backend:?}");
 
     let temp = temp_dir();
-    let (queue, downloader, store, tick_handle) = build_queue_with_tick(&temp);
+    let (queue, downloader, store, tick_handle) = build_queue_with_tick(&temp).await;
 
     let cfg = ResourceConfig::for_src(ResourceSrc::parse(url.as_str()).expect("valid fixture URL"))
         .downloader(downloader.clone())
@@ -406,6 +407,8 @@ async fn local_track_plays_end_to_end(
 
     queue.remove(track_id).expect("remove");
     tick_handle.abort();
+    let _ = tick_handle.await;
+    queue.close().await;
 }
 
 async fn wait_for_queue_event<F>(
@@ -501,7 +504,7 @@ async fn local_queue_playlist_behavior(#[case] backend: DecoderBackend) {
     }
 
     let temp = temp_dir();
-    let (queue, downloader, store, tick_handle) = build_queue_with_tick(&temp);
+    let (queue, downloader, store, tick_handle) = build_queue_with_tick(&temp).await;
 
     queue.set_crossfade_duration(2.0);
 
@@ -682,4 +685,6 @@ async fn local_queue_playlist_behavior(#[case] backend: DecoderBackend) {
     }
 
     tick_handle.abort();
+    let _ = tick_handle.await;
+    queue.close().await;
 }

--- a/tests/tests/kithara_queue/mod.rs
+++ b/tests/tests/kithara_queue/mod.rs
@@ -4,6 +4,7 @@ mod source_helper;
 pub(crate) use source_helper::{app_disk_asset_store, app_track_source};
 
 mod advance_boundary_provenance;
+mod app_fixture_ticks;
 mod architecture_flow;
 mod auto_advance;
 mod cold_seek_middle;

--- a/tests/tests/kithara_queue/mp3_plays_to_its_end.rs
+++ b/tests/tests/kithara_queue/mp3_plays_to_its_end.rs
@@ -18,7 +18,7 @@ use kithara::{
         sync::Arc,
         time::{self, Duration},
     },
-    play::{Resource, ResourceConfig, ResourceSrc, player::PlayerControl},
+    play::{Resource, ResourceConfig, ResourceSrc},
     queue::{Queue, QueueConfig, QueueControl, Transition, test_utils::QueueProbe},
 };
 use kithara_integration_tests::{
@@ -38,14 +38,17 @@ const NO_CROSSFADE_SECS: f32 = 0.0;
 const BLOCK_BUDGET: usize = 3_000;
 
 async fn open_resource(
-    player: &PlayerControl<TestPools>,
+    harness: &OfflinePlayerHarness,
     src: ResourceSrc,
     cache_dir: &Path,
 ) -> Resource {
     let config = ResourceConfig::<TestPools>::for_src(src)
         .store(kithara_integration_tests::disk_asset_store(cache_dir))
         .build();
-    let config = player.prepare_config(config).expect("prepare resource");
+    let config = harness
+        .with_player(move |player| player.prepare_config(config))
+        .await
+        .expect("prepare resource");
     let mut resource = Resource::new(config).await.expect("open resource");
     let _ = resource.preload().await;
     resource
@@ -102,12 +105,16 @@ async fn play_queue(crossfade: f32, temp_dir: &TestTempDir) -> (QueueLog, TrackI
     let mut tracks = Vec::with_capacity(2);
     for index in 0..2 {
         let resource = open_resource(
-            harness.player(),
+            &harness,
             track_src(&server),
             &temp_dir.path().join(format!("track{index}")),
         )
         .await;
-        tracks.push(queue.insert_loaded_for_test(resource));
+        tracks.push(
+            harness
+                .run(&queue, move |q| q.insert_loaded_for_test(resource))
+                .await,
+        );
     }
     let (first, second) = (tracks[0], tracks[1]);
     let transition = if crossfade > 0.0 {
@@ -115,14 +122,15 @@ async fn play_queue(crossfade: f32, temp_dir: &TestTempDir) -> (QueueLog, TrackI
     } else {
         Transition::None
     };
-    queue
-        .select(first, transition)
+    harness
+        .run(&queue, move |q| q.select(first, transition))
+        .await
         .expect("select the first track");
 
     let mut receiver = queue.subscribe();
     let mut log = QueueLog::default();
     for _ in 0..BLOCK_BUDGET {
-        let _ = queue.tick();
+        let _ = harness.run(&queue, |q| q.tick()).await;
         let _ = harness.render(BLOCK_FRAMES).await;
         while let Ok(envelope) = receiver.try_recv() {
             match envelope.event {

--- a/tests/tests/kithara_queue/mp3_plays_to_its_end.rs
+++ b/tests/tests/kithara_queue/mp3_plays_to_its_end.rs
@@ -93,10 +93,11 @@ async fn play_queue(crossfade: f32, temp_dir: &TestTempDir) -> (QueueLog, TrackI
             .block_on_underrun(true)
             .build(),
         SAMPLE_RATE,
-    );
+    )
+    .await;
     let mut config = QueueConfig::builder().player(harness.take_player()).build();
     config.should_autoplay = false;
-    let queue: QueueControl<TestPools> = harness.insert_control(Queue::new(config));
+    let queue: QueueControl<TestPools> = harness.insert_control(Queue::new(config)).await;
 
     let mut tracks = Vec::with_capacity(2);
     for index in 0..2 {
@@ -122,7 +123,7 @@ async fn play_queue(crossfade: f32, temp_dir: &TestTempDir) -> (QueueLog, TrackI
     let mut log = QueueLog::default();
     for _ in 0..BLOCK_BUDGET {
         let _ = queue.tick();
-        let _ = harness.render(BLOCK_FRAMES);
+        let _ = harness.render(BLOCK_FRAMES).await;
         while let Ok(envelope) = receiver.try_recv() {
             match envelope.event {
                 Event::Queue(QueueEvent::CurrentTrackAdvance { id, reason }) => {
@@ -142,6 +143,8 @@ async fn play_queue(crossfade: f32, temp_dir: &TestTempDir) -> (QueueLog, TrackI
         time::sleep(Duration::from_millis(1)).await;
     }
 
+    drop(queue);
+    harness.close().await;
     (log, second)
 }
 

--- a/tests/tests/kithara_queue/non_leading_track_completion.rs
+++ b/tests/tests/kithara_queue/non_leading_track_completion.rs
@@ -65,7 +65,7 @@ fn loaded_track(queue: &QueueControl<TestPools>, value: f32) -> (TrackId, Arc<st
     (id, src)
 }
 
-fn render_loop(
+async fn render_loop(
     queue: &QueueControl<TestPools>,
     harness: &OfflinePlayerHarness,
     block_budget: usize,
@@ -73,19 +73,19 @@ fn render_loop(
     let mut pcm = Vec::new();
     for _ in 0..block_budget {
         let _ = queue.tick();
-        pcm.extend(harness.render(BLOCK_FRAMES));
+        pcm.extend(harness.render(BLOCK_FRAMES).await);
     }
     pcm
 }
 
 /// Three loaded tracks with the first standing in for a non-leading slot.
-fn non_leading_fixture() -> (
+async fn non_leading_fixture() -> (
     OfflinePlayerHarness,
     QueueControl<TestPools>,
     TrackRef,
     TrackId,
 ) {
-    let (harness, queue) = offline_queue_fixture(SAMPLE_RATE);
+    let (harness, queue) = offline_queue_fixture(SAMPLE_RATE).await;
     let (stale, stale_src) = loaded_track(&queue, QUIET);
     let (current, _) = loaded_track(&queue, LOUD);
     let (_next, _) = loaded_track(&queue, QUIET);
@@ -126,16 +126,16 @@ async fn non_leading_completion_does_not_advance_the_queue(
     #[case] completion: Completion,
     #[case] role: NonLeadingRole,
 ) {
-    let (harness, queue, stale, current) = non_leading_fixture();
+    let (harness, queue, stale, current) = non_leading_fixture().await;
     let stale_id = stale.id;
 
     queue
         .select(current, Transition::None)
         .expect("select the current track");
-    let _ = render_loop(&queue, &harness, WARMUP_BLOCKS);
+    let _ = render_loop(&queue, &harness, WARMUP_BLOCKS).await;
 
     publish_completion(&harness, completion, role, stale);
-    let _ = render_loop(&queue, &harness, WARMUP_BLOCKS);
+    let _ = render_loop(&queue, &harness, WARMUP_BLOCKS).await;
 
     assert_eq!(
         queue.current_index(),
@@ -155,6 +155,8 @@ async fn non_leading_completion_does_not_advance_the_queue(
             "a background track's failure must not mark the entry failed: {status:?}"
         );
     }
+    drop(queue);
+    harness.close().await;
 }
 
 /// The audible half of the same defect: the listener hears the current
@@ -165,12 +167,12 @@ async fn non_leading_completion_does_not_advance_the_queue(
 async fn background_completion_does_not_cut_the_current_track_audio(
     #[case] completion: Completion,
 ) {
-    let (harness, queue, stale, current) = non_leading_fixture();
+    let (harness, queue, stale, current) = non_leading_fixture().await;
 
     queue
         .select(current, Transition::None)
         .expect("select the current track");
-    let before_pcm = render_loop(&queue, &harness, WARMUP_BLOCKS);
+    let before_pcm = render_loop(&queue, &harness, WARMUP_BLOCKS).await;
     let before = mean_abs(&before_pcm[before_pcm.len() / 2..]);
     assert!(
         before > 0.005,
@@ -178,7 +180,7 @@ async fn background_completion_does_not_cut_the_current_track_audio(
     );
 
     publish_completion(&harness, completion, NonLeadingRole::Background, stale);
-    let after_pcm = render_loop(&queue, &harness, WARMUP_BLOCKS);
+    let after_pcm = render_loop(&queue, &harness, WARMUP_BLOCKS).await;
     let after = mean_abs(&after_pcm[after_pcm.len() / 2..]);
 
     assert!(
@@ -186,4 +188,6 @@ async fn background_completion_does_not_cut_the_current_track_audio(
         "the current track must keep sounding through a background track's {completion:?} — \
          the quieter successor took over instead: before={before}, after={after}"
     );
+    drop(queue);
+    harness.close().await;
 }

--- a/tests/tests/kithara_queue/non_leading_track_completion.rs
+++ b/tests/tests/kithara_queue/non_leading_track_completion.rs
@@ -48,20 +48,29 @@ enum NonLeadingRole {
 
 /// Load a track whose player-side `src` is its queue URI, the way a real
 /// source arrives.
-fn loaded_track(queue: &QueueControl<TestPools>, value: f32) -> (TrackId, Arc<str>) {
+async fn loaded_track(
+    harness: &OfflinePlayerHarness,
+    queue: &QueueControl<TestPools>,
+    value: f32,
+) -> (TrackId, Arc<str>) {
     let id = queue.register_for_test();
     let src: Arc<str> = Arc::from(format!("test://memory/{}", id.as_u64()));
     let spec = AudioSpec {
         channels: CHANNELS,
         sample_rate: NonZero::new(SAMPLE_RATE).unwrap(),
     };
-    queue.complete_load_for_test(
-        id,
-        resource_from_reader_with_src(
-            TestPcmReader::with_value(spec, TRACK_SECS, value),
-            Arc::clone(&src),
-        ),
-    );
+    let player_src = Arc::clone(&src);
+    harness
+        .run(queue, move |q| {
+            q.complete_load_for_test(
+                id,
+                resource_from_reader_with_src(
+                    TestPcmReader::with_value(spec, TRACK_SECS, value),
+                    player_src,
+                ),
+            )
+        })
+        .await;
     (id, src)
 }
 
@@ -72,7 +81,7 @@ async fn render_loop(
 ) -> Vec<f32> {
     let mut pcm = Vec::new();
     for _ in 0..block_budget {
-        let _ = queue.tick();
+        let _ = harness.run(queue, |q| q.tick()).await;
         pcm.extend(harness.render(BLOCK_FRAMES).await);
     }
     pcm
@@ -86,9 +95,9 @@ async fn non_leading_fixture() -> (
     TrackId,
 ) {
     let (harness, queue) = offline_queue_fixture(SAMPLE_RATE).await;
-    let (stale, stale_src) = loaded_track(&queue, QUIET);
-    let (current, _) = loaded_track(&queue, LOUD);
-    let (_next, _) = loaded_track(&queue, QUIET);
+    let (stale, stale_src) = loaded_track(&harness, &queue, QUIET).await;
+    let (current, _) = loaded_track(&harness, &queue, LOUD).await;
+    let (_next, _) = loaded_track(&harness, &queue, QUIET).await;
     (
         harness,
         queue,
@@ -129,8 +138,9 @@ async fn non_leading_completion_does_not_advance_the_queue(
     let (harness, queue, stale, current) = non_leading_fixture().await;
     let stale_id = stale.id;
 
-    queue
-        .select(current, Transition::None)
+    harness
+        .run(&queue, move |q| q.select(current, Transition::None))
+        .await
         .expect("select the current track");
     let _ = render_loop(&queue, &harness, WARMUP_BLOCKS).await;
 
@@ -169,8 +179,9 @@ async fn background_completion_does_not_cut_the_current_track_audio(
 ) {
     let (harness, queue, stale, current) = non_leading_fixture().await;
 
-    queue
-        .select(current, Transition::None)
+    harness
+        .run(&queue, move |q| q.select(current, Transition::None))
+        .await
         .expect("select the current track");
     let before_pcm = render_loop(&queue, &harness, WARMUP_BLOCKS).await;
     let before = mean_abs(&before_pcm[before_pcm.len() / 2..]);

--- a/tests/tests/kithara_queue/packaged_drm_seek.rs
+++ b/tests/tests/kithara_queue/packaged_drm_seek.rs
@@ -9,7 +9,6 @@ use kithara::{
     platform::{
         CancelToken,
         time::{Duration, Instant, timeout},
-        tokio,
     },
     play::{PlayWorker, PlayWorkerConfig, PlayerConfig, PlayerImpl, policy::DomainKeyPolicy},
     queue::{Queue, QueueConfig, QueueControl, Transition},
@@ -23,7 +22,7 @@ use kithara_integration_tests::{
     TestServerHelper, TestTempDir, Xorshift64,
     fixture_protocol::DelayRule,
     kithara, mixed_codec_ladder_encrypted,
-    offline::{OfflineQueue, drive_queue_ticks},
+    offline::{OfflineQueue, QueueTicker},
     temp_dir,
     waits::{wait_for_position_at_least, wait_for_position_near},
 };
@@ -175,10 +174,7 @@ async fn run_seek_scenario(url: &Url, backend: DecoderBackend, abr: AbrMode, tem
     )
     .await
     .expect("create product offline queue");
-    let tick_handle = tokio::task::spawn(drive_queue_ticks(
-        queue.control(),
-        Duration::from_millis(50),
-    ));
+    let mut tick_handle = QueueTicker::spawn(queue.control(), Duration::from_millis(50));
 
     let source = super::app_track_source(
         url.as_str(),
@@ -227,9 +223,8 @@ async fn run_seek_scenario(url: &Url, backend: DecoderBackend, abr: AbrMode, tem
         );
     }
 
-    tick_handle.abort();
     queue.remove(id).expect("remove");
-    let _ = tick_handle.await;
+    tick_handle.stop().await;
     queue.close().await;
 }
 

--- a/tests/tests/kithara_queue/packaged_drm_seek.rs
+++ b/tests/tests/kithara_queue/packaged_drm_seek.rs
@@ -173,6 +173,7 @@ async fn run_seek_scenario(url: &Url, backend: DecoderBackend, abr: AbrMode, tem
         session_config,
         Queue::new(QueueConfig::builder().player(player).build()),
     )
+    .await
     .expect("create product offline queue");
     let tick_handle = tokio::task::spawn(drive_queue_ticks(
         queue.control(),
@@ -228,6 +229,8 @@ async fn run_seek_scenario(url: &Url, backend: DecoderBackend, abr: AbrMode, tem
 
     tick_handle.abort();
     queue.remove(id).expect("remove");
+    let _ = tick_handle.await;
+    queue.close().await;
 }
 
 #[kithara::test(tokio)]

--- a/tests/tests/kithara_queue/packaged_drm_seek.rs
+++ b/tests/tests/kithara_queue/packaged_drm_seek.rs
@@ -186,7 +186,10 @@ async fn run_seek_scenario(url: &Url, backend: DecoderBackend, abr: AbrMode, tem
     );
 
     let mut rx = queue.subscribe();
-    let id = queue.append(source).expect("append packaged DRM track");
+    let id = queue
+        .run(move |q| q.append(source))
+        .await
+        .expect("append packaged DRM track");
     wait_for_status(
         &mut rx,
         &queue,
@@ -197,7 +200,10 @@ async fn run_seek_scenario(url: &Url, backend: DecoderBackend, abr: AbrMode, tem
     .await
     .unwrap_or_else(|e| panic!("load fail: {e}"));
 
-    queue.select(id, Transition::None).expect("select");
+    queue
+        .run(move |q| q.select(id, Transition::None))
+        .await
+        .expect("select");
     wait_for_position_at_least(&queue, 0.5, Duration::from_secs(15))
         .await
         .unwrap_or_else(|e| panic!("play fail: {e}"));

--- a/tests/tests/kithara_queue/play_before_the_load_lands.rs
+++ b/tests/tests/kithara_queue/play_before_the_load_lands.rs
@@ -4,13 +4,16 @@
 use kithara::{
     host::HostConfig,
     net::{HttpClient, NetOptions},
-    platform::{CancelToken, time::Duration, tokio},
+    platform::{CancelToken, time::Duration},
     play::{PlayWorker, PlayWorkerConfig, PlayerConfig, PlayerImpl, ResourceConfig, ResourceSrc},
     queue::{Queue, QueueConfig, TrackSource},
     stream::dl::{Downloader, DownloaderConfig},
 };
 use kithara_integration_tests::{
-    TestServerHelper, kithara, offline::OfflineQueue, temp_dir, waits::wait_for_position_event,
+    TestServerHelper, kithara,
+    offline::{OfflineQueue, QueueTicker},
+    temp_dir,
+    waits::wait_for_position_event,
 };
 use kithara_test_fixtures::SignalAsset;
 
@@ -61,14 +64,7 @@ async fn play_issued_before_the_load_lands_still_starts_the_track() {
     .await
     .expect("create product offline queue");
     let queue_for_tick = queue.control();
-    let tick_handle = tokio::task::spawn(async move {
-        loop {
-            time::sleep(Duration::from_millis(50)).await;
-            if queue_for_tick.tick().is_err() {
-                break;
-            }
-        }
-    });
+    let mut tick_handle = QueueTicker::spawn(queue_for_tick, Duration::from_millis(50));
     let downloader = Downloader::new(
         DownloaderConfig::for_client(HttpClient::new(
             NetOptions::default(),
@@ -99,7 +95,6 @@ async fn play_issued_before_the_load_lands_still_starts_the_track() {
         "playback must advance past 0.2s, got {position}"
     );
 
-    tick_handle.abort();
-    let _ = tick_handle.await;
+    tick_handle.stop().await;
     queue.close().await;
 }

--- a/tests/tests/kithara_queue/play_before_the_load_lands.rs
+++ b/tests/tests/kithara_queue/play_before_the_load_lands.rs
@@ -58,6 +58,7 @@ async fn play_issued_before_the_load_lands_still_starts_the_track() {
                 .build(),
         ),
     )
+    .await
     .expect("create product offline queue");
     let queue_for_tick = queue.control();
     let tick_handle = tokio::task::spawn(async move {
@@ -99,4 +100,6 @@ async fn play_issued_before_the_load_lands_still_starts_the_track() {
     );
 
     tick_handle.abort();
+    let _ = tick_handle.await;
+    queue.close().await;
 }

--- a/tests/tests/kithara_queue/play_before_the_load_lands.rs
+++ b/tests/tests/kithara_queue/play_before_the_load_lands.rs
@@ -80,9 +80,10 @@ async fn play_issued_before_the_load_lands_still_starts_the_track() {
 
     let mut rx = queue.subscribe();
     queue
-        .append(TrackSource::Config(Box::new(cfg)))
+        .run(move |q| q.append(TrackSource::Config(Box::new(cfg))))
+        .await
         .expect("append play-before-load track");
-    queue.play();
+    queue.run(move |q| q.play()).await;
 
     let position = wait_for_position_event(&mut rx, &queue, 0.2, Duration::from_secs(60))
         .await

--- a/tests/tests/kithara_queue/playback_warms_its_own_analysis.rs
+++ b/tests/tests/kithara_queue/playback_warms_its_own_analysis.rs
@@ -78,7 +78,8 @@ async fn playback_feeds_the_pass_opened_for_the_track_it_plays() {
         .build();
 
     let id = queue
-        .append(TrackSource::Config(Box::new(cfg)))
+        .run(move |q| q.append(TrackSource::Config(Box::new(cfg))))
+        .await
         .expect("analysis fixture track appends");
     wait_until(Duration::from_secs(60), "playback resource load", || {
         queue
@@ -104,7 +105,7 @@ async fn playback_feeds_the_pass_opened_for_the_track_it_plays() {
         0,
     );
     queue.attach_observer(id, producer);
-    queue.play();
+    queue.run(move |q| q.play()).await;
 
     let covered = || {
         analysis

--- a/tests/tests/kithara_queue/playback_warms_its_own_analysis.rs
+++ b/tests/tests/kithara_queue/playback_warms_its_own_analysis.rs
@@ -9,7 +9,7 @@ use kithara::{
     events::TrackStatus,
     host::HostConfig,
     net::{HttpClient, NetOptions},
-    platform::{CancelToken, time::Duration, tokio},
+    platform::{CancelToken, time::Duration},
     play::{PlayWorker, PlayWorkerConfig, PlayerConfig, PlayerImpl, ResourceConfig, ResourceSrc},
     queue::{Queue, QueueConfig, TrackSource},
     resampler::NoResamplerBackend,
@@ -17,7 +17,11 @@ use kithara::{
     stream::dl::{Downloader, DownloaderConfig},
 };
 use kithara_integration_tests::{
-    TestServerHelper, analysis_pass::stalled_reader, kithara, offline::OfflineQueue, temp_dir,
+    TestServerHelper,
+    analysis_pass::stalled_reader,
+    kithara,
+    offline::{OfflineQueue, QueueTicker},
+    temp_dir,
     waits::wait_until,
 };
 use kithara_test_fixtures::SignalAsset;
@@ -58,14 +62,7 @@ async fn playback_feeds_the_pass_opened_for_the_track_it_plays() {
     .await
     .expect("create product offline queue");
     let queue_for_tick = queue.control();
-    let tick_handle = tokio::task::spawn(async move {
-        loop {
-            time::sleep(Duration::from_millis(50)).await;
-            if queue_for_tick.tick().is_err() {
-                break;
-            }
-        }
-    });
+    let mut tick_handle = QueueTicker::spawn(queue_for_tick, Duration::from_millis(50));
 
     let downloader = Downloader::new(
         DownloaderConfig::for_client(HttpClient::new(
@@ -126,7 +123,6 @@ async fn playback_feeds_the_pass_opened_for_the_track_it_plays() {
         "the pass's own reader only stalls, so every covered frame arrived through \
          the attached producer"
     );
-    tick_handle.abort();
-    let _ = tick_handle.await;
+    tick_handle.stop().await;
     queue.close().await;
 }

--- a/tests/tests/kithara_queue/playback_warms_its_own_analysis.rs
+++ b/tests/tests/kithara_queue/playback_warms_its_own_analysis.rs
@@ -55,6 +55,7 @@ async fn playback_feeds_the_pass_opened_for_the_track_it_plays() {
                 .build(),
         ),
     )
+    .await
     .expect("create product offline queue");
     let queue_for_tick = queue.control();
     let tick_handle = tokio::task::spawn(async move {
@@ -126,4 +127,6 @@ async fn playback_feeds_the_pass_opened_for_the_track_it_plays() {
          the attached producer"
     );
     tick_handle.abort();
+    let _ = tick_handle.await;
+    queue.close().await;
 }

--- a/tests/tests/kithara_queue/playlist_stall_fails_load.rs
+++ b/tests/tests/kithara_queue/playlist_stall_fails_load.rs
@@ -109,6 +109,7 @@ async fn stalled_master_playlist_fails_load(temp_dir: TestTempDir) {
         session,
         Queue::new(QueueConfig::builder().player(player).build()),
     )
+    .await
     .expect("create product offline queue");
     let tick_handle = tokio::task::spawn(drive_queue_ticks(
         queue.control(),
@@ -138,4 +139,6 @@ async fn stalled_master_playlist_fails_load(temp_dir: TestTempDir) {
     assert!(!err.is_empty(), "Failed status must carry a typed error");
 
     tick_handle.abort();
+    let _ = tick_handle.await;
+    queue.close().await;
 }

--- a/tests/tests/kithara_queue/playlist_stall_fails_load.rs
+++ b/tests/tests/kithara_queue/playlist_stall_fails_load.rs
@@ -9,7 +9,6 @@ use kithara::{
         CancelToken,
         sync::Arc,
         time::{Duration, Instant, timeout},
-        tokio,
     },
     play::{PlayWorker, PlayWorkerConfig, PlayerConfig, PlayerImpl, ResourceConfig, ResourceSrc},
     queue::{Queue, QueueConfig, QueueControl, TrackSource, Transition},
@@ -17,7 +16,7 @@ use kithara::{
 };
 use kithara_integration_tests::{
     Content, Delivery, FixtureBehavior, TestServerHelper, TestTempDir, kithara,
-    offline::{OfflineQueue, drive_queue_ticks},
+    offline::{OfflineQueue, QueueTicker},
     temp_dir,
 };
 
@@ -111,10 +110,7 @@ async fn stalled_master_playlist_fails_load(temp_dir: TestTempDir) {
     )
     .await
     .expect("create product offline queue");
-    let tick_handle = tokio::task::spawn(drive_queue_ticks(
-        queue.control(),
-        Duration::from_millis(50),
-    ));
+    let mut tick_handle = QueueTicker::spawn(queue.control(), Duration::from_millis(50));
 
     let cfg = ResourceConfig::for_src(ResourceSrc::parse(url.as_str()).expect("valid URL"))
         .downloader(downloader)
@@ -138,7 +134,6 @@ async fn stalled_master_playlist_fails_load(temp_dir: TestTempDir) {
         .unwrap_or_else(|e| panic!("{e}"));
     assert!(!err.is_empty(), "Failed status must carry a typed error");
 
-    tick_handle.abort();
-    let _ = tick_handle.await;
+    tick_handle.stop().await;
     queue.close().await;
 }

--- a/tests/tests/kithara_queue/playlist_stall_fails_load.rs
+++ b/tests/tests/kithara_queue/playlist_stall_fails_load.rs
@@ -125,9 +125,10 @@ async fn stalled_master_playlist_fails_load(temp_dir: TestTempDir) {
 
     let mut rx = queue.subscribe();
     let id = queue
-        .append(TrackSource::Config(Box::new(cfg)))
+        .run(move |q| q.append(TrackSource::Config(Box::new(cfg))))
+        .await
         .expect("append stalled playlist track");
-    let _ = queue.select(id, Transition::None);
+    let _ = queue.run(move |q| q.select(id, Transition::None)).await;
 
     let err = wait_for_failed(&mut rx, &queue, id, Duration::from_secs(30))
         .await

--- a/tests/tests/kithara_queue/rapid_scrub_decode_failure.rs
+++ b/tests/tests/kithara_queue/rapid_scrub_decode_failure.rs
@@ -266,6 +266,7 @@ impl Harness {
             session,
             Queue::new(QueueConfig::builder().player(player).build()),
         )
+        .await
         .expect("create product offline queue");
 
         let tick = tokio::task::spawn(drive_queue_ticks(
@@ -334,8 +335,18 @@ impl Harness {
         }
     }
 
-    fn shutdown(self) {
-        self.tick.abort();
+    async fn close(self) {
+        let Self {
+            queue,
+            rx,
+            master_url,
+            tick,
+        } = self;
+        tick.abort();
+        let _ = tick.await;
+        drop(rx);
+        drop(master_url);
+        queue.close().await;
     }
 }
 
@@ -408,13 +419,13 @@ async fn seek_into_cold_range_does_not_fail(
     let first_outcome = harness.scrub(first_target, first_tag).await;
 
     let Some(second_ratio) = second_ratio else {
-        harness.shutdown();
+        harness.close().await;
         assert_not_failed(first_outcome, first_target, first_tag);
         return;
     };
 
     if let ScrubOutcome::ItemDidFail { src } = first_outcome {
-        harness.shutdown();
+        harness.close().await;
         panic!("[first] CRASHED before second scrub (src={src})");
     }
 
@@ -433,7 +444,7 @@ async fn seek_into_cold_range_does_not_fail(
 
     let second_target = TRACK_DURATION_S * second_ratio;
     let second_outcome = harness.scrub(second_target, "second").await;
-    harness.shutdown();
+    harness.close().await;
     assert_not_failed(second_outcome, second_target, "second");
 }
 
@@ -466,6 +477,6 @@ async fn seek_drag_into_cold_range_does_not_fail(temp_dir: TestTempDir, #[case] 
         SEEK_OBSERVE_BUDGET,
     )
     .await;
-    harness.shutdown();
+    harness.close().await;
     assert_not_failed(outcome, final_target, "drag");
 }

--- a/tests/tests/kithara_queue/rapid_scrub_decode_failure.rs
+++ b/tests/tests/kithara_queue/rapid_scrub_decode_failure.rs
@@ -277,14 +277,18 @@ impl Harness {
             .build();
         let mut rx = queue.subscribe();
         let id = queue
-            .append(TrackSource::Config(Box::new(cfg)))
+            .run(move |q| q.append(TrackSource::Config(Box::new(cfg))))
+            .await
             .expect("append rapid-scrub track");
 
         wait_for_status(&mut rx, &queue, id, TrackStatus::Loaded, LOAD_BUDGET)
             .await
             .unwrap_or_else(|e| panic!("Loaded never arrived: {e}"));
-        queue.select(id, Transition::None).expect("select");
-        queue.play();
+        queue
+            .run(move |q| q.select(id, Transition::None))
+            .await
+            .expect("select");
+        queue.run(move |q| q.play()).await;
 
         Self {
             queue,

--- a/tests/tests/kithara_queue/rapid_scrub_decode_failure.rs
+++ b/tests/tests/kithara_queue/rapid_scrub_decode_failure.rs
@@ -11,7 +11,6 @@ use kithara::{
     platform::{
         CancelToken,
         time::{Duration, Instant, sleep, timeout},
-        tokio,
     },
     play::{PlayWorker, PlayWorkerConfig, PlayerConfig, PlayerImpl, ResourceConfig, ResourceSrc},
     queue::{Queue, QueueConfig, QueueControl, TrackSource, Transition},
@@ -21,7 +20,7 @@ use kithara_integration_tests::{
     HlsFixtureBuilder, TestServerHelper, TestTempDir,
     fixture_protocol::{DelayRule, EncryptionRequest},
     kithara,
-    offline::{OfflineQueue, drive_queue_ticks},
+    offline::{OfflineQueue, QueueTicker},
     temp_dir,
 };
 
@@ -181,7 +180,7 @@ struct Harness {
     queue: OfflineQueue<TestPools>,
     rx: EventReceiver,
     master_url: String,
-    tick: tokio::task::JoinHandle<()>,
+    tick: QueueTicker,
 }
 
 impl Harness {
@@ -269,10 +268,7 @@ impl Harness {
         .await
         .expect("create product offline queue");
 
-        let tick = tokio::task::spawn(drive_queue_ticks(
-            queue.control(),
-            Duration::from_millis(50),
-        ));
+        let tick = QueueTicker::spawn(queue.control(), Duration::from_millis(50));
 
         let cfg = ResourceConfig::for_src(ResourceSrc::parse(master.as_str()).expect("valid URL"))
             .downloader(downloader)
@@ -340,10 +336,9 @@ impl Harness {
             queue,
             rx,
             master_url,
-            tick,
+            mut tick,
         } = self;
-        tick.abort();
-        let _ = tick.await;
+        tick.stop().await;
         drop(rx);
         drop(master_url);
         queue.close().await;

--- a/tests/tests/kithara_queue/real_playlist.rs
+++ b/tests/tests/kithara_queue/real_playlist.rs
@@ -41,9 +41,7 @@ mod test_statics {
 }
 
 async fn shared_test_ctx() -> &'static AppQueueFixture {
-    test_statics::TEST_CTX
-        .get_or_init(|| async { insecure_app_queue() })
-        .await
+    test_statics::TEST_CTX.get_or_init(insecure_app_queue).await
 }
 
 async fn wait_for_status(
@@ -322,7 +320,8 @@ async fn track_plays_end_to_end(
     let mut rx = ctx.queue.subscribe();
     let track_id = ctx
         .queue
-        .append(source)
+        .run(move |q| q.append(source))
+        .await
         .expect("append real playlist track");
 
     wait_for_status(
@@ -352,7 +351,7 @@ async fn track_plays_end_to_end(
     let mut rng = Xorshift64::new(rng_seed);
     for i in 0..3 {
         let target = duration * rng.range_f64(0.05, 0.95);
-        ctx.queue.seek(target).expect("seek");
+        ctx.queue.run(move |q| q.seek(target)).await.expect("seek");
         wait_for_position_near(&ctx.queue, target, 1.0, Duration::from_secs(5))
             .await
             .unwrap_or_else(|e| panic!("seek #{i} to {target:.1}s fail [{url}]: {e}"));
@@ -439,18 +438,16 @@ async fn queue_playlist_behavior(#[case] backend: DecoderBackend) {
     ctx.queue.set_crossfade_duration(2.0);
 
     let mut rx = ctx.queue.subscribe();
-    let ids: Vec<TrackId> = urls
-        .iter()
-        .map(|u| {
-            ctx.queue
-                .run({
-                    let arg0 = build_track_source(u, ctx, backend, AbrMode::Auto(None));
-                    move |q| q.append(arg0)
-                })
-                .await
-                .expect("append playlist track")
-        })
-        .collect();
+    let mut ids = Vec::with_capacity(urls.len());
+    for url in &urls {
+        let source = build_track_source(url, ctx, backend, AbrMode::Auto(None));
+        let id = ctx
+            .queue
+            .run(move |q| q.append(source))
+            .await
+            .expect("append playlist track");
+        ids.push(id);
+    }
 
     ctx.queue
         .run({
@@ -473,7 +470,7 @@ async fn queue_playlist_behavior(#[case] backend: DecoderBackend) {
         .expect("first track position");
 
     let before_pause = ctx.queue.position_seconds().unwrap_or(0.0);
-    ctx.queue.pause();
+    ctx.queue.run(move |q| q.pause()).await;
     time::sleep(Duration::from_secs(2)).await;
     let during_pause = ctx.queue.position_seconds().unwrap_or(0.0);
     assert!(
@@ -499,7 +496,10 @@ async fn queue_playlist_behavior(#[case] backend: DecoderBackend) {
         .duration_seconds()
         .expect("duration for first track");
     let seek_target = duration_0 * 0.4;
-    ctx.queue.seek(seek_target).expect("seek");
+    ctx.queue
+        .run(move |q| q.seek(seek_target))
+        .await
+        .expect("seek");
     wait_for_position_near(&ctx.queue, seek_target, 1.0, Duration::from_secs(5))
         .await
         .expect("seek landed near target");
@@ -562,7 +562,10 @@ async fn queue_playlist_behavior(#[case] backend: DecoderBackend) {
                         .duration_seconds()
                         .ok_or_else(|| "duration unknown".to_string())?;
                     let near_end = (dur - f64::from(xf_duration) - 2.0).max(0.0);
-                    ctx.queue.seek(near_end).map_err(|e| format!("seek: {e}"))?;
+                    ctx.queue
+                        .run(move |q| q.seek(near_end))
+                        .await
+                        .map_err(|e| format!("seek: {e}"))?;
                     wait_for_queue_event(
                     &mut rx,
                     |ev| matches!(
@@ -684,7 +687,8 @@ async fn prod_tracks_sequential_startup_latency() {
         let t0 = kithara::platform::time::Instant::now();
         let track_id = ctx
             .queue
-            .append(source)
+            .run(move |q| q.append(source))
+            .await
             .expect("append Apple production track");
 
         let outcome: Result<(Duration, Duration), String> = async {
@@ -855,21 +859,19 @@ async fn hls_hands_over_to_mpeg_at_its_own_end(#[case] backend: DecoderBackend) 
     let mut rx = ctx.queue.subscribe();
     let hls = ctx
         .queue
-        .append(build_track_source(
-            HLS_URL,
-            ctx,
-            backend,
-            AbrMode::Auto(None),
-        ))
+        .run({
+            let source = build_track_source(HLS_URL, ctx, backend, AbrMode::Auto(None));
+            move |q| q.append(source)
+        })
+        .await
         .expect("append the HLS leg");
     let mpeg = ctx
         .queue
-        .append(build_track_source(
-            MPEG_URL,
-            ctx,
-            backend,
-            AbrMode::Auto(None),
-        ))
+        .run({
+            let source = build_track_source(MPEG_URL, ctx, backend, AbrMode::Auto(None));
+            move |q| q.append(source)
+        })
+        .await
         .expect("append the MPEG leg");
 
     wait_for_status(

--- a/tests/tests/kithara_queue/real_playlist.rs
+++ b/tests/tests/kithara_queue/real_playlist.rs
@@ -336,7 +336,8 @@ async fn track_plays_end_to_end(
     .unwrap_or_else(|e| panic!("load fail [{url}]: {e}"));
 
     ctx.queue
-        .select(track_id, Transition::None)
+        .run(move |q| q.select(track_id, Transition::None))
+        .await
         .expect("select");
     wait_for_position_at_least(&ctx.queue, 0.5, Duration::from_secs(15))
         .await
@@ -442,13 +443,21 @@ async fn queue_playlist_behavior(#[case] backend: DecoderBackend) {
         .iter()
         .map(|u| {
             ctx.queue
-                .append(build_track_source(u, ctx, backend, AbrMode::Auto(None)))
+                .run({
+                    let arg0 = build_track_source(u, ctx, backend, AbrMode::Auto(None));
+                    move |q| q.append(arg0)
+                })
+                .await
                 .expect("append playlist track")
         })
         .collect();
 
     ctx.queue
-        .select(ids[0], Transition::None)
+        .run({
+            let arg0 = ids[0];
+            move |q| q.select(arg0, Transition::None)
+        })
+        .await
         .expect("select first");
     wait_for_status(
         &mut rx,
@@ -471,7 +480,7 @@ async fn queue_playlist_behavior(#[case] backend: DecoderBackend) {
         (during_pause - before_pause).abs() < 0.5,
         "position drifted during pause: {before_pause:.2} → {during_pause:.2}"
     );
-    ctx.queue.play();
+    ctx.queue.run(move |q| q.play()).await;
     wait_for_position_at_least(&ctx.queue, during_pause + 0.01, Duration::from_secs(5))
         .await
         .expect("resume did not advance position");
@@ -691,7 +700,8 @@ async fn prod_tracks_sequential_startup_latency() {
             let load_latency = t0.elapsed();
 
             ctx.queue
-                .select(track_id, Transition::None)
+                .run(move |q| q.select(track_id, Transition::None))
+                .await
                 .map_err(|e| format!("select: {e:?}"))?;
             wait_for_position_at_least(&ctx.queue, 0.1, Duration::from_secs(20))
                 .await
@@ -872,7 +882,8 @@ async fn hls_hands_over_to_mpeg_at_its_own_end(#[case] backend: DecoderBackend) 
     .await
     .unwrap_or_else(|e| panic!("HLS leg load [{HLS_URL}]: {e}"));
     ctx.queue
-        .select(hls, Transition::None)
+        .run(move |q| q.select(hls, Transition::None))
+        .await
         .expect("select the HLS leg");
     wait_for_position_at_least(&ctx.queue, 0.5, Duration::from_secs(15))
         .await

--- a/tests/tests/kithara_queue/select_after_eof.rs
+++ b/tests/tests/kithara_queue/select_after_eof.rs
@@ -55,7 +55,7 @@ async fn render_loop(
 ) -> Vec<f32> {
     let mut pcm = Vec::new();
     for _ in 0..block_budget {
-        let _ = queue.tick();
+        let _ = harness.run(queue, |q| q.tick()).await;
         let block = harness.render(BLOCK_FRAMES).await;
         pcm.extend(block);
     }
@@ -65,8 +65,15 @@ async fn render_loop(
 #[kithara::test(tokio)]
 async fn seek_updates_cached_position_optimistically() {
     let (harness, queue) = offline_queue_fixture(SAMPLE_RATE).await;
-    let id = queue.insert_loaded_for_test(make_resource("seek", 120.0, 0.10));
-    queue.select(id, Transition::None).expect("select track");
+    let id = harness
+        .run(&queue, move |q| {
+            q.insert_loaded_for_test(make_resource("seek", 120.0, 0.10))
+        })
+        .await;
+    harness
+        .run(&queue, move |q| q.select(id, Transition::None))
+        .await
+        .expect("select track");
 
     queue.seek(54.689_879_542).expect("seek must land");
 
@@ -85,12 +92,17 @@ async fn reselect_finished_track_restarts_when_next_track_never_loads() {
 
     let (harness, queue) = offline_queue_fixture(SAMPLE_RATE).await;
 
-    let id_a = queue.insert_loaded_for_test(make_resource("a", TRACK_SECS, TRACK_VALUE));
+    let id_a = harness
+        .run(&queue, move |q| {
+            q.insert_loaded_for_test(make_resource("a", TRACK_SECS, TRACK_VALUE))
+        })
+        .await;
     // Registered but never completed: stands in for a stalled loader.
     let _id_b = queue.register_for_test();
 
-    queue
-        .select(id_a, Transition::None)
+    harness
+        .run(&queue, move |q| q.select(id_a, Transition::None))
+        .await
         .expect("select track A");
     let first_pcm = render_loop(&queue, &harness, BLOCK_BUDGET).await;
     assert!(
@@ -99,8 +111,9 @@ async fn reselect_finished_track_restarts_when_next_track_never_loads() {
     );
 
     queue.supply_test_resource_for_respawn(id_a, make_resource("a2", TRACK_SECS, TRACK_VALUE));
-    queue
-        .select(id_a, Transition::None)
+    harness
+        .run(&queue, move |q| q.select(id_a, Transition::None))
+        .await
         .expect("re-select of the finished track must be accepted");
 
     let second_pcm = render_loop(&queue, &harness, BLOCK_BUDGET).await;
@@ -132,21 +145,31 @@ async fn switch_back_to_consumed_track_switches_audio(#[case] initial_start: Ini
 
     let (harness, queue) = offline_queue_fixture(SAMPLE_RATE).await;
 
-    let id_a = queue.insert_loaded_for_test(make_resource("a", TRACK_SECS, QUIET));
-    let id_b = queue.insert_loaded_for_test(make_resource("b", TRACK_SECS, LOUD));
+    let id_a = harness
+        .run(&queue, move |q| {
+            q.insert_loaded_for_test(make_resource("a", TRACK_SECS, QUIET))
+        })
+        .await;
+    let id_b = harness
+        .run(&queue, move |q| {
+            q.insert_loaded_for_test(make_resource("b", TRACK_SECS, LOUD))
+        })
+        .await;
 
     match initial_start {
-        InitialStart::Play => queue.play(),
-        InitialStart::Select => queue
-            .select(id_a, Transition::None)
+        InitialStart::Play => harness.run(&queue, move |q| q.play()).await,
+        InitialStart::Select => harness
+            .run(&queue, move |q| q.select(id_a, Transition::None))
+            .await
             .expect("select track A"),
     }
     let pcm_a = render_loop(&queue, &harness, WARMUP_BLOCKS).await;
     let mean_a = mean_abs(&pcm_a[pcm_a.len() / 2..]);
     assert!(mean_a > 0.005, "track A must start: mean={mean_a}");
 
-    queue
-        .select(id_b, Transition::None)
+    harness
+        .run(&queue, move |q| q.select(id_b, Transition::None))
+        .await
         .expect("select track B");
     let pcm_b = render_loop(&queue, &harness, WARMUP_BLOCKS).await;
     let mean_b = mean_abs(&pcm_b[pcm_b.len() / 2..]);
@@ -156,8 +179,9 @@ async fn switch_back_to_consumed_track_switches_audio(#[case] initial_start: Ini
     );
 
     queue.supply_test_resource_for_respawn(id_a, make_resource("a2", TRACK_SECS, QUIET));
-    queue
-        .select(id_a, Transition::None)
+    harness
+        .run(&queue, move |q| q.select(id_a, Transition::None))
+        .await
         .expect("switch back to track A");
 
     // Skip the first half of the window: switch latency and the cf=0 cut.
@@ -183,10 +207,18 @@ async fn switch_back_to_consumed_track_switches_audio(#[case] initial_start: Ini
 #[kithara::test(tokio)]
 async fn play_button_marks_current_loaded_track_consumed() {
     let (harness, queue) = offline_queue_fixture(SAMPLE_RATE).await;
-    let id_a = queue.insert_loaded_for_test(make_resource("a", 8.0, 0.3));
-    let _id_b = queue.insert_loaded_for_test(make_resource("b", 8.0, 0.3));
+    let id_a = harness
+        .run(&queue, move |q| {
+            q.insert_loaded_for_test(make_resource("a", 8.0, 0.3))
+        })
+        .await;
+    let _id_b = harness
+        .run(&queue, move |q| {
+            q.insert_loaded_for_test(make_resource("b", 8.0, 0.3))
+        })
+        .await;
 
-    queue.play();
+    harness.run(&queue, move |q| q.play()).await;
     let _ = render_loop(&queue, &harness, 8).await;
 
     let status_a = queue
@@ -215,11 +247,16 @@ async fn reselect_playing_track_cancels_pending_switch() {
 
     let (harness, queue) = offline_queue_fixture(SAMPLE_RATE).await;
 
-    let id_a = queue.insert_loaded_for_test(make_resource("a", TRACK_SECS, TRACK_VALUE));
+    let id_a = harness
+        .run(&queue, move |q| {
+            q.insert_loaded_for_test(make_resource("a", TRACK_SECS, TRACK_VALUE))
+        })
+        .await;
     let id_b = queue.register_for_test();
 
-    queue
-        .select(id_a, Transition::None)
+    harness
+        .run(&queue, move |q| q.select(id_a, Transition::None))
+        .await
         .expect("select track A");
     let warmup_pcm = render_loop(&queue, &harness, WARMUP_BLOCKS).await;
     assert!(
@@ -227,11 +264,13 @@ async fn reselect_playing_track_cancels_pending_switch() {
         "track A must be audibly playing before the pending-switch step"
     );
 
-    queue
-        .select(id_b, Transition::None)
+    harness
+        .run(&queue, move |q| q.select(id_b, Transition::None))
+        .await
         .expect("select of a still-loading track stashes a pending switch");
-    queue
-        .select(id_a, Transition::None)
+    harness
+        .run(&queue, move |q| q.select(id_a, Transition::None))
+        .await
         .expect("re-select of the playing track");
 
     let status_b = queue

--- a/tests/tests/kithara_queue/select_after_eof.rs
+++ b/tests/tests/kithara_queue/select_after_eof.rs
@@ -48,7 +48,7 @@ fn first_onset_frame(pcm: &[f32], threshold: f32) -> Option<usize> {
         .position(|frame| frame.iter().any(|s| s.abs() > threshold))
 }
 
-fn render_loop(
+async fn render_loop(
     queue: &QueueControl<TestPools>,
     harness: &OfflinePlayerHarness,
     block_budget: usize,
@@ -56,21 +56,23 @@ fn render_loop(
     let mut pcm = Vec::new();
     for _ in 0..block_budget {
         let _ = queue.tick();
-        let block = harness.render(BLOCK_FRAMES);
+        let block = harness.render(BLOCK_FRAMES).await;
         pcm.extend(block);
     }
     pcm
 }
 
-#[kithara::test]
-fn seek_updates_cached_position_optimistically() {
-    let (_harness, queue) = offline_queue_fixture(SAMPLE_RATE);
+#[kithara::test(tokio)]
+async fn seek_updates_cached_position_optimistically() {
+    let (harness, queue) = offline_queue_fixture(SAMPLE_RATE).await;
     let id = queue.insert_loaded_for_test(make_resource("seek", 120.0, 0.10));
     queue.select(id, Transition::None).expect("select track");
 
     queue.seek(54.689_879_542).expect("seek must land");
 
     assert_eq!(queue.position_seconds(), Some(54.689_879_542));
+    drop(queue);
+    harness.close().await;
 }
 
 /// Track A plays to natural EOF while B is stuck loading, so auto-advance
@@ -81,7 +83,7 @@ async fn reselect_finished_track_restarts_when_next_track_never_loads() {
     const TRACK_SECS: f64 = 0.4;
     const TRACK_VALUE: f32 = 0.30;
 
-    let (harness, queue) = offline_queue_fixture(SAMPLE_RATE);
+    let (harness, queue) = offline_queue_fixture(SAMPLE_RATE).await;
 
     let id_a = queue.insert_loaded_for_test(make_resource("a", TRACK_SECS, TRACK_VALUE));
     // Registered but never completed: stands in for a stalled loader.
@@ -90,7 +92,7 @@ async fn reselect_finished_track_restarts_when_next_track_never_loads() {
     queue
         .select(id_a, Transition::None)
         .expect("select track A");
-    let first_pcm = render_loop(&queue, &harness, BLOCK_BUDGET);
+    let first_pcm = render_loop(&queue, &harness, BLOCK_BUDGET).await;
     assert!(
         first_onset_frame(&first_pcm, 0.005).is_some(),
         "track A must play through on the first pass"
@@ -101,7 +103,7 @@ async fn reselect_finished_track_restarts_when_next_track_never_loads() {
         .select(id_a, Transition::None)
         .expect("re-select of the finished track must be accepted");
 
-    let second_pcm = render_loop(&queue, &harness, BLOCK_BUDGET);
+    let second_pcm = render_loop(&queue, &harness, BLOCK_BUDGET).await;
     assert!(
         first_onset_frame(&second_pcm, 0.005).is_some(),
         "re-selecting track A after it played to EOF must restart playback \
@@ -112,6 +114,8 @@ async fn reselect_finished_track_restarts_when_next_track_never_loads() {
         Some(0),
         "queue must stay on track A after the restart"
     );
+    drop(queue);
+    harness.close().await;
 }
 
 /// Switching back to a `Consumed` track while another track is audibly
@@ -126,7 +130,7 @@ async fn switch_back_to_consumed_track_switches_audio(#[case] initial_start: Ini
     const LOUD: f32 = 0.80;
     const WARMUP_BLOCKS: usize = 64;
 
-    let (harness, queue) = offline_queue_fixture(SAMPLE_RATE);
+    let (harness, queue) = offline_queue_fixture(SAMPLE_RATE).await;
 
     let id_a = queue.insert_loaded_for_test(make_resource("a", TRACK_SECS, QUIET));
     let id_b = queue.insert_loaded_for_test(make_resource("b", TRACK_SECS, LOUD));
@@ -137,14 +141,14 @@ async fn switch_back_to_consumed_track_switches_audio(#[case] initial_start: Ini
             .select(id_a, Transition::None)
             .expect("select track A"),
     }
-    let pcm_a = render_loop(&queue, &harness, WARMUP_BLOCKS);
+    let pcm_a = render_loop(&queue, &harness, WARMUP_BLOCKS).await;
     let mean_a = mean_abs(&pcm_a[pcm_a.len() / 2..]);
     assert!(mean_a > 0.005, "track A must start: mean={mean_a}");
 
     queue
         .select(id_b, Transition::None)
         .expect("select track B");
-    let pcm_b = render_loop(&queue, &harness, WARMUP_BLOCKS);
+    let pcm_b = render_loop(&queue, &harness, WARMUP_BLOCKS).await;
     let mean_b = mean_abs(&pcm_b[pcm_b.len() / 2..]);
     assert!(
         mean_b > mean_a * 4.0,
@@ -157,7 +161,7 @@ async fn switch_back_to_consumed_track_switches_audio(#[case] initial_start: Ini
         .expect("switch back to track A");
 
     // Skip the first half of the window: switch latency and the cf=0 cut.
-    let pcm = render_loop(&queue, &harness, WARMUP_BLOCKS);
+    let pcm = render_loop(&queue, &harness, WARMUP_BLOCKS).await;
     let mean_back = mean_abs(&pcm[pcm.len() / 2..]);
     assert!(
         mean_back > 0.005,
@@ -169,6 +173,8 @@ async fn switch_back_to_consumed_track_switches_audio(#[case] initial_start: Ini
          but the audio kept playing B: mean_b={mean_b}, mean_back={mean_back}"
     );
     assert_eq!(queue.current_index(), Some(0));
+    drop(queue);
+    harness.close().await;
 }
 
 /// `play()` hands the current item's resource to the engine, so the
@@ -176,12 +182,12 @@ async fn switch_back_to_consumed_track_switches_audio(#[case] initial_start: Ini
 /// keeping the status truthful for later re-selects.
 #[kithara::test(tokio)]
 async fn play_button_marks_current_loaded_track_consumed() {
-    let (harness, queue) = offline_queue_fixture(SAMPLE_RATE);
+    let (harness, queue) = offline_queue_fixture(SAMPLE_RATE).await;
     let id_a = queue.insert_loaded_for_test(make_resource("a", 8.0, 0.3));
     let _id_b = queue.insert_loaded_for_test(make_resource("b", 8.0, 0.3));
 
     queue.play();
-    let _ = render_loop(&queue, &harness, 8);
+    let _ = render_loop(&queue, &harness, 8).await;
 
     let status_a = queue
         .tracks()
@@ -194,6 +200,8 @@ async fn play_button_marks_current_loaded_track_consumed() {
         TrackStatus::Consumed,
         "play() consumed track A's slot resource; its status must say so"
     );
+    drop(queue);
+    harness.close().await;
 }
 
 /// Re-selecting the playing track must cancel a pending switch so a
@@ -205,7 +213,7 @@ async fn reselect_playing_track_cancels_pending_switch() {
     /// Enough blocks to confirm audible playback without reaching EOF.
     const WARMUP_BLOCKS: usize = 64;
 
-    let (harness, queue) = offline_queue_fixture(SAMPLE_RATE);
+    let (harness, queue) = offline_queue_fixture(SAMPLE_RATE).await;
 
     let id_a = queue.insert_loaded_for_test(make_resource("a", TRACK_SECS, TRACK_VALUE));
     let id_b = queue.register_for_test();
@@ -213,7 +221,7 @@ async fn reselect_playing_track_cancels_pending_switch() {
     queue
         .select(id_a, Transition::None)
         .expect("select track A");
-    let warmup_pcm = render_loop(&queue, &harness, WARMUP_BLOCKS);
+    let warmup_pcm = render_loop(&queue, &harness, WARMUP_BLOCKS).await;
     assert!(
         first_onset_frame(&warmup_pcm, 0.005).is_some(),
         "track A must be audibly playing before the pending-switch step"
@@ -239,9 +247,11 @@ async fn reselect_playing_track_cancels_pending_switch() {
          track B's late-finishing load cannot barge in"
     );
 
-    let after_pcm = render_loop(&queue, &harness, WARMUP_BLOCKS);
+    let after_pcm = render_loop(&queue, &harness, WARMUP_BLOCKS).await;
     assert!(
         first_onset_frame(&after_pcm, 0.005).is_some(),
         "track A must keep playing uninterrupted"
     );
+    drop(queue);
+    harness.close().await;
 }

--- a/tests/tests/kithara_queue/source_helper.rs
+++ b/tests/tests/kithara_queue/source_helper.rs
@@ -13,28 +13,12 @@ use kithara_app::{
     config::AppConfig,
     pools::{AppResourceConfig, AppStore, AppTrackSource},
 };
-use kithara_integration_tests::offline::AppQueueFixture;
 use url::Url;
 
 pub(crate) fn app_disk_asset_store(config: &AppConfig, root: impl Into<PathBuf>) -> AppStore {
     AssetStore::builder(config.worker.pools().clone())
         .backend(StorageBackend::Disk { root: root.into() })
         .build()
-}
-
-pub(crate) fn app_drm_track_source(
-    url: &str,
-    ctx: &AppQueueFixture,
-    backend: DecoderBackend,
-) -> AppTrackSource {
-    app_track_source(
-        url,
-        &ctx.config,
-        app_disk_asset_store(&ctx.config, ctx.cache.path()),
-        backend,
-        AbrMode::Auto(None),
-        None,
-    )
 }
 
 pub(crate) fn app_track_source(

--- a/tests/tests/kithara_queue/track_replay_after_switch.rs
+++ b/tests/tests/kithara_queue/track_replay_after_switch.rs
@@ -11,7 +11,6 @@ use kithara::{
     platform::{
         CancelToken,
         time::{self, Duration, sleep},
-        tokio,
     },
     play::{PlayWorker, PlayWorkerConfig, PlayerConfig, PlayerImpl, ResourceConfig, ResourceSrc},
     queue::{Queue, QueueConfig, QueueControl, TrackSource, Transition},
@@ -21,7 +20,7 @@ use kithara_integration_tests::{
     HlsFixtureBuilder, TestServerHelper, TestTempDir,
     fixture_protocol::{DelayRule, EncryptionRequest},
     kithara,
-    offline::{OfflineQueue, drive_queue_ticks},
+    offline::{OfflineQueue, QueueTicker},
     temp_dir,
 };
 use kithara_test_fixtures::SignalAsset;
@@ -110,7 +109,7 @@ async fn build_queue_with_tick(
     OfflineQueue<TestPools>,
     Downloader,
     AssetStore<TestPools>,
-    tokio::task::JoinHandle<()>,
+    QueueTicker,
 ) {
     build_queue_with_tick_cf(temp_dir, 0.0).await
 }
@@ -122,7 +121,7 @@ async fn build_queue_with_tick_cf(
     OfflineQueue<TestPools>,
     Downloader,
     AssetStore<TestPools>,
-    tokio::task::JoinHandle<()>,
+    QueueTicker,
 ) {
     let store = kithara_integration_tests::disk_asset_store(temp_dir.path());
     let pools = pools();
@@ -149,10 +148,7 @@ async fn build_queue_with_tick_cf(
     )
     .await
     .expect("create product offline queue");
-    let tick_handle = tokio::task::spawn(drive_queue_ticks(
-        queue.control(),
-        Duration::from_millis(50),
-    ));
+    let tick_handle = QueueTicker::spawn(queue.control(), Duration::from_millis(50));
     let downloader = Downloader::new(
         DownloaderConfig::for_client(HttpClient::new(
             NetOptions::default(),
@@ -228,7 +224,7 @@ async fn replay_track_after_switch_does_not_hang_loader(#[case] mode: FixtureMod
     let url_b = build_hls(&helper, mode).await;
 
     let temp = temp_dir();
-    let (queue, downloader, store, tick_handle) = build_queue_with_tick(&temp).await;
+    let (queue, downloader, store, mut tick_handle) = build_queue_with_tick(&temp).await;
 
     let mk_cfg = |url: &Url| {
         ResourceConfig::for_src(ResourceSrc::parse(url.as_str()).expect("valid fixture URL"))
@@ -267,7 +263,7 @@ async fn replay_track_after_switch_does_not_hang_loader(#[case] mode: FixtureMod
 
     let result = wait_for_loader_done(&queue, id_a, Consts::LOAD_DEADLINE).await;
 
-    tick_handle.abort();
+    tick_handle.stop().await;
 
     let status = result.unwrap_or_else(|e| {
         panic!(
@@ -282,7 +278,6 @@ async fn replay_track_after_switch_does_not_hang_loader(#[case] mode: FixtureMod
         matches!(status, TrackStatus::Loaded | TrackStatus::Consumed),
         "[{mode:?}] track A re-load ended in unexpected terminal status: {status:?}"
     );
-    let _ = tick_handle.await;
     queue.close().await;
 }
 
@@ -339,7 +334,7 @@ async fn switch_back_to_mp3_restarts_audio_not_just_ui(
         .master_url();
 
     let temp = temp_dir();
-    let (queue, downloader, store, tick_handle) =
+    let (queue, downloader, store, mut tick_handle) =
         build_queue_with_tick_cf(&temp, crossfade_seconds).await;
 
     let mk_cfg = |url: &Url| {
@@ -413,8 +408,7 @@ async fn switch_back_to_mp3_restarts_audio_not_just_ui(
         "queue must report track A as current after the switch-back"
     );
 
-    tick_handle.abort();
-    let _ = tick_handle.await;
+    tick_handle.stop().await;
     queue.close().await;
 }
 

--- a/tests/tests/kithara_queue/track_replay_after_switch.rs
+++ b/tests/tests/kithara_queue/track_replay_after_switch.rs
@@ -104,7 +104,7 @@ async fn build_hls(helper: &TestServerHelper, mode: FixtureMode) -> Url {
         .master_url()
 }
 
-fn build_queue_with_tick(
+async fn build_queue_with_tick(
     temp_dir: &TestTempDir,
 ) -> (
     OfflineQueue<TestPools>,
@@ -112,10 +112,10 @@ fn build_queue_with_tick(
     AssetStore<TestPools>,
     tokio::task::JoinHandle<()>,
 ) {
-    build_queue_with_tick_cf(temp_dir, 0.0)
+    build_queue_with_tick_cf(temp_dir, 0.0).await
 }
 
-fn build_queue_with_tick_cf(
+async fn build_queue_with_tick_cf(
     temp_dir: &TestTempDir,
     crossfade_seconds: f32,
 ) -> (
@@ -147,6 +147,7 @@ fn build_queue_with_tick_cf(
                 .build(),
         ),
     )
+    .await
     .expect("create product offline queue");
     let tick_handle = tokio::task::spawn(drive_queue_ticks(
         queue.control(),
@@ -227,7 +228,7 @@ async fn replay_track_after_switch_does_not_hang_loader(#[case] mode: FixtureMod
     let url_b = build_hls(&helper, mode).await;
 
     let temp = temp_dir();
-    let (queue, downloader, store, tick_handle) = build_queue_with_tick(&temp);
+    let (queue, downloader, store, tick_handle) = build_queue_with_tick(&temp).await;
 
     let mk_cfg = |url: &Url| {
         ResourceConfig::for_src(ResourceSrc::parse(url.as_str()).expect("valid fixture URL"))
@@ -281,6 +282,8 @@ async fn replay_track_after_switch_does_not_hang_loader(#[case] mode: FixtureMod
         matches!(status, TrackStatus::Loaded | TrackStatus::Consumed),
         "[{mode:?}] track A re-load ended in unexpected terminal status: {status:?}"
     );
+    let _ = tick_handle.await;
+    queue.close().await;
 }
 
 /// Wait until the engine-reported position satisfies `pred`. The position
@@ -337,7 +340,7 @@ async fn switch_back_to_mp3_restarts_audio_not_just_ui(
 
     let temp = temp_dir();
     let (queue, downloader, store, tick_handle) =
-        build_queue_with_tick_cf(&temp, crossfade_seconds);
+        build_queue_with_tick_cf(&temp, crossfade_seconds).await;
 
     let mk_cfg = |url: &Url| {
         ResourceConfig::for_src(ResourceSrc::parse(url.as_str()).expect("valid fixture URL"))
@@ -411,6 +414,8 @@ async fn switch_back_to_mp3_restarts_audio_not_just_ui(
     );
 
     tick_handle.abort();
+    let _ = tick_handle.await;
+    queue.close().await;
 }
 
 /// Wait until `pred(queue)` holds, panicking past `deadline`.

--- a/tests/tests/kithara_queue/track_replay_after_switch.rs
+++ b/tests/tests/kithara_queue/track_replay_after_switch.rs
@@ -235,10 +235,18 @@ async fn replay_track_after_switch_does_not_hang_loader(#[case] mode: FixtureMod
     };
 
     let id_a = queue
-        .append(TrackSource::Config(Box::new(mk_cfg(&url_a))))
+        .run({
+            let arg0 = TrackSource::Config(Box::new(mk_cfg(&url_a)));
+            move |q| q.append(arg0)
+        })
+        .await
         .expect("append track A");
     let id_b = queue
-        .append(TrackSource::Config(Box::new(mk_cfg(&url_b))))
+        .run({
+            let arg0 = TrackSource::Config(Box::new(mk_cfg(&url_b)));
+            move |q| q.append(arg0)
+        })
+        .await
         .expect("append track B");
 
     wait_for_loader_done(&queue, id_a, Consts::LOAD_DEADLINE)
@@ -250,15 +258,20 @@ async fn replay_track_after_switch_does_not_hang_loader(#[case] mode: FixtureMod
 
     let mut events = queue.subscribe();
     queue
-        .select(id_a, Transition::None)
+        .run(move |q| q.select(id_a, Transition::None))
+        .await
         .expect("select A (first)");
     wait_for_current_track(&mut events, id_a, Consts::LOAD_DEADLINE).await;
 
-    queue.select(id_b, Transition::None).expect("select B");
+    queue
+        .run(move |q| q.select(id_b, Transition::None))
+        .await
+        .expect("select B");
     wait_for_current_track(&mut events, id_b, Consts::LOAD_DEADLINE).await;
 
     queue
-        .select(id_a, Transition::None)
+        .run(move |q| q.select(id_a, Transition::None))
+        .await
         .expect("re-select A after B");
 
     let result = wait_for_loader_done(&queue, id_a, Consts::LOAD_DEADLINE).await;
@@ -346,10 +359,18 @@ async fn switch_back_to_mp3_restarts_audio_not_just_ui(
     };
 
     let id_a = queue
-        .append(TrackSource::Config(Box::new(mk_cfg(&url_a))))
+        .run({
+            let arg0 = TrackSource::Config(Box::new(mk_cfg(&url_a)));
+            move |q| q.append(arg0)
+        })
+        .await
         .expect("append track A");
     let id_b = queue
-        .append(TrackSource::Config(Box::new(mk_cfg(&url_b))))
+        .run({
+            let arg0 = TrackSource::Config(Box::new(mk_cfg(&url_b)));
+            move |q| q.append(arg0)
+        })
+        .await
         .expect("append track B");
     wait_for_loader_done(&queue, id_a, Consts::LOAD_DEADLINE)
         .await
@@ -371,16 +392,25 @@ async fn switch_back_to_mp3_restarts_audio_not_just_ui(
             .is_some_and(|d| (d - 64.0).abs() < 20.0)
     };
 
-    queue.select(id_a, Transition::None).expect("select A");
+    queue
+        .run(move |q| q.select(id_a, Transition::None))
+        .await
+        .expect("select A");
     wait_for_position(&queue, Consts::LOAD_DEADLINE, "A playing", |p| p >= 3.0).await;
     assert!(sounds_like_a(&queue), "arena must be sounding the mp3");
 
-    queue.select(id_b, transition).expect("select B");
+    queue
+        .run(move |q| q.select(id_b, transition))
+        .await
+        .expect("select B");
     let switch_deadline = Duration::from_secs(30);
     wait_for(&queue, switch_deadline, "arena sounds B", &sounds_like_b).await;
     wait_for_position(&queue, switch_deadline, "B playing", |p| p >= 2.5).await;
 
-    queue.select(id_a, transition).expect("switch back to A");
+    queue
+        .run(move |q| q.select(id_a, transition))
+        .await
+        .expect("switch back to A");
     wait_for_loader_done(&queue, id_a, Consts::LOAD_DEADLINE)
         .await
         .expect("A reloaded after switch-back");

--- a/tests/tests/kithara_queue/track_switch_race.rs
+++ b/tests/tests/kithara_queue/track_switch_race.rs
@@ -28,7 +28,6 @@ use kithara::{
     platform::{
         CancelToken,
         time::{Duration, sleep},
-        tokio,
         tokio::sync::broadcast::error::RecvError,
     },
     play::{PlayWorker, PlayWorkerConfig, PlayerConfig, PlayerImpl, ResourceConfig, ResourceSrc},
@@ -37,7 +36,7 @@ use kithara::{
 };
 use kithara_integration_tests::{
     CreatedHls, HlsFixtureBuilder, InitGateHandle, TestServerHelper, TestTempDir, kithara,
-    offline::{OfflineQueue, drive_queue_ticks},
+    offline::{OfflineQueue, QueueTicker},
     temp_dir,
 };
 use url::Url;
@@ -330,10 +329,7 @@ async fn supersede_while_loading_cancels_slow_track() {
 
     let temp = temp_dir();
     let (queue, downloader, store) = build_queue(&temp).await;
-    let tick_handle = tokio::task::spawn(drive_queue_ticks(
-        queue.control(),
-        Duration::from_millis(50),
-    ));
+    let mut tick_handle = QueueTicker::spawn(queue.control(), Duration::from_millis(50));
 
     let fast_id = queue
         .append(TrackSource::Config(Box::new(mk_cfg(
@@ -438,8 +434,7 @@ async fn supersede_while_loading_cancels_slow_track() {
         .await
         .unwrap_or_else(|e| panic!("{e}"));
 
-    tick_handle.abort();
-    let _ = tick_handle.await;
+    tick_handle.stop().await;
     queue.close().await;
 }
 

--- a/tests/tests/kithara_queue/track_switch_race.rs
+++ b/tests/tests/kithara_queue/track_switch_race.rs
@@ -332,18 +332,18 @@ async fn supersede_while_loading_cancels_slow_track() {
     let mut tick_handle = QueueTicker::spawn(queue.control(), Duration::from_millis(50));
 
     let fast_id = queue
-        .append(TrackSource::Config(Box::new(mk_cfg(
-            &fast_url,
-            &downloader,
-            &store,
-        ))))
+        .run({
+            let source = TrackSource::Config(Box::new(mk_cfg(&fast_url, &downloader, &store)));
+            move |q| q.append(source)
+        })
+        .await
         .expect("append fast track");
     let slow_id = queue
-        .append(TrackSource::Config(Box::new(mk_cfg(
-            &slow_url,
-            &downloader,
-            &store,
-        ))))
+        .run({
+            let source = TrackSource::Config(Box::new(mk_cfg(&slow_url, &downloader, &store)));
+            move |q| q.append(source)
+        })
+        .await
         .expect("append slow track");
 
     // fast is undelayed and ungated → it reaches a terminal loaded state.
@@ -368,11 +368,13 @@ async fn supersede_while_loading_cancels_slow_track() {
 
     // select(slow): slow is loading → stashed as the pending selection.
     queue
-        .select(slow_id, Transition::None)
+        .run(move |q| q.select(slow_id, Transition::None))
+        .await
         .expect("select slow");
     // select(fast): supersedes the pending slow selection → slow Cancelled.
     queue
-        .select(fast_id, Transition::None)
+        .run(move |q| q.select(fast_id, Transition::None))
+        .await
         .expect("select fast");
 
     // Deterministic: the supersede marked slow Cancelled synchronously.
@@ -506,18 +508,18 @@ async fn concurrent_completion_race_does_not_barge_in() {
         let (queue, downloader, store) = build_queue(&temp).await;
 
         let fast_id = queue
-            .append(TrackSource::Config(Box::new(mk_cfg(
-                &fast_url,
-                &downloader,
-                &store,
-            ))))
+            .run({
+                let source = TrackSource::Config(Box::new(mk_cfg(&fast_url, &downloader, &store)));
+                move |q| q.append(source)
+            })
+            .await
             .unwrap_or_else(|error| panic!("[iter {iter}] append fast: {error}"));
         let slow_id = queue
-            .append(TrackSource::Config(Box::new(mk_cfg(
-                &slow_url,
-                &downloader,
-                &store,
-            ))))
+            .run({
+                let source = TrackSource::Config(Box::new(mk_cfg(&slow_url, &downloader, &store)));
+                move |q| q.append(source)
+            })
+            .await
             .unwrap_or_else(|error| panic!("[iter {iter}] append slow: {error}"));
 
         let mut rx = queue.subscribe();
@@ -526,11 +528,13 @@ async fn concurrent_completion_race_does_not_barge_in() {
         // select(slow), then a short delay so slow's loader completion fires
         // around select(fast) — the contended window.
         queue
-            .select(slow_id, Transition::None)
+            .run(move |q| q.select(slow_id, Transition::None))
+            .await
             .unwrap_or_else(|e| panic!("[iter {iter}] select slow: {e}"));
         time::sleep(Consts::RACE_GAP).await;
         queue
-            .select(fast_id, Transition::None)
+            .run(move |q| q.select(fast_id, Transition::None))
+            .await
             .unwrap_or_else(|e| panic!("[iter {iter}] select fast: {e}"));
 
         // Watch the bounded window by following `CurrentTrackChanged` on the

--- a/tests/tests/kithara_queue/track_switch_race.rs
+++ b/tests/tests/kithara_queue/track_switch_race.rs
@@ -110,7 +110,7 @@ async fn build_hls(
         .expect("create local HLS fixture")
 }
 
-fn build_queue(
+async fn build_queue(
     temp_dir: &TestTempDir,
 ) -> (OfflineQueue<TestPools>, Downloader, AssetStore<TestPools>) {
     let store = kithara_integration_tests::disk_asset_store(temp_dir.path());
@@ -135,6 +135,7 @@ fn build_queue(
                 .build(),
         ),
     )
+    .await
     .expect("create product offline queue");
     let downloader = Downloader::new(
         DownloaderConfig::for_client(HttpClient::new(
@@ -328,7 +329,7 @@ async fn supersede_while_loading_cancels_slow_track() {
     let slow_url = slow.master_url();
 
     let temp = temp_dir();
-    let (queue, downloader, store) = build_queue(&temp);
+    let (queue, downloader, store) = build_queue(&temp).await;
     let tick_handle = tokio::task::spawn(drive_queue_ticks(
         queue.control(),
         Duration::from_millis(50),
@@ -438,6 +439,8 @@ async fn supersede_while_loading_cancels_slow_track() {
         .unwrap_or_else(|e| panic!("{e}"));
 
     tick_handle.abort();
+    let _ = tick_handle.await;
+    queue.close().await;
 }
 
 /// Drain any backlog already buffered on `rx` so the completion-race watch
@@ -505,7 +508,7 @@ async fn concurrent_completion_race_does_not_barge_in() {
         let temp = temp_dir();
         // No tick: auto-advance is disabled, so `slow` can only become current
         // via the loader-completion race we are probing.
-        let (queue, downloader, store) = build_queue(&temp);
+        let (queue, downloader, store) = build_queue(&temp).await;
 
         let fast_id = queue
             .append(TrackSource::Config(Box::new(mk_cfg(
@@ -573,6 +576,7 @@ async fn concurrent_completion_race_does_not_barge_in() {
                 break;
             }
         }
+        queue.close().await;
     }
 
     assert!(

--- a/tests/tests/kithara_queue/user_simulation/prod_network.rs
+++ b/tests/tests/kithara_queue/user_simulation/prod_network.rs
@@ -18,10 +18,9 @@ use kithara::{
     platform::{
         CancelToken,
         time::{Duration, sleep},
-        tokio,
     },
     play::{PlayWorker, PlayWorkerConfig, PlayerConfig, PlayerImpl},
-    queue::{Queue, QueueConfig, QueueControl, TrackSource, Transition},
+    queue::{Queue, QueueConfig, TrackSource, Transition},
     stream::dl::{Downloader, DownloaderConfig},
 };
 use kithara_app::{
@@ -31,7 +30,7 @@ use kithara_app::{
 };
 use kithara_integration_tests::{
     TestTempDir, kithara,
-    offline::OfflineQueue,
+    offline::{OfflineQueue, QueueTicker},
     user_sim::{actions::Action, scenarios},
 };
 
@@ -126,7 +125,11 @@ async fn run_prod_drm_scenario(url: &str, actions: Vec<Action>) {
     let q_for_tick = queue.control();
     let mut tick = QueueTicker::spawn(q_for_tick, Duration::from_millis(50));
     let track_id = queue
-        .append(prod_drm_spec(url, &prod))
+        .run({
+            let source = prod_drm_spec(url, &prod);
+            move |q| q.append(source)
+        })
+        .await
         .expect("append production DRM track");
 
     // Use the same harness assertions but skip the per-track-cache
@@ -140,7 +143,8 @@ async fn run_prod_drm_scenario(url: &str, actions: Vec<Action>) {
         .await
         .unwrap_or_else(|e| panic!("prod DRM load fail: {e}"));
     queue
-        .select(track_id, Transition::None)
+        .run(move |q| q.select(track_id, Transition::None))
+        .await
         .expect("select prod DRM");
     wait_for_position_at_least(&queue, 1.0, Duration::from_secs(20))
         .await
@@ -157,7 +161,7 @@ async fn run_prod_drm_scenario(url: &str, actions: Vec<Action>) {
     queue.close().await;
 }
 
-async fn apply_action_to_queue(queue: &QueueControl<AppPools>, action: &Action) {
+async fn apply_action_to_queue(queue: &OfflineQueue<AppPools>, action: &Action) {
     use kithara::play::SeekOutcome;
     let label = action.label();
     let duration = queue.duration_seconds().unwrap_or(0.0);
@@ -167,7 +171,8 @@ async fn apply_action_to_queue(queue: &QueueControl<AppPools>, action: &Action) 
             let target = (duration * r).clamp(0.0, duration);
             let pre_track = queue.current().map(|e| e.id);
             let outcome = queue
-                .seek(target)
+                .run(move |q| q.seek(target))
+                .await
                 .unwrap_or_else(|e| panic!("[{label}] seek Err: {e}"));
             if matches!(outcome, SeekOutcome::PastEof { .. }) {
                 return;
@@ -369,15 +374,23 @@ async fn user_sim_prod_drm_seek_immediately_after_loaded_low() {
 #[kithara::test(tokio, multi_thread, timeout(Duration::from_secs(120)))]
 async fn user_sim_prod_drm_rapid_scrub_no_warmup_no_advance() {
     let prod = build_prod_ctx();
-    let queue = prod_queue(&prod, Some(Duration::from_millis(10)));
+    let queue = prod_queue(&prod, Some(Duration::from_millis(10))).await;
     let q_for_tick = queue.control();
     let mut tick = QueueTicker::spawn(q_for_tick, Duration::from_millis(50));
 
     let track0 = queue
-        .append(prod_drm_spec(PROD_DRM_TRACK, &prod))
+        .run({
+            let source = prod_drm_spec(PROD_DRM_TRACK, &prod);
+            move |q| q.append(source)
+        })
+        .await
         .expect("append production DRM track 0");
     let track1 = queue
-        .append(prod_drm_spec(PROD_DRM_TRACK_ALT, &prod))
+        .run({
+            let source = prod_drm_spec(PROD_DRM_TRACK_ALT, &prod);
+            move |q| q.append(source)
+        })
+        .await
         .expect("append production DRM track 1");
 
     use kithara_integration_tests::user_sim::harness::wait_for_loaded;
@@ -385,7 +398,8 @@ async fn user_sim_prod_drm_rapid_scrub_no_warmup_no_advance() {
         .await
         .unwrap_or_else(|e| panic!("prod DRM load fail: {e}"));
     queue
-        .select(track0, Transition::None)
+        .run(move |q| q.select(track0, Transition::None))
+        .await
         .expect("select prod DRM");
 
     let check_not_advanced = |label: &str| {
@@ -402,7 +416,7 @@ async fn user_sim_prod_drm_rapid_scrub_no_warmup_no_advance() {
 
     let scrub_targets = [5.0_f64, 30.0, 60.0, 15.0, 90.0, 45.0, 20.0, 75.0];
     for target in scrub_targets {
-        let _ = queue.seek(target);
+        let _ = queue.run(move |q| q.seek(target)).await;
         check_not_advanced(&format!("after seek({target:.2}s)"));
         time::sleep(Duration::from_millis(120)).await;
         check_not_advanced(&format!("post-seek({target:.2}s)+120ms"));
@@ -412,6 +426,7 @@ async fn user_sim_prod_drm_rapid_scrub_no_warmup_no_advance() {
     check_not_advanced("after 5s settle");
 
     tick.stop().await;
+    queue.close().await;
 }
 
 /// Like `run_prod_drm_scenario` but seeks AS SOON AS the queue reports
@@ -422,11 +437,15 @@ async fn user_sim_prod_drm_rapid_scrub_no_warmup_no_advance() {
 async fn run_prod_drm_scenario_no_warmup(url: &str, ratio: f64) {
     use kithara::play::SeekOutcome;
     let prod = build_prod_ctx();
-    let queue = prod_queue(&prod, Some(Duration::from_millis(10)));
+    let queue = prod_queue(&prod, Some(Duration::from_millis(10))).await;
     let q_for_tick = queue.control();
     let mut tick = QueueTicker::spawn(q_for_tick, Duration::from_millis(50));
     let track_id = queue
-        .append(prod_drm_spec(url, &prod))
+        .run({
+            let source = prod_drm_spec(url, &prod);
+            move |q| q.append(source)
+        })
+        .await
         .expect("append no-warmup production DRM track");
 
     use kithara_integration_tests::user_sim::harness::wait_for_loaded;
@@ -434,7 +453,8 @@ async fn run_prod_drm_scenario_no_warmup(url: &str, ratio: f64) {
         .await
         .unwrap_or_else(|e| panic!("prod DRM load fail: {e}"));
     queue
-        .select(track_id, Transition::None)
+        .run(move |q| q.select(track_id, Transition::None))
+        .await
         .expect("select prod DRM");
 
     // Wait until duration is *known* (post-mvhd) — that's the contract
@@ -454,7 +474,8 @@ async fn run_prod_drm_scenario_no_warmup(url: &str, ratio: f64) {
     };
     let target = (duration * ratio).clamp(0.0, duration);
     let outcome = queue
-        .seek(target)
+        .run(move |q| q.seek(target))
+        .await
         .unwrap_or_else(|e| panic!("queue.seek Err: {e}"));
     if let SeekOutcome::PastEof {
         duration: reported_dur,
@@ -502,6 +523,7 @@ async fn run_prod_drm_scenario_no_warmup(url: &str, ratio: f64) {
     );
 
     tick.stop().await;
+    queue.close().await;
 }
 
 /// Live prod-DRM tracks, all on `cdn-hls-slicer.zvuk.com` behind the same
@@ -578,8 +600,8 @@ async fn render_audio_frames(
     let mut pcm = Vec::with_capacity(target_frames * channels);
     let mut silent_since = None;
     while pcm.len() / channels < target_frames {
-        let block = queue.render(block_frames);
-        let _ = queue.tick();
+        let block = queue.render(block_frames).await;
+        let _ = queue.run(move |q| q.tick()).await;
         if block.iter().any(|s| s.abs() > SILENCE_FLOOR) {
             silent_since = None;
             pcm.extend_from_slice(&block);
@@ -610,8 +632,8 @@ async fn wait_for_handover(
         .expect("offline render block fits usize");
     let started = kithara::platform::time::Instant::now();
     loop {
-        let _ = queue.tick();
-        let _ = queue.render(block_frames);
+        let _ = queue.run(move |q| q.tick()).await;
+        let _ = queue.render(block_frames).await;
         if queue.current().map(|e| e.id) == Some(track_id)
             && queue.duration_seconds().is_some_and(|d| d > 0.0)
         {
@@ -700,7 +722,11 @@ async fn run_multi_track_select_seek_end_hang(urls: &[&str], label: &str) {
     for url in urls {
         track_ids.push(
             queue
-                .append(prod_drm_spec(url, &prod))
+                .run({
+                    let source = prod_drm_spec(url, &prod);
+                    move |q| q.append(source)
+                })
+                .await
                 .expect("append multi-track production DRM track"),
         );
     }
@@ -716,7 +742,8 @@ async fn run_multi_track_select_seek_end_hang(urls: &[&str], label: &str) {
             let ctx = format!("{label} [rot={rotation} idx={idx}]");
 
             queue
-                .select(track_id, Transition::None)
+                .run(move |q| q.select(track_id, Transition::None))
+                .await
                 .unwrap_or_else(|e| panic!("{ctx} select Err: {e}"));
 
             wait_for_handover(&queue, track_id, &ctx).await;
@@ -730,7 +757,8 @@ async fn run_multi_track_select_seek_end_hang(urls: &[&str], label: &str) {
                 .expect("duration known after wait_for_handover");
             let target = (duration * 0.90).clamp(0.0, duration);
             let outcome = queue
-                .seek(target)
+                .run(move |q| q.seek(target))
+                .await
                 .unwrap_or_else(|e| panic!("{ctx} seek Err: {e}"));
             assert!(
                 matches!(outcome, SeekOutcome::Landed { .. }),

--- a/tests/tests/kithara_queue/user_simulation/prod_network.rs
+++ b/tests/tests/kithara_queue/user_simulation/prod_network.rs
@@ -102,7 +102,7 @@ fn build_prod_ctx() -> ProdCtx {
     }
 }
 
-fn prod_queue(prod: &ProdCtx, pacing: Option<Duration>) -> OfflineQueue<AppPools> {
+async fn prod_queue(prod: &ProdCtx, pacing: Option<Duration>) -> OfflineQueue<AppPools> {
     let session = HostConfig::offline(prod.config.worker.pools().clone())
         .maybe_pacing(pacing)
         .build();
@@ -116,12 +116,13 @@ fn prod_queue(prod: &ProdCtx, pacing: Option<Duration>) -> OfflineQueue<AppPools
         session,
         Queue::new(QueueConfig::builder().player(player).build()),
     )
+    .await
     .expect("create product offline queue")
 }
 
 async fn run_prod_drm_scenario(url: &str, actions: Vec<Action>) {
     let prod = build_prod_ctx();
-    let queue = prod_queue(&prod, Some(Duration::from_millis(10)));
+    let queue = prod_queue(&prod, Some(Duration::from_millis(10))).await;
     let q_for_tick = queue.control();
     let tick = tokio::task::spawn(async move {
         loop {
@@ -161,6 +162,7 @@ async fn run_prod_drm_scenario(url: &str, actions: Vec<Action>) {
 
     tick.abort();
     let _ = tick.await;
+    queue.close().await;
 }
 
 async fn apply_action_to_queue(queue: &QueueControl<AppPools>, action: &Action) {
@@ -712,7 +714,7 @@ async fn run_multi_track_select_seek_end_hang(urls: &[&str], label: &str) {
     use kithara::play::SeekOutcome;
 
     let prod = build_prod_ctx();
-    let queue = prod_queue(&prod, None);
+    let queue = prod_queue(&prod, None).await;
     let ten_seconds_frames = usize::try_from(queue.host().spec().sample_rate.get())
         .expect("offline sample rate fits usize")
         .checked_mul(10)
@@ -765,6 +767,7 @@ async fn run_multi_track_select_seek_end_hang(urls: &[&str], label: &str) {
             assert_audio_live(&pcm_phase2, &phase2);
         }
     }
+    queue.close().await;
 }
 
 /// PROD DRM multi-track near-end seek + ABR up-switch hang repro from

--- a/tests/tests/kithara_queue/user_simulation/prod_network.rs
+++ b/tests/tests/kithara_queue/user_simulation/prod_network.rs
@@ -124,14 +124,7 @@ async fn run_prod_drm_scenario(url: &str, actions: Vec<Action>) {
     let prod = build_prod_ctx();
     let queue = prod_queue(&prod, Some(Duration::from_millis(10))).await;
     let q_for_tick = queue.control();
-    let tick = tokio::task::spawn(async move {
-        loop {
-            sleep(Duration::from_millis(50)).await;
-            if q_for_tick.tick().is_err() {
-                break;
-            }
-        }
-    });
+    let mut tick = QueueTicker::spawn(q_for_tick, Duration::from_millis(50));
     let track_id = queue
         .append(prod_drm_spec(url, &prod))
         .expect("append production DRM track");
@@ -160,8 +153,7 @@ async fn run_prod_drm_scenario(url: &str, actions: Vec<Action>) {
         apply_action_to_queue(&queue, &action).await;
     }
 
-    tick.abort();
-    let _ = tick.await;
+    tick.stop().await;
     queue.close().await;
 }
 
@@ -379,14 +371,7 @@ async fn user_sim_prod_drm_rapid_scrub_no_warmup_no_advance() {
     let prod = build_prod_ctx();
     let queue = prod_queue(&prod, Some(Duration::from_millis(10)));
     let q_for_tick = queue.control();
-    let tick = tokio::task::spawn(async move {
-        loop {
-            time::sleep(Duration::from_millis(50)).await;
-            if q_for_tick.tick().is_err() {
-                break;
-            }
-        }
-    });
+    let mut tick = QueueTicker::spawn(q_for_tick, Duration::from_millis(50));
 
     let track0 = queue
         .append(prod_drm_spec(PROD_DRM_TRACK, &prod))
@@ -426,8 +411,7 @@ async fn user_sim_prod_drm_rapid_scrub_no_warmup_no_advance() {
     time::sleep(Duration::from_secs(5)).await;
     check_not_advanced("after 5s settle");
 
-    tick.abort();
-    let _ = tick.await;
+    tick.stop().await;
 }
 
 /// Like `run_prod_drm_scenario` but seeks AS SOON AS the queue reports
@@ -440,14 +424,7 @@ async fn run_prod_drm_scenario_no_warmup(url: &str, ratio: f64) {
     let prod = build_prod_ctx();
     let queue = prod_queue(&prod, Some(Duration::from_millis(10)));
     let q_for_tick = queue.control();
-    let tick = tokio::task::spawn(async move {
-        loop {
-            sleep(Duration::from_millis(50)).await;
-            if q_for_tick.tick().is_err() {
-                break;
-            }
-        }
-    });
+    let mut tick = QueueTicker::spawn(q_for_tick, Duration::from_millis(50));
     let track_id = queue
         .append(prod_drm_spec(url, &prod))
         .expect("append no-warmup production DRM track");
@@ -524,8 +501,7 @@ async fn run_prod_drm_scenario_no_warmup(url: &str, ratio: f64) {
          post-seek+2s={post_seek_pos:.2}s)"
     );
 
-    tick.abort();
-    let _ = tick.await;
+    tick.stop().await;
 }
 
 /// Live prod-DRM tracks, all on `cdn-hls-slicer.zvuk.com` behind the same

--- a/tests/tests/kithara_queue/user_simulation/tests.rs
+++ b/tests/tests/kithara_queue/user_simulation/tests.rs
@@ -126,7 +126,7 @@ async fn run_scenario(specs: Vec<TrackSpec>, actions: Vec<Action>) {
         tracing::debug!(action = %label, "user_sim: applying");
         harness.apply(action).await;
     }
-    harness.shutdown().await;
+    harness.close().await;
 }
 
 async fn run_single(kind: TrackKind, abr: AbrMode, actions: Vec<Action>) {
@@ -387,6 +387,7 @@ async fn user_sim_seek_immediately_after_loaded(#[case] kind: TrackKind, #[case]
         session_config,
         Queue::new(QueueConfig::builder().player(player).build()),
     )
+    .await
     .expect("create product offline queue");
     let q_for_tick = queue.control();
     // Platform spawn chokepoint, NOT raw `tokio::spawn`: under flash

--- a/tests/tests/kithara_queue/user_simulation/tests.rs
+++ b/tests/tests/kithara_queue/user_simulation/tests.rs
@@ -8,7 +8,7 @@ use kithara::{
     events::AbrMode,
     host::HostConfig,
     net::{HttpClient, NetOptions},
-    platform::{CancelToken, time::Duration, tokio},
+    platform::{CancelToken, time::Duration},
     play::{PlayWorker, PlayWorkerConfig, PlayerConfig, PlayerImpl},
     queue::{Queue, QueueConfig, TrackSource, Transition},
     stream::{
@@ -17,8 +17,11 @@ use kithara::{
     },
 };
 use kithara_integration_tests::{
-    HlsFixtureBuilder, TestServerHelper, fixture_protocol::EncryptionRequest, kithara,
-    offline::OfflineQueue, temp_dir,
+    HlsFixtureBuilder, TestServerHelper,
+    fixture_protocol::EncryptionRequest,
+    kithara,
+    offline::{OfflineQueue, QueueTicker},
+    temp_dir,
 };
 use kithara_test_fixtures::SignalAsset;
 use url::Url;
@@ -390,20 +393,10 @@ async fn user_sim_seek_immediately_after_loaded(#[case] kind: TrackKind, #[case]
     .await
     .expect("create product offline queue");
     let q_for_tick = queue.control();
-    // Platform spawn chokepoint, NOT raw `tokio::spawn`: under flash
-    // this makes the tick driver a quiescence participant with a
-    // virtual `sleep`, so the virtual clock cannot race past the ticks
-    // that drive loading. A raw spawn runs uncounted on real time.
-    let tick = tokio::task::spawn(async move {
-        loop {
-            time::sleep(Duration::from_millis(50)).await;
-            if q_for_tick.tick().is_err() {
-                break;
-            }
-        }
-    });
+    let mut tick = QueueTicker::spawn(q_for_tick, Duration::from_millis(50));
     let track_id = queue
-        .append(TrackSource::Config(Box::new(cfg)))
+        .run(move |queue| queue.append(TrackSource::Config(Box::new(cfg))))
+        .await
         .expect("append immediate-seek track");
 
     use super::harness::wait_for_loaded;
@@ -411,7 +404,8 @@ async fn user_sim_seek_immediately_after_loaded(#[case] kind: TrackKind, #[case]
         .await
         .unwrap_or_else(|e| panic!("load fail: {e}"));
     queue
-        .select(track_id, Transition::None)
+        .run(move |queue| queue.select(track_id, Transition::None))
+        .await
         .expect("select track");
 
     // IMMEDIATELY (no warmup) seek — exactly like the user's UI click
@@ -434,8 +428,7 @@ async fn user_sim_seek_immediately_after_loaded(#[case] kind: TrackKind, #[case]
         );
     }
 
-    tick.abort();
-    let _ = tick.await;
+    tick.stop().await;
 }
 
 /// Aggressive seek storm — many seeks in rapid succession, like a

--- a/tests/tests/kithara_queue/zvuk_drm_trace.rs
+++ b/tests/tests/kithara_queue/zvuk_drm_trace.rs
@@ -29,7 +29,11 @@ async fn zvuk_drm_master_playlist_trace() {
     let source = build_source(url, &config);
 
     let mut rx = ctx.queue.subscribe();
-    let track_id = ctx.queue.append(source).expect("append DRM trace track");
+    let track_id = ctx
+        .queue
+        .run(move |q| q.append(source))
+        .await
+        .expect("append DRM trace track");
     tracing::info!(%url, ?track_id, "DRM trace: track appended");
 
     match wait_for_terminal(&mut rx, &ctx.queue, track_id, Duration::from_secs(20)).await {

--- a/tests/tests/kithara_queue/zvuk_prod_aac_to_flac_switch.rs
+++ b/tests/tests/kithara_queue/zvuk_prod_aac_to_flac_switch.rs
@@ -200,7 +200,7 @@ async fn zvuk_prod_aac_to_flac_switch(#[case] backend: DecoderBackend) {
             .build(),
     )
     .await;
-    player.load_and_fadein(resource);
+    player.load_and_fadein(resource).await;
 
     let pre = render_until(&mut player, "AAC warmup before FLAC switch", |position| {
         position >= PRE_SWITCH_POSITION_SECS

--- a/tests/tests/kithara_queue/zvuk_prod_aac_to_flac_switch.rs
+++ b/tests/tests/kithara_queue/zvuk_prod_aac_to_flac_switch.rs
@@ -79,7 +79,7 @@ where
 
     loop {
         for _ in 0..RENDER_BATCH_BLOCKS {
-            let _ = player.render(BLOCK_FRAMES);
+            let _ = player.render(BLOCK_FRAMES).await;
             rendered_blocks = rendered_blocks.saturating_add(1);
         }
 
@@ -198,7 +198,8 @@ async fn zvuk_prod_aac_to_flac_switch(#[case] backend: DecoderBackend) {
         HostConfig::offline(test_pools())
             .sample_rate(NonZeroU32::new(OUT_RATE).expect("output rate is non-zero"))
             .build(),
-    );
+    )
+    .await;
     player.load_and_fadein(resource);
 
     let pre = render_until(&mut player, "AAC warmup before FLAC switch", |position| {
@@ -250,4 +251,5 @@ async fn zvuk_prod_aac_to_flac_switch(#[case] backend: DecoderBackend) {
          rendered_blocks={}, window={post:?}",
         post.rendered_blocks
     );
+    player.close().await;
 }

--- a/tests/tests/kithara_queue/zvuk_prod_drm_e2e.rs
+++ b/tests/tests/kithara_queue/zvuk_prod_drm_e2e.rs
@@ -1,6 +1,6 @@
 #![cfg(not(target_arch = "wasm32"))]
 
-use kithara::{decode::DecoderBackend, platform::time::Duration, queue::Transition};
+use kithara::{decode::DecoderBackend, hls::AbrMode, platform::time::Duration, queue::Transition};
 use kithara_integration_tests::{
     kithara,
     offline::LazyAppQueueFixture,
@@ -55,7 +55,14 @@ async fn zvuk_prod_drm_track_plays(#[case] backend: DecoderBackend) {
     kithara_integration_tests::apple_warmup::warm_if_apple(backend);
 
     let ctx = CTX.get().await;
-    let source = super::source_helper::app_drm_track_source(PROD_TRACK, ctx, backend);
+    let source = super::source_helper::app_track_source(
+        PROD_TRACK,
+        &ctx.config,
+        super::source_helper::app_disk_asset_store(&ctx.config, ctx.cache.path()),
+        backend,
+        AbrMode::Auto(None),
+        None,
+    );
     let mut rx = ctx.queue.subscribe();
     let track_id = ctx
         .queue

--- a/tests/tests/kithara_queue/zvuk_prod_flac_swallow.rs
+++ b/tests/tests/kithara_queue/zvuk_prod_flac_swallow.rs
@@ -167,7 +167,8 @@ async fn zvuk_prod_flac_no_swallow(#[case] backend: DecoderBackend) {
         HostConfig::offline(test_pools())
             .sample_rate(NonZeroU32::new(OUT_RATE).expect("output rate is non-zero"))
             .build(),
-    );
+    )
+    .await;
     player.load_and_fadein(resource);
 
     // Pace each render window at ~1x wall clock so the real-time deadline is
@@ -177,7 +178,7 @@ async fn zvuk_prod_flac_no_swallow(#[case] backend: DecoderBackend) {
     for _ in 0..windows {
         let started = Instant::now();
         for _ in 0..BLOCKS_PER_WINDOW {
-            let _ = player.render(BLOCK_FRAMES);
+            let _ = player.render(BLOCK_FRAMES).await;
         }
         let elapsed = started.elapsed().as_secs_f64();
         if window_secs > elapsed {
@@ -186,4 +187,5 @@ async fn zvuk_prod_flac_no_swallow(#[case] backend: DecoderBackend) {
     }
 
     assert_no_committed_swallow(&recorder, MAX_COMMITTED_STEP_SECS);
+    player.close().await;
 }

--- a/tests/tests/kithara_queue/zvuk_prod_flac_swallow.rs
+++ b/tests/tests/kithara_queue/zvuk_prod_flac_swallow.rs
@@ -169,7 +169,7 @@ async fn zvuk_prod_flac_no_swallow(#[case] backend: DecoderBackend) {
             .build(),
     )
     .await;
-    player.load_and_fadein(resource);
+    player.load_and_fadein(resource).await;
 
     // Pace each render window at ~1x wall clock so the real-time deadline is
     // exercised — the condition under which the playhead swallows.

--- a/tests/tests/kithara_queue/zvuk_stage_drm_e2e.rs
+++ b/tests/tests/kithara_queue/zvuk_stage_drm_e2e.rs
@@ -1,6 +1,6 @@
 #![cfg(not(target_arch = "wasm32"))]
 
-use kithara::{decode::DecoderBackend, platform::time::Duration, queue::Transition};
+use kithara::{decode::DecoderBackend, hls::AbrMode, platform::time::Duration, queue::Transition};
 use kithara_integration_tests::{
     kithara,
     offline::LazyAppQueueFixture,
@@ -36,7 +36,14 @@ static CTX: LazyAppQueueFixture = LazyAppQueueFixture::const_new();
 #[case::symphonia(DecoderBackend::Symphonia)]
 async fn zvuk_stage_drm_track_plays(#[case] backend: DecoderBackend) {
     let ctx = CTX.get().await;
-    let source = super::source_helper::app_drm_track_source(STAGE_TRACK, ctx, backend);
+    let source = super::source_helper::app_track_source(
+        STAGE_TRACK,
+        &ctx.config,
+        super::source_helper::app_disk_asset_store(&ctx.config, ctx.cache.path()),
+        backend,
+        AbrMode::Auto(None),
+        None,
+    );
     let mut rx = ctx.queue.subscribe();
     let track_id = ctx.queue.append(source).expect("append stage DRM track");
 

--- a/tests/tests/kithara_queue/zvuk_stage_drm_e2e.rs
+++ b/tests/tests/kithara_queue/zvuk_stage_drm_e2e.rs
@@ -45,14 +45,19 @@ async fn zvuk_stage_drm_track_plays(#[case] backend: DecoderBackend) {
         None,
     );
     let mut rx = ctx.queue.subscribe();
-    let track_id = ctx.queue.append(source).expect("append stage DRM track");
+    let track_id = ctx
+        .queue
+        .run(move |q| q.append(source))
+        .await
+        .expect("append stage DRM track");
 
     wait_for_loader_done_event(&mut rx, &ctx.queue, track_id, Duration::from_secs(30))
         .await
         .unwrap_or_else(|e| panic!("stage DRM load fail [{STAGE_TRACK}]: {e}"));
 
     ctx.queue
-        .select(track_id, Transition::None)
+        .run(move |q| q.select(track_id, Transition::None))
+        .await
         .expect("select");
     wait_for_position_at_least(&ctx.queue, 0.5, Duration::from_secs(15))
         .await

--- a/xtask/tests/fixtures/ci-lane-commands.txt
+++ b/xtask/tests/fixtures/ci-lane-commands.txt
@@ -1755,7 +1755,7 @@
 # linux-test-simulated-clock / branch
   <require os> linux
   <require tools> cargo just sccache
-  just test run --profile ci --timings
+  just test run --no-block=on --profile ci --timings
     CARGO_BUILD_JOBS=2
     CARGO_TARGET_DIR=<root>/target/ci-tests
     CARGO_UNSTABLE_CHECKSUM_FRESHNESS=true
@@ -1763,7 +1763,7 @@
 # linux-test-simulated-clock / platforms
   <require os> linux
   <require tools> cargo just sccache
-  just test run --profile ci --timings
+  just test run --no-block=on --profile ci --timings
     CARGO_BUILD_JOBS=2
     CARGO_TARGET_DIR=<root>/target/ci-tests
     CARGO_UNSTABLE_CHECKSUM_FRESHNESS=true
@@ -1771,7 +1771,7 @@
 # linux-test-simulated-clock / merge-request
   <require os> linux
   <require tools> cargo just sccache
-  just test run --profile ci --timings
+  just test run --no-block=on --profile ci --timings
     CARGO_BUILD_JOBS=2
     CARGO_TARGET_DIR=<root>/target/ci-tests
     CARGO_UNSTABLE_CHECKSUM_FRESHNESS=true
@@ -1779,7 +1779,7 @@
 # linux-test-simulated-clock / quarantine
   <require os> linux
   <require tools> cargo just sccache
-  just test run --profile ci --timings
+  just test run --no-block=on --profile ci --timings
     CARGO_BUILD_JOBS=2
     CARGO_TARGET_DIR=<root>/target/ci-tests
     CARGO_UNSTABLE_CHECKSUM_FRESHNESS=true
@@ -1787,7 +1787,7 @@
 # linux-test-simulated-clock / main
   <require os> linux
   <require tools> cargo just sccache
-  just test run --profile ci --timings
+  just test run --no-block=on --profile ci --timings
     CARGO_BUILD_JOBS=2
     CARGO_TARGET_DIR=<root>/target/ci-tests
     CARGO_UNSTABLE_CHECKSUM_FRESHNESS=true
@@ -1795,7 +1795,7 @@
 # linux-test-simulated-clock / nightly
   <require os> linux
   <require tools> cargo just sccache
-  just test run --profile ci --timings
+  just test run --no-block=on --profile ci --timings
     CARGO_BUILD_JOBS=2
     CARGO_TARGET_DIR=<root>/target/ci-tests
     CARGO_UNSTABLE_CHECKSUM_FRESHNESS=true
@@ -1803,7 +1803,7 @@
 # linux-test-simulated-clock / weekly
   <require os> linux
   <require tools> cargo just sccache
-  just test run --profile ci --timings
+  just test run --no-block=on --profile ci --timings
     CARGO_BUILD_JOBS=2
     CARGO_TARGET_DIR=<root>/target/ci-tests
     CARGO_UNSTABLE_CHECKSUM_FRESHNESS=true
@@ -1811,7 +1811,7 @@
 # linux-test-simulated-clock / release
   <require os> linux
   <require tools> cargo just sccache
-  just test run --profile ci --timings
+  just test run --no-block=on --profile ci --timings
     CARGO_BUILD_JOBS=2
     CARGO_TARGET_DIR=<root>/target/ci-tests
     CARGO_UNSTABLE_CHECKSUM_FRESHNESS=true


### PR DESCRIPTION
## Summary

Read the host-configured sample rate from `SessionBinding` instead of querying the session command bridge. Move integration harness control calls onto their owner threads so the `no_block` detector can gate the Linux simulated-clock lane.

## Behavior / scope

- `Host` supplies the requested rate when binding a player. Backend-rate queries continue to use the live session.
- Native `OffThread` harnesses own construction, synchronous control calls, and teardown. `QueueTicker` stays alive for the app fixture lifetime and is joined before the fixture closes its host.
- Make test-harness calls asynchronous in the opt-in network suites, including CPAL ownership, resource admission, selection, seeking, and rendering. Production Host/Player/Queue control methods remain synchronous; test helpers await replies from their owner threads.
- Analysis-service tests use real generated media from `kithara-test-fixtures` instead of global `/tmp` paths, preserving shared and distinct resource identities.
- Move the reusable session double onto the existing mock surface and public-API player tests into integration tests.

## Validation

- `just test run analysis::tests --no-block=on --profile ci`: all 22 analysis-service tests pass using generated media.
- `just test run app_fixture_updates_position_without_manual_ticks --no-block=on --profile ci`: local MP3 playback updates the queue position without manual ticks. The regression fails when the ticker is stopped at construction.
- `cargo check -p kithara-integration-tests --test suite_network --test suite_network_manual --features network,network-manual`: compile-only verification of both opt-in suites.
- `just lint fast`: formatting, Clippy, and repository lint gates.
- The full workspace test suite was not rerun locally for this review-fix commit.
- Shortened completed-work descriptions in `PROGRESS.md`; the document remains within its unchanged 4000-byte gate after merging main (3658 bytes).
- GitHub fork CI passed on `8ce29b3db9ccb8c959f55cd721a0dd582b0fccc5`, including both clock lanes: https://github.com/gerasim13/kithara/actions/runs/34226137256.
- GitLab quarantine verification passed for the same PR head merged with `b326184b0b3f`: https://gitlab.zvq.me/disrupt/kithara/-/pipelines/2144162 (child https://gitlab.zvq.me/disrupt/kithara/-/pipelines/2144306). Apple tests, lint, XCFramework, iOS, dependencies, and verdict all passed; GitHub status `kithara/gitlab-verification` is successful.
- `just fmt check` and the commit lint-fast gate passed for the documentation fix.
- Live network scenarios and app/device acceptance were not run.

## Surface impact

- Public API: session binding carries the host-configured sample rate; the mock feature exports the shared session double.
- Platform/runtime: native harness ownership and teardown; Linux simulated-clock CI enables `no_block`. `OffThread` remains excluded from wasm.
- Perf-sensitive paths: removes a synchronous round trip when validating the requested sample rate.

## Risks / follow-ups

- Live network and device behavior still require separate acceptance. Compile-only checks do not prove playback against a remote service.
- The ticker lifetime regression uses a real clock because the native ticker waits on a timed channel receive. `no_block` stays enabled.
- Existing repository lint findings are unchanged; no suppressions or baseline entries were added.
