### PR TITLE
fix(audio): retire the transition join a seek invalidates

### DIFF
--- a/crates/kithara-audio/src/pipeline/decode/core.rs
+++ b/crates/kithara-audio/src/pipeline/decode/core.rs
@@ -360,6 +360,26 @@ impl ActiveDecode {
         mem::replace(&mut self.active, active)
     }
 
+    /// Retires the transition join a seek invalidated.
+    ///
+    /// A priming incoming means a join is armed on the active generation:
+    /// `outgoing_holdback_is_active` reports one, and decode output flows
+    /// through the holdback so the incoming can be spliced at the frontier it
+    /// latched. Retiring the active generation's staged PCM disarms that
+    /// holdback, and the claim outlives it — the next chunk is rejected as
+    /// unprepared, and the rejection fails the track. Re-arming is no answer
+    /// either: the latched frontier is pre-seek and the repositioned
+    /// generation never reaches it. So the incoming half goes back for
+    /// retirement, and the surviving ABR intent mints a fresh transition.
+    #[must_use]
+    pub(crate) fn notify_seek(&mut self, retire: &dyn ChunkRetire) -> Option<DecoderGeneration> {
+        self.active.notify_seek(retire);
+        if !matches!(self.incoming, Some(IncomingDecode::Priming { .. })) {
+            return None;
+        }
+        self.discard_incoming()
+    }
+
     pub(crate) fn reset(&mut self) {
         self.discontinuity_revision = self.discontinuity_revision.wrapping_add(1);
         self.stage_error = None;
@@ -427,7 +447,6 @@ impl ActiveDecode {
             #[call(finish)]
             pub(crate) fn finish_active(&mut self);
             pub(crate) fn mark_source_exhausted(&mut self);
-            pub(crate) fn notify_seek(&mut self, retire: &dyn ChunkRetire);
         }
         to self.output {
             pub(crate) const fn stats(&self) -> (u64, u64);
@@ -474,7 +493,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        pipeline::decode::transition::IncomingPrime,
+        pipeline::{decode::transition::IncomingPrime, rebuild::retire::Retired},
         test_pools::{Pools, pools, sample_buffer},
         traits::{AudioObserveError, AudioObserverMock},
     };
@@ -652,6 +671,58 @@ mod tests {
             decode.active().staged_span().map(|(_, end, _)| end),
             Some(4)
         );
+    }
+
+    #[kithara::test]
+    fn a_seek_retires_the_transition_join_it_invalidated(decode_quarter: Vec<f32>) {
+        let pools = pools();
+        let spec = AudioSpec::new(2, NonZeroU32::new(44_100).expect("test rate"));
+        let active = generation(spec);
+        let incoming = generation(spec);
+        let abr = AbrState::new(AbrMode::Auto(Some(VariantIndex::new(0))));
+        abr.request_target(VariantIndex::new(1), AbrReason::ManualOverride);
+        let claim = abr
+            .claim_pending_decision(VariantIndex::new(0))
+            .expect("test transition claim");
+        let transition = VariantTransition::new(
+            VariantTransitionId::new(claim.ticket(), 0),
+            VariantIndex::new(0),
+            VariantIndex::new(1),
+        );
+        let mut decode = active_decode(&pools, active, GaplessMode::Disabled);
+        decode.incoming = Some(IncomingDecode::Priming {
+            transition,
+            generation: incoming,
+            frontier: OutgoingFrontier::Awaiting,
+        });
+        decode.prepare_incoming_profile(BlenderProfile::new(spec));
+        let make_chunk = |offset| {
+            AudioChunk::new(
+                AudioChunkInfo {
+                    spec,
+                    frame_offset: offset,
+                    frames: 4,
+                    ..Default::default()
+                },
+                sample_buffer(&pools, &decode_quarter[..4 * usize::from(spec.channels)]),
+            )
+        };
+        decode
+            .push(make_chunk(0))
+            .expect("first holdback chunk is valid");
+
+        let retired = Retired::new(1, 1);
+
+        let invalidated = decode.notify_seek(&retired);
+
+        assert!(
+            invalidated.is_some(),
+            "a seek that retires the join must hand back the incoming half claiming it"
+        );
+        assert!(decode.incoming_transition().is_none());
+        decode
+            .push(make_chunk(1_443_179))
+            .expect("PCM resumed by a seek must not be judged against a join the seek retired");
     }
 
     #[kithara::test]

