### PR TITLE
fix(ci): unblock mac pipelines and cancel superseded reviews

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,9 +38,8 @@ workflow:
     - if: $CI_PIPELINE_SOURCE == "api" && $KITHARA_PLATFORMS
     - when: never
 
-.serialized:
+.dispatch:
   stage: dispatch
-  resource_group: kithara-mac-mini
   variables:
     # The child pipeline gates its platform includes on this, and it does not
     # see what the run was started with unless the trigger forwards it. Unset
@@ -52,7 +51,7 @@ workflow:
     strategy: depend
 
 dispatch:merge-request:
-  extends: .serialized
+  extends: .dispatch
   interruptible: true
   variables:
     KITHARA_CACHE_TRUST: review
@@ -60,16 +59,9 @@ dispatch:merge-request:
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
 
-# Work in progress reaches the Apple host on its own, before anyone opens a
-# merge request. The child verdict propagates through `strategy: depend`, while
-# a resource group of its own prevents a branch push from making
-# `dispatch:main` or a merge request wait behind an hour of somebody's branch.
-# Measurement stays honest regardless — the suites, the simulator run and
-# every perf lane share `kithara-suite` across pipelines, so one of them still
-# holds the machine at a time.
+# Child jobs own host resources; dispatch must not reserve the entire host.
 dispatch:branch:
   stage: dispatch
-  resource_group: kithara-mac-mini-branch
   interruptible: true
   trigger:
     include:
@@ -85,10 +77,9 @@ dispatch:branch:
 # Started by hand to name platforms a push cannot. Its own kind admits the
 # verify and integration sets so the requested platform lanes exist, while the
 # verdict checks the default-branch journal instead of recording this branch as
-# a new baseline. The branch queue keeps it out of the default branch's way.
+# a new baseline.
 dispatch:platforms:
   stage: dispatch
-  resource_group: kithara-mac-mini-branch
   allow_failure: true
   interruptible: true
   trigger:
@@ -110,7 +101,7 @@ dispatch:platforms:
     - if: $CI_PIPELINE_SOURCE == "api" && $KITHARA_PLATFORMS
 
 dispatch:main:
-  extends: .serialized
+  extends: .dispatch
   interruptible: false
   variables:
     KITHARA_CACHE_TRUST: trusted
@@ -119,7 +110,7 @@ dispatch:main:
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
 
 dispatch:quarantine:
-  extends: .serialized
+  extends: .dispatch
   interruptible: true
   variables:
     KITHARA_CACHE_TRUST: quarantine
@@ -128,7 +119,7 @@ dispatch:quarantine:
     - if: $CI_PIPELINE_SOURCE == "api" && $KITHARA_QUARANTINE_SHA
 
 dispatch:nightly:
-  extends: .serialized
+  extends: .dispatch
   interruptible: false
   variables:
     KITHARA_CACHE_TRUST: trusted
@@ -137,7 +128,7 @@ dispatch:nightly:
     - if: $CI_PIPELINE_SOURCE == "schedule" && $KITHARA_SCHEDULE_KIND == "nightly"
 
 dispatch:weekly:
-  extends: .serialized
+  extends: .dispatch
   interruptible: false
   variables:
     KITHARA_CACHE_TRUST: trusted
@@ -146,7 +137,7 @@ dispatch:weekly:
     - if: $CI_PIPELINE_SOURCE == "schedule" && $KITHARA_SCHEDULE_KIND == "weekly"
 
 dispatch:release:
-  extends: .serialized
+  extends: .dispatch
   interruptible: false
   variables:
     KITHARA_CACHE_TRUST: trusted

--- a/.gitlab/ci/common.yml
+++ b/.gitlab/ci/common.yml
@@ -125,12 +125,8 @@
     - if: $KITHARA_PIPELINE_KIND == "main"
     - if: $KITHARA_PIPELINE_KIND == "nightly"
 
