### PR TITLE
test: put the offline render matrices on the flash clock

### DIFF
--- a/tests/crates/audio/tests/no_sync_passthrough.rs
+++ b/tests/crates/audio/tests/no_sync_passthrough.rs
@@ -165,6 +165,16 @@ impl AudioEffect for BurstLoadEffect {
         0
     }
 
+    /// Pass the chunk through, burning real CPU on every `LOAD_INTERVAL_BLOCKS`th
+    /// one.
+    ///
+    /// The real region is what makes the burst a burst. This runs on the
+    /// producer thread, which the quiescence engine counts as running, so a
+    /// virtual `Instant` would have the spin wait for a clock that cannot move
+    /// until the spin ends. Carving the region REAL keeps the deadline on the
+    /// host clock, so the contention the load player is here to create stays
+    /// contention under flash as well as off it.
+    #[kithara::flash(false)]
     fn process(&mut self, chunk: AudioChunk) -> Option<AudioChunk> {
         self.blocks = self.blocks.saturating_add(1);
         if self.blocks.is_multiple_of(LOAD_INTERVAL_BLOCKS) {
@@ -375,6 +385,17 @@ async fn wait_for_preload(audio: &RegisteredAudio<Stream<MemStream>, TestPools>)
     .expect("audio preload gate must open");
 }
 
+/// Render the source at the real device cadence and capture the result.
+///
+/// The guard puts the pacing sleep on the same clock as the decode worker's
+/// park: the worker is a registered pacer, so a block period elapses only once
+/// it has produced. Without it the sleep is a real `tokio` timer — the test
+/// macro rewrites time calls in the test body, not in the helpers it calls —
+/// and the consumer would advance at host speed against a producer advancing at
+/// virtual speed, draining the ring into zeros and making every PCM oracle a
+/// property of the machine. The burst load stays REAL: `BurstLoadEffect` spins
+/// on the producer thread, whose callstack never enters this guard.
+#[kithara::flash(true)]
 async fn render_passthrough(
     source: &[u8],
     stretch: Option<(StretchKind, f32)>,
@@ -486,6 +507,11 @@ async fn render_passthrough(
     capture
 }
 
+/// Render the same source through a `Queue` control at the same cadence.
+///
+/// Carries the clock guard of [`render_passthrough`] for the same reason: the
+/// tick-and-render pair must not outrun the decode worker.
+#[kithara::flash(true)]
 async fn render_queue_passthrough(source: &[u8], stretch: Option<(StretchKind, f32)>) -> Vec<f32> {
     let stretch = stretch_controls(stretch);
     let harness = OfflinePlayerHarness::with_sample_rate(
@@ -786,13 +812,7 @@ fn assert_frame_oracle_load_bearing(control: &[f32]) {
     );
 }
 
-#[kithara::test(
-    tokio,
-    flash(false),
-    serial,
-    timeout(Duration::from_secs(30)),
-    hang_timeout_secs(5)
-)]
+#[kithara::test(tokio, serial, timeout(Duration::from_secs(30)), hang_timeout_secs(5))]
 #[case(StretchKind::Signalsmith)]
 #[cfg_attr(
     not(all(target_os = "windows", target_env = "msvc")),
@@ -805,13 +825,7 @@ async fn no_sync_unity_player_and_queue_playback_is_bit_exact_and_cochlea_clean(
     run_no_sync_passthrough(source_pcm, backend, false).await;
 }
 
-#[kithara::test(
-    tokio,
-    flash(false),
-    serial,
-    timeout(Duration::from_secs(30)),
-    hang_timeout_secs(5)
-)]
+#[kithara::test(tokio, serial, timeout(Duration::from_secs(30)), hang_timeout_secs(5))]
 #[case(StretchKind::Signalsmith)]
 #[cfg_attr(
     not(all(target_os = "windows", target_env = "msvc")),
@@ -826,13 +840,7 @@ async fn no_sync_active_keylock_is_continuous_and_preserves_pitch(
     run_active_stretch(source_pcm, marked_source_pcm, shifted_pitch, backend, false).await;
 }
 
-#[kithara::test(
-    tokio,
-    flash(false),
-    serial,
-    timeout(Duration::from_secs(60)),
-    hang_timeout_secs(5)
-)]
+#[kithara::test(tokio, serial, timeout(Duration::from_secs(60)), hang_timeout_secs(5))]
 #[case(StretchKind::Signalsmith)]
 #[cfg_attr(
     not(all(target_os = "windows", target_env = "msvc")),
@@ -846,13 +854,7 @@ async fn record_no_sync_unity_playback_artifacts(
     run_no_sync_passthrough(source_pcm, backend, true).await;
 }
 
-#[kithara::test(
-    tokio,
-    flash(false),
-    serial,
-    timeout(Duration::from_secs(60)),
-    hang_timeout_secs(5)
-)]
+#[kithara::test(tokio, serial, timeout(Duration::from_secs(60)), hang_timeout_secs(5))]
 #[case(StretchKind::Signalsmith)]
 #[cfg_attr(
     not(all(target_os = "windows", target_env = "msvc")),

--- a/tests/crates/play/tests/no_sync_real_media.rs
+++ b/tests/crates/play/tests/no_sync_real_media.rs
@@ -173,28 +173,14 @@ struct CapturedAudio {
     start_positions_secs: Vec<f64>,
 }
 
