### PR TITLE
fix(ci): let the nightly release build ask for no version

### DIFF
--- a/.config/xtask.toml
+++ b/.config/xtask.toml
@@ -2255,14 +2255,13 @@ wasm_asset = "kithara-wasm-pages.zip"
 wasm_dist = "crates/kithara-ffi/dist"
 pages_branch = "gh-pages"
 
-# What each packaging run collects. The version gate belongs to publishing a
-# version, so a snapshot taken of a commit under review does not ask for one.
+# What each packaging run collects. Whether a version has to be named is the
+# pipeline's answer rather than a profile's: this same release profile builds
+# the versioned release and the rolling nightly, which names no version.
 [ext.release.packages.release]
-version_gate = true
 assets = ["core", "merged"]
 
 [ext.release.packages.snapshot]
-version_gate = false
 assets = ["merged"]
 
 # What delivery requires before it runs and what it then performs. The nightly

--- a/xtask/src/ci/release.rs
+++ b/xtask/src/ci/release.rs
@@ -7,9 +7,9 @@ use anyhow::{Context, Result, bail};
 use kithara_devtools::{Ctx, common::tools::ToolsConfig};
 use sha2::{Digest, Sha256};
 
-use super::process::Process;
+use super::{process::Process, run::PipelineKind};
 use crate::{
-    config::{KitharaExt, PackageProfile, PublishStep, ReleaseConfig},
+    config::{KitharaExt, PublishStep, ReleaseConfig},
     publish, release,
 };
 
