### PR TITLE
fix(devtools,ci): unblock the nightly architecture and network lanes

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -94,6 +94,9 @@ jobs:
       && (inputs.kind || 'nightly') == 'nightly'
       && (inputs.only || '') == ''
     uses: ./.github/workflows/network.yml
+    # A called workflow starts with no secrets of its own, so the keys its
+    # build bakes in arrive empty unless the caller hands them over.
+    secrets: inherit
 
   # Three machines the Linux fan-out cannot reach: each has a runner pool of
   # its own, named by a variable of its own, so each stays a workflow of its

--- a/.github/workflows/network.yml
+++ b/.github/workflows/network.yml
@@ -1,7 +1,7 @@
 name: Network
 
 # The one test lane the catalog cannot declare. Its build bakes production DRM
-# keys into the binary, so it needs four repository secrets at compile time -
+# keys into the binary, so it needs five repository secrets at compile time -
 # and one executor serves every declared lane, so handing them to it would hand
 # them to all of them. A lane that needs more than a recipe stays a workflow of
 # its own, beside the three that need a machine of their own.
@@ -45,6 +45,7 @@ jobs:
           KITHARA_DRM_PROD_KEY: ${{ secrets.KITHARA_DRM_PROD_KEY }}
           KITHARA_DRM_PROD_AUTH_TOKEN: ${{ secrets.KITHARA_DRM_PROD_AUTH_TOKEN }}
           KITHARA_DRM_PROD_SP_ZV_TOKEN: ${{ secrets.KITHARA_DRM_PROD_SP_ZV_TOKEN }}
+          KITHARA_DRM_STAGE_KEY: ${{ secrets.KITHARA_DRM_STAGE_KEY }}
           KITHARA_DRM_STAGE_AUTH_TOKEN: ${{ secrets.KITHARA_DRM_STAGE_AUTH_TOKEN }}
         # A build of its own, because these binaries carry production keys
         # the declared lanes' do not - but on the volume the other lanes build

--- a/crates/kithara-devtools/src/orphans/declared.rs
+++ b/crates/kithara-devtools/src/orphans/declared.rs
@@ -6,16 +6,26 @@ use std::{
 
 use anyhow::{Context, Result};
 
-/// Every file some `mod` declaration under `src` names, whatever gates it.
+/// Every file some `mod` declaration names, whatever gates it.
 ///
 /// `cargo modules orphans` answers from one resolved configuration and pairs a
 /// file with its parent by directory convention, so a module behind a `cfg`
 /// this build does not set, or one reached through `#[path]` from a sibling
 /// file, reads as unreferenced to it. Both are declared in the source, and this
 /// walk reads the declaration instead of the resolution.
-pub(super) fn declared_files(src: &Path) -> Result<HashSet<PathBuf>> {
+///
+/// The build script is read alongside `src` because `cargo modules` selects
+/// only a library or a binary: a file the build script alone names is
+/// declared in the source, yet invisible to every target a sweep can ask
+/// about.
+pub(super) fn declared_files(src: &Path, build_script: Option<&Path>) -> Result<HashSet<PathBuf>> {
     let mut declared = HashSet::new();
     walk(src, &mut declared)?;
+    if let Some(script) = build_script {
+        let text =
+            fs::read_to_string(script).with_context(|| format!("read {}", script.display()))?;
+        collect(script, &text, &mut declared);
+    }
     Ok(declared)
 }
 
@@ -137,7 +147,7 @@ mod tests {
             }
             fs::write(&path, contents).expect("write source");
         }
-        let found = declared_files(temp.path()).expect("declared files");
+        let found = declared_files(temp.path(), None).expect("declared files");
         found
             .into_iter()
             .map(|path| {
@@ -152,6 +162,33 @@ mod tests {
         declared(files)
             .into_iter()
             .map(|path| path.display().to_string())
+            .collect()
+    }
+
+    fn names_at_package_root(files: &[(&str, &str)], script: Option<&str>) -> HashSet<String> {
+        let temp = tempdir().expect("tempdir");
+        for (name, contents) in files {
+            let path = temp.path().join(name);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).expect("create source directory");
+            }
+            fs::write(&path, contents).expect("write source");
+        }
+        let build_script = script.map(|text| {
+            let path = temp.path().join("build.rs");
+            fs::write(&path, text).expect("write build script");
+            path
+        });
+        let found = declared_files(&temp.path().join("src"), build_script.as_deref())
+            .expect("declared files");
+        found
+            .into_iter()
+            .map(|path| {
+                path.strip_prefix(temp.path())
+                    .unwrap_or(&path)
+                    .display()
+                    .to_string()
+            })
             .collect()
     }
 
@@ -243,5 +280,25 @@ mod tests {
         let found = names(&[("mod.rs", "fn probe() {\n    let path = \"stray.rs\";\n}\n")]);
 
         assert!(!found.contains("stray.rs"));
+    }
+
+    /// `cargo modules` selects only a library or a binary, so a file the build
+    /// script alone names is invisible to every target a sweep can ask about
+    /// while still being declared in the source.
+    #[test]
+    fn a_declaration_the_build_script_alone_names_counts_as_declared() {
+        let found = names_at_package_root(
+            &[("src/lib.rs", "")],
+            Some("#[path = \"src/defs/mod.rs\"]\nmod defs;\n"),
+        );
+
+        assert!(found.contains("src/defs/mod.rs"));
+    }
+
+    #[test]
+    fn the_same_file_stays_undeclared_without_the_build_script() {
+        let found = names_at_package_root(&[("src/lib.rs", "")], None);
+
+        assert!(!found.contains("src/defs/mod.rs"));
     }
 }

