### PR TITLE
test(events): read a first-event property from its own topic

### DIFF
--- a/crates/kithara-events/src/event.rs
+++ b/crates/kithara-events/src/event.rs
@@ -14,6 +14,12 @@ pub trait Event: Clone + core::fmt::Debug + Send + Sync + 'static {}
 ///
 /// Every `Event` is a one-member set through the blanket impl below; a
 /// multi-member set is a consumer-local enum with `#[derive(EventSet)]`.
+///
+/// A multi-member receiver polls its members in declaration order and yields
+/// the first that has an event queued, so it reports no order between
+/// members: an earlier-declared member preempts one that published first.
+/// Publication order holds inside a member, which is where a consumer reads
+/// it from — a one-member receiver.
 pub trait EventSet: Sized + Send + 'static {
     type Receivers: Send;
 

--- a/crates/kithara-events/src/receiver.rs
+++ b/crates/kithara-events/src/receiver.rs
@@ -80,7 +80,8 @@ impl<S: EventSet> EventReceiver<S> {
         Self { rx }
     }
 
-    /// Waits for the next event from any member of the set.
+    /// Waits for the next event from any member of the set, preferring the
+    /// earlier-declared member when several have one queued.
     ///
     /// # Errors
     /// Returns lag information or `Closed` when all members close.
@@ -88,7 +89,8 @@ impl<S: EventSet> EventReceiver<S> {
         S::recv(&mut self.rx).await
     }
 
-    /// Takes the next queued event from any member of the set.
+    /// Takes the next queued event from any member of the set, preferring the
+    /// earlier-declared member when several have one queued.
     ///
     /// # Errors
     /// Returns `Empty`, lag information, or `Closed` when all members close.

--- a/tests/crates/audio/tests/audio_tests.rs
+++ b/tests/crates/audio/tests/audio_tests.rs
@@ -1,6 +1,6 @@
 #![cfg(not(target_arch = "wasm32"))]
 