@@ -23,10 +23,12 @@ pub(crate) fn xcframework(
     ext: &KitharaExt,
     temp: &Path,
     package: &str,
+    kind: PipelineKind,
 ) -> Result<()> {
     process.require_os("macos", "Apple release")?;
     let profile = ext.release.package(package)?;
-    let expected = expected_checksum(profile, &ctx.root.join(&ext.release.manifest))?;
+    let version = version_variable(kind).map(required_env).transpose()?;
+    let expected = expected_checksum(version.as_deref(), &ctx.root.join(&ext.release.manifest))?;
 
     process.run(
         ctx.config.tools.program("just"),
@@ -111,16 +113,29 @@ fn write_provenance(
     fs::write(&path, body).with_context(|| format!("writing {}", path.display()))
 }
 
-/// The checksum the built framework has to match, or `None` when the profile
-/// carries no version. The manifest pins what a released version resolves to,
-/// so the two must agree before that version is published; packaging a commit
-/// for someone to install by hand answers a different question and names no
-/// version to check against.
-fn expected_checksum(profile: &PackageProfile, manifest_path: &Path) -> Result<Option<String>> {
-    if !profile.version_gate {
-        return Ok(None);
+/// The variable naming the version this pipeline publishes, or `None` when it
+/// publishes none. A release is a version: someone names it, and the framework
+/// built here has to match what the Swift manifest records for that version.
+/// The rolling nightly channel names no version by design, and neither does
+/// the door that asks only whether the build lanes still work - one job builds
+/// for all three, so a gate the job carries unconditionally fails the two that
+/// have no value to give it.
+const fn version_variable(kind: PipelineKind) -> Option<&'static str> {
+    match kind {
+        PipelineKind::Release => Some("KITHARA_RELEASE_VERSION"),
+        _ => None,
     }
-    let version = required_env("KITHARA_RELEASE_VERSION")?;
+}
+
+/// The checksum the built framework has to match, or `None` when no version is
+/// being published. The manifest pins what a released version resolves to, so
+/// the two must agree before that version is published; packaging a commit for
+/// someone to install by hand answers a different question and names no
+/// version to check against.
+fn expected_checksum(version: Option<&str>, manifest_path: &Path) -> Result<Option<String>> {
+    let Some(version) = version else {
+        return Ok(None);
+    };
     let manifest = fs::read_to_string(manifest_path)
         .with_context(|| format!("reading {}", manifest_path.display()))?;
     let manifest_version = manifest_field(&manifest, "version")?;
@@ -405,7 +420,6 @@ fn required_env(name: &str) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::AssetKey;
 
     #[test]
     fn provenance_names_the_commit_and_every_asset() {
@@ -455,14 +469,22 @@ mod tests {
     }
 
     #[test]
-    fn a_gate_free_profile_asks_for_no_version() {
-        let profile = PackageProfile {
-            version_gate: false,
-            assets: vec![AssetKey::Merged],
-        };
+    fn a_release_pipeline_publishes_the_version_it_was_given() {
+        assert_eq!(
+            version_variable(PipelineKind::Release),
+            Some("KITHARA_RELEASE_VERSION")
+        );
+    }
 
-        let expected = expected_checksum(&profile, Path::new("Package.swift"))
-            .expect("a gate-free profile reads no manifest");
+    #[test]
+    fn the_rolling_nightly_publishes_no_version() {
+        assert_eq!(version_variable(PipelineKind::Nightly), None);
+    }
+
+    #[test]
+    fn a_pipeline_without_a_version_reads_no_manifest() {
+        let expected = expected_checksum(None, Path::new("Package.swift"))
+            .expect("no version reads no manifest");
 
         assert!(expected.is_none());
     }

--- a/xtask/src/ci/run.rs
+++ b/xtask/src/ci/run.rs
@@ -403,7 +403,7 @@ fn execute(args: &RunArgs, ctx: &Ctx) -> Result<()> {
         has_server_uds,
         || match lane {
             Lane::ReleaseXcframework => {
-                super::release::xcframework(&process, ctx, &ext, &temp, &args.package)
+                super::release::xcframework(&process, ctx, &ext, &temp, &args.package, args.kind)
             }
             Lane::ReleaseDocs => super::release::docs(&process, ctx, &ext),
             Lane::ReleaseWasm => super::release::wasm(&process, ctx, &ext),

--- a/xtask/src/config.rs
+++ b/xtask/src/config.rs
@@ -578,13 +578,13 @@ pub(crate) enum AssetKey {
     Wasm,
 }
 
-/// What a packaging run collects, and whether the built framework has to match
-/// the version the Swift manifest records. Publishing a version asks that
-/// question; taking a snapshot of a commit does not.
+/// What a packaging run collects. Whether the built framework has to match a
+/// version belongs to the pipeline rather than to the profile: one job builds
+/// the same assets for a release someone named a version for and for the
+/// rolling nightly, which names none.
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub(crate) struct PackageProfile {
-    pub(crate) version_gate: bool,
     pub(crate) assets: Vec<AssetKey>,
 }
 
@@ -714,7 +714,7 @@ merged_asset = "Kithara.xcframework.zip"
     }
 
     #[test]
-    fn a_packaging_profile_names_its_assets_and_gate() {
+    fn a_packaging_profile_names_its_assets() {
         let ctx = ctx_from_config(
             r#"
 [ext.release]
@@ -722,7 +722,6 @@ core_asset = "KitharaFFIInternal.xcframework.zip"
 merged_asset = "Kithara.xcframework.zip"
 
 [ext.release.packages.snapshot]
-version_gate = false
 assets = ["merged"]
 "#,
         );
@@ -730,7 +729,7 @@ assets = ["merged"]
         let ext = KitharaExt::from_ctx(&ctx).expect("parse kithara extension");
 
         let profile = ext.release.package("snapshot").expect("snapshot profile");
-        assert!(!profile.version_gate);
+
         assert_eq!(profile.assets, vec![AssetKey::Merged]);
     }
 
@@ -840,7 +839,6 @@ assets = ["mergd"]
         let ctx = ctx_from_config(
             r#"
 [ext.release.packages.release]
-version_gate = true
 assets = ["core", "merged"]
 "#,
         );


### PR DESCRIPTION
## What was broken

The rolling `nightly` channel has published nothing since **12 August**. Every
scheduled nightly since then has failed `release:xcframework` eleven seconds in
and skipped `release:publish`:

| lane | pipeline 2142594 (`b326184b0`, 8 Sep) |
| --- | --- |
| `release:wasm` | success |
| `release:docs` | success |
| `release:android` | success |
| `release:xcframework` | **failed, 11s** |
| `release:publish` | skipped |

The same shape in 2139482, 2138584, 2131638, 2128717 — it is not a flake.

```
Error: KITHARA_RELEASE_VERSION is required
  at xtask::ci::release::required_env      (xtask/src/ci/release.rs:402)
  at xtask::ci::release::expected_checksum (xtask/src/ci/release.rs:123)
  at xtask::ci::release::xcframework       (xtask/src/ci/release.rs:29)
```

`.rules-release` deliberately runs the build lanes for the release kind and the
nightly kind, and says so: *"What differs is the checksum gate a version
carries and the tag the publish job writes, and the lanes read the kind for
both."* The lanes did not. `release:xcframework` passes `--package release`
unconditionally, that profile carried `version_gate = true`, and the gate
demands `KITHARA_RELEASE_VERSION` — a variable a nightly has no value for and
which `[ext.release.channels.nightly]` already declares it does not need
(`requires_version = false`).

Introduced by 4600587ae (#189), which split the packaging profiles and put the
gate on the profile rather than on the pipeline.

The `KITHARA_VERIFY_RELEASE_LANES` door failed for the same reason: it exists to
answer whether the build lanes still work, on a kind that names no version.

## The fix

Whether a version is being published is the pipeline's answer, not a profile's,
and the lane already receives the kind. It reads it there:

```rust
const fn version_variable(kind: PipelineKind) -> Option<&'static str> {
    match kind {
        PipelineKind::Release => Some("KITHARA_RELEASE_VERSION"),
        _ => None,
    }
}
```

`version_gate` leaves `PackageProfile` and the catalog — one concept lived in
two places that had to agree, and they had drifted. The profile is left saying
what it collects. No YAML changes.

- kind `release` → the gate applies, unchanged.
- kind `nightly` → no gate, the lane builds, `release:publish` runs.
- the verify door on any other kind → no gate, the lane builds.

## Validation

- `cargo test -p xtask` — 451 lib tests pass, including three new ones:
  `a_release_pipeline_publishes_the_version_it_was_given`,
  `the_rolling_nightly_publishes_no_version`,
  `a_pipeline_without_a_version_reads_no_manifest`.
- `just lint fast` — clean, through the commit hook.
- End-to-end is not reachable from a branch: `.rules-release` admits the build
  lanes only on the release and nightly kinds, or through the verify door on a
  protected ref. The proof is to play the `nightly` schedule (id 284) once this
  is on `develop`.