--- a/crates/kithara-devtools/src/orphans/sweep.rs
+++ b/crates/kithara-devtools/src/orphans/sweep.rs
@@ -52,6 +52,7 @@ struct Job {
     label: String,
     package: String,
     selector: Vec<String>,
+    build_script: Option<PathBuf>,
 }
 
 /// A module the tool reported, at the file it named.
@@ -313,7 +314,7 @@ fn examine(job: &Job, root: &Path, program: &str) -> Report {
     if found.is_empty() && !output.status.success() {
         return Report::failed(job, failure(program, &output.status.to_string(), &text));
     }
-    let declared = match declared_files(&job.src) {
+    let declared = match declared_files(&job.src, job.build_script.as_deref()) {
         Ok(declared) => declared,
         Err(err) => return Report::failed(job, format!("{err:#}")),
     };
@@ -391,6 +392,11 @@ fn scope(metadata: &Metadata, wanted: &[String], excluded: &[String]) -> (Vec<Jo
             continue;
         };
         let src = dir.as_std_path().join("src");
+        let build_script = package
+            .targets
+            .iter()
+            .find(|target| target.is_custom_build())
+            .map(|target| target.src_path.clone().into_std_path_buf());
         for target in &package.targets {
             let selector = if target.is_bin() {
                 Some((
@@ -410,6 +416,7 @@ fn scope(metadata: &Metadata, wanted: &[String], excluded: &[String]) -> (Vec<Jo
                 selector,
                 package: name.clone(),
                 src: src.clone(),
+                build_script: build_script.clone(),
             });
         }
     }


### PR DESCRIPTION
Two of the chronic nightly failures, both root-caused rather than worked around.

## `quality-architecture`: the orphan sweep could not see a build script

`cargo modules` selects only a library or a binary, so a module a build script
alone declares is invisible to every target the sweep can ask about and reads
back as unreferenced. `kithara-test-fixtures` declares `defs` and `registry`
only in `build.rs` — deliberately, so asset declarations never enter the
library — and the lane failed on both, every night, with `--deny`.

The declaration scan now reads the package's build script beside `src`, which
is where the declaration lives. `collect` already resolves `#[path]` against
the declaring file's directory, so a build script at the package root resolves
`src/defs/mod.rs` correctly without further work.

Rejected alternatives: declaring the two modules in `lib.rs` under a `cfg`
(contradicts the crate's documented contract and adds dead library code), and
adding the package to `orphans.exclude_packages` (a suppression).

## `network`: the lane never received the keys the repository already held

A called workflow starts with no secrets of its own. `dispatch.yml` calls
`network.yml` without handing any over, so every `secrets.KITHARA_DRM_*`
resolved to the empty string and the build script refused the build, naming
all five. The four secrets it named are set in the repository and always were.

`KITHARA_DRM_STAGE_KEY` was also absent from the lane's environment block
although the build requires it, so the lane could not have built even with the
handover in place. It is now declared; the secret itself has to be created once
in repository settings.

## Validation

- `just arch orphans -p kithara-test-fixtures --deny` — `no orphans` (was one
  package reporting two).
- `just arch orphans --deny` across all 58 targets — `no orphans`.
- `cargo test -p kithara-devtools --lib orphans::` — 26 passed, including a
  pair that proves the new behaviour is not vacuous: a build-script `#[path]`
  counts as declared, and the same file stays undeclared when no build script
  is read.
- `just fmt` clean; `lint-fast` gate passed on both commits.