-use std::{fs::File, io::Write};
+use std::{fs::File, io::Write, num::NonZeroU32};
 
 use kithara::{
     assets::{AssetStore, StorageBackend},
@@ -13,6 +13,7 @@ use kithara::{
     file::{FileConfig, FileSrc},
     platform::time::{self, Duration, Instant},
     play::{PlayWorker, PlayWorkerConfig},
+    signal::AudioSpec,
     stream::{ContainerFormat, MediaInfo, SeekEpoch},
 };
 use kithara_integration_tests::{
@@ -103,13 +104,19 @@ async fn test_audio_new(#[case] wav_input: NamedTempFile) {
     let _audio = worker.open(config).await.unwrap();
 }
 
+/// The decoder topic opens with the initial `DecoderChanged`.
+///
+/// The receiver takes that one topic on purpose. A multi-member set polls its
+/// members in declaration order, so a worker that already enqueued
+/// `AudioEvent::FormatDetected` on its first pass would preempt this event on
+/// a shared receiver no matter which was published first.
 #[kithara::test(tokio)]
 async fn test_audio_new_publishes_initial_decoder_changed(wav_1000: NamedTempFile) {
     let region = pools();
     let worker = PlayWorker::new(PlayWorkerConfig::builder(region).build());
     let (_cache, config) = test_wav_config(&wav_1000, &worker);
     let bus = EventBus::new(16);
-    let mut events = bus.subscribe();
+    let mut events: EventReceiver<DecoderEvent> = bus.subscribe();
     let config = AudioConfig::<kithara::file::File<TestPools>>::for_stream(config.stream().clone())
         .maybe_hint(config.hint().map(str::to_owned))
         .events(bus)
@@ -119,13 +126,13 @@ async fn test_audio_new_publishes_initial_decoder_changed(wav_1000: NamedTempFil
     let expected_backend = DecoderBackend::Symphonia;
 
     match events.try_recv().map(|env| env.event) {
-        Ok(TestEvent::Decoder(DecoderEvent::DecoderChanged {
+        Ok(DecoderEvent::DecoderChanged {
             backend,
             sample_rate,
             channels,
             cause,
             ..
-        })) => {
+        }) => {
             assert_eq!(backend, expected_backend);
             assert_eq!(sample_rate, audio.spec().sample_rate.get());
             assert_eq!(channels, audio.spec().channels);
@@ -133,6 +140,33 @@ async fn test_audio_new_publishes_initial_decoder_changed(wav_1000: NamedTempFil
         }
         other => panic!("expected initial DecoderChanged event, got {other:?}"),
     }
+}
+
+/// A receiver over several topics reports no order between them.
+///
+/// It polls its members in declaration order and yields the first that holds
+/// an event, so `TestEvent`'s `Audio` preempts a `Decoder` event published
+/// before it. Publication order survives only inside one topic.
+#[kithara::test]
+fn a_shared_receiver_prefers_its_earlier_declared_topic() {
+    let bus = EventBus::new(16);
+    let mut shared: EventReceiver<TestEvent> = bus.subscribe();
+    let mut decoder: EventReceiver<DecoderEvent> = bus.subscribe();
+    let spec = AudioSpec::new(2, NonZeroU32::new(44_100).expect("test rate"));
+
+    bus.publish(DecoderEvent::TransitionHold {
+        source_exhausted: false,
+    });
+    bus.publish(AudioEvent::FormatDetected { spec });
+
+    assert!(matches!(
+        shared.try_recv().map(|env| env.event),
+        Ok(TestEvent::Audio(AudioEvent::FormatDetected { .. }))
+    ));
+    assert!(matches!(
+        decoder.try_recv().map(|env| env.event),
+        Ok(DecoderEvent::TransitionHold { .. })
+    ));
 }
 
 #[kithara::test]

--- a/tests/crates/play/tests/player_internal.rs
+++ b/tests/crates/play/tests/player_internal.rs
@@ -275,13 +275,10 @@ async fn player_advance_emits_event(constant_half: &'static [u8]) {
     let player = PlayerImpl::new(default_player_config());
     player.insert(make_resource(constant_half, 1.0), TrackId::allocate(), None);
     player.insert(make_resource(constant_half, 2.0), TrackId::allocate(), None);
-    let mut rx = player.subscribe();
+    let mut rx: EventReceiver<PlayerEvent> = player.subscribe();
     player.advance_to_next_item();
     let event = rx.try_recv().map(|env| env.event);
-    assert!(matches!(
-        event,
-        Ok(TestEvent::Player(PlayerEvent::CurrentItemChanged { .. }))
-    ));
+    assert!(matches!(event, Ok(PlayerEvent::CurrentItemChanged { .. })));
 }
 
 #[kithara::test]

--- a/tests/crates/queue/tests/auto_advance.rs
+++ b/tests/crates/queue/tests/auto_advance.rs
@@ -4,6 +4,7 @@ use std::num::NonZeroU32;
 
 use kithara::{
     self,
+    events::EventReceiver,
     platform::sync::Arc,
     play::Resource,
     queue::{
@@ -190,14 +191,14 @@ async fn repeat_one_natural_advance_keeps_current_track(constant_three: &'static
         .run(&queue, move |q| q.select(id, Transition::None))
         .await
         .expect("select repeat-one track");
-    let mut receiver = queue.subscribe();
+    let mut receiver: EventReceiver<QueueEvent> = queue.subscribe();
     queue.set_repeat(RepeatMode::One);
 
     assert!(matches!(
         receiver.try_recv().map(|envelope| envelope.event),
-        Ok(TestEvent::Queue(QueueEvent::RepeatModeChanged {
+        Ok(QueueEvent::RepeatModeChanged {
             mode: kithara::queue::QueueRepeatMode::One,
-        }))
+        })
     ));
     assert_eq!(
         harness
@@ -246,14 +247,14 @@ async fn repeat_all_natural_advance_wraps_last_track_to_first(
         .run(&queue, move |q| q.select(last, Transition::None))
         .await
         .expect("select last repeat-all track");
-    let mut receiver = queue.subscribe();
+    let mut receiver: EventReceiver<QueueEvent> = queue.subscribe();
     queue.set_repeat(RepeatMode::All);
 
     assert!(matches!(
         receiver.try_recv().map(|envelope| envelope.event),
-        Ok(TestEvent::Queue(QueueEvent::RepeatModeChanged {
+        Ok(QueueEvent::RepeatModeChanged {
             mode: kithara::queue::QueueRepeatMode::All,
-        }))
+        })
     ));
     assert_eq!(
         harness


### PR DESCRIPTION
## Why

Run [34514525301](https://github.com/gerasim13/kithara/actions/runs/34514525301) on `main`
(`1596ee424`) failed one lane, `linux-test-real-clock`, on one test:

```
FAIL [0.030s] kithara-audio-tests::audio audio_tests::test_audio_new_publishes_initial_decoder_changed
panicked at tests/crates/audio/tests/audio_tests.rs:134:18:
expected initial DecoderChanged event, got Ok(Audio(FormatDetected { spec: AudioSpec { sample_rate: 44100, channels: 2 } }))
```

## Root cause

#354 gave every event type its own broadcast channel. The derived
`EventSet::try_recv` polls the members of a set in **declaration order** and returns
the first one holding an event, so a multi-member receiver reports no order between
members — an earlier-declared member preempts one that published first. `TestEvent`
declares `Audio` before `Decoder`.

The test drains one event after construction and requires it to be
`DecoderChanged { cause: Initial }`. Both of these are true at that moment:

- the initial decoder events are published directly on the bus in
  `publish_initial_events` (`crates/kithara-audio/src/audio/build.rs:103`), before the
  source becomes registrable;
- `AudioEvent::FormatDetected` is enqueued from the decode worker's first output pass
  (`crates/kithara-audio/src/pipeline/decode/output.rs:23`) — which the doc comment at
  `build.rs:94` already states may happen.

So whenever the worker gets its first chunk out before the test polls, the Audio topic
wins the poll and the assertion fails, no matter which event was published first. Before
#354 every event shared one channel and the assertion was a real property; the port kept
its shape and silently turned it into a race. #361 is not causal — its run is simply the
one that lost the race.

## What changed

- `test_audio_new_publishes_initial_decoder_changed` subscribes to the `DecoderEvent`
  topic. Publication order is real inside one topic, so the initial `DecoderChanged` is
  the first event on that channel by construction.
- Two sibling assertions of the same shape take their own topic as well:
  `repeat_one_natural_advance_replays_current_track` and
  `repeat_all_natural_advance_wraps_last_track_to_first` (`QueueEvent`), and
  `player_advance_emits_event` (`PlayerEvent`).
- The ordering contract is written down where it is owned: on `EventSet` and on
  `EventReceiver::{recv, try_recv}`.

No assertion was weakened. Each one still requires its event to be the **first** on the
topic that owns it, and none of the three ever inspected another topic — the foreign
event that preempted them was an accident of the shared receiver.

## Validation

The mechanism is pinned next to the repaired test:
`a_shared_receiver_prefers_its_earlier_declared_topic` publishes a `DecoderEvent` and
then an `AudioEvent` on one bus, and the shared receiver hands back the **later**
published `Audio` event while the one-topic receiver hands back the `Decoder` one — the
premise the old assertion rested on, disproved.

```
PASS kithara-audio-tests::audio audio_tests::a_shared_receiver_prefers_its_earlier_declared_topic
PASS kithara-audio-tests::audio audio_tests::test_audio_new_publishes_initial_decoder_changed
PASS kithara-queue-tests::queue auto_advance::repeat_one_natural_advance_keeps_current_track
PASS kithara-queue-tests::queue auto_advance::repeat_all_natural_advance_wraps_last_track_to_first
PASS kithara-play-tests::play player_internal::player_advance_emits_event
```

`just fmt check` clean. `just lint fast` clean: `16 deny, 1898 warn, 0 regression(s), 0 new
across 37 check(s)` and `0 deny, 996 warn, 0 regression(s), 0 new across 11 check(s)`.
Full `just test` reported in a comment.