-# A branch push runs the iOS-facing subset, not everything: the platform under
-# focus, on the host that is that platform. The branch kind is therefore added
-# to the jobs that subset names rather than to the shared sets above, which the
-# Linux, Android and web lanes also extend. Cancellation comes from the parent
-# `dispatch:branch`, which is interruptible and takes the child pipeline with
-# it, so these keep the interruptibility their own kind asks for.
+# Review checks can be superseded by another commit on the same branch.
+# Child jobs declare cancellation themselves; the trigger cannot do it for them.
 .rules-verify-and-branch:
   interruptible: true
   rules:
@@ -141,7 +137,9 @@
   interruptible: false
   rules:
     - if: $KITHARA_PIPELINE_KIND == "branch"
+      interruptible: true
     - if: $KITHARA_PIPELINE_KIND == "merge-request"
+      interruptible: true
     - !reference [.rules-integration, rules]
 
 # Long lanes a review ref asks for on purpose. Keeping them off `main` leaves
@@ -151,7 +149,9 @@
   interruptible: false
   rules:
     - if: $KITHARA_PIPELINE_KIND == "branch"
+      interruptible: true
     - if: $KITHARA_PIPELINE_KIND == "merge-request"
+      interruptible: true
     - if: $KITHARA_PIPELINE_KIND == "nightly"
 
 .rules-nightly:

--- a/.gitlab/ci/pipeline.yml
+++ b/.gitlab/ci/pipeline.yml
@@ -11,6 +11,15 @@ include:
   - local: .gitlab/ci/lanes.yml
   - local: .gitlab/ci/release.yml
 
+workflow:
+  auto_cancel:
+    on_new_commit: none
+  rules:
+    - if: $KITHARA_PIPELINE_KIND == "branch" || $KITHARA_PIPELINE_KIND == "merge-request"
+      auto_cancel:
+        on_new_commit: interruptible
+    - when: always
+
 stages:
   - apple
   - linux

--- a/docs/guides/ci-host.md
+++ b/docs/guides/ci-host.md
@@ -68,6 +68,12 @@ owns its checkout and compiler-cache slot, and the verdict journal locks its
 read-modify-write transaction. Raising the runner limit is a separate host-capacity
 change, not a prerequisite for removing idle time between pipelines.
 
+Superseded branch and merge-request child pipelines cancel interruptible checks,
+including iOS and end-to-end review suites. Main, scheduled, release, and explicit
+platform runs retain their cancellation policy. Quarantine refs are unique per
+head/base pair; the bridge retires obsolete attempts rather than relying on
+same-ref push cancellation.
+
 ## Windows
 
 `xtask ci host` provisions the UTM guest under `<host_root>/vm/windows` from the

--- a/docs/guides/ci-host.md
+++ b/docs/guides/ci-host.md
@@ -59,6 +59,15 @@ shell jobs inherit that scheduling policy, so marking the parent `Background`
 throttles Cargo and the single-threaded source linters. Colima stays background;
 Linux work has its own container CPU limit.
 
+## Pipeline scheduling
+
+Dispatch waits for its child's verdict without holding a host resource group.
+Independent pipelines can therefore fill the runner's available slots. Measured
+child jobs retain `kithara-suite`; the runner limits total parallelism, each job
+owns its checkout and compiler-cache slot, and the verdict journal locks its
+read-modify-write transaction. Raising the runner limit is a separate host-capacity
+change, not a prerequisite for removing idle time between pipelines.
+
 ## Windows
 
 `xtask ci host` provisions the UTM guest under `<host_root>/vm/windows` from the

--- a/xtask/tests/gitlab_pipelines.rs
+++ b/xtask/tests/gitlab_pipelines.rs
@@ -221,7 +221,7 @@ impl GitlabConfig {
                             .as_str()
                             .unwrap_or_else(|| panic!("`{rules_owner}` has a non-string rule key"));
                         assert!(
-                            matches!(key, "if" | "when"),
+                            matches!(key, "if" | "when" | "interruptible"),
                             "`{rules_owner}` uses unsupported rule key `{key}`"
                         );
                     }
@@ -778,4 +778,53 @@ fn dispatch_does_not_reserve_the_host_while_children_run() {
             "{job} must retain measurement isolation"
         );
     }