--- a/crates/kithara-audio/src/pipeline/source.rs
+++ b/crates/kithara-audio/src/pipeline/source.rs
@@ -222,6 +222,18 @@ impl<T: StreamType> StreamAudioSource<T> {
         }
     }
 
+    /// Applies a seek to the decode core, retiring what the seek invalidates.
+    ///
+    /// Repositioning the active generation retires the transition join with
+    /// it, so the incoming half that claimed one cannot outlive the call.
+    /// Pairing the two here is what keeps a caller from doing one and not the
+    /// other.
+    pub(super) fn notify_seek(&mut self) {
+        if let Some(generation) = self.decode.notify_seek(&self.retired) {
+            self.retired.retire_generation(generation);
+        }
+    }
+
     /// Drops the in-flight transition an applied seek superseded.
     ///
     /// `VariantTransitionId` binds a transition to the seek epoch that minted

--- a/crates/kithara-audio/src/pipeline/track/fsm.rs
+++ b/crates/kithara-audio/src/pipeline/track/fsm.rs
@@ -114,7 +114,7 @@ pub(super) fn apply_seek_transition<T: StreamType>(
             src.seek_engine.commit_decode_epoch(epoch, "seek_applied");
             src.readiness
                 .finalize_seek_pending(src.seek.as_ref(), epoch);
-            src.decode.notify_seek(&src.retired);
+            src.notify_seek();
             src.discard_superseded_incoming(epoch);
             src.update_state(Track::<AwaitingResume>::new(resume).erase());
         }
@@ -198,7 +198,7 @@ pub(crate) fn dispatch<T: StreamType>(src: &mut StreamAudioSource<T>) -> TrackSt
             .erase(),
         );
         src.decode.reset();
