### PR TITLE
test(wasm): hear the live browser graph, and fix what kept it silent

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -47,8 +47,8 @@ rustflags = [
   # imported shared memory, the same reason the TLS symbols are named above.
   "-C",
   "link-arg=--export=__heap_base",
-  # panic=abort (NOT immediate-abort) so panic messages appear in the
-  # browser console.  console_error_panic_hook shows stack traces.
+  # panic=abort (NOT immediate-abort) so a panic still reaches whichever hook
+  # the binary installed, instead of lowering to a trap that reports nothing.
   "-C",
   "panic=abort",
 ]

--- a/.config/just/test.just
+++ b/.config/just/test.just
@@ -112,6 +112,15 @@ wasm BROWSER="chrome" SUITE="all":
         -Z build-std=std,panic_abort,core,alloc \
         -Z build-std-features=optimize_for_size \
         -p kithara-integration-tests --test suite_heavy
+      # The live-graph oracle needs the page's main thread: the product web
+      # session creates its `AudioContext` there. `wasm-bindgen-test` picks the
+      # thread per binary, so the oracle gets a binary of its own.
+      WASM_BINDGEN_TEST_TIMEOUT=300 WASM_BINDGEN_USE_BROWSER=1 \
+        cargo "+$toolchain" test --profile test-release \
+        --target wasm32-unknown-unknown \
+        -Z build-std=std,panic_abort,core,alloc \
+        -Z build-std-features=optimize_for_size \
+        -p kithara-integration-tests --test suite_live_web_audio
     fi
     # `webcodecs_browser` belongs to kithara-decode, not to any integration
     # suite, so it is its own cargo invocation. WebCodecs is a Chromium API;

--- a/.config/just/test.just
+++ b/.config/just/test.just
@@ -112,9 +112,8 @@ wasm BROWSER="chrome" SUITE="all":
         -Z build-std=std,panic_abort,core,alloc \
         -Z build-std-features=optimize_for_size \
         -p kithara-integration-tests --test suite_heavy
-      # The live-graph oracle needs the page's main thread: the product web
-      # session creates its `AudioContext` there. `wasm-bindgen-test` picks the
-      # thread per binary, so the oracle gets a binary of its own.
+      # `wasm-bindgen-test` picks its thread per binary, and the live-graph
+      # oracle needs the page's main thread.
       WASM_BINDGEN_TEST_TIMEOUT=300 WASM_BINDGEN_USE_BROWSER=1 \
         cargo "+$toolchain" test --profile test-release \
         --target wasm32-unknown-unknown \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1640,16 +1640,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console_error_panic_hook"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