+}
+
+#[test]
+fn superseded_review_checks_are_cancelable_in_the_child_pipeline() {
+    let root = workspace_root();
+    let document = yaml(root.join(".gitlab/ci/pipeline.yml"));
+    assert_eq!(
+        document["workflow"]["auto_cancel"]["on_new_commit"].as_str(),
+        Some("none")
+    );
+    let rules = document["workflow"]["rules"]
+        .as_sequence()
+        .expect("workflow rules");
+    assert_eq!(
+        rules[0]["if"].as_str(),
+        Some("$KITHARA_PIPELINE_KIND == \"branch\" || $KITHARA_PIPELINE_KIND == \"merge-request\"")
+    );
+    assert_eq!(
+        rules[0]["auto_cancel"]["on_new_commit"].as_str(),
+        Some("interruptible")
+    );
+    assert_eq!(rules[1]["when"].as_str(), Some("always"));
+    let config = GitlabConfig::load(root);
+    for owner in [".rules-integration-and-review", ".rules-review-or-nightly"] {
+        let rules = config.definition(owner)["rules"]
+            .as_sequence()
+            .expect("job rules");
+        for kind in ["branch", "merge-request"] {
+            let condition = format!("$KITHARA_PIPELINE_KIND == \"{kind}\"");
+            let rule = rules
+                .iter()
+                .find(|rule| rule.get("if").and_then(Value::as_str) == Some(condition.as_str()))
+                .expect("review rule");
+            assert_eq!(
+                rule["interruptible"].as_bool(),
+                Some(true),
+                "{owner}: {kind}"
+            );
+        }
+        assert_eq!(
+            config.definition(owner)["interruptible"].as_bool(),
+            Some(false),
+            "non-review jobs retain their policy"
+        );
+    }
+    assert_eq!(
+        config.definition(".rules-release")["interruptible"].as_bool(),
+        Some(false)
+    );
 }

