### PR TITLE
fix(audio): retire a variant transition its seek epoch superseded

### DIFF
--- a/crates/kithara-audio/src/pipeline/source.rs
+++ b/crates/kithara-audio/src/pipeline/source.rs
@@ -224,6 +224,33 @@ impl<T: StreamType> StreamAudioSource<T> {
         }
     }
 
+    /// Drops the in-flight transition an applied seek superseded.
+    ///
+    /// `VariantTransitionId` binds a transition to the seek epoch that minted
+    /// it, and `SeekPrepare::prepare` already dropped the source's half of one
+    /// minted earlier. The local half outlives that: its generation holds a
+    /// latched pre-seek `OutgoingFrontier` that the repositioned outgoing
+    /// generation never reaches, so `transition_holds_output` would hold every
+    /// decode output against a promotion that can no longer be proven. The
+    /// pending ABR intent survives, exactly as it does on the source side, so
+    /// the new epoch can mint its own transition.
+    pub(super) fn discard_superseded_incoming(&mut self, epoch: u64) {
+        let Some(transition) = self
+            .decode
+            .incoming_transition()
+            .filter(|transition| transition.id().seek_epoch() != epoch)
+        else {
+            return;
+        };
+        debug!(
+            epoch,
+            latched_frontier = ?self.decode.incoming_frontier(),
+            ?transition,
+            "seek superseded a variant transition: discarding the incoming half"
+        );
+        self.discard_local_incoming();
+    }
+
     fn prepare_incoming_transition(
         &mut self,
         control: &dyn VariantControl,

--- a/crates/kithara-audio/src/pipeline/track/fsm.rs
+++ b/crates/kithara-audio/src/pipeline/track/fsm.rs
@@ -113,6 +113,7 @@ pub(super) fn apply_seek_transition<T: StreamType>(
             src.readiness
                 .finalize_seek_pending(src.seek.as_ref(), epoch);
             src.decode.notify_seek(&src.retired);
+            src.discard_superseded_incoming(epoch);
             src.update_state(Track::<AwaitingResume>::new(resume).erase());
         }
         SeekTransition::AtEof { epoch } => {

--- a/crates/kithara-audio/src/pipeline/track/tests/transition.rs
+++ b/crates/kithara-audio/src/pipeline/track/tests/transition.rs
@@ -19,7 +19,7 @@ use crate::{
     pipeline::{
         decode::{DecoderGeneration, transition::OutgoingFrontier},
         rebuild::{DecoderBuildComplete, DecoderBuildPurpose, state::BuildId},
-        seek::{SeekContext, SeekRequest, engine::SeekTransition},
+        seek::{ResumeState, SeekContext, SeekRequest, engine::SeekTransition},
         track::{
             AtEof, CurrentFsm, Failed, Track, TrackFailure, TrackStep, fsm::apply_seek_transition,
         },
@@ -155,6 +155,50 @@ async fn eof_transition_retires_staged_incoming_and_aborts_variant(route_pcm: Ro
 
     assert!(fixture.source.decode.incoming_transition().is_none());
     assert_eq!(fixture.control.aborted_transition(), Some(transition));
+    assert_eq!(fixture.drops.lock().as_slice(), &[99]);
+}
+
+#[kithara::test(tokio)]
+async fn an_applied_seek_retires_the_incoming_its_epoch_superseded(route_pcm: RoutePcm) {
+    let mut fixture = route_signal_source(&route_pcm, Consts::SAMPLE_RATE).await;
+    let plan = incoming_plan();
+    let transition = plan.transition();
+    fixture.control.set_exact_plan(plan);
+    fixture.control.set_exact_reader_ready();
+
+    fixture.source.flush_deferred();
+    wait_for_incoming_priming(&mut fixture, transition).await;
+
+    assert!(fixture.source.decode.incoming_is_priming(transition));
+
+    let target = Duration::from_secs(1);
+    let epoch = fixture.source.shared_stream.seek_control().begin(target);
+    assert_ne!(
+        epoch,
+        transition.id().seek_epoch(),
+        "the fixture seek must supersede the epoch that minted the transition"
+    );
+    apply_seek_transition(
+        &mut fixture.source,
+        SeekTransition::Applied {
+            epoch,
+            resume: ResumeState {
+                seek: SeekContext { target, epoch },
+                ..Default::default()
+            },
+        },
+    );
+
+    assert!(matches!(
+        fixture.source.state,
+        CurrentFsm::AwaitingResume(_)
+    ));
+    assert!(fixture.source.decode.incoming_transition().is_none());
+    assert!(!fixture.source.decode.transition_holds_output());
+    assert_eq!(fixture.control.aborted_transition(), None);
+
+    fixture.source.flush_deferred();
+
     assert_eq!(fixture.drops.lock().as_slice(), &[99]);
 }
 


### PR DESCRIPTION
## Problem

`VariantTransitionId` binds a variant transition to the seek epoch that minted
it, and `VariantPromotion::Stale` names the rule outright: a transition is stale
once it is *"invalidated by a seek epoch change"*.

Only one side kept the rule. The HLS source enforces it at five sites in
`crates/kithara-hls/src/stream/transition.rs`, and `HlsCoord::prepare_for_seek`
discards its half of an in-flight transition on every seek. The produce core
never did: `ActiveDecode::notify_seek` resets only the *active* generation, so an
`IncomingDecode::Priming` minted before a seek survived it, still holding the
`OutgoingFrontier` it latched from the pre-seek outgoing generation.

A repositioned outgoing generation never reaches that frontier, so
`transition_holds_output` stayed true forever, and the pipeline wedged:

- `promotion_readiness` -> `NeedIncoming`
- `decode_step` -> `DecodeAction::TransitionPending`
- the track parks in `AwaitingResume`

Both exits are unreachable from there. `progress_variant_transition` gates on
FSM state and returns early for `AwaitingResume`, and it runs on every single
tick (`Task::recycle` -> `prepare_deferred`), each time doing nothing.
`promote_ready_incoming`'s `Stale` arm never runs either, because
`prepare_promotion` returns `None` — there is no overlap left to prove.

A hang dump from the stress lane caught exactly this: `stuck at observer.rs:30`,
9209 ticks without progress, `waiting branch
branch="awaiting_resume_transition_pending" (x9211)`, parked on
`VariantTransitionId { abr_ticket: AbrTicket(2), seek_epoch: 2 }` with
`frontier=Some(Exact { frame: 2893824 })` against a staged incoming that ends at
frame 2878464. The source's own log, `discarding incoming variant session` for
the same ticket, is a few lines above it — the two halves disagreeing in one
trace.

## Fix

`apply_seek_transition`'s `Applied` arm drops the local half beside the line
that already resets the active generation for the new epoch, gated on the
transition's epoch differing from the applied one.

The gate is load-bearing: `SeekHandle::begin` calls `prepare` *before* it bumps
the epoch, so a transition minted inside that window carries the new epoch and
is legitimately current. An unconditional discard would kill it.

The pending ABR claim is left alone, mirroring the source side's
`abort_intent = false`, so a user's manual variant choice survives the seek and
the new epoch mints its own transition against the same claim. No new type, no
cross-crate contract change: the change closes an asymmetry the repo already
declares.

## Validation

`an_applied_seek_retires_the_incoming_its_epoch_superseded` fails on the parent
commit with `assertion failed: fixture.source.decode.incoming_transition()
.is_none()` and passes with the fix. It pins all four halves of the contract:
the incoming is gone, output is no longer held, the ABR claim is *not* aborted,
and the retired generation reaches the drop list.

It does not duplicate `stale_prepared_promotion_returns_incoming_for_shell_
retirement`, its nearest sibling: that test reaches `VariantPromotion::Stale`
*through* the promotion path, having minted the overlap proof first. This one
has no promotion proof at all, which is the whole reason the wedge was
unreachable.