-dependencies = [
- "cfg-if",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5031,7 +5021,6 @@ name = "kithara-ffi"
 version = "0.0.1-alpha4"
 dependencies = [
  "bytes",
- "console_error_panic_hook",
  "cpal 0.18.1",
  "dashmap",
  "delegate",
@@ -5195,7 +5184,6 @@ dependencies = [
  "bytes",
  "cbc",
  "cochlea-features",
- "console_error_panic_hook",
  "criterion",
  "firewheel",
  "futures",
@@ -5227,6 +5215,7 @@ dependencies = [
  "tower",
  "tower-http 0.7.0",
  "tracing",
+ "tracing-log",
  "tracing-subscriber",
  "tracing-wasm",
  "unimock",
@@ -5316,7 +5305,6 @@ version = "0.0.1-alpha4"
 dependencies = [
  "arc-swap",
  "assert_no_alloc",
- "console_error_panic_hook",
  "cpu-time",
  "criterion",
  "delegate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -281,7 +281,6 @@ clap = { version = "4.6", features = ["derive", "env"] }
 cochlea-features = "0.1.0"
 cochlea-render = "0.7.0"
 cochlea-score = "0.7.0"
-console_error_panic_hook = "0.1"
 core-foundation = "0.10"
 core-foundation-sys = "0.8"
 cpal = { version = "0.18", default-features = false }

--- a/crates/kithara-audio/src/audio/core.rs
+++ b/crates/kithara-audio/src/audio/core.rs
@@ -21,7 +21,7 @@ use super::{
     ring::{RecvCtx, RingConsumer},
     seek::{SeekHandle, SeekHandleParts},
 };
-use crate::traits::SeekBegin;
+use crate::{ConsumerWakeMode, traits::SeekBegin};
 
 /// Pull-based PCM facade over a bounded producer ring.
 pub struct Audio<S> {
@@ -377,6 +377,11 @@ impl<S> AudioControl for Audio<S> {
         Some(Self::seek_handle(self))
     }
 
+    fn set_consumer_wake_mode(&mut self, mode: ConsumerWakeMode) {
+        self.ring.set_consumer_wake_mode(mode);
+        self.events.set_wake_mode(self.ring.consumer_wake_mode());
+    }
+
     fn set_host_sample_rate(&self, sample_rate: NonZeroU32) {
         let previous = self
             .controls
@@ -590,6 +595,29 @@ mod tests {
             vec![epoch],
             "an ImmediateOffRt consumer runs off the real-time thread, so the SeekComplete born inside its read is on the bus when the read returns"
         );
+    }
+
+    #[kithara::test]
+    fn an_adopted_realtime_mode_moves_the_reader_events_with_the_ring(trim_silence: Vec<f32>) {
+        let mut fixture = AudioFixture::with_wake_mode(ConsumerWakeMode::ImmediateOffRt);
+        let mut receiver = fixture.audio.events.bus().subscribe();
+        AudioControl::set_consumer_wake_mode(
+            &mut fixture.audio,
+            ConsumerWakeMode::RealtimeDeferred,
+        );
+        let epoch = seek_and_stage(&trim_silence, &mut fixture);
+
+        let mut buf = [0.0f32; 8];
+        fixture.audio.read(&mut buf).expect("staged read");
+
+        assert_eq!(
+            drain_seek_completions(&mut receiver),
+            Vec::<u64>::new(),
+            "a reader that adopted RealtimeDeferred reads on the audio callback, so it defers what its read births"
+        );
+
+        fixture.emit.flush();
+        assert_eq!(drain_seek_completions(&mut receiver), vec![epoch]);
     }
 
     #[kithara::test]

--- a/crates/kithara-audio/src/audio/event.rs
+++ b/crates/kithara-audio/src/audio/event.rs
@@ -174,6 +174,10 @@ impl AudioEvents {
         self.underrun_active = false;
     }
 
+    pub(super) const fn set_wake_mode(&mut self, wake_mode: ConsumerWakeMode) {
+        self.wake_mode = wake_mode;
+    }
+
     pub(super) const fn take_wake_pending(&mut self) -> bool {
         let pending = self.wake_pending;
         self.wake_pending = false;

--- a/crates/kithara-audio/src/audio/ring.rs
+++ b/crates/kithara-audio/src/audio/ring.rs
@@ -61,11 +61,8 @@ pub(super) struct RingParts {
 
 impl RingConsumer {
     pub(super) fn new(parts: RingParts) -> Self {
-        let consumer_wake_mode = if parts.block_on_underrun {
-            ConsumerWakeMode::ImmediateOffRt
-        } else {
-            parts.consumer_wake_mode
-        };
+        let consumer_wake_mode =
+            resolve_wake_mode(parts.consumer_wake_mode, parts.block_on_underrun);
         Self {
             consumer_wake_mode,
             audio_rx: parts.audio_rx,
@@ -267,6 +264,10 @@ impl RingConsumer {
         }
     }
 
+    pub(super) fn set_consumer_wake_mode(&mut self, mode: ConsumerWakeMode) {
+        self.consumer_wake_mode = resolve_wake_mode(mode, self.block_on_underrun);
+    }
+
     fn source_span(
         &mut self,
         data: &AudioChunk,
@@ -323,6 +324,16 @@ impl RingConsumer {
 
     pub(super) fn wake_worker(&self, worker: Option<&dyn WorkerWake>) {
         wake_worker(worker, self.consumer_wake_mode);
+    }
+}
+
+/// A consumer that blocks on underrun waits on the producer thread, so it wakes
+/// it inline whatever the session declares.
+const fn resolve_wake_mode(mode: ConsumerWakeMode, block_on_underrun: bool) -> ConsumerWakeMode {
+    if block_on_underrun {
+        ConsumerWakeMode::ImmediateOffRt
+    } else {
+        mode
     }
 }
 
@@ -470,6 +481,21 @@ mod tests {
     #[kithara::test]
     fn block_on_underrun_forces_immediate_off_rt_wakes() {
         let fixture = RingFixture::with_wake_mode(false, true, ConsumerWakeMode::RealtimeDeferred);
+
+        assert_eq!(
+            fixture.ring.consumer_wake_mode,
+            ConsumerWakeMode::ImmediateOffRt
+        );
+    }
+
+    #[kithara::test]
+    fn an_adopted_mode_still_yields_to_blocking_reads() {
+        let mut fixture =
+            RingFixture::with_wake_mode(false, true, ConsumerWakeMode::ImmediateOffRt);
+
+        fixture
+            .ring
+            .set_consumer_wake_mode(ConsumerWakeMode::RealtimeDeferred);
 
         assert_eq!(
             fixture.ring.consumer_wake_mode,

--- a/crates/kithara-audio/src/traits/reader.rs
+++ b/crates/kithara-audio/src/traits/reader.rs
@@ -6,7 +6,7 @@ use kithara_platform::{sync::Arc, time::Duration};
 use kithara_signal::AudioSpec;
 
 use super::{ChunkOutcome, ReadOutcome, SeekOutcome};
-use crate::producer::PreloadGate;
+use crate::{ConsumerWakeMode, producer::PreloadGate};
 
 mod kithara {
     pub(crate) use kithara_test_macros::mock;
@@ -185,6 +185,12 @@ pub trait AudioControl {
     fn seek_handle(&self) -> Option<Arc<dyn SeekBegin>> {
         None
     }
+
+    /// Adopt the wake capability of the consumer that will read this reader.
+    ///
+    /// The owning session declares it; readers with no ring to arm keep the
+    /// default no-op.
+    fn set_consumer_wake_mode(&mut self, _mode: ConsumerWakeMode) {}
 
     /// Set the target sample rate of the audio host.
     ///

--- a/crates/kithara-events/src/deferred.rs
+++ b/crates/kithara-events/src/deferred.rs
@@ -6,18 +6,14 @@ use crate::{BusEvent, Envelope, Event, EventBus, EventMeta};
 
 /// Decode-core → shell hand-off for reader-hook events.
 ///
-/// Reader hooks run on the worker's forbid-blocking decode core, where they
-/// resolve a fully-formed event from live cursor state. Publishing it goes
-/// through `tokio::broadcast::Sender::send`, which takes an internal lock —
-/// forbidden on the produce core. `DeferredBus` splits the two:
-/// [`enqueue`](Self::enqueue) pushes the resolved event into a fixed,
-/// lock-free ring on the decode core (no alloc, no lock, no clock);
-/// [`flush`](Self::flush) drains the ring, stamps each envelope and publishes
-/// from the scheduler's unchecked shell, once per pass. The ring is FIFO, so
-/// events keep their decode order.
+/// Reader hooks resolve events on the worker's forbid-blocking decode core,
+/// where `tokio::broadcast::Sender::send` cannot run: it takes an internal
+/// lock. [`enqueue`](Self::enqueue) pushes into a fixed lock-free ring;
+/// [`flush`](Self::flush) drains it FIFO, stamping each envelope, from the
+/// scheduler's unchecked shell once per pass.
 ///
-/// The element is the narrow per-domain event (`HlsEvent` / `FileEvent`),
-/// converted to [`Event`] only at publish time, so the ring stays small.
+/// The element is the narrow per-domain event, converted to [`Event`] only at
+/// publish time, so the ring stays small.
 #[derive(fieldwork::Fieldwork)]
 #[fieldwork(opt_in, get)]
 pub struct DeferredBus<E> {
@@ -50,7 +46,8 @@ impl<E: Into<Event>> DeferredBus<E> {
     /// Queue a resolved event for shell-side publish.
     ///
     /// Lock-free, alloc-free and clock-free, so it is safe to call from the
-    /// decode core and from an audio thread whose global scope offers no clock.
+    /// decode core.
+    ///
     /// Drops the event if the ring is full: the only high-volume producer is
     /// monotonic progress, where the next pass's event supersedes a dropped
     /// one, so a drop under burst is self-healing.
@@ -67,8 +64,8 @@ impl<E: Into<Event>> DeferredBus<E> {
     /// Drain the ring and publish every queued event in FIFO order.
     ///
     /// Runs in the unchecked scheduler shell, so the `broadcast::send` lock and
-    /// the clock read that stamps each envelope stay off the forbid-blocking
-    /// decode core. `seq`, taken at enqueue, carries the producer's order.
+    /// the stamp's clock read stay off the decode core. `seq`, taken at
+    /// enqueue, carries the producer's order.
     pub fn flush(&self) {
         while let Some(event) = self.pending.pop() {
             self.bus.publish_envelope(Envelope {
@@ -94,7 +91,6 @@ impl<E: Into<Event>> DeferredBus<E> {
 
 #[cfg(all(test, feature = "file"))]
 mod tests {
-    use kithara_platform::time::Duration;
     use kithara_test_utils::kithara;
 
     use super::*;
@@ -168,8 +164,9 @@ mod tests {
         deferred.enqueue(progress(1));
         deferred.enqueue(progress(2));
 
-        // Wide enough that a stamp taken on the core would sit below `before`.
-        kithara_platform::time::sleep(Duration::from_millis(10)).await;
+        // Leaving the enqueue tick puts a stamp taken there below `before`.
+        let enqueued = crate::bus::ts_micros();
+        while crate::bus::ts_micros() <= enqueued {}
         let before = crate::bus::ts_micros();
         deferred.flush();
         let after = crate::bus::ts_micros();

--- a/crates/kithara-events/src/deferred.rs
+++ b/crates/kithara-events/src/deferred.rs
@@ -11,9 +11,10 @@ use crate::{BusEvent, Envelope, Event, EventBus, EventMeta};
 /// through `tokio::broadcast::Sender::send`, which takes an internal lock —
 /// forbidden on the produce core. `DeferredBus` splits the two:
 /// [`enqueue`](Self::enqueue) pushes the resolved event into a fixed,
-/// lock-free ring on the decode core (no alloc, no lock); [`flush`](Self::flush)
-/// drains the ring and publishes from the scheduler's unchecked shell, once
-/// per pass. The ring is FIFO, so events keep their decode order.
+/// lock-free ring on the decode core (no alloc, no lock, no clock);
+/// [`flush`](Self::flush) drains the ring, stamps each envelope and publishes
+/// from the scheduler's unchecked shell, once per pass. The ring is FIFO, so
+/// events keep their decode order.
 ///
 /// The element is the narrow per-domain event (`HlsEvent` / `FileEvent`),
 /// converted to [`Event`] only at publish time, so the ring stays small.
@@ -30,7 +31,6 @@ pub struct DeferredBus<E> {
 struct DeferredEvent<E> {
     event: E,
     seq: u64,
-    ts_micros: u64,
 }
 
 impl<E: Into<Event>> DeferredBus<E> {
@@ -49,7 +49,8 @@ impl<E: Into<Event>> DeferredBus<E> {
 
     /// Queue a resolved event for shell-side publish.
     ///
-    /// Lock-free and alloc-free, so it is safe to call from the decode core.
+    /// Lock-free, alloc-free and clock-free, so it is safe to call from the
+    /// decode core and from an audio thread whose global scope offers no clock.
     /// Drops the event if the ring is full: the only high-volume producer is
     /// monotonic progress, where the next pass's event supersedes a dropped
     /// one, so a drop under burst is self-healing.
@@ -57,7 +58,6 @@ impl<E: Into<Event>> DeferredBus<E> {
         let pending = DeferredEvent {
             event,
             seq: self.next_seq.fetch_add(1, Ordering::Relaxed),
-            ts_micros: crate::bus::ts_micros(),
         };
         if self.pending.push(pending).is_err() {
             self.dropped.fetch_add(1, Ordering::Relaxed);
@@ -66,15 +66,16 @@ impl<E: Into<Event>> DeferredBus<E> {
 
     /// Drain the ring and publish every queued event in FIFO order.
     ///
-    /// Runs in the unchecked scheduler shell, so the `broadcast::send` lock
-    /// stays off the forbid-blocking decode core.
+    /// Runs in the unchecked scheduler shell, so the `broadcast::send` lock and
+    /// the clock read that stamps each envelope stay off the forbid-blocking
+    /// decode core. `seq`, taken at enqueue, carries the producer's order.
     pub fn flush(&self) {
         while let Some(event) = self.pending.pop() {
             self.bus.publish_envelope(Envelope {
                 meta: EventMeta {
                     origin: self.bus.scope.id(),
                     seq: event.seq,
-                    ts_micros: event.ts_micros,
+                    ts_micros: crate::bus::ts_micros(),
                     deck: self.bus.label.deck,
                     track: self.bus.label.track,
                 },
@@ -93,6 +94,7 @@ impl<E: Into<Event>> DeferredBus<E> {
 
 #[cfg(all(test, feature = "file"))]
 mod tests {
+    use kithara_platform::time::Duration;
     use kithara_test_utils::kithara;
 
     use super::*;
@@ -158,14 +160,19 @@ mod tests {
     }
 
     #[kithara::test(tokio)]
-    async fn flush_preserves_enqueue_time_seq_and_ts() {
+    async fn flush_stamps_the_publish_time_and_keeps_enqueue_order() {
         let bus = EventBus::new(16);
         let mut rx = bus.subscribe();
         let deferred = DeferredBus::new(bus, 4);
 
         deferred.enqueue(progress(1));
         deferred.enqueue(progress(2));
+
+        // Wide enough that a stamp taken on the core would sit below `before`.
+        kithara_platform::time::sleep(Duration::from_millis(10)).await;
+        let before = crate::bus::ts_micros();
         deferred.flush();
+        let after = crate::bus::ts_micros();
 
         let first = rx.recv().await.unwrap();
         let second = rx.recv().await.unwrap();
@@ -179,7 +186,14 @@ mod tests {
             ts_micros: second_ts,
             ..
         } = second.meta;
+        assert_progress(&first, 1);
+        assert_progress(&second, 2);
         assert!(first_seq < second_seq);
-        assert!(first_ts <= second_ts);
+        for ts in [first_ts, second_ts] {
+            assert!(
+                (before..=after).contains(&ts),
+                "stamp {ts} lies outside the {before}..={after} the flush spans"
+            );
+        }
     }
 }

--- a/crates/kithara-ffi/Cargo.toml
+++ b/crates/kithara-ffi/Cargo.toml
@@ -126,7 +126,6 @@ kithara = { workspace = true, default-features = false, features = [
 kithara-test-macros = { workspace = true }
 
 bytes = { workspace = true }
-console_error_panic_hook = { workspace = true }
 js-sys = { workspace = true }
 # Wraps the `!Send` `js_sys::Function` behind a `Send + Sync` guard (with a
 # runtime same-thread assertion) so the JS-backed observer impls satisfy the

--- a/crates/kithara-ffi/src/web/bindings.rs
+++ b/crates/kithara-ffi/src/web/bindings.rs
@@ -11,7 +11,7 @@ static HEAP_END: u8 = 0;
 #[cfg_attr(target_family = "wasm", allow(unreachable_pub))]
 #[wasm_bindgen(start)]
 pub fn setup() -> Result<(), JsValue> {
-    console_error_panic_hook::set_once();
+    kithara::platform::logging::install_panic_hook();
 
     // WHY: Worker threads import `<shim>.js` for `initSync`; register our wasm-bindgen output name so the engine worker loads the right
     // shim (auto-detection mis-picks a co-loaded `.js` like coi-serviceworker).

--- a/crates/kithara-host/src/session/dispatch.rs
+++ b/crates/kithara-host/src/session/dispatch.rs
@@ -3,12 +3,16 @@ use std::num::NonZeroU32;
 use firewheel::{FirewheelCtx, backend::AudioBackend, error::UpdateError};
 use kithara_bufpool::HasPool;
 use kithara_output::OutputGroup;
+#[cfg(any(target_arch = "wasm32", test))]
+use kithara_platform::sync::mpsc;
 use kithara_play::{PlayError, StreamShape, player::PlayerMember};
 use kithara_warp::{
     SyncCapability, SyncError, SyncGroup, SyncOperation, SyncRejected, TopologyOperation,
 };
 use tracing::{debug, trace, warn};
 
+#[cfg(any(target_arch = "wasm32", test))]
+use super::protocol::HostCmdMsg;
 use super::{
     graph::{controls, lifecycle, player_index, slots, tap},
     protocol::{
@@ -265,6 +269,26 @@ pub(super) fn tick_session<B: AudioBackend, S>(state: &mut SessionState<B, S>) -
         return handle_update_error(state, err);
     }
     Reply::Ok
+}
+
+#[cfg(any(target_arch = "wasm32", test))]
+pub(super) fn drain_host_channel<B, S>(
+    state: &mut SessionState<B, S>,
+    rx: &mpsc::Receiver<HostCmdMsg<S>>,
+    mut observe: impl FnMut(&HostReply),
+) where
+    B: AudioBackend,
+    S: HasPool<f32> + Send + Sync + 'static,
+{
+    for msg in rx.try_iter() {
+        let reply = run_host_cmd(state, msg.cmd);
+        observe(&reply);
+        msg.reply_tx.send(reply).ok();
+    }
+
+    if let Reply::Err(err) = tick_session(state) {
+        warn!(?err, "session tick in host drain failed");
+    }
 }
 
 fn unregister_player<B: AudioBackend, S>(
@@ -1111,6 +1135,35 @@ mod tests {
             deck(&state, 0).slots.len(),
             2,
             "session must accept a future slot after route-loss reinit"
+        );
+        assert!(!state.stream_needs_restart);
+    }
+
+    #[kithara::test]
+    fn stream_loss_seen_while_draining_host_commands_restarts_the_stream() {
+        route_loss(RouteLossProbe::reset);
+
+        let mut state = test_state(start_route_loss_stream);
+        let player_id = register_player(&mut state);
+
+        assert!(matches!(
+            run_cmd(&mut state, start_command(player_id, 44_100)),
+            Reply::Ok
+        ));
+        assert_eq!(
+            route_loss(|probe| probe.start_count.load(Ordering::SeqCst)),
+            1
+        );
+
+        let (_tx, rx) = mpsc::channel::<HostCmdMsg<TestPools>>();
+
+        route_loss(|probe| probe.fail_next_poll.store(true, Ordering::SeqCst));
+        drain_host_channel(&mut state, &rx, |_| {});
+
+        assert_eq!(
+            route_loss(|probe| probe.start_count.load(Ordering::SeqCst)),
+            2,
+            "a stream drop observed during a host command drain must restart the stream"
         );
         assert!(!state.stream_needs_restart);
     }

--- a/crates/kithara-host/src/session/offline/client.rs
+++ b/crates/kithara-host/src/session/offline/client.rs
@@ -83,8 +83,10 @@ impl<S> OfflineSessionClient<S> {
 }
 
 impl<S: Send + Sync + 'static> SessionDispatcher<S> for OfflineSessionClient<S> {
+    /// Offline render pulls the graph from the session task, an ordinary thread
+    /// that may block and read the clock, so a reader wakes its producer inline.
     fn consumer_wake_mode(&self) -> ConsumerWakeMode {
-        ConsumerWakeMode::RealtimeDeferred
+        ConsumerWakeMode::ImmediateOffRt
     }
 
     fn exec(&self, cmd: Cmd<S>) -> Result<Reply, PlayError> {

--- a/crates/kithara-host/src/session/state.rs
+++ b/crates/kithara-host/src/session/state.rs
@@ -249,11 +249,6 @@ impl<B: AudioBackend, S> SessionState<B, S> {
         }
     }
 
-    #[cfg(target_arch = "wasm32")]
-    pub(crate) const fn ctx_mut(&mut self) -> Option<&mut FirewheelCtx<B>> {
-        self.ctx.as_mut()
-    }
-
     pub(super) fn publish_root(&self) {
         self.root_view.publish(&self.root);
     }

--- a/crates/kithara-host/src/session/web/bridge.rs
+++ b/crates/kithara-host/src/session/web/bridge.rs
@@ -3,13 +3,12 @@ use std::{cell::RefCell, num::NonZeroU32, sync::atomic::Ordering};
 use firewheel::FirewheelCtx;
 use kithara_bufpool::HasPool;
 use kithara_platform::sync::{Arc, mpsc};
-use tracing::warn;
 
 use super::client::WebSessionState;
 use crate::{
     bridge::PlaybackShared,
     session::{
-        dispatch::run_host_cmd,
+        dispatch::drain_host_channel,
         protocol::{HostCmdMsg, HostReply, Reply},
         state::ensure_ctx,
     },
@@ -40,21 +39,13 @@ pub(crate) fn tick_and_poll_remote<S>(
         return;
     };
 
-    for msg in rx.try_iter() {
-        let reply = run_host_cmd(state, msg.cmd);
-        if let HostReply::Play(Reply::SlotAllocated(ref allocated)) = reply {
+    drain_host_channel(state, rx, |reply| {
+        if let HostReply::Play(Reply::SlotAllocated(allocated)) = reply {
             BRIDGE_PLAYBACK.with(|playback| {
                 *playback.borrow_mut() = Some(Arc::clone(&allocated.control.playback));
             });
         }
-        msg.reply_tx.send(reply).ok();
-    }
-
-    if let Some(ctx) = state.ctx_mut()
-        && let Err(err) = ctx.update()
-    {
-        warn!("session graph update in tick failed: {err:?}");
-    }
+    });
 }
 
 pub(crate) fn bridge_position_secs() -> f64 {

--- a/crates/kithara-platform/Cargo.toml
+++ b/crates/kithara-platform/Cargo.toml
@@ -50,7 +50,6 @@ pin-project-lite = { workspace = true }
 tokio = { workspace = true, features = ["time", "sync", "rt", "macros"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-console_error_panic_hook = { workspace = true }
 js-sys = { workspace = true }
 parking_lot_core = { workspace = true, features = ["nightly"] }
 tokio_with_wasm = { workspace = true }

--- a/crates/kithara-platform/src/wasm/logging.rs
+++ b/crates/kithara-platform/src/wasm/logging.rs
@@ -3,14 +3,10 @@ use std::{panic, sync::Once};
 use js_sys::JsString;
 use web_sys::console;
 
-/// `String.fromCharCode` takes one argument per code unit, so a message is fed
-/// to it in slices that stay inside an engine's argument list.
+/// `String.fromCharCode` takes one argument per code unit.
 const CODE_UNITS_PER_CALL: usize = 1024;
 
-/// Build a JS string from the code units of `msg`.
-///
-/// Every scope can read code units, `AudioWorkletGlobalScope` included, which
-/// is where the audio render pass reports from.
+/// Build a JS string from the code units of `msg`, which every scope can read.
 fn js_string(msg: &str) -> JsString {
     let mut units = msg.encode_utf16();
     let mut line = JsString::from_char_code(&[]);
@@ -33,20 +29,15 @@ fn js_string(msg: &str) -> JsString {
 ///
 /// On native this routes through `tracing`. On wasm it writes to the browser
 /// `console` directly: the global `tracing` subscriber marks its spans through
-/// `performance`, a global the `AudioWorkletGlobalScope` of the audio render
-/// pass leaves undefined. `console.error` is a per-realm import that is valid
-/// in every scope, and [`js_string`] builds its argument the way every scope
-/// can.
+/// `performance`, which `AudioWorkletGlobalScope` leaves undefined.
 pub fn log_error(msg: &str) {
     console::error_1(&js_string(msg));
 }
 
 /// Report a panic through [`log_error`], on whichever thread panicked.
 ///
-/// `set_hook` writes one process-wide slot, so a binary's entry point is where
-/// this belongs. A build that lowers a panic to a trap (`-C
-/// panic=immediate-abort`, which the web artifact takes) reaches no hook at
-/// all.
+/// `set_hook` writes one process-wide slot, so a binary's entry point owns this
+/// call. `-C panic=immediate-abort` traps instead and reaches no hook.
 pub fn install_panic_hook() {
     static INSTALLED: Once = Once::new();
 

--- a/crates/kithara-platform/src/wasm/logging.rs
+++ b/crates/kithara-platform/src/wasm/logging.rs
@@ -1,14 +1,64 @@
-use wasm_bindgen::JsValue;
+use std::{panic, sync::Once};
+
+use js_sys::JsString;
 use web_sys::console;
+
+/// `String.fromCharCode` takes one argument per code unit, so a message is fed
+/// to it in slices that stay inside an engine's argument list.
+const CODE_UNITS_PER_CALL: usize = 1024;
+
+/// Build a JS string from the code units of `msg`.
+///
+/// Every scope can read code units, `AudioWorkletGlobalScope` included, which
+/// is where the audio render pass reports from.
+fn js_string(msg: &str) -> JsString {
+    let mut units = msg.encode_utf16();
+    let mut line = JsString::from_char_code(&[]);
+    let mut chunk = [0u16; CODE_UNITS_PER_CALL];
+
+    loop {
+        let mut filled = 0;
+        for (slot, unit) in chunk.iter_mut().zip(units.by_ref()) {
+            *slot = unit;
+            filled += 1;
+        }
+        if filled == 0 {
+            return line;
+        }
+        line = line.concat(&JsString::from_char_code(&chunk[..filled]));
+    }
+}
 
 /// Emit an error-level diagnostic line through the platform-appropriate sink.
 ///
 /// On native this routes through `tracing`. On wasm it writes to the browser
-/// `console` directly rather than through the global `tracing` subscriber: on
-/// a non-main wasm instance (e.g. the audio worklet) that subscriber is a
-/// `dyn` object whose vtable lives in the main instance's function table, so
-/// dispatching to it cross-instance would trap. `console.error` is a per-realm
-/// import that is valid in every scope, including `AudioWorkletGlobalScope`.
+/// `console` directly: the global `tracing` subscriber marks its spans through
+/// `performance`, a global the `AudioWorkletGlobalScope` of the audio render
+/// pass leaves undefined. `console.error` is a per-realm import that is valid
+/// in every scope, and [`js_string`] builds its argument the way every scope
+/// can.
 pub fn log_error(msg: &str) {
-    console::error_1(&JsValue::from_str(msg));
+    console::error_1(&js_string(msg));
+}
+
+/// Report a panic through [`log_error`], on whichever thread panicked.
+///
+/// `set_hook` writes one process-wide slot, so a binary's entry point is where
+/// this belongs. A build that lowers a panic to a trap (`-C
+/// panic=immediate-abort`, which the web artifact takes) reaches no hook at
+/// all.
+pub fn install_panic_hook() {
+    static INSTALLED: Once = Once::new();
+
+    INSTALLED.call_once(|| {
+        panic::set_hook(Box::new(|info| {
+            let payload = info
+                .payload_as_str()
+                .unwrap_or("panic payload is not a string");
+            match info.location() {
+                Some(at) => log_error(&format!("panicked at {at}: {payload}")),
+                None => log_error(&format!("panicked: {payload}")),
+            }
+        }));
+    });
 }

--- a/crates/kithara-platform/src/wasm/thread.rs
+++ b/crates/kithara-platform/src/wasm/thread.rs
@@ -169,10 +169,7 @@ where
         builder = builder.shim_name(shim.clone());
     }
     builder
-        .spawn(move || {
-            console_error_panic_hook::set_once();
-            f()
-        })
+        .spawn(f)
         .expect("BUG: WASM Worker spawn must succeed; only fails on OS resource exhaustion")
 }
 

--- a/crates/kithara-play/src/player/core.rs
+++ b/crates/kithara-play/src/player/core.rs
@@ -104,6 +104,7 @@ impl<S> PlayerRuntime<S> {
         let Some(item) = self.core.items.take_for_load(
             index,
             self.core.engine.master_sample_rate(),
+            self.core.engine.consumer_wake_mode(),
             self.core.engine.pools(),
         )?
         else {

--- a/crates/kithara-play/src/player/flow/prepare.rs
+++ b/crates/kithara-play/src/player/flow/prepare.rs
@@ -99,7 +99,6 @@ where
             bus,
             cancel,
             worker: Some(self.player.core.worker.clone()),
-            consumer_wake_mode: Some(self.player.core.engine.consumer_wake_mode()),
             block_on_underrun: self.player.core.block_on_underrun,
             audio,
             host_sample_rate,
@@ -140,8 +139,6 @@ where
 #[cfg(test)]
 mod tests {
     use kithara_assets::AssetStore;
-    use kithara_audio::ConsumerWakeMode;
-    use kithara_platform::sync::Arc;
     use kithara_test_utils::kithara;
     use kithara_warp::WarpConfig;
 
@@ -150,21 +147,8 @@ mod tests {
         PlayError, PlayWorker, PlayWorkerConfig, PlaybackResamplerBackend, mock,
         player::PlayerConfig,
         resource::ResourceSrc,
-        session::{Cmd, Reply, SessionBinding, SessionDispatcher},
         test_pools::{TestPools, pools},
     };
-
-    struct ImmediateSession(Arc<dyn SessionDispatcher<TestPools>>);
-
-    impl SessionDispatcher<TestPools> for ImmediateSession {
-        fn consumer_wake_mode(&self) -> ConsumerWakeMode {
-            ConsumerWakeMode::ImmediateOffRt
-        }
-
-        fn exec(&self, cmd: Cmd<TestPools>) -> Result<Reply, PlayError> {
-            self.0.exec(cmd)
-        }
-    }
 
     fn resource_config(source: &str) -> ResourceConfig<TestPools> {
         let pools = pools();
@@ -203,41 +187,6 @@ mod tests {
         )
     }
 
-    #[kithara::test]
-    fn prepare_config_propagates_session_consumer_wake_mode_to_audio() {
-        let session = SessionBinding::new(
-            Arc::new(ImmediateSession(mock::session().dispatcher())),
-            mock::SAMPLE_RATE,
-        );
-        let player = PlayerImpl::new(
-            PlayerConfig::builder()
-                .sample_rate(mock::SAMPLE_RATE)
-                .worker(worker())
-                .session(session)
-                .build(),
-        );
-
-        let prepared = player
-            .prepare_config(resource_config("https://example.com/song.mp3"))
-            .expect("test session answers stream-shape queries");
-        assert_eq!(
-            prepared.consumer_wake_mode,
-            Some(ConsumerWakeMode::ImmediateOffRt)
-        );
-        assert!(prepared.decoder.resampler().is_none());
-        let audio = prepared.build_file_config(player.worker(), None);
-        assert_eq!(audio.consumer_wake_mode(), ConsumerWakeMode::ImmediateOffRt);
-
-        let prepared = player
-            .prepare_config(resource_config("https://example.com/live.m3u8"))
-            .expect("test session answers stream-shape queries");
-        let audio = prepared
-            .build_hls_config(player.worker(), None)
-            .expect("valid HLS config");
-        assert_eq!(audio.consumer_wake_mode(), ConsumerWakeMode::ImmediateOffRt);
-    }
-
-    #[kithara::test]
     #[kithara::test]
     fn prepare_config_sizes_default_resampling_work_to_the_output_block() {
         let shape = StreamShape::new(

--- a/crates/kithara-play/src/player/state/items.rs
+++ b/crates/kithara-play/src/player/state/items.rs
@@ -1,5 +1,6 @@
 use std::num::NonZeroU32;
 
+use kithara_audio::ConsumerWakeMode;
 use kithara_bufpool::{HasPool, PoolError, PoolRegion};
 use kithara_events::{EventBus, TrackId};
 use kithara_platform::sync::{Arc, Mutex};
@@ -91,6 +92,7 @@ impl ItemQueue {
         &self,
         index: usize,
         host_sample_rate: u32,
+        consumer_wake_mode: ConsumerWakeMode,
         pools: &PoolRegion<S>,
     ) -> Result<Option<TakenItem>, PoolError>
     where
@@ -104,7 +106,7 @@ impl ItemQueue {
         let Some(queued) = playlist.take(index) else {
             return Ok(None);
         };
-        let (item_id, resource) = (queued.item_id, queued.resource);
+        let (item_id, mut resource) = (queued.item_id, queued.resource);
         let duration_seconds = resource
             .duration()
             .map_or(0.0, |duration| duration.as_secs_f64());
@@ -112,6 +114,7 @@ impl ItemQueue {
         if let Some(sample_rate) = NonZeroU32::new(host_sample_rate) {
             resource.set_host_sample_rate(sample_rate);
         }
+        resource.set_consumer_wake_mode(consumer_wake_mode);
         let src = Arc::clone(resource.src());
         let player_resource = PlayerResource::new(resource, Arc::clone(&src), pools)?;
         drop(playlist);

--- a/crates/kithara-play/src/resource/build.rs
+++ b/crates/kithara-play/src/resource/build.rs
@@ -77,10 +77,7 @@ where
             .maybe_cancel(self.cancel.clone())
             .maybe_hint(extension)
             .maybe_observer(observer)
-            .consumer_wake_mode(
-                self.consumer_wake_mode
-                    .unwrap_or(ConsumerWakeMode::ImmediateOffRt),
-            )
+            .consumer_wake_mode(ConsumerWakeMode::ImmediateOffRt)
             .block_on_underrun(self.block_on_underrun)
             .maybe_host_sample_rate(self.host_sample_rate)
             .decoder(self.decoder)
@@ -121,10 +118,7 @@ where
             .maybe_cancel(self.cancel.clone())
             .maybe_hint(self.hint)
             .maybe_observer(observer)
-            .consumer_wake_mode(
-                self.consumer_wake_mode
-                    .unwrap_or(ConsumerWakeMode::ImmediateOffRt),
-            )
+            .consumer_wake_mode(ConsumerWakeMode::ImmediateOffRt)
             .block_on_underrun(self.block_on_underrun)
             .maybe_host_sample_rate(self.host_sample_rate)
             .decoder(self.decoder)

--- a/crates/kithara-play/src/resource/config.rs
+++ b/crates/kithara-play/src/resource/config.rs
@@ -3,7 +3,7 @@ use std::num::NonZeroU32;
 use bon::Builder;
 use kithara_abr::AbrMode;
 use kithara_assets::AssetStore;
-use kithara_audio::{AudioConfigPatch, AudioDecoderConfig, ConsumerWakeMode};
+use kithara_audio::{AudioConfigPatch, AudioDecoderConfig};
 use kithara_bufpool::HasPool;
 use kithara_events::EventBus;
 use kithara_file::FileConfigPatch;
@@ -76,11 +76,6 @@ where
     /// children via [`CancelToken::child`]. `None` lets each subsystem own a
     /// standalone scope (see [`CancelScope::new`](kithara_platform::CancelScope)).
     pub(crate) cancel: Option<CancelToken>,
-    /// Session-owned audio-consumer wake capability. Player preparation fills
-    /// this field; `None` identifies a direct resource consumed off RT. Not a
-    /// document key: the session owns it.
-    #[builder(skip)]
-    pub(crate) consumer_wake_mode: Option<ConsumerWakeMode>,
     /// Optional cache discriminator mixed into the asset root.
     pub(crate) discriminator: Option<String>,
     /// Shared downloader instance.
@@ -138,7 +133,6 @@ where
             hls: self.hls.clone(),
             file: self.file.clone(),
             audio: self.audio.clone(),
-            consumer_wake_mode: self.consumer_wake_mode,
             block_on_underrun: self.block_on_underrun,
             host_sample_rate: self.host_sample_rate,
             preferred_peak_bitrate: self.preferred_peak_bitrate,
@@ -192,12 +186,6 @@ mod tests {
         Ok(ResourceConfig::for_src(ResourceSrc::parse(input)?)
             .store(store())
             .build())
-    }
-
-    #[kithara::test]
-    fn direct_config_has_no_session_wake_policy() {
-        let config = test_config("https://example.com/track.mp3").expect("valid config");
-        assert_eq!(config.consumer_wake_mode, None);
     }
 
     fn worker() -> PlayWorker<TestPools> {
@@ -447,10 +435,6 @@ mod tests {
         let config = test_config("https://example.com/song.mp3").expect("valid config");
 
         assert!((config.preferred_peak_bitrate - 0.0).abs() < f64::EPSILON);
-        assert_eq!(
-            config.consumer_wake_mode, None,
-            "a direct resource carries no session wake policy"
-        );
         assert!(!config.block_on_underrun);
         assert!(config.host_sample_rate.is_none());
         assert!(

--- a/crates/kithara-play/src/resource/reader.rs
+++ b/crates/kithara-play/src/resource/reader.rs
@@ -2,7 +2,8 @@ use std::num::NonZeroU32;
 
 use delegate::delegate;
 use kithara_audio::{
-    AudioObserver, AudioReader, ChunkOutcome, ReadOutcome, ResamplerBackend, SeekOutcome,
+    AudioObserver, AudioReader, ChunkOutcome, ConsumerWakeMode, ReadOutcome, ResamplerBackend,
+    SeekOutcome,
 };
 use kithara_bufpool::HasPool;
 use kithara_decode::{DecodeError, DecodeResult, TrackMetadata};
@@ -362,6 +363,9 @@ impl Resource {
             /// readers with no worker-backed seek.
             #[must_use]
             pub fn seek_handle(&self) -> Option<Arc<dyn kithara_audio::SeekBegin>>;
+            /// Adopt the wake capability of the consumer that will read this
+            /// resource.
+            pub fn set_consumer_wake_mode(&mut self, mode: ConsumerWakeMode);
             /// Adopt a seek epoch begun through `seek_handle`. Lock-free.
             pub fn sync_seek(&mut self);
             /// Set the target sample rate of the audio host.

--- a/crates/kithara-play/src/session/protocol.rs
+++ b/crates/kithara-play/src/session/protocol.rs
@@ -303,12 +303,6 @@ mod handle {
         pub(crate) fn requested_sample_rate(&self) -> NonZeroU32 {
             self.requested_sample_rate
         }
-
-        #[cfg(test)]
-        #[must_use]
-        pub(crate) fn dispatcher(&self) -> Arc<dyn SessionDispatcher<S>> {
-            Arc::clone(&self.dispatcher)
-        }
     }
 
     impl<S> Clone for SessionBinding<S> {

--- a/crates/kithara-play/src/worker/reader.rs
+++ b/crates/kithara-play/src/worker/reader.rs
@@ -1,8 +1,8 @@
 use std::num::NonZeroU32;
 
 use kithara_audio::{
-    Audio, AudioControl, AudioRead, AudioSession, ChunkOutcome, PreloadGate, ReadOutcome,
-    SeekBegin, SeekOutcome,
+    Audio, AudioControl, AudioRead, AudioSession, ChunkOutcome, ConsumerWakeMode, PreloadGate,
+    ReadOutcome, SeekBegin, SeekOutcome,
 };
 use kithara_decode::{DecodeError, TrackMetadata};
 use kithara_events::EventBus;
@@ -114,6 +114,7 @@ impl<T: MaybeSend, S> AudioControl for RegisteredAudio<T, S> {
         to self.warp.source_mut() {
             fn preload(&mut self) -> Result<(), DecodeError>;
             fn seek(&mut self, position: Duration) -> Result<SeekOutcome, DecodeError>;
+            fn set_consumer_wake_mode(&mut self, mode: ConsumerWakeMode);
             fn sync_seek(&mut self);
         }
         to self.warp.source() {

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -241,12 +241,15 @@ kithara = { workspace = true, default-features = false, features = [
 # fetching their bytes from the native test server.
 kithara-test-fixtures = { workspace = true }
 
-console_error_panic_hook = { workspace = true }
 gloo-timers = { workspace = true }
 
 # WASM-specific
 js-sys = { workspace = true }
 reqwest = { workspace = true }
+
+# The Web Audio backend reports its own start-up failures through `log`; without
+# the bridge a silent audio node is silent in the lane output too.
+tracing-log = { workspace = true }
 tracing-wasm = { workspace = true }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
@@ -282,6 +285,10 @@ path = "tests/suite_light.rs"
 [[test]]
 name = "suite_heavy"
 path = "tests/suite_heavy.rs"
+
+[[test]]
+name = "suite_live_web_audio"
+path = "tests/suite_live_web_audio.rs"
 
 [[test]]
 name = "suite_stress"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -100,6 +100,7 @@ cbc = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
 num-traits = { workspace = true }
+ringbuf = { workspace = true }
 rkyv = { workspace = true }
 
 # Serialization
@@ -166,7 +167,6 @@ rand = { workspace = true }
 
 # HTTP server (axum stack not available on WASM)
 reqwest = { workspace = true, features = ["rustls", "stream"] }
-ringbuf = { workspace = true }
 
 # WebDriver automation
 thirtyfour = { workspace = true }

--- a/tests/README.md
+++ b/tests/README.md
@@ -72,7 +72,13 @@ check/build/size-check only and runs no tests.
 - A `wasm32` build makes no host binary and the runner looks for `test_server`
   beside itself, so the recipe builds it first.
 - Only `suite_heavy` is built for `wasm32`, with every native module compiled
-  out — `kithara_ffi_web` is the browser-visible coverage.
+  out — `kithara_ffi_web` and `kithara_play::offline_browser` are the
+  browser-visible coverage.
+- The offline harness in `tests/src/offline` builds on both targets; only
+  `app.rs`, which needs `kithara-app`, is gated to native.
+- `OfflineWorker` owns the `OfflinePlayer`, on wasm from a Web Worker, because
+  `Platform::offline` refuses a Host on the browser main thread. Open the
+  resource inside a command, not on the driver.
 - `webcodecs` belongs to `kithara-decode`, not any integration suite, and is
   Chromium-only.
 

--- a/tests/src/audio_mock.rs
+++ b/tests/src/audio_mock.rs
@@ -16,7 +16,8 @@ use std::{
 
 use kithara::{
     audio::{
-        AudioControl, AudioRead, AudioSession, PendingReason, ReadOutcome, SeekBegin, SeekOutcome,
+        AudioControl, AudioRead, AudioSession, ConsumerWakeMode, PendingReason, ReadOutcome,
+        SeekBegin, SeekOutcome,
     },
     decode::{DecodeError, TrackMetadata},
     events::EventBus,
@@ -247,8 +248,10 @@ pub struct MockReader {
 }
 
 enum MockBehavior {
-    SampleRateTracking {
+    /// Records the session-owned capabilities an owner applies to the reader.
+    AdoptionTracking {
         recorded_host_rate: Arc<AtomicU32>,
+        recorded_wake_mode: Arc<Mutex<Option<ConsumerWakeMode>>>,
         duration: Duration,
     },
     SeekTracking {
@@ -264,6 +267,14 @@ enum MockBehavior {
     },
     Faulty(Fault),
     SeekSplit(SeekSplitCounts),
+}
+
+fn adoption_tracking(recorded_host_rate: Arc<AtomicU32>, duration: Duration) -> MockBehavior {
+    MockBehavior::AdoptionTracking {
+        recorded_host_rate,
+        recorded_wake_mode: Arc::new(Mutex::new(None)),
+        duration,
+    }
 }
 
 impl MockReader {
@@ -287,14 +298,23 @@ impl MockReader {
         duration: Duration,
     ) -> (Self, Arc<AtomicU32>) {
         let recorded = Arc::new(AtomicU32::new(0));
-        let reader = Self::with_behavior(
-            spec,
-            MockBehavior::SampleRateTracking {
-                recorded_host_rate: Arc::clone(&recorded),
-                duration,
-            },
-        );
+        let reader = Self::with_behavior(spec, adoption_tracking(Arc::clone(&recorded), duration));
         (reader, recorded)
+    }
+
+    /// Reader recording the consumer wake mode its owner applies to it.
+    #[must_use]
+    pub fn wake_mode_tracking(spec: AudioSpec) -> (Self, Arc<Mutex<Option<ConsumerWakeMode>>>) {
+        let behavior = adoption_tracking(Arc::new(AtomicU32::new(0)), Duration::from_secs(60));
+        let MockBehavior::AdoptionTracking {
+            ref recorded_wake_mode,
+            ..
+        } = behavior
+        else {
+            unreachable!("adoption tracking builds one variant")
+        };
+        let recorded = Arc::clone(recorded_wake_mode);
+        (Self::with_behavior(spec, behavior), recorded)
     }
 
     #[must_use]
@@ -347,7 +367,7 @@ impl MockReader {
                 source: std::io::Error::other("mock decode failure"),
             }),
             MockBehavior::Faulty(Fault::Stall | Fault::RefuseSeek)
-            | MockBehavior::SampleRateTracking { .. }
+            | MockBehavior::AdoptionTracking { .. }
             | MockBehavior::SeekTracking { .. }
             | MockBehavior::SeekSplit(_) => Ok(ReadOutcome::Pending {
                 position: Duration::ZERO,
@@ -366,7 +386,7 @@ impl MockReader {
 impl AudioSession for MockReader {
     fn duration(&self) -> Option<Duration> {
         match &self.behavior {
-            MockBehavior::SampleRateTracking { duration, .. } => Some(*duration),
+            MockBehavior::AdoptionTracking { duration, .. } => Some(*duration),
             MockBehavior::SeekTracking { .. } => None,
             MockBehavior::MisreportedDuration { .. } => Some(Duration::from_secs(10)),
             MockBehavior::LiveFrontier { .. } => Some(Duration::from_secs(180)),
@@ -501,8 +521,19 @@ impl AudioControl for MockReader {
         })
     }
 
+    fn set_consumer_wake_mode(&mut self, mode: ConsumerWakeMode) {
+        if let MockBehavior::AdoptionTracking {
+            recorded_wake_mode, ..
+        } = &self.behavior
+        {
+            *recorded_wake_mode
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(mode);
+        }
+    }
+
     fn set_host_sample_rate(&self, sample_rate: NonZeroU32) {
-        if let MockBehavior::SampleRateTracking {
+        if let MockBehavior::AdoptionTracking {
             recorded_host_rate, ..
         } = &self.behavior
         {

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -52,7 +52,6 @@ pub mod memory_source;
 mod native;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod net_fixture;
-#[cfg(not(target_arch = "wasm32"))]
 pub mod offline;
 pub mod packed_audio;
 pub mod reads;

--- a/tests/src/offline/host.rs
+++ b/tests/src/offline/host.rs
@@ -20,25 +20,12 @@ use kithara::{
     queue::Queue,
     signal::AudioSpec,
 };
-#[cfg(not(target_arch = "wasm32"))]
-use kithara::{
-    platform::{
-        sync::mpsc::{self, RecvTimeoutError},
-        thread::{JoinHandle, spawn_named},
-        time::Instant,
-        tokio::{runtime::Handle, task::spawn_blocking},
-    },
-    queue::QueueControl,
-};
-#[cfg(not(target_arch = "wasm32"))]
-use kithara_test_utils::off_thread::OffThread as HostOwner;
 use ringbuf::{
     HeapCons, HeapRb,
     traits::{Consumer, Observer, Split},
 };
 
-#[cfg(target_arch = "wasm32")]
-use self::inline::InlineOwner as HostOwner;
+use super::owner::HostOwner;
 
 const CHANNELS: u16 = 2;
 const ENDPOINT_SLACK_SECS: f64 = 0.5;
@@ -128,78 +115,6 @@ where
 }
 
 pub type OfflineQueue<S> = OfflineResident<Queue<S>, S>;
-
-#[cfg(not(target_arch = "wasm32"))]
-/// Drives `QueueControl::tick` from a dedicated thread, the way the FFI
-/// bridge and the app update loop do, until the queue closes or `stop`.
-pub struct QueueTicker {
-    stop: Option<mpsc::Sender<()>>,
-    thread: Option<JoinHandle<()>>,
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-impl QueueTicker {
-    /// Spawns the ticker; the thread enters the caller's runtime like the
-    /// product app thread, so a tick may spawn loads.
-    pub fn spawn<S>(queue: QueueControl<S>, interval: Duration) -> Self
-    where
-        S: HasPool<u8> + HasPool<f32> + Send + Sync + 'static,
-    {
-        let (stop, stop_receiver) = mpsc::channel::<()>();
-        let runtime = Handle::current();
-        let thread = spawn_named("queue-ticks", move || {
-            let _runtime = runtime.enter();
-            while let Err(RecvTimeoutError::Timeout) =
-                stop_receiver.recv_timeout(Instant::now() + interval)
-            {
-                if queue.tick().is_err() {
-                    break;
-                }
-            }
-        });
-        Self {
-            stop: Some(stop),
-            thread: Some(thread),
-        }
-    }
-
-    /// Whether the thread exited: the queue closed or a tick panicked.
-    pub fn is_finished(&self) -> bool {
-        self.thread.as_ref().is_some_and(JoinHandle::is_finished)
-    }
-
-    /// Stops ticking and joins the thread; `Err` is the message of a tick panic.
-    pub async fn join(&mut self) -> Result<(), String> {
-        drop(self.stop.take());
-        let Some(thread) = self.thread.take() else {
-            return Ok(());
-        };
-        spawn_blocking(move || thread.join())
-            .await
-            .expect("join the queue ticker")
-            .map_err(|payload| {
-                payload
-                    .downcast_ref::<String>()
-                    .cloned()
-                    .or_else(|| payload.downcast_ref::<&str>().map(|s| (*s).to_owned()))
-                    .unwrap_or_else(|| "non-string panic payload".to_owned())
-            })
-    }
-
-    /// Stops ticking and waits for the thread; a tick panic fails the caller.
-    pub async fn stop(&mut self) {
-        if let Err(panic) = self.join().await {
-            panic!("queue ticker panicked: {panic}");
-        }
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-impl Drop for QueueTicker {
-    fn drop(&mut self) {
-        drop(self.stop.take());
-    }
-}
 
 impl<S> OfflineHostHarness<S>
 where
@@ -417,31 +332,4 @@ pub fn offline_gain_window(
     let rate =
         (f64::from(block_frames.get()) / f64::from(sample_rate.get())) / pacing.as_secs_f64();
     GAIN_FLOOR_SECS..=(rate * (window_secs + ENDPOINT_SLACK_SECS))
-}
-
-/// Owner of a Host on the calling thread, for the wasm harness whose caller is
-/// already the worker the Host belongs to.
-#[cfg(target_arch = "wasm32")]
-mod inline {
-    use kithara::platform::sync::Mutex;
-
-    pub(super) struct InlineOwner<T>(Mutex<T>);
-
-    impl<T: 'static> InlineOwner<T> {
-        pub(super) async fn spawn<E, I>(_name: &'static str, init: I) -> Result<Self, E>
-        where
-            I: FnOnce() -> Result<T, E>,
-        {
-            init().map(|value| Self(Mutex::new(value)))
-        }
-
-        pub(super) async fn call<R, F>(&self, job: F) -> R
-        where
-            F: FnOnce(&mut T) -> R,
-        {
-            job(&mut self.0.lock())
-        }
-
-        pub(super) async fn close(self) {}
-    }
 }

--- a/tests/src/offline/host.rs
+++ b/tests/src/offline/host.rs
@@ -9,24 +9,36 @@ use kithara::{
     output::{OfflineRenderRequest, OfflineRenderer, OutputGroup, RenderSink, RenderSinkError},
     platform::{
         CancelScope,
+        maybe_send::MaybeSend,
         sync::{
             Arc,
             atomic::{AtomicU64, Ordering},
-            mpsc::{self, RecvTimeoutError},
         },
-        thread::{JoinHandle, spawn_named},
-        time::{Duration, Instant},
-        tokio::{runtime::Handle, task::spawn_blocking},
+        time::Duration,
     },
     play::{MixTapWriter, PlayError, TransportRevision, player::PlayerControlSource},
-    queue::{Queue, QueueControl},
+    queue::Queue,
     signal::AudioSpec,
 };
-use kithara_test_utils::off_thread::OffThread;
+#[cfg(not(target_arch = "wasm32"))]
+use kithara::{
+    platform::{
+        sync::mpsc::{self, RecvTimeoutError},
+        thread::{JoinHandle, spawn_named},
+        time::Instant,
+        tokio::{runtime::Handle, task::spawn_blocking},
+    },
+    queue::QueueControl,
+};
+#[cfg(not(target_arch = "wasm32"))]
+use kithara_test_utils::off_thread::OffThread as HostOwner;
 use ringbuf::{
     HeapCons, HeapRb,
     traits::{Consumer, Observer, Split},
 };
+
+#[cfg(target_arch = "wasm32")]
+use self::inline::InlineOwner as HostOwner;
 
 const CHANNELS: u16 = 2;
 const ENDPOINT_SLACK_SECS: f64 = 0.5;
@@ -46,7 +58,7 @@ struct HostState<S> {
 
 /// Test owner for the product offline Host and its monotonic render cursor.
 pub struct OfflineHostHarness<S> {
-    off: OffThread<HostState<S>>,
+    off: HostOwner<HostState<S>>,
     position: Arc<AtomicU64>,
     spec: AudioSpec,
     max_block_frames: NonZeroU32,
@@ -64,8 +76,8 @@ where
 
 impl<P, S> OfflineResident<P, S>
 where
-    P: PlayerControlSource<Schema = S> + Send + 'static,
-    P::Control: Send,
+    P: PlayerControlSource<Schema = S> + MaybeSend + 'static,
+    P::Control: MaybeSend,
     S: HasPool<f32> + Send + Sync + 'static,
 {
     pub async fn new(config: HostConfig<S>, player: P) -> Result<Self, PlayError> {
@@ -83,10 +95,10 @@ where
     }
 
     /// Issues a control call from the host owner thread, as the app would.
-    pub async fn run<R>(&self, f: impl FnOnce(&P::Control) -> R + Send + 'static) -> R
+    pub async fn run<R>(&self, f: impl FnOnce(&P::Control) -> R + MaybeSend + 'static) -> R
     where
-        P::Control: Clone + Send + 'static,
-        R: Send + 'static,
+        P::Control: Clone + MaybeSend + 'static,
+        R: MaybeSend + 'static,
     {
         let control = self.control();
         self.host.run(move || f(&control)).await
@@ -117,6 +129,7 @@ where
 
 pub type OfflineQueue<S> = OfflineResident<Queue<S>, S>;
 
+#[cfg(not(target_arch = "wasm32"))]
 /// Drives `QueueControl::tick` from a dedicated thread, the way the FFI
 /// bridge and the app update loop do, until the queue closes or `stop`.
 pub struct QueueTicker {
@@ -124,6 +137,7 @@ pub struct QueueTicker {
     thread: Option<JoinHandle<()>>,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl QueueTicker {
     /// Spawns the ticker; the thread enters the caller's runtime like the
     /// product app thread, so a tick may spawn loads.
@@ -180,6 +194,7 @@ impl QueueTicker {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl Drop for QueueTicker {
     fn drop(&mut self) {
         drop(self.stop.take());
@@ -199,7 +214,7 @@ where
         let pacing = config.pacing();
         let position = Arc::new(AtomicU64::new(0));
         let owned = Arc::clone(&position);
-        let off = OffThread::spawn("offline-host", move || {
+        let off = HostOwner::spawn("offline-host", move || {
             Host::new(config).map(|host| HostState {
                 host,
                 position: owned,
@@ -221,18 +236,18 @@ where
     }
 
     /// Runs an arbitrary Host operation on the owner thread.
-    pub async fn with<R>(&self, f: impl FnOnce(&mut Host<S>) -> R + Send + 'static) -> R
+    pub async fn with<R>(&self, f: impl FnOnce(&mut Host<S>) -> R + MaybeSend + 'static) -> R
     where
-        R: Send + 'static,
+        R: MaybeSend + 'static,
     {
         self.off.call(move |state| f(&mut state.host)).await
     }
 
     /// Runs a control call on the owner thread, the way product callers issue
     /// it from the app thread rather than from a runtime worker.
-    pub async fn run<R>(&self, f: impl FnOnce() -> R + Send + 'static) -> R
+    pub async fn run<R>(&self, f: impl FnOnce() -> R + MaybeSend + 'static) -> R
     where
-        R: Send + 'static,
+        R: MaybeSend + 'static,
     {
         self.off.call(move |_| f()).await
     }
@@ -240,16 +255,16 @@ where
     /// Transfer one configured player facade into the product Host.
     pub async fn insert<P>(&self, player: P) -> Result<HostOwned<P>, PlayError>
     where
-        P: PlayerControlSource<Schema = S> + Send + 'static,
-        P::Control: Send,
+        P: PlayerControlSource<Schema = S> + MaybeSend + 'static,
+        P::Control: MaybeSend,
     {
         self.off.call(move |state| state.host.insert(player)).await
     }
 
     pub async fn insert_control<P>(&self, player: P) -> Result<P::Control, PlayError>
     where
-        P: PlayerControlSource<Schema = S> + Send + 'static,
-        P::Control: Send,
+        P: PlayerControlSource<Schema = S> + MaybeSend + 'static,
+        P::Control: MaybeSend,
     {
         self.insert(player)
             .await
@@ -402,4 +417,31 @@ pub fn offline_gain_window(
     let rate =
         (f64::from(block_frames.get()) / f64::from(sample_rate.get())) / pacing.as_secs_f64();
     GAIN_FLOOR_SECS..=(rate * (window_secs + ENDPOINT_SLACK_SECS))
+}
+
+/// Owner of a Host on the calling thread, for the wasm harness whose caller is
+/// already the worker the Host belongs to.
+#[cfg(target_arch = "wasm32")]
+mod inline {
+    use kithara::platform::sync::Mutex;
+
+    pub(super) struct InlineOwner<T>(Mutex<T>);
+
+    impl<T: 'static> InlineOwner<T> {
+        pub(super) async fn spawn<E, I>(_name: &'static str, init: I) -> Result<Self, E>
+        where
+            I: FnOnce() -> Result<T, E>,
+        {
+            init().map(|value| Self(Mutex::new(value)))
+        }
+
+        pub(super) async fn call<R, F>(&self, job: F) -> R
+        where
+            F: FnOnce(&mut T) -> R,
+        {
+            job(&mut self.0.lock())
+        }
+
+        pub(super) async fn close(self) {}
+    }
 }

--- a/tests/src/offline/mod.rs
+++ b/tests/src/offline/mod.rs
@@ -1,14 +1,20 @@
+#[cfg(not(target_arch = "wasm32"))]
 mod app;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod harness;
 pub mod host;
 pub mod player;
 mod window;
+mod worker;
 
+#[cfg(not(target_arch = "wasm32"))]
 pub use app::{AppQueueFixture, LazyAppQueueFixture, app_queue, insecure_app_queue};
+#[cfg(not(target_arch = "wasm32"))]
 pub use harness::{OfflinePlayerHarness, OfflinePlayerOptions, offline_queue_fixture};
+#[cfg(not(target_arch = "wasm32"))]
+pub use host::QueueTicker;
 pub use host::{
-    MixTapProbe, OfflineHostHarness, OfflineQueue, OfflineResident, QueueTicker,
-    offline_gain_window,
+    MixTapProbe, OfflineHostHarness, OfflineQueue, OfflineResident, offline_gain_window,
 };
 pub use player::{
     NotificationKind, OfflinePlayer, resource_from_reader, resource_from_reader_with_src,
@@ -16,3 +22,4 @@ pub use player::{
 pub use window::{
     TimedPlayerEvent, WindowStats, deinterleave_left, max_silence_run, mean_abs, peak, rms,
 };
+pub use worker::OfflineWorker;

--- a/tests/src/offline/mod.rs
+++ b/tests/src/offline/mod.rs
@@ -3,7 +3,10 @@ mod app;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod harness;
 pub mod host;
+mod owner;
 pub mod player;
+#[cfg(not(target_arch = "wasm32"))]
+mod ticker;
 mod window;
 mod worker;
 
@@ -11,14 +14,14 @@ mod worker;
 pub use app::{AppQueueFixture, LazyAppQueueFixture, app_queue, insecure_app_queue};
 #[cfg(not(target_arch = "wasm32"))]
 pub use harness::{OfflinePlayerHarness, OfflinePlayerOptions, offline_queue_fixture};
-#[cfg(not(target_arch = "wasm32"))]
-pub use host::QueueTicker;
 pub use host::{
     MixTapProbe, OfflineHostHarness, OfflineQueue, OfflineResident, offline_gain_window,
 };
 pub use player::{
     NotificationKind, OfflinePlayer, resource_from_reader, resource_from_reader_with_src,
 };
+#[cfg(not(target_arch = "wasm32"))]
+pub use ticker::QueueTicker;
 pub use window::{
     TimedPlayerEvent, WindowStats, deinterleave_left, max_silence_run, mean_abs, peak, rms,
 };

--- a/tests/src/offline/owner.rs
+++ b/tests/src/offline/owner.rs
@@ -1,0 +1,33 @@
+//! Owner of a Host for the offline harness: a dedicated thread natively, the
+//! calling thread on wasm, where the caller is already the worker the Host
+//! belongs to.
+
+#[cfg(target_arch = "wasm32")]
+pub(super) use inline::InlineOwner as HostOwner;
+#[cfg(not(target_arch = "wasm32"))]
+pub(super) use kithara_test_utils::off_thread::OffThread as HostOwner;
+
+#[cfg(target_arch = "wasm32")]
+mod inline {
+    use kithara::platform::sync::Mutex;
+
+    pub(in crate::offline) struct InlineOwner<T>(Mutex<T>);
+
+    impl<T: 'static> InlineOwner<T> {
+        pub(in crate::offline) async fn spawn<E, I>(_name: &'static str, init: I) -> Result<Self, E>
+        where
+            I: FnOnce() -> Result<T, E>,
+        {
+            init().map(|value| Self(Mutex::new(value)))
+        }
+
+        pub(in crate::offline) async fn call<R, F>(&self, job: F) -> R
+        where
+            F: FnOnce(&mut T) -> R,
+        {
+            job(&mut self.0.lock())
+        }
+
+        pub(in crate::offline) async fn close(self) {}
+    }
+}

--- a/tests/src/offline/player.rs
+++ b/tests/src/offline/player.rs
@@ -9,13 +9,14 @@ use kithara::{
     },
 };
 
-use super::{OfflineResident, host::offline_pools};
+use super::{OfflineHostHarness, OfflineResident, host::offline_pools};
 use crate::bufpool_ext::TestPools;
 
 /// Product Player and Host wired for deterministic finite rendering.
 pub struct OfflinePlayer {
     events: EventReceiver,
     player: OfflineResident<PlayerImpl<TestPools>, TestPools>,
+    worker: PlayWorker<TestPools>,
 }
 
 impl OfflinePlayer {
@@ -32,18 +33,34 @@ impl OfflinePlayer {
         let player = PlayerImpl::new(
             PlayerConfig::builder()
                 .sample_rate(sample_rate)
-                .worker(worker)
+                .worker(worker.clone())
                 .build(),
         );
         let events = player.subscribe();
         let player = OfflineResident::new(session, player)
             .await
             .unwrap_or_else(|error| panic!("create product offline player: {error}"));
-        Self { events, player }
+        Self {
+            events,
+            player,
+            worker,
+        }
     }
 
     fn control(&self) -> PlayerControl<TestPools> {
         self.player.control()
+    }
+
+    /// Offline Host owning this player, for probes the Host installs.
+    #[must_use]
+    pub const fn host(&self) -> &OfflineHostHarness<TestPools> {
+        self.player.host()
+    }
+
+    /// Decode worker this player pulls from, for opening resources beside it.
+    #[must_use]
+    pub const fn worker(&self) -> &PlayWorker<TestPools> {
+        &self.worker
     }
 
     /// Load one resource and start playback.
@@ -119,8 +136,13 @@ impl OfflinePlayer {
     }
 
     pub async fn close(self) {
-        let Self { events, player } = self;
+        let Self {
+            events,
+            player,
+            worker,
+        } = self;
         drop(events);
+        drop(worker);
         player.close().await;
     }
 }

--- a/tests/src/offline/ticker.rs
+++ b/tests/src/offline/ticker.rs
@@ -1,0 +1,79 @@
+use kithara::{
+    bufpool::HasPool,
+    platform::{
+        sync::mpsc::{self, RecvTimeoutError},
+        thread::{JoinHandle, spawn_named},
+        time::{Duration, Instant},
+        tokio::{runtime::Handle, task::spawn_blocking},
+    },
+    queue::QueueControl,
+};
+
+/// Drives `QueueControl::tick` from a dedicated thread, the way the FFI
+/// bridge and the app update loop do, until the queue closes or `stop`.
+pub struct QueueTicker {
+    stop: Option<mpsc::Sender<()>>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl QueueTicker {
+    /// Spawns the ticker; the thread enters the caller's runtime like the
+    /// product app thread, so a tick may spawn loads.
+    pub fn spawn<S>(queue: QueueControl<S>, interval: Duration) -> Self
+    where
+        S: HasPool<u8> + HasPool<f32> + Send + Sync + 'static,
+    {
+        let (stop, stop_receiver) = mpsc::channel::<()>();
+        let runtime = Handle::current();
+        let thread = spawn_named("queue-ticks", move || {
+            let _runtime = runtime.enter();
+            while let Err(RecvTimeoutError::Timeout) =
+                stop_receiver.recv_timeout(Instant::now() + interval)
+            {
+                if queue.tick().is_err() {
+                    break;
+                }
+            }
+        });
+        Self {
+            stop: Some(stop),
+            thread: Some(thread),
+        }
+    }
+
+    /// Whether the thread exited: the queue closed or a tick panicked.
+    pub fn is_finished(&self) -> bool {
+        self.thread.as_ref().is_some_and(JoinHandle::is_finished)
+    }
+
+    /// Stops ticking and joins the thread; `Err` is the message of a tick panic.
+    pub async fn join(&mut self) -> Result<(), String> {
+        drop(self.stop.take());
+        let Some(thread) = self.thread.take() else {
+            return Ok(());
+        };
+        spawn_blocking(move || thread.join())
+            .await
+            .expect("join the queue ticker")
+            .map_err(|payload| {
+                payload
+                    .downcast_ref::<String>()
+                    .cloned()
+                    .or_else(|| payload.downcast_ref::<&str>().map(|s| (*s).to_owned()))
+                    .unwrap_or_else(|| "non-string panic payload".to_owned())
+            })
+    }
+
+    /// Stops ticking and waits for the thread; a tick panic fails the caller.
+    pub async fn stop(&mut self) {
+        if let Err(panic) = self.join().await {
+            panic!("queue ticker panicked: {panic}");
+        }
+    }
+}
+
+impl Drop for QueueTicker {
+    fn drop(&mut self) {
+        drop(self.stop.take());
+    }
+}

--- a/tests/src/offline/worker.rs
+++ b/tests/src/offline/worker.rs
@@ -1,0 +1,95 @@
+#[cfg(target_arch = "wasm32")]
+use futures::future::LocalBoxFuture;
+#[cfg(not(target_arch = "wasm32"))]
+use kithara::platform::sync::Mutex;
+#[cfg(target_arch = "wasm32")]
+use kithara::platform::{
+    sync::mpsc::{Sender, channel},
+    thread::{keep_worker_alive, spawn_named},
+    tokio::task,
+};
+
+use super::OfflinePlayer;
+
+/// Owner of the offline player on the thread the product allows it on: the
+/// caller's on native, a Web Worker on wasm.
+pub struct OfflineWorker {
+    #[cfg(not(target_arch = "wasm32"))]
+    player: Mutex<OfflinePlayer>,
+    #[cfg(target_arch = "wasm32")]
+    commands: Sender<Command>,
+}
+
+/// One operation applied to the offline player wherever it lives. The future
+/// runs on the thread that made it, so it is not `Send`.
+#[cfg(target_arch = "wasm32")]
+type Command = Box<dyn for<'a> FnOnce(&'a mut OfflinePlayer) -> LocalBoxFuture<'a, ()> + Send>;
+
+#[cfg(not(target_arch = "wasm32"))]
+impl OfflineWorker {
+    /// Build the offline player on the calling thread.
+    pub async fn new<F>(build: F) -> Self
+    where
+        F: AsyncFnOnce() -> OfflinePlayer + Send + 'static,
+    {
+        Self {
+            player: Mutex::new(build().await),
+        }
+    }
+
+    /// Apply one operation to the offline player and return its result.
+    pub async fn call<F, R>(&self, f: F) -> R
+    where
+        F: AsyncFnOnce(&mut OfflinePlayer) -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        f(&mut self.player.lock()).await
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl OfflineWorker {
+    /// Build the offline player on a Web Worker that then serves commands until
+    /// this owner drops.
+    pub async fn new<F>(build: F) -> Self
+    where
+        F: AsyncFnOnce() -> OfflinePlayer + Send + 'static,
+    {
+        let (commands, rx) = channel::<Command>();
+        spawn_named("offline-harness", move || {
+            keep_worker_alive();
+            task::spawn(async move {
+                let mut player = build().await;
+                while let Ok(command) = rx.recv_async().await {
+                    command(&mut player).await;
+                }
+            });
+        });
+        Self { commands }
+    }
+
+    /// Apply one operation to the offline player and return its result,
+    /// leaving the browser's event loop free while the Worker runs it.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the harness Worker is gone.
+    pub async fn call<F, R>(&self, f: F) -> R
+    where
+        F: AsyncFnOnce(&mut OfflinePlayer) -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        let (reply_tx, reply_rx) = channel::<R>();
+        self.commands
+            .send(Box::new(move |player| {
+                Box::pin(async move {
+                    let _ = reply_tx.send(f(player).await);
+                })
+            }))
+            .unwrap_or_else(|_| panic!("offline harness Worker is gone"));
+        reply_rx
+            .recv_async()
+            .await
+            .unwrap_or_else(|error| panic!("offline harness Worker is gone: {error}"))
+    }
+}

--- a/tests/src/offline/worker/mod.rs
+++ b/tests/src/offline/worker/mod.rs
@@ -1,0 +1,9 @@
+#[cfg(not(target_arch = "wasm32"))]
+mod native;
+#[cfg(target_arch = "wasm32")]
+mod wasm;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use native::OfflineWorker;
+#[cfg(target_arch = "wasm32")]
+pub use wasm::OfflineWorker;

--- a/tests/src/offline/worker/native.rs
+++ b/tests/src/offline/worker/native.rs
@@ -1,0 +1,30 @@
+use kithara::platform::sync::Mutex;
+
+use crate::offline::OfflinePlayer;
+
+/// Owner of the offline player on the thread the product allows it on: the
+/// caller's.
+pub struct OfflineWorker {
+    player: Mutex<OfflinePlayer>,
+}
+
+impl OfflineWorker {
+    /// Build the offline player on the calling thread.
+    pub async fn new<F>(build: F) -> Self
+    where
+        F: AsyncFnOnce() -> OfflinePlayer + Send + 'static,
+    {
+        Self {
+            player: Mutex::new(build().await),
+        }
+    }
+
+    /// Apply one operation to the offline player and return its result.
+    pub async fn call<F, R>(&self, f: F) -> R
+    where
+        F: AsyncFnOnce(&mut OfflinePlayer) -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        f(&mut self.player.lock()).await
+    }
+}

--- a/tests/src/offline/worker/wasm.rs
+++ b/tests/src/offline/worker/wasm.rs
@@ -1,53 +1,22 @@
-#[cfg(target_arch = "wasm32")]
 use futures::future::LocalBoxFuture;
-#[cfg(not(target_arch = "wasm32"))]
-use kithara::platform::sync::Mutex;
-#[cfg(target_arch = "wasm32")]
 use kithara::platform::{
     sync::mpsc::{Sender, channel},
     thread::{keep_worker_alive, spawn_named},
     tokio::task,
 };
 
-use super::OfflinePlayer;
+use crate::offline::OfflinePlayer;
 
-/// Owner of the offline player on the thread the product allows it on: the
-/// caller's on native, a Web Worker on wasm.
+/// Owner of the offline player on the thread the product allows it on: a Web
+/// Worker.
 pub struct OfflineWorker {
-    #[cfg(not(target_arch = "wasm32"))]
-    player: Mutex<OfflinePlayer>,
-    #[cfg(target_arch = "wasm32")]
     commands: Sender<Command>,
 }
 
 /// One operation applied to the offline player wherever it lives. The future
 /// runs on the thread that made it, so it is not `Send`.
-#[cfg(target_arch = "wasm32")]
 type Command = Box<dyn for<'a> FnOnce(&'a mut OfflinePlayer) -> LocalBoxFuture<'a, ()> + Send>;
 
-#[cfg(not(target_arch = "wasm32"))]
-impl OfflineWorker {
-    /// Build the offline player on the calling thread.
-    pub async fn new<F>(build: F) -> Self
-    where
-        F: AsyncFnOnce() -> OfflinePlayer + Send + 'static,
-    {
-        Self {
-            player: Mutex::new(build().await),
-        }
-    }
-
-    /// Apply one operation to the offline player and return its result.
-    pub async fn call<F, R>(&self, f: F) -> R
-    where
-        F: AsyncFnOnce(&mut OfflinePlayer) -> R + Send + 'static,
-        R: Send + 'static,
-    {
-        f(&mut self.player.lock()).await
-    }
-}
-
-#[cfg(target_arch = "wasm32")]
 impl OfflineWorker {
     /// Build the offline player on a Web Worker that then serves commands until
     /// this owner drops.

--- a/tests/tests/kithara_ffi_web/stress.rs
+++ b/tests/tests/kithara_ffi_web/stress.rs
@@ -44,7 +44,7 @@ impl Xorshift64 {
 }
 
 async fn create_stress_source(jitter: bool) -> (TestServerHelper, Url) {
-    console_error_panic_hook::set_once();
+    kithara::platform::logging::install_panic_hook();
     let _ = tracing_wasm::try_set_as_global_default();
     let helper = TestServerHelper::new().await;
     let bytes_per_second = 44_100.0 * 2.0 * 2.0;

--- a/tests/tests/kithara_play/offline_browser.rs
+++ b/tests/tests/kithara_play/offline_browser.rs
@@ -1,0 +1,121 @@
+//! Offline render through the product graph, measured the same way on the
+//! browser and on native.
+
+use kithara::{
+    assets::{AssetStore, StorageBackend},
+    host::HostConfig,
+    platform::time::Duration,
+    play::{Resource, ResourceConfig, ResourceSrc},
+};
+use kithara_integration_tests::{
+    TestServerHelper,
+    bufpool_ext::{TestPools, pools},
+    offline::{OfflinePlayer, OfflineWorker, max_silence_run, peak, rms},
+};
+use kithara_test_fixtures::SignalAsset;
+
+const SAMPLE_RATE: u32 = 44_100;
+const CHANNELS: usize = 2;
+const BLOCK_FRAMES: usize = 512;
+const WARMUP_BLOCKS: usize = 8;
+const MEASURE_BLOCKS: usize = 32;
+const TAP_CAPACITY: usize = 65_536;
+const SILENCE_THRESHOLD: f32 = 0.001;
+/// The signal route serves every tone at full scale, so a sine has RMS
+/// `1/sqrt(2)`; the band leaves room for the limiter and mp3 framing.
+const MIN_RMS: f32 = 0.55;
+const MAX_RMS: f32 = 0.75;
+
+/// One offline player on the fixture sine, playing with no fade. Everything
+/// that waits on the fixture bytes is opened on the harness thread.
+async fn playing_worker() -> OfflineWorker {
+    let server = TestServerHelper::new().await;
+    let url = server.signal(SignalAsset::MP3_SINE440_60S);
+    let region = pools();
+    let host = HostConfig::offline(region.clone())
+        .sample_rate(SAMPLE_RATE.try_into().expect("the sample rate is non-zero"))
+        .build();
+    let worker = OfflineWorker::new(async move || OfflinePlayer::new(host).await).await;
+    worker
+        .call(async move |player| {
+            let config: ResourceConfig<TestPools> = ResourceConfig::for_src(
+                ResourceSrc::parse(url.as_str())
+                    .expect("the fixture URL parses as a resource source"),
+            )
+            .worker(player.worker().clone())
+            .store(
+                AssetStore::builder(region)
+                    .backend(StorageBackend::Memory)
+                    .build(),
+            )
+            .build();
+            let mut resource = Resource::new(config)
+                .await
+                .expect("open the fixture as a product resource");
+            resource.preload().await.expect("preload the fixture");
+            player.set_fade_duration(0.0);
+            player.load_and_fadein(resource).await;
+        })
+        .await;
+    worker
+}
+
+async fn render_blocks(worker: &OfflineWorker, blocks: usize) -> Vec<f32> {
+    let mut rendered = Vec::with_capacity(blocks * BLOCK_FRAMES * CHANNELS);
+    for _ in 0..blocks {
+        let block = worker
+            .call(async move |player| player.render(BLOCK_FRAMES).await)
+            .await;
+        rendered.extend_from_slice(&block);
+    }
+    rendered
+}
+
+#[kithara::test(
+    tokio,
+    browser,
+    serial,
+    timeout(Duration::from_secs(10)),
+    hang_timeout_secs(1)
+)]
+async fn offline_render_carries_fixture_signal() {
+    let worker = playing_worker().await;
+    let _warmup = render_blocks(&worker, WARMUP_BLOCKS).await;
+    let measured = render_blocks(&worker, MEASURE_BLOCKS).await;
+
+    assert_eq!(measured.len(), MEASURE_BLOCKS * BLOCK_FRAMES * CHANNELS);
+    let level = rms(&measured);
+    assert!(
+        (MIN_RMS..=MAX_RMS).contains(&level),
+        "full-scale sine renders at RMS {level:.4}, outside {MIN_RMS}..={MAX_RMS}"
+    );
+    let ceiling = peak(&measured);
+    assert!(ceiling <= 1.0, "render clipped at peak {ceiling:.4}");
+    let silence = max_silence_run(&measured, 0, measured.len(), SILENCE_THRESHOLD);
+    assert!(
+        silence < BLOCK_FRAMES * CHANNELS,
+        "render went silent for {silence} samples, a whole block or more"
+    );
+}
+
+#[kithara::test(
+    tokio,
+    browser,
+    serial,
+    timeout(Duration::from_secs(10)),
+    hang_timeout_secs(1)
+)]
+async fn offline_mix_tap_mirrors_render() {
+    let worker = playing_worker().await;
+    let _warmup = render_blocks(&worker, WARMUP_BLOCKS).await;
+    let mut tap = worker
+        .call(async move |player| player.host().enable_mix_tap(TAP_CAPACITY).await)
+        .await
+        .expect("enable the mix tap");
+
+    let rendered = render_blocks(&worker, MEASURE_BLOCKS).await;
+    let tapped = tap.drain();
+
+    assert_eq!(tapped, rendered, "the tap carries what the sink received");
+    assert_eq!(tap.drops(), 0);
+}

--- a/tests/tests/kithara_play/player_internal.rs
+++ b/tests/tests/kithara_play/player_internal.rs
@@ -21,7 +21,10 @@ use kithara::{
         bridge::slot_channels,
     },
 };
-use kithara_integration_tests::{audio_mock::TestPcmReader, test_defaults::Consts};
+use kithara_integration_tests::{
+    audio_mock::{MockReader, TestPcmReader},
+    test_defaults::Consts,
+};
 use kithara_test_fixtures::integration_fixtures::constant_half;
 
 use crate::bufpool_ext::{TestPools, pools};
@@ -301,6 +304,38 @@ fn replay_same_item_does_not_re_emit_current_item_changed(constant_half: &'stati
     assert_eq!(
         second_count, 0,
         "resuming the same item must not re-announce CurrentItemChanged: {second:?}"
+    );
+}
+
+/// `insert` is the queue entry that never passes `ConfigPrep`, so adoption
+/// into the real-time arena is the only place a session wake policy can reach
+/// the resource. A reader left on the direct-consumer default publishes its
+/// reader events inline from the audio callback.
+#[kithara::test(tokio)]
+async fn an_inserted_resource_adopts_the_session_wake_mode() {
+    let (player, _session) = make_fixture_player(0.0);
+    let (reader, recorded) = MockReader::wake_mode_tracking(Consts::AUDIO_SPEC);
+
+    player.insert(
+        Resource::from_reader(reader, None),
+        TrackId::allocate(),
+        None,
+    );
+    player
+        .ensure_engine_started()
+        .expect("start the fixture engine");
+    player.ensure_slot().expect("allocate the fixture slot");
+    player
+        .select_item(0, true)
+        .expect("select the inserted item");
+
+    let applied = *recorded
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    assert_eq!(
+        applied,
+        Some(ConsumerWakeMode::RealtimeDeferred),
+        "adoption must apply the session wake mode to an inserted resource"
     );
 }
 

--- a/tests/tests/suite_heavy.rs
+++ b/tests/tests/suite_heavy.rs
@@ -33,8 +33,8 @@ mod kithara_decode {
 }
 
 // The rest of this suite drives the local test server, the filesystem, and
-// several players at once. The browser has none of that; only
-// `kithara_ffi_web` is meant to run there.
+// several players at once. The browser has none of that; `kithara_ffi_web` and
+// `kithara_play::offline_browser` are what is meant to run there.
 #[cfg(not(target_arch = "wasm32"))]
 mod kithara_file {
     mod live_stress_real_mp3;
@@ -49,6 +49,10 @@ mod kithara_hls {
 }
 
 mod kithara_ffi_web;
+
+mod kithara_play {
+    mod offline_browser;
+}
 
 #[cfg(not(target_arch = "wasm32"))]
 mod multi_instance;

--- a/tests/tests/suite_live_web_audio.rs
+++ b/tests/tests/suite_live_web_audio.rs
@@ -1,0 +1,367 @@
+#![forbid(unsafe_code)]
+#![cfg(target_arch = "wasm32")]
+#![expect(
+    clippy::unwrap_used,
+    reason = "integration test crate - unwraps are acceptable in test code"
+)]
+//! Live playback through the product web graph, heard on the browser main
+//! thread's mix tap and measured against the rate the session asked the device
+//! for.
+//!
+//! `wasm-bindgen-test` picks its thread from a link-section flag that covers a
+//! whole binary, and `kithara::test` sets that flag to a dedicated worker. The
+//! product web session opens its `AudioContext` on the main thread only, so it
+//! gets a binary whose flag says so, and stays the only session in it.
+
+use std::num::NonZeroU32;
+
+use kithara::{
+    assets::{AssetStore, StorageBackend},
+    host::{Host, HostConfig, wasm},
+    output::OutputGroup,
+    platform::{
+        sync::{
+            Arc,
+            atomic::{AtomicU64, Ordering},
+        },
+        thread::{keep_worker_alive, spawn_named},
+        time::{Duration, sleep},
+        tokio::task,
+    },
+    play::{
+        MixTapWriter, PlayWorker, PlayWorkerConfig, PlayerConfig, PlayerImpl, Resource,
+        ResourceConfig, ResourceSrc,
+    },
+    queue::TrackId,
+};
+use kithara_integration_tests::{
+    TestServerHelper,
+    bufpool_ext::{TestPools, pools},
+    offline::{deinterleave_left, rms},
+};
+use kithara_test_fixtures::SignalAsset;
+use ringbuf::{
+    HeapCons, HeapRb,
+    traits::{Consumer, Split},
+};
+use wasm_bindgen::prelude::wasm_bindgen;
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+/// Console output for both halves of the graph: `tracing` from the workspace,
+/// and `log` from the Web Audio backend that reports its own failures there.
+fn init_diagnostics() {
+    kithara::platform::logging::install_panic_hook();
+    let _ = tracing_log::LogTracer::init();
+    kithara_test_utils::test::setup_tracing();
+}
+
+const RATE: NonZeroU32 = NonZeroU32::new(44_100).unwrap();
+const CHANNELS: usize = 2;
+/// Eight seconds of stereo headroom, so a poll that arrives late still finds
+/// the ring with room.
+const TAP_CAPACITY: usize = 8 * 44_100 * CHANNELS;
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+const POLL_BUDGET: usize = 300;
+const AUDIBLE_THRESHOLD: f32 = 0.01;
+const TONE_HZ: f64 = 440.0;
+const TONE_TOLERANCE: f64 = 0.02;
+/// The signal route serves every tone at full scale, so a sine has RMS
+/// `1/sqrt(2)`; the band leaves room for the limiter and mp3 framing.
+const MIN_RMS: f32 = 0.55;
+const MAX_RMS: f32 = 0.75;
+
+/// One player on the fixture sine, owned by the Worker the wasm Host requires
+/// for insertion. It keeps ticking until the test's Host route closes.
+fn spawn_player_worker(sender: wasm::HostSender<TestPools>) {
+    spawn_named("live-web-audio-player", move || {
+        keep_worker_alive();
+        task::spawn(async move {
+            let mut host = wasm::remote_host(sender);
+            let region = pools();
+            let worker = PlayWorker::new(PlayWorkerConfig::builder(region.clone()).build());
+            let player = PlayerImpl::new(
+                PlayerConfig::builder()
+                    .sample_rate(host.requested_sample_rate())
+                    .worker(worker.clone())
+                    .build(),
+            );
+            let owner = host
+                .insert(player)
+                .expect("insert the player into the Host");
+            let control = owner.control().clone();
+            control.set_crossfade_duration(0.0);
+
+            let server = TestServerHelper::new().await;
+            let url = server.signal(SignalAsset::MP3_SINE440_60S);
+            let config: ResourceConfig<TestPools> = ResourceConfig::for_src(
+                ResourceSrc::parse(url.as_str())
+                    .expect("the fixture URL parses as a resource source"),
+            )
+            .worker(worker)
+            .store(
+                AssetStore::builder(region)
+                    .backend(StorageBackend::Memory)
+                    .build(),
+            )
+            .build();
+            let mut resource = Resource::new(config)
+                .await
+                .expect("open the fixture as a product resource");
+            resource.preload().await.expect("preload the fixture");
+
+            control.insert(resource, TrackId(0), None);
+            control
+                .select_item(0, true)
+                .expect("select the fixture for playback");
+            control.play();
+
+            while control.tick().is_ok() {
+                sleep(POLL_INTERVAL).await;
+            }
+        });
+    });
+}
+
+/// Append what the tap holds, starting the window at the first audible frame.
+fn collect_tap(tap: &mut HeapCons<f32>, window: &mut Vec<f32>) {
+    let drained: Vec<f32> = tap.pop_iter().collect();
+    if window.is_empty() {
+        let Some(start) = first_audible_sample(&drained) else {
+            return;
+        };
+        window.extend_from_slice(&drained[start..]);
+        return;
+    }
+    window.extend_from_slice(&drained);
+}
+
+fn first_audible_sample(samples: &[f32]) -> Option<usize> {
+    samples
+        .chunks_exact(CHANNELS)
+        .position(|frame| frame.iter().any(|sample| sample.abs() > AUDIBLE_THRESHOLD))
+        .map(|frame| frame * CHANNELS)
+}
+
+/// Dominant frequency of a mono window, taken from its rising zero crossings.
+fn zero_crossing_hz(mono: &[f32], sample_rate: f64) -> f64 {
+    let rising: Vec<usize> = mono
+        .windows(2)
+        .enumerate()
+        .filter(|(_, pair)| pair[0] <= 0.0 && pair[1] > 0.0)
+        .map(|(index, _)| index)
+        .collect();
+    let (Some(&first), Some(&last)) = (rising.first(), rising.last()) else {
+        return 0.0;
+    };
+    if last == first {
+        return 0.0;
+    }
+    let periods = f64::from(u32::try_from(rising.len() - 1).unwrap());
+    let span = f64::from(u32::try_from(last - first).unwrap());
+    periods * sample_rate / span
+}
+
+#[wasm_bindgen_test]
+async fn live_web_audio_plays_at_session_rate() {
+    init_diagnostics();
+
+    let host: Host<TestPools> = Host::new(HostConfig::builder().sample_rate_hint(RATE).build())
+        .expect("build the product web Host");
+    let (sender, receiver) = wasm::worker_host_channel(&host).expect("open the Worker route");
+    wasm::warm_up_audio(&host).expect("warm up the audio context");
+
+    let (pcm_tx, mut pcm_rx) = HeapRb::<f32>::new(TAP_CAPACITY).split();
+    let drops = Arc::new(AtomicU64::new(0));
+    let mut outputs = OutputGroup::new();
+    outputs.push(MixTapWriter::new(pcm_tx, Arc::clone(&drops)));
+    host.enable_outputs(outputs).expect("install the mix tap");
+
+    spawn_player_worker(sender);
+
+    let document = web_sys::window()
+        .expect("the browser main thread owns a window")
+        .document()
+        .expect("the runner page owns a document");
+    let target = usize::try_from(RATE.get()).unwrap() * CHANNELS;
+    let mut window: Vec<f32> = Vec::with_capacity(target);
+    let mut polls = 0;
+    while polls < POLL_BUDGET && window.len() < target {
+        wasm::tick_and_poll(&receiver);
+        let click = web_sys::Event::new("click").expect("build a click event");
+        document.dispatch_event(&click).expect("dispatch the click");
+        sleep(POLL_INTERVAL).await;
+        collect_tap(&mut pcm_rx, &mut window);
+        polls += 1;
+    }
+
+    let frames = window.len() / CHANNELS;
+    let dropped = drops.load(Ordering::Relaxed);
+    let rates = host.sample_rate().expect("read the session output rate");
+    assert_eq!(
+        (rates.requested, rates.measured),
+        (RATE.get(), Some(RATE.get())),
+        "the session plays at a rate it did not ask for, having tapped {frames} frames \
+         with {dropped} dropped"
+    );
+
+    let measured = rates.output();
+    let second = usize::try_from(measured).unwrap();
+    assert!(
+        frames >= second,
+        "tap carried {frames} frames of the {second} one second holds at {measured} Hz, \
+         with {dropped} dropped"
+    );
+    assert_eq!(
+        dropped, 0,
+        "tap dropped samples while carrying {frames} frames"
+    );
+
+    let steady = &window[(second / 2 * CHANNELS)..];
+    let tone = zero_crossing_hz(&deinterleave_left(steady, CHANNELS), f64::from(measured));
+    let level = rms(steady);
+    tracing::info!(
+        polls,
+        frames,
+        measured,
+        tone,
+        level,
+        "live web audio window"
+    );
+    assert!(
+        (tone - TONE_HZ).abs() <= TONE_HZ * TONE_TOLERANCE,
+        "tap carries {tone:.1} Hz, further than {TONE_TOLERANCE} from {TONE_HZ} Hz"
+    );
+    assert!(
+        (MIN_RMS..=MAX_RMS).contains(&level),
+        "full-scale sine plays at RMS {level:.4}, outside {MIN_RMS}..={MAX_RMS}"
+    );
+}
+
+/// A diagnostic that spans several `String.fromCharCode` calls and puts a
+/// surrogate pair on the boundary between two of them.
+fn diagnostic_probe_message() -> String {
+    let mut message = "a".repeat(1023);
+    message.push('\u{1F600}');
+    message.push_str("tail");
+    message
+}
+
+/// Reached from inside an `AudioWorkletGlobalScope`, the scope the audio render
+/// pass runs in, through the bindgen module the worklet imports.
+#[wasm_bindgen]
+pub fn kithara_worklet_diagnostic_probe() {
+    kithara::platform::logging::log_error(&diagnostic_probe_message());
+}
+
+const PANIC_PROBE_PAYLOAD: &str = "the render scope reports a panic";
+
+/// Panics in the render scope. `init_diagnostics` fills the process-wide hook
+/// slot from the main thread, so this pins that a panic in another instance of
+/// the module reports through it, in the console of its own realm.
+#[wasm_bindgen]
+pub fn kithara_worklet_panic_probe() {
+    panic!("{PANIC_PROBE_PAYLOAD}");
+}
+
+/// Loads the bindgen module into an `AudioWorkletGlobalScope`, calls the named
+/// export there and resolves to what `console.error` received. A call that
+/// traps still resolves: the diagnostic under test is written before the trap.
+const WORKLET_PROBE: &str = r#"
+const source = `
+registerProcessor("kithara-diagnostic-probe", class extends AudioWorkletProcessor {
+  constructor(options) {
+    super();
+    const [module, memory, probe] = options.processorOptions;
+    let thrown = "";
+    const reported = [];
+    console.error = (line) => reported.push(line);
+    try {
+      bindgen.initSync({ module, memory, thread_stack_size: 1048576 });
+      bindgen[probe]();
+    } catch (error) {
+      thrown = "threw: " + String(error);
+    }
+    this.port.postMessage(reported.length ? reported.join("") : thrown);
+  }
+  process() { return false; }
+});`;
+const url = URL.createObjectURL(new Blob(
+  ["import init, * as bindgen from '" + moduleUrl + "';\n\n", source],
+  { type: "text/javascript" },
+));
+const context = new AudioContext();
+const reported = context.audioWorklet.addModule(url).then(() => new Promise((resolve) => {
+  const node = new AudioWorkletNode(context, "kithara-diagnostic-probe", {
+    processorOptions: [wasmModule, wasmMemory, probeName],
+  });
+  node.port.onmessage = (event) => resolve(event.data);
+}));
+const deadline = new Promise((resolve) => setTimeout(
+  () => resolve("the worklet never reached the diagnostic"),
+  2000,
+));
+return Promise.race([reported, deadline]).finally(() => {
+  URL.revokeObjectURL(url);
+  context.close();
+});
+"#;
+
+#[wasm_bindgen]
+extern "C" {
+    type ImportMeta;
+
+    #[wasm_bindgen(method, getter)]
+    fn url(this: &ImportMeta) -> js_sys::JsString;
+
+    #[wasm_bindgen(js_namespace = import, js_name = meta, thread_local_v2)]
+    static IMPORT_META: ImportMeta;
+}
+
+async fn reported_from_the_render_scope(probe_name: &str) -> String {
+    let probe = js_sys::Function::new_with_args(
+        "moduleUrl, wasmModule, wasmMemory, probeName",
+        WORKLET_PROBE,
+    );
+    let pending = probe
+        .apply(
+            &wasm_bindgen::JsValue::NULL,
+            &js_sys::Array::of4(
+                &IMPORT_META.with(ImportMeta::url).into(),
+                &wasm_bindgen::module(),
+                &wasm_bindgen::memory(),
+                &wasm_bindgen::JsValue::from_str(probe_name),
+            ),
+        )
+        .expect("start the worklet probe");
+
+    wasm_bindgen_futures::JsFuture::from(js_sys::Promise::from(pending))
+        .await
+        .expect("await the worklet probe")
+        .as_string()
+        .unwrap_or_default()
+}
+
+#[wasm_bindgen_test]
+async fn a_platform_diagnostic_reaches_the_console_from_the_render_scope() {
+    let reported = reported_from_the_render_scope("kithara_worklet_diagnostic_probe").await;
+
+    assert_eq!(
+        reported,
+        diagnostic_probe_message(),
+        "the platform diagnostic did not survive the audio render scope"
+    );
+}
+
+#[wasm_bindgen_test]
+async fn a_panic_in_the_render_scope_reports_through_the_hook_the_main_thread_installed() {
+    init_diagnostics();
+
+    let reported = reported_from_the_render_scope("kithara_worklet_panic_probe").await;
+
+    assert!(
+        reported.starts_with("panicked at ") && reported.ends_with(PANIC_PROBE_PAYLOAD),
+        "a panic in the audio render scope reported {reported:?}"
+    );
+}

--- a/tests/tests/suite_live_web_audio.rs
+++ b/tests/tests/suite_live_web_audio.rs
@@ -44,7 +44,7 @@ use ringbuf::{
     HeapCons, HeapRb,
     traits::{Consumer, Split},
 };
-use wasm_bindgen::prelude::wasm_bindgen;
+use wasm_bindgen::{JsCast, JsValue, closure::Closure, prelude::wasm_bindgen};
 use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 
 wasm_bindgen_test_configure!(run_in_browser);
@@ -59,11 +59,13 @@ fn init_diagnostics() {
 
 const RATE: NonZeroU32 = NonZeroU32::new(44_100).unwrap();
 const CHANNELS: usize = 2;
-/// Eight seconds of stereo headroom, so a poll that arrives late still finds
+/// Eight seconds of stereo headroom, so a frame that arrives late still finds
 /// the ring with room.
 const TAP_CAPACITY: usize = 8 * 44_100 * CHANNELS;
-const POLL_INTERVAL: Duration = Duration::from_millis(50);
-const POLL_BUDGET: usize = 300;
+/// The cadence the product Worker ticks its queue at.
+const WORKER_TICK: Duration = Duration::from_millis(100);
+/// How long the tap may take to carry its second of audio.
+const AUDIO_BUDGET_MS: f64 = 15_000.0;
 const AUDIBLE_THRESHOLD: f32 = 0.01;
 const TONE_HZ: f64 = 440.0;
 const TONE_TOLERANCE: f64 = 0.02;
@@ -72,12 +74,34 @@ const TONE_TOLERANCE: f64 = 0.02;
 const MIN_RMS: f32 = 0.55;
 const MAX_RMS: f32 = 0.75;
 
+/// How far the player Worker got. Its console is not the one
+/// `wasm-bindgen-test` captures, so a failure there reads only from here.
+const STAGES: [&str; 8] = [
+    "spawning the Worker",
+    "inserting the player into the Host",
+    "starting the test server",
+    "opening the fixture resource",
+    "preloading the fixture",
+    "starting playback",
+    "ticking the queue",
+    "past the tick loop",
+];
+
+fn stage_name(stage: u64) -> &'static str {
+    usize::try_from(stage)
+        .ok()
+        .and_then(|index| STAGES.get(index))
+        .copied()
+        .unwrap_or("an unknown stage")
+}
+
 /// One player on the fixture sine, owned by the Worker the wasm Host requires
 /// for insertion. It keeps ticking until the test's Host route closes.
-fn spawn_player_worker(sender: wasm::HostSender<TestPools>) {
+fn spawn_player_worker(sender: wasm::HostSender<TestPools>, stage: Arc<AtomicU64>) {
     spawn_named("live-web-audio-player", move || {
         keep_worker_alive();
         task::spawn(async move {
+            stage.store(1, Ordering::Relaxed);
             let mut host = wasm::remote_host(sender);
             let region = pools();
             let worker = PlayWorker::new(PlayWorkerConfig::builder(region.clone()).build());
@@ -90,10 +114,12 @@ fn spawn_player_worker(sender: wasm::HostSender<TestPools>) {
             let owner = host
                 .insert(player)
                 .expect("insert the player into the Host");
+            stage.store(2, Ordering::Relaxed);
             let control = owner.control().clone();
             control.set_crossfade_duration(0.0);
 
             let server = TestServerHelper::new().await;
+            stage.store(3, Ordering::Relaxed);
             let url = server.signal(SignalAsset::MP3_SINE440_60S);
             let config: ResourceConfig<TestPools> = ResourceConfig::for_src(
                 ResourceSrc::parse(url.as_str())
@@ -109,32 +135,49 @@ fn spawn_player_worker(sender: wasm::HostSender<TestPools>) {
             let mut resource = Resource::new(config)
                 .await
                 .expect("open the fixture as a product resource");
+            stage.store(4, Ordering::Relaxed);
             resource.preload().await.expect("preload the fixture");
+            stage.store(5, Ordering::Relaxed);
 
             control.insert(resource, TrackId(0), None);
             control
                 .select_item(0, true)
                 .expect("select the fixture for playback");
             control.play();
+            stage.store(6, Ordering::Relaxed);
 
             while control.tick().is_ok() {
-                sleep(POLL_INTERVAL).await;
+                sleep(WORKER_TICK).await;
             }
+            stage.store(7, Ordering::Relaxed);
         });
     });
 }
 
+/// One `requestAnimationFrame` turn, the cadence `tick_and_poll` documents.
+async fn next_frame(window: &web_sys::Window) {
+    let promise = js_sys::Promise::new(&mut |resolve, _| {
+        let frame = Closure::once_into_js(move |_: JsValue| {
+            let _ = resolve.call0(&JsValue::NULL);
+        });
+        window
+            .request_animation_frame(frame.unchecked_ref())
+            .expect("schedule the next animation frame");
+    });
+    let _ = wasm_bindgen_futures::JsFuture::from(promise).await;
+}
+
 /// Append what the tap holds, starting the window at the first audible frame.
-fn collect_tap(tap: &mut HeapCons<f32>, window: &mut Vec<f32>) {
+fn collect_tap(tap: &mut HeapCons<f32>, window: &mut Vec<f32>) -> usize {
     let drained: Vec<f32> = tap.pop_iter().collect();
     if window.is_empty() {
-        let Some(start) = first_audible_sample(&drained) else {
-            return;
-        };
-        window.extend_from_slice(&drained[start..]);
-        return;
+        if let Some(start) = first_audible_sample(&drained) {
+            window.extend_from_slice(&drained[start..]);
+        }
+    } else {
+        window.extend_from_slice(&drained);
     }
-    window.extend_from_slice(&drained);
+    drained.len()
 }
 
 fn first_audible_sample(samples: &[f32]) -> Option<usize> {
@@ -142,6 +185,11 @@ fn first_audible_sample(samples: &[f32]) -> Option<usize> {
         .chunks_exact(CHANNELS)
         .position(|frame| frame.iter().any(|sample| sample.abs() > AUDIBLE_THRESHOLD))
         .map(|frame| frame * CHANNELS)
+}
+
+fn session_is_live(host: &Host<TestPools>) -> bool {
+    host.sample_rate()
+        .is_ok_and(|rates| rates.measured == Some(rates.requested))
 }
 
 /// Dominant frequency of a mono window, taken from its rising zero crossings.
@@ -178,32 +226,44 @@ async fn live_web_audio_plays_at_session_rate() {
     outputs.push(MixTapWriter::new(pcm_tx, Arc::clone(&drops)));
     host.enable_outputs(outputs).expect("install the mix tap");
 
-    spawn_player_worker(sender);
+    let stage = Arc::new(AtomicU64::new(0));
+    spawn_player_worker(sender, Arc::clone(&stage));
 
-    let document = web_sys::window()
-        .expect("the browser main thread owns a window")
-        .document()
-        .expect("the runner page owns a document");
+    let page = web_sys::window().expect("the browser main thread owns a window");
+    let document = page.document().expect("the runner page owns a document");
     let target = usize::try_from(RATE.get()).unwrap() * CHANNELS;
     let mut window: Vec<f32> = Vec::with_capacity(target);
-    let mut polls = 0;
-    while polls < POLL_BUDGET && window.len() < target {
+    let mut frames_pumped = 0u64;
+    let mut tapped = 0usize;
+    let deadline = js_sys::Date::now() + AUDIO_BUDGET_MS;
+    let mut opened = false;
+    while js_sys::Date::now() < deadline && window.len() < target {
         wasm::tick_and_poll(&receiver);
+        // Firewheel resumes a suspended `AudioContext` only from a document
+        // interaction event, and the Worker installs that listener mid-run.
         let click = web_sys::Event::new("click").expect("build a click event");
         document.dispatch_event(&click).expect("dispatch the click");
-        sleep(POLL_INTERVAL).await;
-        collect_tap(&mut pcm_rx, &mut window);
-        polls += 1;
+        next_frame(&page).await;
+        tapped += collect_tap(&mut pcm_rx, &mut window);
+        frames_pumped += 1;
+        // A session that reported its rate and then stopped has lost its stream,
+        // and waiting out the budget would report silence instead of the drop.
+        if session_is_live(&host) {
+            opened = true;
+        } else if opened {
+            break;
+        }
     }
 
     let frames = window.len() / CHANNELS;
     let dropped = drops.load(Ordering::Relaxed);
+    let stage = stage_name(stage.load(Ordering::Relaxed));
     let rates = host.sample_rate().expect("read the session output rate");
     assert_eq!(
         (rates.requested, rates.measured),
         (RATE.get(), Some(RATE.get())),
-        "the session plays at a rate it did not ask for, having tapped {frames} frames \
-         with {dropped} dropped"
+        "the session lost the rate it asked for after {frames_pumped} frames, having tapped \
+         {frames} frames with {dropped} dropped while the Worker was {stage}"
     );
 
     let measured = rates.output();
@@ -211,7 +271,8 @@ async fn live_web_audio_plays_at_session_rate() {
     assert!(
         frames >= second,
         "tap carried {frames} frames of the {second} one second holds at {measured} Hz, \
-         with {dropped} dropped"
+         with {dropped} dropped over {frames_pumped} frames and {tapped} samples tapped, \
+         while the Worker was {stage}"
     );
     assert_eq!(
         dropped, 0,
@@ -222,7 +283,7 @@ async fn live_web_audio_plays_at_session_rate() {
     let tone = zero_crossing_hz(&deinterleave_left(steady, CHANNELS), f64::from(measured));
     let level = rms(steady);
     tracing::info!(
-        polls,
+        frames_pumped,
         frames,
         measured,
         tone,
@@ -326,12 +387,12 @@ async fn reported_from_the_render_scope(probe_name: &str) -> String {
     );
     let pending = probe
         .apply(
-            &wasm_bindgen::JsValue::NULL,
+            &JsValue::NULL,
             &js_sys::Array::of4(
                 &IMPORT_META.with(ImportMeta::url).into(),
                 &wasm_bindgen::module(),
                 &wasm_bindgen::memory(),
-                &wasm_bindgen::JsValue::from_str(probe_name),
+                &JsValue::from_str(probe_name),
             ),
         )
         .expect("start the worklet probe");


### PR DESCRIPTION
## What

`suite_live_web_audio` opens the product web session on the page's main thread,
installs the session mix tap and measures what the graph delivers against the
rate the session asked the device for. It is the first oracle that hears live
browser playback rather than asserting on events.

The oracle was red. Four defects it found are fixed here.

This PR carries a second commit, `test(offline): render the offline harness in
the browser`, which sat unpublished on the author's `main` and has no PR of its
own. The oracle builds on it, so it lands here.

## Highlights

- `DeferredBus::enqueue` read the clock to stamp the envelope it queued, so a
  producer on the forbid-blocking decode core, or on an audio thread whose
  global scope offers no clock object, paid for a timestamp it could not take.
  The stamp moves to `flush`, beside the `broadcast::send` lock it already
  carries; `seq`, assigned at enqueue, keeps the producer's order.

- `ConsumerWakeMode` had two writers. Every session declares `RealtimeDeferred`,
  but only `prepare_config` asked, so a `Resource` built elsewhere and admitted
  through `PlayerControl::insert` kept the builder's `ImmediateOffRt` and
  published reader events inline from the render pass, where the stamp's clock
  read killed the worklet node on its first poll.
  `AudioControl::set_consumer_wake_mode` lets an owner declare which thread will
  read a built reader, and `ItemQueue::take_for_load` applies the session's mode
  at the one place a queued resource becomes a real-time one. `ResourceConfig`
  carries no wake policy at all, and the offline session declares the
  `ImmediateOffRt` its render thread has.

- The `AudioWorkletGlobalScope` has no `TextDecoder`, so passing a Rust string
  to `console.error` threw there and replaced a panic's text with
  `TypeError: Cannot read properties of undefined (reading 'decode')`.
  `logging::log_error` and the panic hook build the console argument from UTF-16
  code units, and the hook has one owner: a binary's entry point.
  `console_error_panic_hook` leaves the workspace. The oracle pins both halves
  from inside a worklet; without the main-thread install the panic probe reports
  ``wasm-bindgen: imported JS function that was not marked as `catch` threw an
  error:`` -- the mask itself.

- `session::web::bridge` ran its own `ctx.update()` and discarded the result
  into a `warn!`. The Worker sends `Cmd::Tick` every 100 ms while the main
  thread ticks on every animation frame, so the bridge won almost every race,
  and firewheel reports a dropped stream a bounded number of times rather than
  latching it: in the captured run 1 worklet throw, 2 drop reports, 0 restarts
  and 299 `Cannot resume a closed AudioContext`. `drain_host_channel` now owns
  "drain the channel, then tick" for both callers and routes every update
  through `tick_session`, the owner that arms `stream_needs_restart`. The wasm
  `cfg` gate is required: `just check clippy` runs without `--all-targets`, so a
  host-target-only definition fails as `dead_code`; the wasm arm is compiled by
  `just platform wasm check` through `kithara-ffi`.

The panic probe is last in `suite_live_web_audio` by source order and that
ordering is load-bearing: it aborts a wasm instance sharing linear memory with
the main one. Nothing enforces it.

## Rebase onto #322

#322 moved the offline test harness onto `OffThread`, which is gated
`cfg(not(target_arch = "wasm32"))`: it needs `Handle::current()`, a blocking
`recv()`, and `Send` on every value that reaches the owner thread. On wasm
`SessionDispatcher: MaybeSend + MaybeSync` is empty, so `PlayerImpl` is not
`Send` there and `tests/src/offline` stopped building for the browser.

On wasm the owner off the runtime worker is already `OfflineWorker`, the Web
Worker the harness runs inside, so `OfflineHostHarness` selects its owner by
target: `OffThread` natively, `InlineOwner` (the value on the calling thread) on
wasm. The bounds on `P`, `P::Control` and `R` relax to `MaybeSend`; `S` stays
`Send + Sync`, which is what the product `Host` requires. `QueueTicker` and
`harness.rs` are queue fixtures the browser suite does not use, and are gated
off wasm.

`OffThread` gets no second implementation: its jobs are synchronous, the offline
player's operations are async, and a same-named parallel implementation is the
thing to avoid.

## Rebase onto #339 and #340

#339 deleted `PROGRESS.md` and #340 moved every crate `CONTEXT.md` to the wiki.
Both commits here edited those files; the deletions are accepted. The wasm
diagnostics contract this PR introduces -- `logging::log_error`, the
entry-point-owned panic hook, `panic=immediate-abort` -- therefore has no
in-repo home and needs a wiki page, outside this PR.

## Validation

Measured on `49bbd432`, rebased onto `695d9078`.

- `just test`: 4468 passed, 0 failed, 220 skipped.
- `just fmt check`: clean. `just lint fast`: 0 deny, 0 regression, 0 new.
- `just test wasm`: all nine targets pass -- `session` 3, `kithara-host` 57,
  `web-observer` 3, `kithara-worker` 17, `kithara-analysis` 190,
  `web-analysis` 2, `suite_heavy` 11, `suite_live_web_audio` 3, `webcodecs` 8.
- The oracle's lane failure is root-caused, not fixed. firewheel's
  `WasmProcessor` constructor throws inside the worklet realm; firewheel marks
  the stream dropped, the session reports `StreamStoppedUnexpectedly` on its
  first tick and the `AudioContext` closes, so the tap stays silent for the
  whole wait. Chrome reports only `WasmProcessor invoking user-supplied
  constructor failed` and withholds the exception, so the throw is not
  observable through `onprocessorerror`. Captured directly from the worklet it
  is `RuntimeError: Atomics.wait cannot be called in this context`, thrown from
  the module bootstrap (`initSync` -> `__wbg_finalize_init`), which
  `AudioWorkletGlobalScope` forbids: a blocking lock taken while another thread
  holds it. That capture came from a locally instrumented firewheel build, so
  the roughly 1-in-4 rate observed there is a rate under instrumentation, not a
  measured product rate. The oracle now leaves its wait
  as soon as a session that reported its rate stops reporting it: it fails in
  0.28s naming the Worker's stage, the frames pumped and the samples tapped,
  rather than waiting out 15s and reporting silence. Six consecutive green pair
  runs afterwards are not evidence the flake is gone. The oracle keeps its
  bounds and is not gated.
- Safari is recorded, not gated: a bare `AudioContext` stays suspended under
  `safaridriver`, where Chrome's lane carries `--autoplay-policy`, and that lane
  stops at the first failing suite short of the oracle.

## Open

- A lost worklet bootstrap now costs a restart instead of the session, but the
  `Atomics.wait` race itself lives outside this repository, in firewheel's
  worklet constructor. Fourteen runs of the pre-rewrite oracle behind
  `suite_heavy` on the fix were green with zero throws, so the recovery path
  they were meant to exercise never ran; the routing contract rests on the unit
  test.
- An app still cannot learn its audio stream died: nothing surfaces
  `StreamStoppedUnexpectedly` to the caller. The oracle reads the loss through
  the session rate instead.
- The wasm diagnostics contract has no documentation home since #340.
- `block_on_underrun` still overrides the session's wake-mode declaration, and
  `EventBus::publish` reads the clock in its caller's thread.
- `Audio::prepare` blocks the Chrome main thread for a remote file,
  `File::create_remote` returning before a byte arrived.
- The oracle's JS probe duplicates the worklet bootstrap with no drift signal,
  and no ratchet catches a `&str` crossing the JS boundary in render-reachable
  code.