--- a/xtask/tests/gitlab_pipelines.rs
+++ b/xtask/tests/gitlab_pipelines.rs
@@ -427,7 +427,7 @@ fn merge_request_dispatch_is_admitted_without_duplicate_push_pipelines() {
     );
     assert_eq!(
         review.get("extends").and_then(Value::as_str),
-        Some(".serialized")
+        Some(".dispatch")
     );
     let variables = mapping(
         review
@@ -461,25 +461,24 @@ fn merge_request_dispatch_is_admitted_without_duplicate_push_pipelines() {
     );
     assert!(!review.contains_key("allow_failure"));
 
-    let serialized = mapping(
+    let template = mapping(
         dispatch
-            .get(".serialized")
-            .expect("dispatch has a serialized template"),
-        "the serialized dispatch template",
+            .get(".dispatch")
+            .expect("dispatch has a shared template"),
+        "the dispatch template",
     );
     assert_automatic_when(
-        serialized.get("when").map(|when| {
-            when.as_str()
-                .expect("serialized dispatch `when` is a string")
-        }),
-        ".serialized",
+        template
+            .get("when")
+            .map(|when| when.as_str().expect("dispatch template `when` is a string")),
+        ".dispatch",
     );
-    assert!(!serialized.contains_key("allow_failure"));
+    assert!(!template.contains_key("allow_failure"));
     let trigger = mapping(
-        serialized
+        template
             .get("trigger")
-            .expect("serialized dispatch has a trigger"),
-        "the serialized trigger",
+            .expect("dispatch template has a trigger"),
+        "the template trigger",
     );
     assert_eq!(
         trigger.get("strategy").and_then(Value::as_str),
@@ -488,7 +487,7 @@ fn merge_request_dispatch_is_admitted_without_duplicate_push_pipelines() {
     let includes = trigger
         .get("include")
         .and_then(Value::as_sequence)
-        .expect("serialized trigger includes child configuration");
+        .expect("template trigger includes child configuration");
     assert!(includes.iter().any(|include| {
         include
             .as_mapping()
@@ -749,4 +748,34 @@ fn cargo_fetches_through_the_git_binary_that_reads_the_pinned_http_version() {
         Some("true"),
         "the pinned HTTP version reaches Cargo only through the git binary"
     );
+}
+
+#[test]
+fn dispatch_does_not_reserve_the_host_while_children_run() {
+    let document = yaml(workspace_root().join(".gitlab-ci.yml"));
+    for (name, definition) in mapping(&document, "dispatch pipeline") {
+        let Some(job) = definition.as_mapping() else {
+            continue;
+        };
+        assert!(
+            !job.contains_key("resource_group"),
+            "{name:?} must leave resource ownership to child jobs"
+        );
+    }
+    let config = GitlabConfig::load(workspace_root());
+    for job in [
+        "apple:test",
+        "apple:test-flash-off",
+        "apple:ios-test",
+        "apple:e2e",
+    ] {
+        assert_eq!(
+            config
+                .effective_value(job, "resource_group")
+                .as_ref()
+                .and_then(Value::as_str),
+            Some("kithara-suite"),
+            "{job} must retain measurement isolation"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
Mac CI reserved the entire host for the lifetime of each child pipeline, so a PR could not use a free runner slot while main was running its Apple matrix. Remove dispatch-level resource groups and leave scheduling to the existing runner slots and child-job resource groups. Superseded branch and merge-request checks also cancel in the child pipeline, including long iOS/e2e jobs that previously refused cancellation.

## Behavior / scope
- Independent main, review, branch, quarantine, and scheduled pipelines can submit runnable child jobs concurrently.
- Measured suites and iOS tests still share `kithara-suite`. Runner concurrency remains two; test selection, budgets, child verdict propagation, and trust variables are unchanged.
- Child workflows explicitly enable interruptible cancellation for branch and merge-request runs; main, scheduled, release, and explicit platform runs retain their policy. Unique quarantine refs remain owned by bridge cleanup.
- Rename the shared dispatch template and document the existing checkout, compiler-cache-slot, and transactional-journal ownership.
- This change removes whole-pipeline queueing. Build/execution splitting and increasing the runner limit are outside this PR.

## Validation
- Live cancellation observed: old quarantine parent 2145391 and child 2145392 were canceled, including running `apple:test` job 9603900 at 22:40:33 UTC. The bridge log records removal of obsolete verification branches. This proves quarantine cleanup, not the new same-ref branch/MR auto-cancel behavior; that live demonstration remains outstanding.
- `just fmt check` and `just lint fast`: passed; normal commit hook required, no bypasses or new baseline entries.
- `just test run --lane=tooling -p xtask --test gitlab_pipelines`: 11 passed, 0 skipped.
- Regression proof: restoring the old dispatch resource group made the new test fail at its host-reservation assertion; after restoration of the fix all scheduling tests passed. The cancellation regression also failed on the previous child configuration; the final suite passed all 11 tests.
- GitLab project CI lint: dispatch dry-run on develop and the updated child workflow/common rules are valid, with no errors or warnings; generated dispatch has no resource group.
- Read-only pre-change host observation: M4, 10 CPUs, 24 GiB RAM, two configured runner slots; only one job running with CPU 86–94% idle while test jobs waited for their measurement resource and PR pipelines waited for the whole-host resource.
- Not run: full product suite, live modified pipelines, a two-push cancellation demonstration, or post-deployment throughput comparison. Runtime code is unchanged; local acceptance covers the affected scheduling configuration.

## Surface impact
- Public API: none.
- Platform/runtime: GitLab scheduling on the Mac CI host; no deployed host settings changed.
- Perf-sensitive paths: none; measurement serialization retained.

## Risks / follow-ups
- Draft pending current-head Mac CI. The live bridge admitted this PR: [pipeline 2145398](https://gitlab.zvq.me/disrupt/kithara/-/pipelines/2145398), child [2145399](https://gitlab.zvq.me/disrupt/kithara/-/pipelines/2145399), verifies `ca5cbd88b` merged with main `bbcce71c65bf`. The earlier assertion that the bridge would reject this CI-control change is not supported by its current behavior.
- Linux GitHub runners are down. No hosted-green or measured speedup claim is made.
- After reviewed deployment, compare queue and wall-clock time for concurrent main/PR pipelines and check individual test outcomes. The remaining two-slot limit and serialized test execution can still produce queueing.
- PR #341 is unchanged. Production merge remains user-controlled.