-#[kithara::test(
-    native,
-    tokio,
-    multi_thread,
-    serial,
-    flash(false),
-    timeout(Duration::from_secs(300))
-)]
+#[kithara::test(native, tokio, multi_thread, serial, timeout(Duration::from_secs(300)))]
 async fn no_sync_real_media_matrix_is_continuous_and_unsynchronized(
     #[future(awt)] real_media_sources: (TestServerHelper, Url, TestTempDir),
 ) {
     run_real_media_matrix(false, real_media_sources).await;
 }
 
-#[kithara::test(
-    native,
-    tokio,
-    multi_thread,
-    serial,
-    flash(false),
-    timeout(Duration::from_secs(360))
-)]
+#[kithara::test(native, tokio, multi_thread, serial, timeout(Duration::from_secs(360)))]
 #[ignore = "writes opt-in listening artifacts; run explicitly with KITHARA_AUDIO_ARTIFACT_DIR"]
 async fn record_no_sync_real_media_artifacts(
     #[future(awt)] real_media_sources: (TestServerHelper, Url, TestTempDir),
@@ -1042,6 +1028,16 @@ async fn open_resource(
     resource
 }
 
+/// Consume one block from every deck and let the clock advance by exactly its
+/// duration.
+///
+/// The guard puts that advance on the same clock as the decks' producers, which
+/// are registered pacers: the block period elapses only once they have parked.
+/// Without it the sleep is a real `tokio` timer — the test macro rewrites time
+/// calls in the test body, not in the helpers it calls — and the consumer would
+/// drain the rings at host speed against producers advancing at virtual speed,
+/// making every captured window a property of the machine.
+#[kithara::flash(true)]
 async fn render_paced(
     host: &OfflineHostHarness<TestPools>,
     decks: &[Deck],


### PR DESCRIPTION
## Why

The offline render matrices wait on real wall time. `#[kithara::test]` rewrites
time calls in the test body, not in the helpers it calls, so a pacing sleep
inside a `render_*` helper is a real `tokio` timer — and both of these modules
additionally opted their whole callstack out of flash with `flash(false)`. Every
lane therefore paid host seconds for audio the engine could have skipped.

Ranked from the Stress raw artifact, summed over the three `reproduction` lanes,
these are the two biggest offline-render payers: `no_sync_passthrough`
~5040 test-seconds and `no_sync_real_media` ~4200 test-seconds.

## What

- `render_passthrough`, `render_queue_passthrough` and `render_paced` carry
  `#[kithara::flash(true)]`, the shape already sanctioned by
  `quality_switch_continuity::render_paced`: the pacing sleep lands on the same
  clock as the decode worker's park, so a block period elapses only once the
  worker — a registered pacer — has produced.
- The four test declarations drop `flash(false)`.
- `BurstLoadEffect::process` gets an explicit `#[kithara::flash(false)]` real
  region.

## Why this loses no coverage

`.config/xtask.toml` declares `[stress.modes.reproduction-flash-off] features = []`.
Off the `flash` feature every flash attribute compiles away to the bare body, so
on that lane both matrices keep running on real clocks, before and after this
change alike. The "real deadline" property keeps being exercised on the lane that
exists for exactly that, while `reproduction-flash-on`, `reproduction-no-block`
and ordinary CI stop paying for it.

The load case keeps its discriminators: `load_observed_during_capture` and
bit-exact PCM under concurrent shared-pool work are both clock-independent, and
the 18 ms bursts stay real CPU because of the carve below. The recorder
manifests show `underruns: 0` in all three captures on both backends, so the
zero-underrun assertion was already a guard rather than the thing that separates
the load case from the others.

## The burst had to stay real

`BurstLoadEffect::process` measures its spin with the clock-agnostic `Instant`,
and it runs on the producer thread, which the quiescence engine counts as
running. Under flash the spin therefore waited for a clock it was itself
holding: this does not look like a deadlock, because the engine force-advances —
the virtual clock merely crawls. Measured 4 s of virtual time per 30 s of real
time, ending in a wall timeout. The hang dump named the holder
(`kithara-play-worker-N`, continuously emitting `build_chunk`), and the sibling
case that never sets `with_load` passed in 4 s. Carving the region real keeps the
deadline on the host clock, so the contention the load player exists to create
stays contention under flash as well as off it.

## Measured

Each matrix measured with its own test, `--cargo-profile test-release -F flash`
(the profile the lanes use):

| test | before | after |
| --- | --- | --- |
| `no_sync_passthrough` (4 cases) | 15.2 s | **7.6 s** |
| `no_sync_real_media` | 49.5 s | **30.5 s** |

Both green. The two `#[ignore]` artifact recorders in these modules were also
run explicitly and pass under flash.

## Validation

- `just fmt check`, `just lint fast`: clean, no new baseline entries and no
  suppressions.
- `just test`: 4558 passed, 0 failed, 227 skipped. Both modules are in that
  run — the default filter only drops `flash_attr`, `flash_spawn` and the
  integration helper library.
- Fork CI on this branch (`3ac1cd839`, run 34408873741): all 20 gate lanes green,
  including both clock lanes — `linux-test-simulated-clock` (flash on) and
  `linux-test-real-clock` (`just test run --flash=off`, which omits the flash
  features, so these modules compile to exactly the code they had before).
  `deps-semver` is green here too, since the branch sits directly on `main`.
- Lane wall time against the parent commit's own green run (34403351911 on
  `ce9392df2`), build included and therefore noisy: simulated clock 454s -> 326s,
  real clock 1105s -> 943s.

Independent of #353: disjoint files, branched off `main`, mergeable in either
order.
