### PR TITLE
fix(ci): activate scoped s3 compiler cache

### DIFF
--- a/xtask/src/ci/cache/mod.rs
+++ b/xtask/src/ci/cache/mod.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::BTreeMap,
     env,
     path::{Path, PathBuf},
     process::Command,
@@ -8,9 +9,52 @@ use anyhow::{Context, Result, ensure};
 use clap::{Args, Subcommand};
 
 use super::config::{CiPins, PINS_PATH};
+use crate::ci::host::read_secret;
 
 mod provision;
 mod verify;
+
+const CLIENT_KEYS: [&str; 7] = [
+    "SCCACHE_BUCKET",
+    "SCCACHE_ENDPOINT",
+    "SCCACHE_REGION",
+    "SCCACHE_S3_USE_SSL",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_EC2_METADATA_DISABLED",
+];
+
+/// Read the restricted environment a cache client may inherit.
+pub(crate) fn client_environment(path: &Path) -> Result<BTreeMap<String, String>> {
+    let mut environment = BTreeMap::new();
+    for line in read_secret(path)?.lines() {
+        let (key, value) = line
+            .split_once('=')
+            .context("invalid cache environment entry")?;
+        ensure!(
+            CLIENT_KEYS.contains(&key),
+            "unexpected cache environment key"
+        );
+        ensure!(!value.is_empty(), "empty cache environment value");
+        ensure!(
+            !value
+                .chars()
+                .any(|character| character.is_control() || matches!(character, '"' | '\\')),
+            "unsafe cache environment value"
+        );
+        ensure!(
+            environment
+                .insert(key.to_owned(), value.to_owned())
+                .is_none(),
+            "duplicate cache environment key"
+        );
+    }
+    ensure!(
+        environment.len() == CLIENT_KEYS.len(),
+        "incomplete cache environment"
+    );
+    Ok(environment)
+}
 
 #[derive(Debug, Args)]
 pub(crate) struct CacheArgs {

--- a/xtask/src/ci/cache/verify.rs
+++ b/xtask/src/ci/cache/verify.rs
@@ -9,17 +9,7 @@ use anyhow::{Context, Result, ensure};
 use tempfile::TempDir;
 use tracing::info;
 
-use crate::ci::host::read_secret;
-
-const CLIENT_KEYS: [&str; 7] = [
-    "SCCACHE_BUCKET",
-    "SCCACHE_ENDPOINT",
-    "SCCACHE_REGION",
-    "SCCACHE_S3_USE_SSL",
-    "AWS_ACCESS_KEY_ID",
-    "AWS_SECRET_ACCESS_KEY",
-    "AWS_EC2_METADATA_DISABLED",
-];
+use super::client_environment;
 
 struct Probe {
     root: TempDir,
@@ -85,31 +75,6 @@ fn require_success(output: &Output) -> Result<()> {
     Ok(())
 }
 
-fn environment(body: &str) -> Result<BTreeMap<String, String>> {
-    let mut environment = BTreeMap::new();
-    for line in body.lines() {
-        let (key, value) = line
-            .split_once('=')
-            .context("invalid cache environment entry")?;
-        ensure!(
-            CLIENT_KEYS.contains(&key),
-            "unexpected cache environment key"
-        );
-        ensure!(!value.is_empty(), "empty cache environment value");
-        ensure!(
-            environment
-                .insert(key.to_owned(), value.to_owned())
-                .is_none(),
-            "duplicate cache environment key"
-        );
-    }
-    ensure!(
-        environment.len() == CLIENT_KEYS.len(),
-        "incomplete cache environment"
-    );
-    Ok(environment)
-}
-
 fn require_counter(stats: &str, name: &str, expected: usize) -> Result<()> {
     let count = stats
         .lines()
@@ -130,7 +95,7 @@ pub(super) fn run(env_file: &Path) -> Result<()> {
         root: tempfile::Builder::new()
             .prefix("ci-cache-")
             .tempdir_in("/tmp")?,
-        environment: environment(&read_secret(env_file)?)?,
+        environment: client_environment(env_file)?,
     };
     fs::create_dir(probe.root.path().join("out"))?;
     for name in ["seed", "target"] {
@@ -165,18 +130,21 @@ pub(super) fn run(env_file: &Path) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use std::os::unix::fs::PermissionsExt;
+
     use super::*;
 
     #[test]
     fn cache_probe_rejects_process_environment_injection() {
-        assert!(environment("PATH=/tmp").is_err());
-        assert!(
-            environment(
-                "SCCACHE_BUCKET=one
-SCCACHE_BUCKET=two"
-            )
-            .is_err()
-        );
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("cache.env");
+        fs::write(&path, "PATH=/tmp").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+        assert!(client_environment(&path).is_err());
+        fs::write(&path, "SCCACHE_BUCKET=one\nSCCACHE_BUCKET=two").unwrap();
+        assert!(client_environment(&path).is_err());
+        fs::write(&path, "SCCACHE_BUCKET=one\\two").unwrap();
+        assert!(client_environment(&path).is_err());
     }
 
     #[test]

--- a/xtask/src/ci/config/host.rs
+++ b/xtask/src/ci/config/host.rs
@@ -112,6 +112,9 @@ pub(crate) struct CiHost {
     pub(crate) removable_roots: Vec<String>,
     /// Aggregate whole-gigabyte sccache budget, divided between host jobs.
     pub(crate) sccache_size: String,
+    /// A mode-0600 file with the scoped S3 settings real jobs inherit.
+    #[serde(default)]
+    pub(crate) sccache_s3_env_file: Option<PathBuf>,
     pub(crate) soft_cleanup_bytes: u64,
     pub(crate) sync_uid: u32,
     pub(crate) sync_user: String,

--- a/xtask/src/ci/host/runners.rs
+++ b/xtask/src/ci/host/runners.rs
@@ -11,6 +11,7 @@ use tracing::info;
 
 use super::services::launchd;
 use crate::ci::{
+    cache::client_environment,
     config::{CiConfig, MAC_CONFIG_PATH},
     environment::PROVISIONED_LINUX_IMAGE_ENV,
     process::Process,
@@ -102,7 +103,7 @@ impl<'a> RunnerManager<'a> {
 
         write_secure(
             &runner_root.join("config.toml"),
-            &self.runner_config(&home, &tokens),
+            &self.runner_config(&home, &tokens)?,
         )?;
         self.install_runner_agents(&home)?;
         self.process.run(
@@ -267,7 +268,7 @@ impl<'a> RunnerManager<'a> {
     /// machine's twenty-four gigabytes, its build tree started empty after every
     /// recycle, and sccache died inside it often enough that jobs compiled
     /// locally — a suite that runs in three minutes took an hour to reach.
-    fn runner_config(&self, home: &Path, tokens: &Tokens) -> String {
+    fn runner_config(&self, home: &Path, tokens: &Tokens) -> Result<String> {
         let concurrency = self.config.host.job_concurrency;
         let cargo_build_jobs = self.cargo_build_jobs_env();
         let root = self.config.host.host_root.display();
@@ -277,19 +278,30 @@ impl<'a> RunnerManager<'a> {
         let lane_config = MAC_CONFIG_PATH;
         let image = &self.config.pins.linux_image;
         let provisioned_image = format!("{PROVISIONED_LINUX_IMAGE_ENV}={image}");
-        format!(
+        let sccache_s3 = self
+            .config
+            .host
+            .sccache_s3_env_file
+            .as_deref()
+            .map(client_environment)
+            .transpose()?
+            .into_iter()
+            .flatten()
+            .map(|(name, value)| format!(", \"{name}={value}\""))
+            .collect::<String>();
+        Ok(format!(
             "concurrent = {concurrency}\ncheck_interval = 3\nshutdown_timeout = 30\n\n\
-             [[runners]]\n  name = \"kithara-mac-mini-linux\"\n  url = \"{url}\"\n  token = \"{}\"\n  executor = \"docker\"\n  builds_dir = \"{builds}/workspaces/gitlab\"\n  output_limit = 16384\n  environment = [\"KITHARA_CI_CACHE_ROOT={cache}\", \"KITHARA_CI_HOST_CONFIG={lane_config}\", \"{provisioned_image}\", \"RUSTUP_HOME=/usr/local/rustup\", \"{cargo_build_jobs}\"]\n\
+             [[runners]]\n  name = \"kithara-mac-mini-linux\"\n  url = \"{url}\"\n  token = \"{}\"\n  executor = \"docker\"\n  builds_dir = \"{builds}/workspaces/gitlab\"\n  output_limit = 16384\n  environment = [\"KITHARA_CI_CACHE_ROOT={cache}\", \"KITHARA_CI_HOST_CONFIG={lane_config}\", \"{provisioned_image}\", \"RUSTUP_HOME=/usr/local/rustup\", \"{cargo_build_jobs}\"{sccache_s3}]\n\
              [runners.docker]\n    host = \"{}\"\n    image = \"{image}\"\n    pull_policy = \"never\"\n    allowed_pull_policies = [\"never\"]\n    allowed_images = [\"{image}\"]\n    cpus = \"5\"\n    memory = \"6500m\"\n    privileged = false\n    disable_cache = true\n    shm_size = 1073741824\n    volumes = [\"{root}/cache:{cache}:rw\", \"{root}/cache/gitlab-runner:/cache:rw\", \"{root}/services/mac-host.toml:{lane_config}:ro\"]\n\n\
-             [[runners]]\n  name = \"kithara-mac-mini-macos\"\n  url = \"{url}\"\n  token = \"{}\"\n  executor = \"shell\"\n  shell = \"bash\"\n  builds_dir = \"{builds}/workspaces/gitlab\"\n  output_limit = 16384\n  environment = [\"KITHARA_CI_CACHE_ROOT={root}/cache\", \"KITHARA_CI_HOST_CONFIG={lane_config}\", \"{cargo_build_jobs}\"]\n\n\
-             [[runners]]\n  name = \"kithara-mac-mini-android\"\n  url = \"{url}\"\n  token = \"{}\"\n  executor = \"shell\"\n  shell = \"bash\"\n  builds_dir = \"{builds}/workspaces/gitlab\"\n  output_limit = 16384\n  environment = [\"KITHARA_CI_CACHE_ROOT={root}/cache\", \"KITHARA_CI_HOST_CONFIG={lane_config}\", \"{cargo_build_jobs}\"]\n\n\
-             [[runners]]\n  name = \"kithara-mac-mini-release\"\n  url = \"{url}\"\n  token = \"{}\"\n  executor = \"shell\"\n  shell = \"bash\"\n  builds_dir = \"{builds}/workspaces/gitlab\"\n  output_limit = 16384\n  environment = [\"KITHARA_CI_CACHE_ROOT={root}/cache\", \"KITHARA_CI_HOST_CONFIG={lane_config}\", \"{cargo_build_jobs}\"]\n",
+             [[runners]]\n  name = \"kithara-mac-mini-macos\"\n  url = \"{url}\"\n  token = \"{}\"\n  executor = \"shell\"\n  shell = \"bash\"\n  builds_dir = \"{builds}/workspaces/gitlab\"\n  output_limit = 16384\n  environment = [\"KITHARA_CI_CACHE_ROOT={root}/cache\", \"KITHARA_CI_HOST_CONFIG={lane_config}\", \"{cargo_build_jobs}\"{sccache_s3}]\n\n\
+             [[runners]]\n  name = \"kithara-mac-mini-android\"\n  url = \"{url}\"\n  token = \"{}\"\n  executor = \"shell\"\n  shell = \"bash\"\n  builds_dir = \"{builds}/workspaces/gitlab\"\n  output_limit = 16384\n  environment = [\"KITHARA_CI_CACHE_ROOT={root}/cache\", \"KITHARA_CI_HOST_CONFIG={lane_config}\", \"{cargo_build_jobs}\"{sccache_s3}]\n\n\
+             [[runners]]\n  name = \"kithara-mac-mini-release\"\n  url = \"{url}\"\n  token = \"{}\"\n  executor = \"shell\"\n  shell = \"bash\"\n  builds_dir = \"{builds}/workspaces/gitlab\"\n  output_limit = 16384\n  environment = [\"KITHARA_CI_CACHE_ROOT={root}/cache\", \"KITHARA_CI_HOST_CONFIG={lane_config}\", \"{cargo_build_jobs}\"{sccache_s3}]\n",
             tokens.linux,
             docker_host(home, &self.config.host.colima_profile),
             tokens.macos,
             tokens.android,
             tokens.release,
-        )
+        ))
     }
 
     /// A bind mount is resolved by the Docker daemon, which lives inside
@@ -846,7 +858,8 @@ mod tests {
             release: "glrt-release".into(),
         };
 
-        let rendered: toml::Value = toml::from_str(&manager.runner_config(&home, &tokens)).unwrap();
+        let rendered: toml::Value =
+            toml::from_str(&manager.runner_config(&home, &tokens).unwrap()).unwrap();
         let runners = rendered["runners"].as_array().unwrap();
         for token in ["glrt-macos", "glrt-linux", "glrt-android", "glrt-release"] {
             assert!(
@@ -885,7 +898,8 @@ mod tests {
             release: "glrt-release".into(),
         };
 
-        let rendered: toml::Value = toml::from_str(&manager.runner_config(&home, &tokens)).unwrap();
+        let rendered: toml::Value =
+            toml::from_str(&manager.runner_config(&home, &tokens).unwrap()).unwrap();
         assert_eq!(
             rendered["concurrent"].as_integer(),
             Some(config.host.job_concurrency as i64)
@@ -966,6 +980,50 @@ mod tests {
         );
     }
 
+    #[test]
+    fn every_runner_inherits_the_configured_s3_cache_environment() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let env_file = directory.path().join("cache.env");
+        fs::write(
+            &env_file,
+            "SCCACHE_BUCKET=cache\nSCCACHE_ENDPOINT=http://cache\nSCCACHE_REGION=us-east-1\nSCCACHE_S3_USE_SSL=false\nAWS_ACCESS_KEY_ID=key\nAWS_SECRET_ACCESS_KEY=secret\nAWS_EC2_METADATA_DISABLED=true\n",
+        )
+        .expect("write cache environment");
+        fs::set_permissions(&env_file, fs::Permissions::from_mode(0o600))
+            .expect("restrict cache environment");
+
+        let mut config = fixture();
+        config.host.sccache_s3_env_file = Some(env_file);
+        let process = Process::new(Path::new("/"), BTreeMap::new());
+        let manager = RunnerManager::new(&config, &process);
+        let tokens = Tokens {
+            macos: "glrt-macos".into(),
+            linux: "glrt-linux".into(),
+            android: "glrt-android".into(),
+            release: "glrt-release".into(),
+        };
+        let rendered: toml::Value = toml::from_str(
+            &manager
+                .runner_config(&manager.ci_home(), &tokens)
+                .expect("render runner config"),
+        )
+        .expect("runner config is TOML");
+
+        for runner in rendered["runners"].as_array().expect("runners") {
+            assert!(
+                runner["environment"]
+                    .as_array()
+                    .expect("runner environment")
+                    .iter()
+                    .any(|value| value.as_str() == Some("SCCACHE_BUCKET=cache")),
+                "{} does not inherit the S3 cache: {runner}",
+                runner["name"]
+            );
+        }
+    }
+
     /// The runner config and the colima agent are written by two different
     /// functions and read by two different programs; nothing but this test
     /// says they have to agree. When they stopped agreeing, Docker filled the
@@ -987,8 +1045,8 @@ mod tests {
             android: "glrt-android".into(),
             release: "glrt-release".into(),
         };
-        let rendered: toml::Value =
-            toml::from_str(&manager.runner_config(&home, &tokens)).expect("runner config is TOML");
+        let rendered: toml::Value = toml::from_str(&manager.runner_config(&home, &tokens).unwrap())
+            .expect("runner config is TOML");
         // The pipeline builds `SCCACHE_DIR` out of this, so a runner that
         // leaves it unset would resolve the compiler cache against the
         // filesystem root and fail every build on that executor.
@@ -1079,7 +1137,7 @@ mod tests {
             socket.display()
         );
 
-        let rendered = manager.runner_config(&home, &tokens);
+        let rendered = manager.runner_config(&home, &tokens).unwrap();
         assert!(
             rendered.contains(&docker_host(&home, &config.host.colima_profile)),
             "the runner config does not point at the configured profile's socket: {rendered}"
@@ -1111,7 +1169,7 @@ mod tests {
             release: "glrt-release".into(),
         };
 
-        let runner = manager.runner_config(&home, &tokens);
+        let runner = manager.runner_config(&home, &tokens).unwrap();
         for rendered in [&runner] {
             for forbidden in [
                 "tls-ca-file",

--- a/xtask/src/ci/linux/profile.rs
+++ b/xtask/src/ci/linux/profile.rs
@@ -29,6 +29,9 @@ pub(crate) struct LinuxHost {
     pub(crate) cache_root: PathBuf,
     /// Docker network the runners are confined to.
     pub(crate) network: String,
+    /// A mode-0600 file with the scoped S3 settings every runner inherits.
+    #[serde(default)]
+    pub(crate) sccache_s3_env_file: Option<PathBuf>,
     /// Address block of that network, fenced off from the rest of the machine.
     pub(crate) subnet: String,
     /// Serialised last: TOML requires tables after plain values.

--- a/xtask/src/ci/linux/services.rs
+++ b/xtask/src/ci/linux/services.rs
@@ -10,7 +10,7 @@ use super::{
     container::{Container, container},
     profile::{LINUX_CONFIG_PATH, LinuxHost, LinuxRunner, RunnerFlavor},
 };
-use crate::ci::{config::CiPins, process::Process};
+use crate::ci::{cache::client_environment, config::CiPins, process::Process};
 
 /// Where the services live and what they call.
 ///
@@ -293,6 +293,10 @@ fn unit(
     for entry in Container::environment() {
         write!(unit, " --env {entry}")?;
     }
+    if let Some(path) = &host.sccache_s3_env_file {
+        client_environment(path)?;
+        write!(unit, " --env-file {}", path.display())?;
+    }
     for (volume, target) in &job.mounts {
         let mount_type = Container::mount_type(volume);
         write!(
@@ -350,6 +354,8 @@ pub(super) fn health(process: &Process, host: &LinuxHost) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use std::os::unix::fs::PermissionsExt;
+
     use clap::Parser;
 
     use super::*;
@@ -471,6 +477,36 @@ mod tests {
         for entry in Container::environment() {
             assert!(text.contains(&format!("--env {entry}")), "{entry}:\n{text}");
         }
+    }
+
+    #[test]
+    fn a_unit_inherits_the_configured_s3_cache_environment() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let env_file = directory.path().join("cache.env");
+        std::fs::write(
+            &env_file,
+            "SCCACHE_BUCKET=cache\nSCCACHE_ENDPOINT=http://cache\nSCCACHE_REGION=us-east-1\nSCCACHE_S3_USE_SSL=false\nAWS_ACCESS_KEY_ID=key\nAWS_SECRET_ACCESS_KEY=secret\nAWS_EC2_METADATA_DISABLED=true\n",
+        )
+        .expect("write cache environment");
+        std::fs::set_permissions(&env_file, std::fs::Permissions::from_mode(0o600))
+            .expect("restrict cache environment");
+
+        let mut host = host_fixture();
+        host.sccache_s3_env_file = Some(env_file.clone());
+        let pins = &fixture().pins;
+        let text = unit(
+            &host,
+            host.runner("kithara-ci-octocat").expect("runner"),
+            "0,1,2",
+            pins,
+            "/usr/local/bin/kithara-ci",
+        )
+        .expect("the unit must render");
+
+        assert!(
+            text.contains(&format!("--env-file {}", env_file.display())),
+            "{text}"
+        );
     }
 
     /// The whole fleet declares one runtime directory, so systemd must be told


### PR DESCRIPTION
## Summary
CI cache storage is already available on both hosts, but generated runners did not receive its S3 settings and therefore used only local disk sccache. This change passes a validated review-scoped S3 client environment to Linux and macOS runners while retaining the local cache directory.

## Behavior / scope
- contract or behavior: an optional mode-0600 `sccache_s3_env_file` is validated against the existing restricted client environment schema before it is rendered into runner configuration.
- affected area: generated Linux systemd Docker units and macOS GitLab runner configuration.

## Validation
- `just fmt check`
- `just lint fast` (pre-commit hook)
- `cargo test -p xtask s3_cache`
- `cargo test -p xtask cache_probe_rejects_process_environment_injection`

## Surface impact
- Public API: none
- Platform/runtime: changed: CI runner provisioning on Linux and macOS
- Perf-sensitive paths: changed: compiler cache backend selection in CI jobs

## Risks / follow-ups
- Deployment remains deliberately staged: configure a single Linux canary with the existing `review` scope and verify objects created by a real job before fleet rollout.