-        src.decode.notify_seek(&src.retired);
+        src.notify_seek();
         return TrackStep::StateChanged;
     }
     if !matches!(

--- a/crates/kithara-audio/src/pipeline/track/recreate.rs
+++ b/crates/kithara-audio/src/pipeline/track/recreate.rs
@@ -212,7 +212,7 @@ fn transition_to_seek_request<T: StreamType>(
 ) -> TrackStep<AudioChunk> {
     src.update_state(Track::<SeekRequested>::new(request).erase());
     src.decode.reset();
-    src.decode.notify_seek(&src.retired);
+    src.notify_seek();
     TrackStep::StateChanged
 }
 

--- a/crates/kithara-audio/src/pipeline/track/tests/transition.rs
+++ b/crates/kithara-audio/src/pipeline/track/tests/transition.rs
@@ -204,6 +204,41 @@ async fn an_applied_seek_retires_the_incoming_its_epoch_superseded(route_pcm: Ro
 }
 
 #[kithara::test(tokio)]
+async fn a_preempting_seek_retires_the_incoming_it_leaves_without_a_join(route_pcm: RoutePcm) {
+    let mut fixture = route_signal_source(&route_pcm, Consts::SAMPLE_RATE).await;
+    let plan = incoming_plan();
+    let transition = plan.transition();
+    fixture.control.set_exact_plan(plan);
+    fixture.control.set_exact_reader_ready();
+
+    fixture.source.flush_deferred();
+    wait_for_incoming_priming(&mut fixture, transition).await;
+
+    assert!(fixture.source.decode.incoming_is_priming(transition));
+    assert!(fixture.drops.lock().is_empty());
+
+    fixture
+        .source
+        .shared_stream
+        .seek_control()
+        .begin(Duration::from_secs(1));
+
+    assert!(matches!(
+        fixture.source.step_track(),
+        TrackStep::StateChanged
+    ));
+
+    assert!(matches!(fixture.source.state, CurrentFsm::SeekRequested(_)));
+    assert!(fixture.source.decode.incoming_transition().is_none());
+    assert!(!fixture.source.decode.transition_holds_output());
+    assert_eq!(fixture.control.aborted_transition(), None);
+
+    fixture.source.flush_deferred();
+
+    assert_eq!(fixture.drops.lock().as_slice(), &[99]);
+}
+
+#[kithara::test(tokio)]
 async fn failed_source_removal_retires_staged_incoming_and_aborts_variant(route_pcm: RoutePcm) {
     let mut fixture = route_signal_source(&route_pcm, Consts::SAMPLE_RATE).await;
     let plan = incoming_plan();


### PR DESCRIPTION
## What breaks

`ActiveDecode::notify_seek` repositions the active generation: it retires the staged PCM the transition holdback accumulated and clears the holdback itself. An `IncomingDecode::Priming` outlives that, and it is the only state `outgoing_holdback_is_active` reads — so the decode core keeps claiming an armed join it no longer has.

The next chunk to reach `push` or `next_with_holdback` is then rejected by `push_holdback_chunk` as `transition holdback was not prepared`, `reject_stage` turns that into a `DecodeError`, `decode_failed` answers `TrackFailure::Decode`, and the queue kills a track whose only sin was a seek.

Re-arming the join is no answer: the latched `OutgoingFrontier` is pre-seek and the repositioned outgoing generation never reaches it — that is the hang #361 closed. So the incoming half has to go with the join.

## What #361 left open

#361 covered one of the three seek sites, and covered it by epoch: the `Applied` arm of `apply_seek_transition` discards an incoming whose transition was minted at a *different* epoch. The other two retired the join and kept the incoming unconditionally:

- the `dispatch` preempt (`track/fsm.rs`), which is the path a seek arriving mid-transition actually takes;
- `transition_to_seek_request` after a superseded rebuild (`track/recreate.rs`).

## Fix

`ActiveDecode::notify_seek` now hands the invalidated incoming generation back (`#[must_use] -> Option<DecoderGeneration>`), and `StreamAudioSource::notify_seek` retires it. All three sites call the pair through that one method, so no caller can do one without the other. `discard_superseded_incoming` keeps its epoch filter for the incoming states that hold no join (`Preparing`, `Building`, `Failed`), and the pending ABR intent is still left alone, so the new epoch mints its own transition.

## Evidence

Stress run 34484119171 (no-block lane) holds the failure face: a manual override to variant 2 minted `AbrTicket(3)`, seek epoch 6 → 7 resumed the generation at frame 1443179 (`seek::skip trimmed the head of a resumed generation`), and the track ended at `PlaybackStopped {reason: Failed, seek_epoch: 7}` → `ItemDidFail`. The reason itself never reached a log line: `emit_failure_log` only runs on a re-entry into `dispatch`, and the whole lane log holds no `track failed` line — that observability gap is filed as #365, not fixed here.

## Pins

| test | level |
| --- | --- |
| `a_seek_retires_the_transition_join_it_invalidated` | `ActiveDecode` — reproduces the rejection directly |
| `a_preempting_seek_retires_the_incoming_it_leaves_without_a_join` | track FSM — walks the preempt path the artifact walked |

Both fail on the parent (`transition holdback was not prepared`, and `incoming_transition()` still `Some`). #361's own test stays green either way, because its epoch filter is independent of this change.

## Validation

- `cargo test -p kithara-audio --lib`: 180/180.
- `just fmt check`, `just lint fast`: clean, 0 regressions and 0 new entries in both namespaces.
- `just test`: reported in a comment below.
- Stress run [34516148051](https://github.com/gerasim13/kithara/actions/runs/34516148051) launched on `235ffa529d7198ad32f4e187ba3daacb10f4f7ce`; the verdict is judged from the artifact report only.
