### PR TITLE
feat(quality): include diagnostic LCOM4 in quality reports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4649,7 +4649,6 @@ dependencies = [
  "kithara",
  "kithara-integration-tests",
  "kithara-test-utils",
- "serial_test",
 ]
 
 [[package]]
@@ -4738,7 +4737,6 @@ dependencies = [
  "kithara",
  "kithara-app",
  "kithara-integration-tests",
- "kithara-test-fixtures",
  "kithara-test-utils",
  "num-traits",
  "url",
@@ -5209,7 +5207,6 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serial_test",
  "thirtyfour",
  "tracing",
  "tracing-wasm",
@@ -5290,7 +5287,6 @@ dependencies = [
  "kithara",
  "kithara-integration-tests",
  "kithara-test-utils",
- "serial_test",
  "tempfile",
  "wasm-bindgen",
  "web-sys",
@@ -5416,7 +5412,6 @@ dependencies = [
  "rand 0.10.2",
  "reqwest",
  "ringbuf 0.5.0",
- "rkyv",
  "serde",
  "serde_json",
  "serial_test",
@@ -5902,6 +5897,7 @@ dependencies = [
  "rtsan-standalone",
  "serde",
  "serde_json",
+ "serial_test",
  "tracing",
  "tracing-subscriber",
  "tracing-wasm",

--- a/crates/kithara-devtools/src/ci_report.rs
+++ b/crates/kithara-devtools/src/ci_report.rs
@@ -12,6 +12,7 @@ use serde_json::Value;
 use crate::{
     Ctx,
     common::project::{HealthConfig, ProjectConfig},
+    quality_assessment::lcom,
 };
 
 /// Names the producing tools own. They are contracts with those tools rather
@@ -60,9 +61,26 @@ fn render(artifacts: &Path, config: &ProjectConfig) -> Result<String> {
     out.push_str(&assessment(artifacts)?);
     out.push_str(&health(artifacts, health_report_name(&config.health)?)?);
     out.push_str(&coverage_risk(artifacts, budgets.crap_rows)?);
+    out.push_str(&type_cohesion(
+        artifacts,
+        config.quality.render.summary_rows,
+    )?);
     out.push_str(&architecture(artifacts, budgets.top_contours)?);
     out.push_str(&duplication(artifacts, budgets.similarity_rows)?);
     Ok(out)
+}
+
+fn type_cohesion(artifacts: &Path, rows: usize) -> Result<String> {
+    let Some(assessment) = find(artifacts, &|path| {
+        named(path, "assessment.json") && under(path, Consts::ASSESSMENT_DIRECTORY)
+    })?
+    else {
+        return Ok(missing(
+            "Type cohesion (LCOM4)",
+            "quality-assessment/assessment.json",
+        ));
+    };
+    lcom::render_file(&assessment, rows)
 }
 
 /// The health report is this workspace's own artifact rather than a foreign
@@ -484,6 +502,31 @@ mod tests {
     #[test]
     fn the_default_configuration_carries_similarity_rows() {
         assert!(ProjectConfig::default().ci_report.similarity_rows > 0);
+    }
+
+    #[test]
+    fn consolidated_report_includes_lcom4_and_crap_from_the_same_run() {
+        let temp = tempdir().expect("directory");
+        write(
+            &temp
+                .path()
+                .join("quality-assessment/rev/product-standard/assessment.json"),
+            r#"{
+            "lcom4": {"notes": ["diagnostic only"], "types": [
+                {"name": "demo::Pair", "target": "lib", "location": "src/lib.rs:1", "lcom4": 2,
+                 "groups": [{"methods": ["read"], "fields": ["a"]}, {"methods": ["write"], "fields": ["b"]}]}
+            ]}
+        }"#,
+        );
+        write(
+            &temp.path().join("quality-lab/rev/cargo-crap/report.md"),
+            "| function | CRAP |\n| parse | 12 |\n",
+        );
+        let report = render(temp.path(), &ProjectConfig::default()).expect("report");
+        assert!(report.contains("## Type cohesion (LCOM4)"));
+        assert!(report.contains("demo::Pair"));
+        assert!(report.contains("`read` (a); `write` (b)"));
+        assert!(report.contains("| parse | 12 |"));
     }
 
     #[test]

--- a/crates/kithara-devtools/src/cohesion.rs
+++ b/crates/kithara-devtools/src/cohesion.rs
@@ -1,0 +1,447 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use anyhow::Result;
+use glob::Pattern;
+use serde::{Deserialize, Serialize};
+use syn::{
+    Expr, ExprCall, ExprField, ExprMethodCall, ImplItemFn, Item, Member,
+    visit::{self, Visit},
+};
+
+use crate::Ctx;
+
+mod source;
+
+use source::{Source, join, methods};
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct Report {
+    pub(crate) notes: Vec<String>,
+    pub(crate) types: Vec<TypeCohesion>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct TypeCohesion {
+    pub(crate) location: String,
+    pub(crate) name: String,
+    pub(crate) target: String,
+    pub(crate) groups: Vec<Group>,
+    pub(crate) lcom4: usize,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct Group {
+    pub(crate) fields: BTreeSet<String>,
+    pub(crate) methods: BTreeSet<String>,
+}
+
+#[derive(Default)]
+struct Method {
+    calls: BTreeSet<String>,
+    fields: BTreeSet<String>,
+    name: String,
+}
+
+pub(crate) fn collect(
+    ctx: &Ctx,
+    tests: bool,
+    selected: Option<&str>,
+    selected_module: Option<&str>,
+) -> Result<Report> {
+    let excluded = ctx
+        .config
+        .architecture
+        .filters
+        .exclude_crates
+        .iter()
+        .map(|pattern| Pattern::new(pattern))
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut report = Report { types: Vec::new(), notes: vec![
+        "Source-level LCOM4 for structs: number of connected receiver-method groups; shared direct self fields and unambiguous self.method() and Self::method(self) calls connect methods. Associated functions and Drop are excluded; fieldless receiver methods remain isolated unless connected by calls.".to_owned(),
+        "Diagnostic only: no debt, verdict, or CI threshold effect. Macros, deref/alias-based access, UFCS trait calls, generic dispatch, and glob imports are not resolved. Non-test cfg alternatives are combined; this is not a measurement of one compiled configuration.".to_owned(),
+    ] };
+    for package in ctx.metadata()?.workspace_packages() {
+        if selected.is_some_and(|name| name != package.name.as_str())
+            || selected.is_none()
+                && !tests
+                && excluded
+                    .iter()
+                    .any(|pattern| pattern.matches(package.name.as_str()))
+        {
+            continue;
+        }
+        for target in &package.targets {
+            if !tests
+                && (target.is_test()
+                    || target.is_bench()
+                    || target.is_example()
+                    || target.is_custom_build())
+            {
+                continue;
+            }
+            let source = Source::read(&ctx.root, target.src_path.as_std_path(), tests)?;
+            append_source(
+                &mut report,
+                &source,
+                package.name.as_str(),
+                &format!("{}:{:?}", target.name, target.kind),
+                selected_module,
+                tests,
+            );
+        }
+    }
+    report.types.sort_by(|left, right| {
+        right
+            .groups
+            .len()
+            .cmp(&left.groups.len())
+            .then_with(|| (&left.name, &left.target).cmp(&(&right.name, &right.target)))
+    });
+    report.notes[2..].sort();
+    report.notes.dedup();
+    Ok(report)
+}
+
+fn append_source(
+    report: &mut Report,
+    source: &Source,
+    package: &str,
+    target: &str,
+    selected: Option<&str>,
+    tests: bool,
+) {
+    let mut types: BTreeMap<String, Vec<Method>> = BTreeMap::new();
+    report.notes.extend(
+        source
+            .notes
+            .iter()
+            .map(|note| format!("{package}/{target}: {note}")),
+    );
+    for implementation in &source.implementations {
+        let item = &implementation.item;
+        let trait_name = item.trait_.as_ref().map(|(path, _)| {
+            path.segments
+                .iter()
+                .map(|segment| segment.ident.to_string())
+                .collect::<Vec<_>>()
+                .join("::")
+        });
+        if trait_name
+            .as_deref()
+            .is_some_and(|name| matches!(name, "Drop" | "std::ops::Drop" | "core::ops::Drop"))
+        {
+            continue;
+        }
+        let Some(owner) = source.owner(implementation) else {
+            if methods(item, tests).next().is_some() {
+                report.notes.push(format!(
+                    "{package}/{target} {}: impl owner unresolved; methods omitted",
+                    implementation.location
+                ));
+            }
+            continue;
+        };
+        if source
+            .definitions
+            .get(&owner)
+            .is_some_and(|definition| definition.is_enum)
+        {
+            continue;
+        }
+        for method in methods(item, tests) {
+            let name = trait_name.as_ref().map_or_else(
+                || method.sig.ident.to_string(),
+                |name| format!("<{name}>::{}", method.sig.ident),
+            );
+            types
+                .entry(owner.clone())
+                .or_default()
+                .push(scan_method(method, name));
+        }
+    }
+    for (name, definition) in &source.definitions {
+        if selected.is_some_and(|module| {
+            definition.module != module && !definition.module.starts_with(&format!("{module}::"))
+        }) {
+            continue;
+        }
+        if definition.is_enum {
+            report.notes.push(format!(
+                "{}: LCOM4 not applicable to enum variant state; not measured",
+                join(package, name)
+            ));
+            continue;
+        }
+        let methods = types.remove(name).unwrap_or_default();
+        if methods.is_empty() {
+            continue;
+        }
+        let groups = groups(&methods);
+        report.types.push(TypeCohesion {
+            name: join(package, name),
+            target: target.to_owned(),
+            location: definition.location.clone(),
+            lcom4: groups.len(),
+            groups,
+        });
+    }
+}
+
+fn scan_method(method: &ImplItemFn, name: String) -> Method {
+    let mut result = Method {
+        name,
+        ..Method::default()
+    };
+    result.visit_block(&method.block);
+    result
+}
+
+impl<'ast> Visit<'ast> for Method {
+    fn visit_expr_call(&mut self, expression: &'ast ExprCall) {
+        if let Expr::Path(path) = expression.func.as_ref()
+            && path.qself.is_none()
+            && path.path.segments.len() == 2
+            && path.path.segments[0].ident == "Self"
+            && expression.args.first().is_some_and(is_self)
+        {
+            self.calls.insert(path.path.segments[1].ident.to_string());
+        }
+        visit::visit_expr_call(self, expression);
+    }
+
+    fn visit_expr_field(&mut self, expression: &'ast ExprField) {
+        if is_self(&expression.base) {
+            let field = match &expression.member {
+                Member::Named(name) => name.to_string(),
+                Member::Unnamed(index) => index.index.to_string(),
+            };
+            self.fields.insert(field);
+        }
+        visit::visit_expr_field(self, expression);
+    }
+
+    fn visit_expr_method_call(&mut self, expression: &'ast ExprMethodCall) {
+        if is_self(&expression.receiver) {
+            self.calls.insert(expression.method.to_string());
+        }
+        visit::visit_expr_method_call(self, expression);
+    }
+
+    fn visit_item(&mut self, _: &'ast Item) {}
+}
+
+fn is_self(expression: &Expr) -> bool {
+    match expression {
+        Expr::Path(path) => path.path.is_ident("self"),
+        Expr::Reference(reference) => is_self(&reference.expr),
+        Expr::Paren(paren) => is_self(&paren.expr),
+        Expr::Group(group) => is_self(&group.expr),
+        _ => false,
+    }
+}
+
+/// ponytail: pairwise method scan; index field users if large types dominate scan time.
+fn groups(methods: &[Method]) -> Vec<Group> {
+    let mut names: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
+    for method in methods {
+        names
+            .entry(method.name.rsplit("::").next().unwrap_or(&method.name))
+            .or_default()
+            .insert(&method.name);
+    }
+    let resolves = |caller: &Method, callee: &Method| {
+        caller.calls.iter().any(|call| {
+            if names
+                .get(call.as_str())
+                .is_some_and(|matches| matches.contains(call.as_str()))
+            {
+                callee.name == *call
+            } else {
+                names.get(call.as_str()).is_some_and(|matches| {
+                    matches.len() == 1 && matches.contains(callee.name.as_str())
+                })
+            }
+        })
+    };
+    let mut remaining: BTreeSet<usize> = (0..methods.len()).collect();
+    let mut groups = Vec::new();
+    while let Some(start) = remaining.pop_first() {
+        let mut pending = vec![start];
+        let mut group = Group {
+            methods: BTreeSet::new(),
+            fields: BTreeSet::new(),
+        };
+        while let Some(index) = pending.pop() {
+            let method = &methods[index];
+            group.methods.insert(method.name.clone());
+            group.fields.extend(method.fields.iter().cloned());
+            let connected = remaining
+                .iter()
+                .copied()
+                .filter(|other| {
+                    let other = &methods[*other];
+                    method.name == other.name
+                        || !method.fields.is_disjoint(&other.fields)
+                        || resolves(method, other)
+                        || resolves(other, method)
+                })
+                .collect::<Vec<_>>();
+            for other in connected {
+                remaining.remove(&other);
+                pending.push(other);
+            }
+        }
+        groups.push(group);
+    }
+    groups.sort_by(|left, right| left.methods.cmp(&right.methods));
+    groups
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn lcom4_tracks_fields_calls_and_full_module_owners_across_files() {
+        let temp = tempdir().expect("directory");
+        fs::write(
+            temp.path().join("lib.rs"),
+            r#"
+            mod first { pub struct Same { a: u8, b: u8 } }
+            mod second { pub struct Same { a: u8 } impl Same { fn only(&self) { self.a; } } }
+            mod behavior;
+            #[cfg(test)] mod fixture;
+        "#,
+        )
+        .expect("root");
+        fs::write(
+            temp.path().join("behavior.rs"),
+            r#"
+            use crate::first::Same as Owner;
+            impl Owner {
+                fn new() -> Self { todo!() }
+                fn a(&self) { self.a; }
+                fn b(&self) { self.b; }
+                fn bridge(&self) { self.a(); Self::b(self); }
+                fn alone(&self) {}
+                #[cfg(test)] fn test_bridge(&self) { self.alone(); self.bridge(); }
+            }
+            impl Drop for Owner { fn drop(&mut self) { self.alone(); self.bridge(); } }
+        "#,
+        )
+        .expect("impls");
+        let source = Source::read(temp.path(), &temp.path().join("lib.rs"), false).expect("source");
+        let mut report = Report {
+            types: Vec::new(),
+            notes: Vec::new(),
+        };
+        append_source(&mut report, &source, "demo", "lib", None, false);
+        assert!(report.notes.is_empty(), "{:?}", report.notes);
+        assert_eq!(report.types.len(), 2);
+        let first = &report.types[0];
+        assert_eq!(first.name, "demo::first::Same");
+        assert_eq!(first.groups.len(), 2);
+        assert!(first.groups.iter().any(|group| group.methods
+            == BTreeSet::from(["a".to_owned(), "b".to_owned(), "bridge".to_owned()])
+            && group.fields == BTreeSet::from(["a".to_owned(), "b".to_owned()])));
+        assert_eq!(report.types[1].groups.len(), 1);
+    }
+    #[test]
+    fn lcom4_handles_tuple_fields_trait_names_and_unresolved_owners() {
+        let temp = tempdir().expect("directory");
+        fs::write(temp.path().join("lib.rs"), r#"
+            struct Pair(u8, u8);
+            enum State { Ready, Done }
+            impl State { fn ready(&self) -> bool { matches!(self, Self::Ready) } }
+            impl Pair { fn a(&self) { self.0; } fn same(&self) { self.0; } fn other(&self) { self.1; } }
+            trait One { fn shared(&self); }
+            trait Two { fn shared(&self); }
+            impl One for Pair { fn shared(&self) { self.0; } }
+            impl Two for Pair { fn shared(&self) { self.1; } }
+            impl Pair { fn ambiguous(&self) { self.shared(); } }
+            mod unrelated { impl Pair { fn bogus(&self) { self.0; self.1; } } }
+        "#).expect("root");
+        let source = Source::read(temp.path(), &temp.path().join("lib.rs"), false).expect("source");
+        let mut report = Report {
+            types: Vec::new(),
+            notes: Vec::new(),
+        };
+        append_source(&mut report, &source, "demo", "lib", None, false);
+        assert_eq!(report.types.len(), 1);
+        assert_eq!(report.types[0].lcom4, 3);
+        assert_eq!(report.notes.len(), 2);
+        assert!(
+            report
+                .notes
+                .iter()
+                .any(|note| note.contains("impl owner unresolved"))
+        );
+        assert!(
+            report
+                .notes
+                .iter()
+                .any(|note| note.contains("LCOM4 not applicable to enum"))
+        );
+        assert!(
+            report.types[0]
+                .groups
+                .iter()
+                .any(|group| group.methods.contains("<One>::shared")
+                    && group.methods.contains("same")
+                    && group.fields.contains("0"))
+        );
+    }
+
+    #[test]
+    fn lcom4_module_scope_preserves_external_impls_and_complete_includes_tests() {
+        let temp = tempdir().expect("directory");
+        fs::write(
+            temp.path().join("lib.rs"),
+            r#"
+            #[path = "model.rs"] mod data;
+            mod operations;
+            #[cfg_attr(feature = "x", path = "on.rs")]
+            #[cfg_attr(not(feature = "x"), path = "off.rs")]
+            mod conditional;
+            #[cfg(test)] mod fixture { struct Fixture; impl Fixture { fn run(&self) {} } }
+        "#,
+        )
+        .expect("root");
+        fs::write(
+            temp.path().join("model.rs"),
+            "pub struct Data { a: u8, b: u8 }",
+        )
+        .expect("type");
+        fs::write(
+            temp.path().join("operations.rs"),
+            r#"
+            impl crate::data::Data {
+                fn a(&self) { self.a; }
+                fn b(&self) { self.b; }
+                #[cfg(test)] fn bridge(&self) { self.a(); self.b(); }
+            }
+        "#,
+        )
+        .expect("impl");
+        fs::write(temp.path().join("on.rs"), "struct On;").expect("conditional on");
+        fs::write(temp.path().join("off.rs"), "struct Off;").expect("conditional off");
+        for (tests, expected) in [(false, 2), (true, 1)] {
+            let source =
+                Source::read(temp.path(), &temp.path().join("lib.rs"), tests).expect("source");
+            assert!(source.definitions.contains_key("conditional::On"));
+            assert!(source.definitions.contains_key("conditional::Off"));
+            let mut report = Report {
+                types: Vec::new(),
+                notes: Vec::new(),
+            };
+            append_source(&mut report, &source, "demo", "lib", Some("data"), tests);
+            assert!(report.notes.is_empty());
+            assert_eq!(report.types.len(), 1);
+            assert_eq!(report.types[0].lcom4, expected);
+        }
+    }
+}

--- a/crates/kithara-devtools/src/cohesion/metric.rs
+++ b/crates/kithara-devtools/src/cohesion/metric.rs
@@ -8,11 +8,8 @@ use syn::{
     visit::{self, Visit},
 };
 
+use super::source::{Source, join, methods};
 use crate::Ctx;
-
-mod source;
-
-use source::{Source, join, methods};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub(crate) struct Report {

--- a/crates/kithara-devtools/src/cohesion/mod.rs
+++ b/crates/kithara-devtools/src/cohesion/mod.rs
@@ -1,0 +1,4 @@
+mod metric;
+mod source;
+
+pub(crate) use metric::{Report, collect};

--- a/crates/kithara-devtools/src/cohesion/source.rs
+++ b/crates/kithara-devtools/src/cohesion/source.rs
@@ -1,0 +1,339 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result, bail};
+use syn::{
+    Attribute, Expr, ImplItem, Item, ItemImpl, Lit, Meta, Type, UseTree, punctuated::Punctuated,
+    spanned::Spanned,
+};
+
+use crate::common::{
+    exclude::{attrs_are_test_only, item_attrs},
+    parse::parse_file,
+};
+
+pub(super) struct Definition {
+    pub(super) location: String,
+    pub(super) module: String,
+    pub(super) is_enum: bool,
+}
+
+#[derive(Default)]
+pub(super) struct Source {
+    pub(super) definitions: BTreeMap<String, Definition>,
+    pub(super) notes: BTreeSet<String>,
+    pub(super) implementations: Vec<Implementation>,
+    imports: BTreeMap<String, BTreeMap<String, BTreeSet<String>>>,
+    root: PathBuf,
+    include_tests: bool,
+}
+
+pub(super) struct Implementation {
+    pub(super) item: ItemImpl,
+    pub(super) location: String,
+    pub(super) module: String,
+}
+
+impl Source {
+    fn definition(&mut self, module: &str, name: &str, location: String, is_enum: bool) {
+        let name = join(module, name);
+        if self.definitions.contains_key(&name) {
+            self.notes.insert(format!(
+                "{name}: multiple source definitions (cfg alternatives combined)"
+            ));
+        }
+        self.definitions.insert(
+            name,
+            Definition {
+                is_enum,
+                location,
+                module: module.to_owned(),
+            },
+        );
+    }
+
+    fn file(&mut self, path: &Path, module: &str, active: &mut BTreeSet<PathBuf>) -> Result<()> {
+        let canonical = path
+            .canonicalize()
+            .with_context(|| format!("resolve LCOM4 source {}", path.display()))?;
+        if !active.insert(canonical.clone()) {
+            bail!("recursive LCOM4 module source: {}", path.display());
+        }
+        let file = parse_file(path)?;
+        if !self.include_tests && attrs_are_test_only(&file.attrs) {
+            active.remove(&canonical);
+            return Ok(());
+        }
+        let parent = path.parent().context("LCOM4 source has no parent")?;
+        let directory = match path.file_stem().and_then(|stem| stem.to_str()) {
+            Some("lib" | "main" | "mod") => parent.to_path_buf(),
+            Some(stem) if !module.is_empty() => parent.join(stem),
+            _ => parent.to_path_buf(),
+        };
+        self.items(path, &directory, module, &file.items, active)?;
+        active.remove(&canonical);
+        Ok(())
+    }
+
+    fn items(
+        &mut self,
+        file: &Path,
+        directory: &Path,
+        module: &str,
+        items: &[Item],
+        active: &mut BTreeSet<PathBuf>,
+    ) -> Result<()> {
+        for item in items {
+            if !self.include_tests && attrs_are_test_only(item_attrs(item)) {
+                continue;
+            }
+            let location = format!(
+                "{}:{}",
+                file.strip_prefix(&self.root).unwrap_or(file).display(),
+                item.span().start().line
+            );
+            match item {
+                Item::Struct(value) => {
+                    self.definition(module, &value.ident.to_string(), location, false);
+                }
+                Item::Enum(value) => {
+                    self.definition(module, &value.ident.to_string(), location, true);
+                }
+                Item::Impl(value) => self.implementations.push(Implementation {
+                    location,
+                    item: value.clone(),
+                    module: module.to_owned(),
+                }),
+                Item::Use(value) => {
+                    let mut imports = Vec::new();
+                    collect_imports(&value.tree, "", &mut imports);
+                    for (name, path) in imports {
+                        self.imports
+                            .entry(module.to_owned())
+                            .or_default()
+                            .entry(name)
+                            .or_default()
+                            .insert(path);
+                    }
+                }
+                Item::Mod(value) => {
+                    let child = join(module, &value.ident.to_string());
+                    if let Some((_, items)) = &value.content {
+                        self.items(
+                            file,
+                            &directory.join(value.ident.to_string()),
+                            &child,
+                            items,
+                            active,
+                        )?;
+                    } else {
+                        for path in
+                            module_files(file, directory, &value.ident.to_string(), &value.attrs)?
+                        {
+                            if path.is_file() {
+                                self.file(&path, &child, active)?;
+                            } else {
+                                self.notes.insert(format!(
+                                    "{location}: module source unavailable: {}",
+                                    path.display()
+                                ));
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn owner(&self, implementation: &Implementation) -> Option<String> {
+        let Type::Path(path) = implementation.item.self_ty.as_ref() else {
+            return None;
+        };
+        if path.qself.is_some() || path.path.leading_colon.is_some() {
+            return None;
+        }
+        let path = path
+            .path
+            .segments
+            .iter()
+            .map(|segment| segment.ident.to_string())
+            .collect::<Vec<_>>()
+            .join("::");
+        let owner = self.resolve(&implementation.module, &path, &mut BTreeSet::new())?;
+        self.definitions.contains_key(&owner).then_some(owner)
+    }
+
+    pub(super) fn read(root: &Path, entry: &Path, include_tests: bool) -> Result<Self> {
+        let mut source = Self {
+            root: root.to_path_buf(),
+            include_tests,
+            ..Self::default()
+        };
+        source.file(entry, "", &mut BTreeSet::new())?;
+        Ok(source)
+    }
+
+    fn resolve(&self, module: &str, path: &str, visited: &mut BTreeSet<String>) -> Option<String> {
+        if !visited.insert(format!("{module}|{path}")) {
+            return None;
+        }
+        let mut parts = path.split("::").collect::<Vec<_>>();
+        let first = *parts.first()?;
+        if first == "crate" {
+            return self.resolve_absolute(&parts[1..].join("::"), visited);
+        }
+        if first == "self" {
+            return self.resolve_absolute(&join(module, &parts[1..].join("::")), visited);
+        }
+        if first == "super" {
+            let mut parents = module
+                .split("::")
+                .filter(|part| !part.is_empty())
+                .collect::<Vec<_>>();
+            while parts.first() == Some(&"super") {
+                parents.pop()?;
+                parts.remove(0);
+            }
+            return self.resolve_absolute(&join(&parents.join("::"), &parts.join("::")), visited);
+        }
+        if let Some(paths) = self
+            .imports
+            .get(module)
+            .and_then(|imports| imports.get(first))
+        {
+            if paths.len() != 1 {
+                return None;
+            }
+            let imported = paths.first()?;
+            return self.resolve(module, &join(imported, &parts[1..].join("::")), visited);
+        }
+        self.resolve_absolute(&join(module, path), visited)
+    }
+
+    fn resolve_absolute(&self, path: &str, visited: &mut BTreeSet<String>) -> Option<String> {
+        if self.definitions.contains_key(path) {
+            return Some(path.to_owned());
+        }
+        let (module, name) = path.rsplit_once("::").unwrap_or(("", path));
+        let paths = self.imports.get(module)?.get(name)?;
+        if paths.len() != 1 {
+            return None;
+        }
+        self.resolve(module, paths.first()?, visited)
+    }
+}
+
+fn module_files(
+    file: &Path,
+    directory: &Path,
+    name: &str,
+    attrs: &[Attribute],
+) -> Result<Vec<PathBuf>> {
+    let parent = file.parent().context("module source has no parent")?;
+    let mut paths = BTreeSet::new();
+    let mut conditional = false;
+    for attr in attrs {
+        if let Some(path) = declared_path(&attr.meta) {
+            paths.insert(parent.join(path));
+        }
+        if let Meta::List(list) = &attr.meta
+            && list.path.is_ident("cfg_attr")
+        {
+            let nested =
+                list.parse_args_with(Punctuated::<Meta, syn::Token![,]>::parse_terminated)?;
+            for meta in nested.iter().skip(1) {
+                if let Some(path) = declared_path(meta) {
+                    paths.insert(parent.join(path));
+                    conditional = true;
+                }
+            }
+        }
+    }
+    if paths.is_empty() || conditional {
+        let flat = directory.join(format!("{name}.rs"));
+        let nested = directory.join(name).join("mod.rs");
+        match (flat.is_file(), nested.is_file()) {
+            (true, true) => bail!(
+                "ambiguous module source: {} and {}",
+                flat.display(),
+                nested.display()
+            ),
+            (true, false) => {
+                paths.insert(flat);
+            }
+            (false, true) => {
+                paths.insert(nested);
+            }
+            (false, false) if paths.is_empty() => {
+                paths.insert(flat);
+            }
+            (false, false) => {}
+        }
+    }
+    Ok(paths.into_iter().collect())
+}
+
+fn declared_path(meta: &Meta) -> Option<String> {
+    if let Meta::NameValue(value) = meta
+        && value.path.is_ident("path")
+        && let Expr::Lit(value) = &value.value
+        && let Lit::Str(value) = &value.lit
+    {
+        Some(value.value())
+    } else {
+        None
+    }
+}
+
+fn collect_imports(tree: &UseTree, prefix: &str, output: &mut Vec<(String, String)>) {
+    match tree {
+        UseTree::Path(path) => {
+            collect_imports(&path.tree, &join(prefix, &path.ident.to_string()), output);
+        }
+        UseTree::Name(name) if name.ident == "self" => {
+            if let Some(name) = prefix.rsplit("::").next() {
+                output.push((name.to_owned(), prefix.to_owned()));
+            }
+        }
+        UseTree::Name(name) => output.push((
+            name.ident.to_string(),
+            join(prefix, &name.ident.to_string()),
+        )),
+        UseTree::Rename(name) => output.push((
+            name.rename.to_string(),
+            join(prefix, &name.ident.to_string()),
+        )),
+        UseTree::Group(group) => {
+            for tree in &group.items {
+                collect_imports(tree, prefix, output);
+            }
+        }
+        UseTree::Glob(_) => {}
+    }
+}
+
+pub(super) fn join(parent: &str, name: &str) -> String {
+    if parent.is_empty() {
+        name.to_owned()
+    } else if name.is_empty() {
+        parent.to_owned()
+    } else {
+        format!("{parent}::{name}")
+    }
+}
+
+pub(super) fn methods(item: &ItemImpl, tests: bool) -> impl Iterator<Item = &syn::ImplItemFn> {
+    item.items.iter().filter_map(move |item| match item {
+        ImplItem::Fn(method)
+            if method.sig.receiver().is_some()
+                && (tests || !attrs_are_test_only(&method.attrs)) =>
+        {
+            Some(method)
+        }
+        _ => None,
+    })
+}

--- a/crates/kithara-devtools/src/common/exclude.rs
+++ b/crates/kithara-devtools/src/common/exclude.rs
@@ -94,7 +94,7 @@ fn collect_declared_test_modules(
 }
 
 /// Whether the attributes carry a cfg that holds in no build but a test one.
-fn attrs_are_test_only(attrs: &[syn::Attribute]) -> bool {
+pub(crate) fn attrs_are_test_only(attrs: &[syn::Attribute]) -> bool {
     attrs.iter().any(|a| match &a.meta {
         Meta::List(list) if list.path.is_ident("cfg") => {
             syn::parse2::<Meta>(list.tokens.clone()).is_ok_and(|m| cfg_predicate_is_test_only(&m))

--- a/crates/kithara-devtools/src/lib.rs
+++ b/crates/kithara-devtools/src/lib.rs
@@ -6,6 +6,7 @@ pub mod audit;
 pub mod audit_clippy;
 pub mod ci_report;
 pub mod clippy;
+mod cohesion;
 pub mod common;
 pub mod ctx;
 pub mod format;

--- a/crates/kithara-devtools/src/quality_assessment.rs
+++ b/crates/kithara-devtools/src/quality_assessment.rs
@@ -9,6 +9,7 @@ use crate::Ctx;
 mod adapters;
 mod artifact;
 mod collect;
+pub(crate) mod lcom;
 mod model;
 mod orchestrator;
 mod summary;
@@ -136,7 +137,7 @@ mod tests {
         .expect("package manifest");
         fs::write(
             temp.path().join("demo/src/lib.rs"),
-            "pub struct Demo;\nimpl Demo {\n    pub fn new() -> Self { Self }\n}\n",
+            "pub struct Demo { a: u8, b: u8 }\nimpl Demo {\n    pub fn a(&self) -> u8 { self.a }\n    pub fn b(&self) -> u8 { self.b }\n}\n",
         )
         .expect("source");
         for namespace in ["arch", "style", "idioms"] {
@@ -183,6 +184,54 @@ mod tests {
         assert_eq!(assessment["summary"]["debt_threshold"], 100);
         assert_eq!(assessment["verdict"], "refactor");
         assert_eq!(assessment["scope"]["kind"], "workspace");
+        assert_eq!(
+            assessment["lcom4"]["types"][0]["groups"]
+                .as_array()
+                .expect("groups")
+                .len(),
+            2
+        );
+        let markdown = fs::read_to_string(output.join("assessment.md")).expect("Markdown");
+        assert!(markdown.contains("Type cohesion (LCOM4)"));
+        assert!(markdown.contains("demo::Demo"));
+    }
+
+    #[test]
+    fn lcom4_changes_do_not_change_debt_or_verdict() {
+        let temp = tempdir().expect("directory");
+        fs::write(
+            temp.path().join("Cargo.toml"),
+            "[workspace]\nmembers = [\"demo\"]\nresolver = \"3\"\n",
+        )
+        .expect("workspace");
+        fs::create_dir_all(temp.path().join("demo/src")).expect("source directory");
+        fs::write(
+            temp.path().join("demo/Cargo.toml"),
+            "[package]\nname = \"demo\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+        )
+        .expect("package");
+        let source = temp.path().join("demo/src/lib.rs");
+        fs::write(&source, "pub struct Pair { a: u8, b: u8 } impl Pair { fn a(&self) { self.a; } fn b(&self) { self.b; } }").expect("disconnected source");
+        let ctx = Ctx::load_from_manifest(&temp.path().join("Cargo.toml")).expect("context");
+        let args = AssessArgs {
+            depth: AssessmentDepth::Standard,
+            profile: AssessmentProfile::Product,
+            baseline: None,
+            krate: None,
+            module: None,
+            reuse_existing: true,
+        };
+        let disconnected = collect::collect(&args, &ctx, &[]).expect("disconnected assessment");
+        fs::write(&source, "pub struct Pair { a: u8, b: u8 } impl Pair { fn a(&self) { self.a; } fn b(&self) { self.a; } }").expect("connected source");
+        let connected = collect::collect(&args, &ctx, &[]).expect("connected assessment");
+        assert_eq!(disconnected.lcom4.types[0].lcom4, 2);
+        assert_eq!(connected.lcom4.types[0].lcom4, 1);
+        assert_eq!(disconnected.verdict, connected.verdict);
+        assert_eq!(
+            disconnected.summary.debt_units,
+            connected.summary.debt_units
+        );
+        assert_eq!(disconnected.summary.findings, connected.summary.findings);
     }
 
     #[test]

--- a/crates/kithara-devtools/src/quality_assessment/artifact.rs
+++ b/crates/kithara-devtools/src/quality_assessment/artifact.rs
@@ -123,6 +123,7 @@ fn markdown(assessment: &Assessment, root: &Path, budgets: &QualityRenderBudgets
     output.push_str(verdict_guidance(assessment));
     append_comparison(&mut output, assessment);
     append_signals(&mut output, assessment, budgets);
+    super::lcom::append(&mut output, &assessment.lcom4, budgets.findings);
     append_coverage(&mut output, assessment);
     append_stages(&mut output, assessment);
     append_findings(&mut output, assessment, budgets);

--- a/crates/kithara-devtools/src/quality_assessment/collect.rs
+++ b/crates/kithara-devtools/src/quality_assessment/collect.rs
@@ -24,7 +24,7 @@ use crate::{
     },
 };
 
-const SCHEMA_VERSION: u32 = 1;
+const SCHEMA_VERSION: u32 = 2;
 const WORKSPACE_DEBT_THRESHOLD: u64 = 100;
 
 pub(super) struct Revision {
@@ -55,7 +55,14 @@ pub(super) fn collect(
     let adapted = adapters::collect(ctx, &revision.directory, &selection.name, args, stages)?;
     findings.extend(adapted.findings);
     let debt_units = findings.iter().map(|finding| finding.debt_units).sum();
-    let tool_coverage = tool_coverage(args, ctx, stages, &adapted.coverage);
+    let mut tool_coverage = tool_coverage(args, ctx, stages, &adapted.coverage);
+    tool_coverage.push(ToolCoverage {
+        tool: "lcom4".to_owned(),
+        status: CoverageStatus::Executed,
+        owner: Some("cohesion".to_owned()),
+        note: "Native source-level diagnostic; limitations and unresolved ownership are recorded in lcom4.notes.".to_owned(),
+        evidence_artifacts: vec!["assessment.json".to_owned()],
+    });
     let evidence_gaps = tool_coverage
         .iter()
         .filter(|coverage| coverage.status == CoverageStatus::EvidenceGap)
@@ -94,7 +101,20 @@ pub(super) fn collect(
     );
     let output_directory =
         output_directory(&ctx.root, &revision.directory, args.profile, args.depth);
+    let selected_module = args
+        .module
+        .as_deref()
+        .and_then(|module| module.split_once("::"));
+    let lcom4 = crate::cohesion::collect(
+        ctx,
+        args.profile == AssessmentProfile::Complete,
+        args.krate
+            .as_deref()
+            .or_else(|| selected_module.map(|(package, _)| package)),
+        selected_module.map(|(_, module)| module),
+    )?;
     Ok(Assessment {
+        lcom4,
         schema_version: SCHEMA_VERSION,
         revision: revision.directory,
         content_digest: revision.digest,

--- a/crates/kithara-devtools/src/quality_assessment/lcom.rs
+++ b/crates/kithara-devtools/src/quality_assessment/lcom.rs
@@ -1,0 +1,78 @@
+use std::{fs, path::Path};
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+use super::artifact;
+use crate::cohesion::Report;
+
+#[derive(Deserialize)]
+struct AssessmentCohesion {
+    lcom4: Report,
+}
+
+pub(crate) fn render_file(path: &Path, rows: usize) -> Result<String> {
+    let text = fs::read_to_string(path)
+        .with_context(|| format!("read LCOM4 assessment {}", path.display()))?;
+    let assessment: AssessmentCohesion = serde_json::from_str(&text)
+        .with_context(|| format!("parse LCOM4 assessment {}", path.display()))?;
+    let mut output = String::new();
+    append(&mut output, &assessment.lcom4, rows);
+    Ok(output)
+}
+
+pub(super) fn append(output: &mut String, report: &Report, rows: usize) {
+    let disconnected = report.types.iter().filter(|entry| entry.lcom4 > 1).count();
+    output.push_str(&format!(
+        "\n## Type cohesion (LCOM4)\n\nMeasured types: {}; types with LCOM4 > 1: {}.\n\n",
+        report.types.len(),
+        disconnected,
+    ));
+    for note in report.notes.iter().take(rows) {
+        output.push_str(&format!("- {}\n", artifact::escape(note)));
+    }
+    if report.notes.len() > rows {
+        output.push_str(&format!(
+            "- {} additional analysis notes in assessment.json.\n",
+            report.notes.len() - rows
+        ));
+    }
+    if report.types.is_empty() {
+        output.push_str("\n_No types with receiver methods were measured._\n");
+        return;
+    }
+    output.push_str("\n| Type | Target | Location | LCOM4 | Method groups (fields) |\n| --- | --- | --- | ---: | --- |\n");
+    for entry in report.types.iter().take(rows) {
+        let groups = entry
+            .groups
+            .iter()
+            .map(|group| {
+                format!(
+                    "{} ({})",
+                    group
+                        .methods
+                        .iter()
+                        .map(|name| format!("`{name}`"))
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                    group.fields.iter().cloned().collect::<Vec<_>>().join(", "),
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("; ");
+        output.push_str(&format!(
+            "| {} | {} | {} | {} | {} |\n",
+            artifact::escape(&entry.name),
+            artifact::escape(&entry.target),
+            artifact::escape(&entry.location),
+            entry.lcom4,
+            artifact::escape(&groups),
+        ));
+    }
+    if report.types.len() > rows {
+        output.push_str(&format!(
+            "\n_{} additional LCOM4 rows in assessment.json._\n",
+            report.types.len() - rows
+        ));
+    }
+}

--- a/crates/kithara-devtools/src/quality_assessment/model.rs
+++ b/crates/kithara-devtools/src/quality_assessment/model.rs
@@ -170,6 +170,7 @@ pub(super) struct Assessment {
     pub(super) content_digest: Option<String>,
     #[serde(skip)]
     pub(super) output_directory: PathBuf,
+    pub(super) lcom4: crate::cohesion::Report,
     pub(super) scope: Scope,
     pub(super) revision: String,
     pub(super) summary: Summary,

--- a/crates/kithara-devtools/src/quality_assessment/summary.rs
+++ b/crates/kithara-devtools/src/quality_assessment/summary.rs
@@ -75,6 +75,7 @@ fn render(
     let mut output = header(&assessment);
     append_crap(&mut output, &assessment, crap_report, budgets)?;
     append_architecture(&mut output, &assessment, budgets)?;
+    super::lcom::append(&mut output, &assessment.lcom4, budgets.summary_rows);
     append_evidence_gaps(&mut output, &assessment, budgets)?;
     output.push_str(
         "Full details are in the uploaded quality assessment artifact (`assessment.md` and `assessment.json`).\n",
@@ -335,6 +336,38 @@ mod tests {
             .find("uploaded quality assessment artifact")
             .expect("artifact pointer");
         assert!(decision < crap && crap < architecture && architecture < gaps && gaps < artifact);
+    }
+
+    #[test]
+    fn lcom4_renders_beside_crap_with_groups_and_existing_row_budget() {
+        let temp = tempdir().expect("tempdir");
+        let directory = write_assessment(temp.path(), &[]);
+        let path = directory.join("assessment.json");
+        let mut assessment: Value =
+            serde_json::from_slice(&fs::read(&path).expect("assessment")).expect("JSON");
+        assessment["lcom4"] = json!({
+            "notes": ["Source-level diagnostic only"],
+            "types": [
+                {"name": "demo::Split", "target": "lib", "location": "src/lib.rs:1", "lcom4": 2,
+                 "groups": [{"methods": ["read"], "fields": ["a"]}, {"methods": ["write"], "fields": ["b"]}]},
+                {"name": "demo::Together", "target": "lib", "location": "src/lib.rs:9", "lcom4": 1,
+                 "groups": [{"methods": ["get", "set"], "fields": ["value"]}]}
+            ]
+        });
+        write_json(&path, &assessment);
+        let budgets = QualityRenderBudgets {
+            summary_rows: 1,
+            ..QualityRenderBudgets::default()
+        };
+        let output = render(&directory, None, &budgets).expect("summary");
+        assert!(output.contains("## Coverage risk (CRAP)"));
+        assert!(output.contains("## Type cohesion (LCOM4)"));
+        assert!(output.contains("Measured types: 2; types with LCOM4 > 1: 1."));
+        assert!(
+            output.contains("| demo::Split | lib | src/lib.rs:1 | 2 | `read` (a); `write` (b) |")
+        );
+        assert!(output.contains("1 additional LCOM4 rows in assessment.json"));
+        assert!(!output.contains("demo::Together"));
     }
 
     #[test]
@@ -624,7 +657,7 @@ mod tests {
                     "manifest": "manifest.json",
                     "stages": "stages/"
                 },
-                "schema_version": 1
+                "schema_version": 2
             }),
         );
         write_json(
@@ -640,6 +673,7 @@ mod tests {
                     "workspace_loc": 162702
                 },
                 "revision": "a8a67acb3135",
+                "lcom4": { "types": [], "notes": [] },
                 "summary": {
                     "debt_threshold": 100,
                     "debt_units": 229,
@@ -658,7 +692,7 @@ mod tests {
                     "evidence_artifacts": []
                 }],
                 "verdict": "refactor",
-                "schema_version": 1
+                "schema_version": 2
             }),
         );
         directory

--- a/crates/kithara-test-macros/src/test/shared.rs
+++ b/crates/kithara-test-macros/src/test/shared.rs
@@ -11,7 +11,9 @@ use super::parse::TestArgs;
 
 pub(crate) fn make_serial_attr(args: &TestArgs) -> TokenStream2 {
     if args.is_serial {
-        quote! { #[serial_test::serial] }
+        quote! {
+            #[::kithara_test_utils::serial_test::serial(crate = ::kithara_test_utils::serial_test)]
+        }
     } else {
         quote! {}
     }

--- a/crates/kithara-test-utils/Cargo.toml
+++ b/crates/kithara-test-utils/Cargo.toml
@@ -42,6 +42,7 @@ usdt = { workspace = true, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 backtrace = { workspace = true, optional = true }
+serial_test = { workspace = true }
 
 [target.'cfg(rtsan)'.dependencies]
 pin-project-lite = { workspace = true }

--- a/crates/kithara-test-utils/src/lib.rs
+++ b/crates/kithara-test-utils/src/lib.rs
@@ -11,6 +11,9 @@ extern crate self as kithara_test_utils;
 /// `::kithara_test_utils::kithara_platform::flash::…` for its body-injected
 /// flash wrapping.
 pub use kithara_platform;
+/// Native serialization runtime used by generated test wrappers.
+#[cfg(not(target_arch = "wasm32"))]
+pub use serial_test;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub mod flight;

--- a/tests/crates/abr/Cargo.toml
+++ b/tests/crates/abr/Cargo.toml
@@ -25,8 +25,6 @@ kithara-integration-tests = { workspace = true }
 
 kithara-test-utils = { workspace = true, features = ["hang", "mock", "probe"] }
 
-serial_test = { workspace = true }
-
 [lints]
 workspace = true
 

--- a/tests/crates/app/Cargo.toml
+++ b/tests/crates/app/Cargo.toml
@@ -30,7 +30,6 @@ kithara = { workspace = true, features = [
 ] }
 kithara-app = { workspace = true, features = ["analysis-waveform", "beat-nn-small", "lib-only"] }
 kithara-integration-tests = { workspace = true }
-kithara-test-fixtures = { workspace = true }
 
 kithara-test-utils = { workspace = true, features = ["hang", "mock", "probe"] }
 

--- a/tests/crates/ffi-web/Cargo.toml
+++ b/tests/crates/ffi-web/Cargo.toml
@@ -28,7 +28,6 @@ kithara-test-utils = { workspace = true, features = ["hang", "mock", "probe"] }
 reqwest = { workspace = true, features = ["rustls", "stream"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serial_test = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 

--- a/tests/crates/harness/Cargo.toml
+++ b/tests/crates/harness/Cargo.toml
@@ -16,7 +16,6 @@ no-block = ["kithara/no-block", "kithara-integration-tests/no-block"]
 kithara = { workspace = true, features = ["platform", "test-utils"] }
 kithara-integration-tests = { workspace = true }
 kithara-test-utils = { workspace = true, features = ["hang", "mock", "probe"] }
-serial_test = { workspace = true }
 tempfile = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/tests/crates/integration/Cargo.toml
+++ b/tests/crates/integration/Cargo.toml
@@ -65,7 +65,6 @@ futures = { workspace = true }
 hex = { workspace = true }
 num-traits = { workspace = true }
 ringbuf = { workspace = true }
-rkyv = { workspace = true }
 
 # Serialization
 serde = { workspace = true }

--- a/tests/crates/platform/tests/loom.rs
+++ b/tests/crates/platform/tests/loom.rs
@@ -23,7 +23,7 @@ use kithara::platform::{
 #[cfg(feature = "flash")]
 const SIGNAL_BACKSTOP: Duration = Duration::from_secs(5);
 
-#[kithara::test(loom)]
+#[kithara_test_utils::kithara::test(loom)]
 fn platform_mutex_is_explored_by_loom() {
     let value = Arc::new(Mutex::new(0));
     let other = Arc::clone(&value);
@@ -48,7 +48,7 @@ fn wait_until_ready(condvar: &Condvar, mut ready: MutexGuard<'_, bool>) {
     }
 }
 
-#[kithara::test(loom)]
+#[kithara_test_utils::kithara::test(loom)]
 fn platform_condvar_is_explored_by_loom() {
     let state = Arc::new((Mutex::new(false), Condvar::default()));
     let waiter_state = Arc::clone(&state);
@@ -64,7 +64,7 @@ fn platform_condvar_is_explored_by_loom() {
     assert!(waiter.join().is_ok());
 }
 
-#[kithara::test(loom)]
+#[kithara_test_utils::kithara::test(loom)]
 fn platform_channel_is_explored_by_loom() {
     let (sender, receiver) = mpsc::channel();
     let producer = thread::spawn(move || sender.send(7));
@@ -73,7 +73,7 @@ fn platform_channel_is_explored_by_loom() {
     assert!(matches!(producer.join(), Ok(Ok(()))));
 }
 
-#[kithara::test(loom)]
+#[kithara_test_utils::kithara::test(loom)]
 fn platform_atomics_are_explored_by_loom() {
     let published = Arc::new(AtomicBool::new(false));
     let producer_flag = Arc::clone(&published);
@@ -89,7 +89,7 @@ fn platform_atomics_are_explored_by_loom() {
 }
 
 #[cfg(feature = "flash")]
-#[kithara::test(loom)]
+#[kithara_test_utils::kithara::test(loom)]
 fn platform_spawn_propagates_flash_ambient() {
     let child = thread::spawn(ambient_snapshot);
 
@@ -97,7 +97,7 @@ fn platform_spawn_propagates_flash_ambient() {
 }
 
 #[cfg(feature = "flash")]
-#[kithara::test(loom)]
+#[kithara_test_utils::kithara::test(loom)]
 fn thread_gate_closes_hls_snapshot_probe_park_race() {
     let gate = Arc::new(ThreadGate::default());
     let ready = Arc::new(AtomicBool::new(false));
@@ -118,7 +118,7 @@ fn thread_gate_closes_hls_snapshot_probe_park_race() {
 }
 
 #[cfg(feature = "flash")]
-#[kithara::test(loom)]
+#[kithara_test_utils::kithara::test(loom)]
 fn thread_gate_refreshes_waiter_after_thread_handoff() {
     let gate = Arc::new(ThreadGate::default());
 


### PR DESCRIPTION
## Summary

Quality reports now show LCOM4 alongside CRAP so reviewers can inspect disconnected responsibilities within Rust structs. The native collector retains connected method groups and the fields they use, and one renderer serves the assessment document, quality summary, and consolidated CI report. The branch also fixes the `deps-unused` CI lane by centralizing the native `serial_test` runtime behind the existing test-runtime crate.

## Behavior / scope

- Assessment schema v2 includes per-type LCOM4, groups, locations, Cargo target identity, and analysis notes.
- Shared direct fields and unambiguous receiver calls connect methods across impl blocks. Module paths, explicit imports, and conditional source paths preserve ownership.
- Existing report row budgets limit presentation; JSON retains every measured group.
- LCOM4 is diagnostic and does not change debt, verdicts, or CI thresholds.
- `#[kithara::test(serial)]` resolves its native serialization attribute and runtime through `kithara-test-utils`; test consumers no longer declare `serial_test` solely for macro expansion.
- Removed two genuinely unused direct test dependencies reported by cargo-machete.

## Validation

- `just test run --flash=off -p kithara-devtools -E 'test(cohesion::) | test(quality_assessment::) | test(ci_report::)'` — 52 passed, including score calculation, scope handling, report integration, and verdict independence.
- `just quality assess --reuse-existing` — inspected schema-v2 manifest and JSON: 1,103 structs measured, 317 with LCOM4 > 1, no unavailable module files.
- `just quality summary --directory target/quality-assessment/49b1f8741836-dirty-2a14f7cef55acde7/product-standard` and `just ci report --artifacts target/quality-assessment/49b1f8741836-dirty-2a14f7cef55acde7` — verified LCOM4 rendering in both reports.
- `just deps machete` — passed after reproducing and resolving the six reported unused manifest entries.
- `just test run --flash=off -p kithara-abr-tests -p kithara-platform-tests -p kithara-test-macros` — 59 passed, including native serial macro consumers.
- `just fmt check`, `just check clippy`, and `just lint fast` — passed; no new lint violations or baseline growth.
- Fresh coverage/CRAP and full assessment stages were not run; existing external evidence was reused.

## Surface impact

- Public API: no Rust API changes; assessment JSON advances to schema v2.
- Platform/runtime: tooling reports and native test macro expansion only.
- Perf-sensitive paths: none; the assessment performs a native source scan.

## Risks / follow-ups

- Source-level analysis does not resolve macro expansion, alias/deref-based access, UFCS trait calls, generic dispatch, or glob imports. Parsed cfg alternatives are combined; unresolved owners remain explicit notes.
- Enum variant state is explicitly not applicable. Fieldless receiver methods can form separate groups and require interpretation.
- The owning wiki contract updates are prepared separately and should be published with the merged behavior.
