### PR TITLE
test(ci): fail a lane that retried a test into a pass

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -51,9 +51,12 @@ leak-timeout = "2s"
 fail-fast = false
 test-threads = "num-cpus"
 leak-timeout = "2s"
-# The verdict reads a single failure as a regression, so one bad throw blocks
-# whichever change is under it. One retry removes that class; a test that
-# survives two attempts is a bug to look at, not a number to raise.
+# One retry, and a retried pass still fails the lane: `test.known_flakes` in
+# `.config/xtask.toml` owns the exceptions, and starts empty. What the extra
+# attempt buys is evidence — nextest keeps the failing attempt inside
+# `flakyFailure` with its streams and its dump, and whether the second attempt
+# passes is what separates a test that is non-deterministic from a change that
+# broke it.
 retries = 1
 
 # `path` resolves against the profile's store directory

--- a/.config/xtask.toml
+++ b/.config/xtask.toml
@@ -491,6 +491,16 @@ default_lane = "workspace"
 default_backend = "wreq"
 feature_arg = "--features"
 loom_lane = "loom"
+# The file that owns every runner profile. A lane's verdict reads the retry
+# count and the report location from there instead of repeating them here.
+nextest_config = ".config/nextest.toml"
+# Tests a lane may pass on a retry, each naming the issue that owns the defect:
+# `{ test = "<suite>::<test>", issue = "<url>" }`.
+#
+# Empty, and meant to stay that way. A retry keeps the failing attempt's
+# evidence; it does not make the lane clean. Adding an entry admits in the diff
+# that a known defect is being waited on instead of fixed.
+known_flakes = []
 # Features shared by every lane. UI renderer features belong to the dedicated
 # `ui` lane so the general workspace run does not build those test targets.
 features = []

--- a/crates/kithara-devtools/src/common/project.rs
+++ b/crates/kithara-devtools/src/common/project.rs
@@ -532,12 +532,35 @@ pub struct TestCommandConfig {
     pub default_lane: String,
     pub feature_arg: String,
     pub loom_lane: String,
+    /// The file that owns every runner profile, so a lane's verdict reads the
+    /// retry count and the report location where they are declared rather than
+    /// keeping a second copy of them here.
+    pub nextest_config: String,
     pub flash: TestFlashConfig,
     pub no_block: TestNoBlockConfig,
     pub features: Vec<String>,
+    /// Tests whose retried pass a lane tolerates, each naming the issue that
+    /// owns the defect.
+    ///
+    /// Empty is the intended state. A retry exists to keep the failing
+    /// attempt's evidence, not to let the lane pass on it, so an entry here is
+    /// a visible act in the diff with an owner attached — not a list a lane
+    /// grows to stay green.
+    pub known_flakes: Vec<KnownFlake>,
     /// Paths that belong to no single lane: a change to one of them runs every
     /// lane that declares `owns`, because the routing itself moved.
     pub shared_paths: Vec<String>,
+}
+
+/// One test allowed to reach a pass through a retry, and the issue it waits on.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq)]
+#[non_exhaustive]
+#[serde(default, deny_unknown_fields)]
+pub struct KnownFlake {
+    /// The issue that owns the defect, so the entry names who removes it.
+    pub issue: String,
+    /// `<suite>::<test>`, exactly as the `JUnit` report names the case.
+    pub test: String,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/kithara-devtools/src/lib.rs
+++ b/crates/kithara-devtools/src/lib.rs
@@ -27,6 +27,7 @@ pub mod powerset;
 pub mod quality;
 pub mod quality_assessment;
 pub mod quality_lab;
+mod retried;
 pub mod sccache;
 pub mod scope;
 pub mod semver;

--- a/crates/kithara-devtools/src/retried.rs
+++ b/crates/kithara-devtools/src/retried.rs
@@ -1,0 +1,370 @@
+//! Whether a lane that exited zero hid a failure inside a retry.
+
+use std::{
+    collections::BTreeSet,
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use anyhow::{Context, Result, bail, ensure};
+use toml::Value;
+
+use crate::{
+    common::project::{KnownFlake, TestCommandConfig},
+    junit::{CaseTiming, parse_junit},
+    stress_report::{MAX_JUNIT_BYTES, read_bounded_utf8},
+};
+
+/// The profile nextest runs when a command names none, and the profile every
+/// other one inherits its unset keys from.
+const DEFAULT_PROFILE: &str = "default";
+
+/// What one nextest profile declares about hiding a failure.
+struct Declared {
+    /// Where the profile writes its report, relative to the profile's own
+    /// store directory.
+    junit: Option<String>,
+    /// Attempts the profile grants after the first.
+    retries: u64,
+}
+
+/// Fails a lane whose runner retried a test into a pass.
+///
+/// nextest keeps the failing attempt — its streams, its panic and its dump —
+/// and exits zero, so a lane judged by its exit code alone reads a defect that
+/// reproduced as a clean run. The retry makes that attempt legible; it is not
+/// permission to pass. A profile granting no retry can hide nothing.
+///
+/// # Errors
+///
+/// Returns an error when the profile grants retries and keeps no report, when
+/// the report it declares is absent, or when the report names a retried pass
+/// that no `test.known_flakes` entry owns.
+pub(crate) fn verdict(
+    lane_name: &str,
+    root: &Path,
+    config: &TestCommandConfig,
+    command: &Command,
+) -> Result<()> {
+    let Some(profile) = nextest_profile(command) else {
+        return Ok(());
+    };
+    let declared = declared_profile(root, config, &profile)?;
+    if declared.retries == 0 {
+        return Ok(());
+    }
+    let Some(relative) = declared.junit else {
+        bail!(
+            "nextest profile `{profile}` grants {} retries and declares no JUnit report: a retried pass would leave nothing to judge the lane by",
+            declared.retries
+        );
+    };
+    let report = report_path(root, &profile, &relative);
+    ensure!(
+        report.is_file(),
+        "test lane `{lane_name}` ran nextest profile `{profile}`, which declares a JUnit report at {}: without it a retried pass is unjudgeable",
+        report.display()
+    );
+    let xml = read_bounded_utf8(&report, MAX_JUNIT_BYTES, "test lane JUnit")?;
+    let cases = parse_junit(&xml)
+        .with_context(|| format!("parse test lane JUnit at {}", report.display()))?;
+    let retried = unowned(&cases, &config.known_flakes);
+    if retried.is_empty() {
+        return Ok(());
+    }
+    bail!(
+        "test lane `{lane_name}` reports {} test(s) that passed only on a retry, which is a defect that reproduced:\n{}\
+         Every failing attempt is printed above and kept in {}.\n\
+         Fix the defect, or name the test in `test.known_flakes` with the issue that owns it.",
+        retried.len(),
+        listing(&retried),
+        report.display()
+    );
+}
+
+/// nextest resolves `junit.path` against its own store directory, and that
+/// store stays under the workspace root even when the build is sent elsewhere
+/// through `CARGO_TARGET_DIR`.
+fn report_path(root: &Path, profile: &str, relative: &str) -> PathBuf {
+    root.join("target")
+        .join("nextest")
+        .join(profile)
+        .join(relative)
+}
+
+/// The nextest profile a lane's command selects, or `None` when the lane runs
+/// no nextest and so cannot retry anything.
+///
+/// `--profile` names the Cargo profile to `cargo test` and the runner profile
+/// to `cargo nextest`, so it is only read past the `nextest` subcommand. The
+/// last one wins, as it does on nextest's own command line: a lane that names
+/// a profile can still be asked for a different one.
+fn nextest_profile(command: &Command) -> Option<String> {
+    let args = command
+        .get_args()
+        .map(|arg| arg.to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
+    let start = args.iter().position(|arg| arg == "nextest")?;
+    let mut profile = DEFAULT_PROFILE.to_owned();
+    let mut awaiting_value = false;
+    for arg in args.iter().skip(start.saturating_add(1)) {
+        if awaiting_value {
+            profile = arg.clone();
+            awaiting_value = false;
+        } else if let Some(value) = arg.strip_prefix("--profile=") {
+            profile = value.to_owned();
+        } else {
+            awaiting_value = matches!(arg.as_str(), "--profile" | "-P");
+        }
+    }
+    Some(profile)
+}
+
+fn declared_profile(root: &Path, config: &TestCommandConfig, profile: &str) -> Result<Declared> {
+    let path = root.join(&config.nextest_config);
+    let text = fs::read_to_string(&path)
+        .with_context(|| format!("read nextest config: {}", path.display()))?;
+    declaration(&text, profile)
+        .with_context(|| format!("read nextest profile `{profile}` from {}", path.display()))
+}
+
+/// Reads one profile the way nextest resolves it: a key the profile does not
+/// set is inherited from `default`.
+fn declaration(config: &str, profile: &str) -> Result<Declared> {
+    let config: toml::Table = toml::from_str(config).context("parse nextest config")?;
+    let profiles = config.get("profile");
+    let declared = |key: &str| -> Option<&Value> {
+        let profiles = profiles?;
+        profiles
+            .get(profile)
+            .and_then(|declared| declared.get(key))
+            .or_else(|| {
+                profiles
+                    .get(DEFAULT_PROFILE)
+                    .and_then(|fallback| fallback.get(key))
+            })
+    };
+    let retries = declared("retries").map_or(Ok(0), retry_count)?;
+    let junit = declared("junit")
+        .and_then(|junit| junit.get("path"))
+        .map(|path| {
+            path.as_str()
+                .map(str::to_owned)
+                .context("junit path is not a string")
+        })
+        .transpose()?;
+    Ok(Declared { junit, retries })
+}
+
+/// nextest spells `retries` either as the count itself or as a table whose
+/// `count` is that number with a backoff around it.
+fn retry_count(value: &Value) -> Result<u64> {
+    let count = match value {
+        Value::Integer(count) => Some(*count),
+        Value::Table(table) => table.get("count").and_then(Value::as_integer),
+        _ => None,
+    };
+    let count = count.context("retries is neither a count nor a table declaring one")?;
+    u64::try_from(count).context("retries is negative")
+}
+
+/// The retried passes the registry does not own.
+fn unowned<'a>(cases: &'a [CaseTiming], known: &[KnownFlake]) -> Vec<&'a CaseTiming> {
+    let owned = known
+        .iter()
+        .map(|flake| flake.test.as_str())
+        .collect::<BTreeSet<_>>();
+    cases
+        .iter()
+        .filter(|case| case.flaky && !owned.contains(case_id(case).as_str()))
+        .collect()
+}
+
+/// `<suite>::<name>`: the identity the report gives a case, and the one a
+/// registry entry names it by.
+fn case_id(case: &CaseTiming) -> String {
+    format!("{}::{}", case.suite, case.name)
+}
+
+fn listing(cases: &[&CaseTiming]) -> String {
+    cases
+        .iter()
+        .map(|case| format!("  - {}\n", case_id(case)))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+
+    const RETRYING_PROFILE: &str = "\
+[profile.default]
+fail-fast = false
+
+[profile.ci]
+retries = 1
+
+[profile.ci.junit]
+path = \"junit.xml\"
+";
+
+    /// The shape nextest writes for a case it retried into a pass: the failing
+    /// attempt lives inside `flakyFailure`, and the run reports no failures.
+    const RETRIED_PASS: &str = "\
+<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<testsuites name=\"nextest-run\" tests=\"1\" failures=\"0\" errors=\"0\" uuid=\"1\" timestamp=\"t\" time=\"0.049\">
+    <testsuite name=\"kithara_queue\" tests=\"1\" disabled=\"0\" errors=\"0\" failures=\"0\">
+        <testcase name=\"delayed_target\" classname=\"kithara_queue\" time=\"0.019\">
+            <flakyFailure message=\"panicked at delayed.rs:9\" type=\"test failure with exit code 101\">assertion failed</flakyFailure>
+        </testcase>
+    </testsuite>
+</testsuites>
+";
+
+    fn config(nextest_config: &str, known: &[(&str, &str)]) -> TestCommandConfig {
+        TestCommandConfig {
+            nextest_config: nextest_config.to_owned(),
+            known_flakes: known
+                .iter()
+                .map(|(test, issue)| KnownFlake {
+                    test: (*test).to_owned(),
+                    issue: (*issue).to_owned(),
+                })
+                .collect(),
+            ..TestCommandConfig::default()
+        }
+    }
+
+    fn lane(nextest_config: &str, report: Option<&str>) -> TempDir {
+        let temp = TempDir::new().expect("temp root");
+        fs::write(temp.path().join("nextest.toml"), nextest_config).expect("write nextest config");
+        if let Some(report) = report {
+            let dir = temp.path().join("target").join("nextest").join("ci");
+            fs::create_dir_all(&dir).expect("create store");
+            fs::write(dir.join("junit.xml"), report).expect("write report");
+        }
+        temp
+    }
+
+    fn command(args: &[&str]) -> Command {
+        let mut command = Command::new("cargo");
+        command.args(args);
+        command
+    }
+
+    #[test]
+    fn a_retried_pass_fails_the_lane_that_reported_it() {
+        let temp = lane(RETRYING_PROFILE, Some(RETRIED_PASS));
+
+        let error = verdict(
+            "workspace",
+            temp.path(),
+            &config("nextest.toml", &[]),
+            &command(&["nextest", "run", "--profile", "ci"]),
+        )
+        .expect_err("a retried pass is not a clean lane");
+
+        let error = error.to_string();
+        assert!(
+            error.contains("kithara_queue::delayed_target"),
+            "the verdict names the retried test: {error}"
+        );
+    }
+
+    #[test]
+    fn a_registry_entry_owns_the_retried_pass_it_names() {
+        let temp = lane(RETRYING_PROFILE, Some(RETRIED_PASS));
+
+        verdict(
+            "workspace",
+            temp.path(),
+            &config(
+                "nextest.toml",
+                &[("kithara_queue::delayed_target", "https://example.test/1")],
+            ),
+            &command(&["nextest", "run", "--profile", "ci"]),
+        )
+        .expect("an owned retried pass keeps the lane green");
+    }
+
+    #[test]
+    fn a_profile_that_retries_without_a_report_cannot_be_judged() {
+        let temp = lane("[profile.ci]\nretries = 1\n", None);
+
+        let error = verdict(
+            "workspace",
+            temp.path(),
+            &config("nextest.toml", &[]),
+            &command(&["nextest", "run", "--profile", "ci"]),
+        )
+        .expect_err("a retry that leaves no trace is unjudgeable")
+        .to_string();
+
+        assert!(error.contains("declares no JUnit report"), "{error}");
+    }
+
+    #[test]
+    fn a_declared_report_the_lane_did_not_leave_fails_it() {
+        let temp = lane(RETRYING_PROFILE, None);
+
+        let error = verdict(
+            "workspace",
+            temp.path(),
+            &config("nextest.toml", &[]),
+            &command(&["nextest", "run", "--profile", "ci"]),
+        )
+        .expect_err("a missing report is a lane that presented no evidence")
+        .to_string();
+
+        assert!(error.contains("junit.xml"), "{error}");
+    }
+
+    #[test]
+    fn a_profile_that_grants_no_retry_is_not_judged() {
+        let temp = lane(RETRYING_PROFILE, Some(RETRIED_PASS));
+
+        verdict(
+            "workspace",
+            temp.path(),
+            &config("nextest.toml", &[]),
+            &command(&["nextest", "run"]),
+        )
+        .expect("the default profile retries nothing, so it hides nothing");
+    }
+
+    #[test]
+    fn a_lane_that_runs_no_nextest_is_not_judged() {
+        let temp = lane(RETRYING_PROFILE, Some(RETRIED_PASS));
+
+        verdict(
+            "browser",
+            temp.path(),
+            &config("nextest.toml", &[]),
+            &command(&["test", "--profile", "ci"]),
+        )
+        .expect("`--profile` on `cargo test` names a Cargo profile");
+    }
+
+    #[test]
+    fn a_profile_inherits_the_retry_count_it_does_not_set() {
+        let declared = declaration("[profile.default]\nretries = 2\n\n[profile.ci]\n", "ci")
+            .expect("read profile");
+
+        assert_eq!(declared.retries, 2);
+        assert_eq!(declared.junit, None);
+    }
+
+    #[test]
+    fn retries_may_be_declared_as_a_table_around_its_count() {
+        let declared = declaration(
+            "[profile.ci]\nretries = { backoff = \"exponential\", count = 3 }\n",
+            "ci",
+        )
+        .expect("read profile");
+
+        assert_eq!(declared.retries, 3);
+    }
+}

--- a/crates/kithara-devtools/src/test.rs
+++ b/crates/kithara-devtools/src/test.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     common::project::{ProjectConfig, TestCommandConfig, TestLaneConfig},
-    sccache, touched,
+    retried, sccache, touched,
     verdict::ChildFailure,
 };
 
@@ -115,21 +115,26 @@ impl TestRequest {
 }
 
 pub(crate) fn run(args: &TestArgs) -> Result<()> {
+    /// Where the test command is run from, and so where every path it reads
+    /// or judges is anchored.
+    const ROOT: &str = ".";
+
     let request = TestRequest::parse(&args.args)?;
-    let project = ProjectConfig::load(Path::new("."))?;
+    let root = Path::new(ROOT);
+    let project = ProjectConfig::load(root)?;
     let test = &project.test;
     validate_config(test)?;
 
     if request.touched {
-        return run_touched(&project, &request);
+        return run_touched(&project, root, &request);
     }
     let (lane_name, lane) = select_lane(test, &request)?;
-    run_lane(&project, lane_name, lane, &request)
+    run_lane(&project, root, lane_name, lane, &request)
 }
 
 /// Run every lane the branch touched, serially, without letting the first
 /// failure hide the rest: this exists to name which lane broke.
-fn run_touched(project: &ProjectConfig, request: &TestRequest) -> Result<()> {
+fn run_touched(project: &ProjectConfig, root: &Path, request: &TestRequest) -> Result<()> {
     if request.lane.is_some() {
         bail!("--touched selects its own lanes and conflicts with --lane");
     }
@@ -146,7 +151,7 @@ fn run_touched(project: &ProjectConfig, request: &TestRequest) -> Result<()> {
             .get(lane_name)
             .with_context(|| format!("test lane `{lane_name}` is not configured"))?;
         println!("=== {lane_name} ===");
-        if run_lane(project, lane_name, lane, request).is_err() {
+        if run_lane(project, root, lane_name, lane, request).is_err() {
             failed.push(lane_name.clone());
         }
     }
@@ -158,6 +163,7 @@ fn run_touched(project: &ProjectConfig, request: &TestRequest) -> Result<()> {
 
 fn run_lane(
     project: &ProjectConfig,
+    root: &Path,
     lane_name: &str,
     lane: &TestLaneConfig,
     request: &TestRequest,
@@ -177,7 +183,7 @@ fn run_lane(
             status.code(),
         ));
     }
-    Ok(())
+    retried::verdict(lane_name, root, &project.test, &cmd)
 }
 
 fn lane_command(
@@ -239,6 +245,9 @@ fn validate_config(config: &TestCommandConfig) -> Result<()> {
     if config.feature_arg.is_empty() {
         bail!("missing test.feature_arg in .config/xtask.toml");
     }
+    if config.nextest_config.is_empty() {
+        bail!("missing test.nextest_config in .config/xtask.toml");
+    }
     if !config.lanes.contains_key(&config.default_lane) {
         bail!(
             "test.default_lane `{}` is not defined in test.lanes",
@@ -262,6 +271,21 @@ fn validate_config(config: &TestCommandConfig) -> Result<()> {
             bail!("test.lanes.{name}.program is empty");
         }
         passthrough_position(lane).with_context(|| format!("test.lanes.{name}.passthrough"))?;
+    }
+    let mut named = BTreeSet::new();
+    for flake in &config.known_flakes {
+        if flake.test.is_empty() {
+            bail!("test.known_flakes entry names no test");
+        }
+        if flake.issue.is_empty() {
+            bail!(
+                "test.known_flakes entry `{}` names no issue: an entry without an owner is a flake nobody removes",
+                flake.test
+            );
+        }
+        if !named.insert(flake.test.as_str()) {
+            bail!("test.known_flakes names `{}` twice", flake.test);
+        }
     }
     Ok(())
 }
@@ -599,11 +623,13 @@ fn parse_toggle(name: &str, value: &str) -> Result<bool> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    use std::{collections::BTreeMap, fs};
+
+    use tempfile::TempDir;
 
     use super::*;
     use crate::common::project::{
-        AuditClippyConfig, HealthConfig, LintExcludeConfig, OrphansConfig, PerfConfig,
+        AuditClippyConfig, HealthConfig, KnownFlake, LintExcludeConfig, OrphansConfig, PerfConfig,
         ProjectIdentity, QualityConfig, StressConfig, TestFlashConfig, TestNetBackendConfig,
         TestNoBlockConfig, WorkspaceScan,
     };
@@ -721,6 +747,8 @@ mod tests {
                 default_lane: "workspace".to_owned(),
                 default_backend: "http".to_owned(),
                 feature_arg: "--features".to_owned(),
+                nextest_config: ".config/nextest.toml".to_owned(),
+                known_flakes: Vec::new(),
                 features: vec!["base-feature".to_owned()],
                 flash: TestFlashConfig {
                     features: vec!["virtual-time".to_owned()],
@@ -1070,6 +1098,68 @@ mod tests {
         let cmd = lane_command(&project, name, lane, &request).expect("default lane command");
 
         assert!(envs_of(&cmd).is_empty());
+    }
+
+    /// A lane is clean only once its report agrees. The verdict lives past
+    /// the exit code because nextest exits zero on a retried pass, so a lane
+    /// read by status alone reported a defect that reproduced as a clean run.
+    ///
+    /// The lane runs a program that exits without building anything while its
+    /// command line still names the runner profile it would have run under.
+    #[test]
+    fn a_green_status_is_not_the_whole_verdict_of_a_retrying_lane() {
+        let temp = TempDir::new().expect("temp root");
+        fs::create_dir_all(temp.path().join(".config")).expect("create .config");
+        fs::write(
+            temp.path().join(".config").join("nextest.toml"),
+            "[profile.ci]\nretries = 1\n",
+        )
+        .expect("write nextest config");
+        let mut project = synthetic_project();
+        project.test.nextest_config = ".config/nextest.toml".to_owned();
+        project.test.lanes.insert(
+            "retrying".to_owned(),
+            TestLaneConfig {
+                program: "cargo".to_owned(),
+                prefix_args: vec![
+                    "--version".to_owned(),
+                    "nextest".to_owned(),
+                    "run".to_owned(),
+                    "--profile".to_owned(),
+                    "ci".to_owned(),
+                ],
+                suffix_args: Vec::new(),
+                default_features: Vec::new(),
+                default_flash: Some(false),
+                default_no_block: Some(false),
+                passthrough: String::new(),
+                env: BTreeMap::new(),
+                owns: Vec::new(),
+            },
+        );
+        let request = TestRequest::parse(&[]).expect("parse request");
+        let lane = &project.test.lanes["retrying"];
+
+        let error = run_lane(&project, temp.path(), "retrying", lane, &request)
+            .expect_err("a lane that ran a retrying profile is judged by its report")
+            .to_string();
+
+        assert!(error.contains("declares no JUnit report"), "{error}");
+    }
+
+    #[test]
+    fn a_tolerated_flake_without_an_owner_is_not_configuration() {
+        let mut project = synthetic_project();
+        project.test.known_flakes = vec![KnownFlake {
+            test: "kithara_queue::delayed_target".to_owned(),
+            issue: String::new(),
+        }];
+
+        let error = validate_config(&project.test)
+            .expect_err("an entry nobody owns is a flake nobody removes")
+            .to_string();
+
+        assert!(error.contains("names no issue"), "{error}");
     }
 
     #[test]

--- a/xtask/src/ci/config/profile.rs
+++ b/xtask/src/ci/config/profile.rs
@@ -95,10 +95,12 @@ mod tests {
         }
     }
 
-    /// Without retries a single flaky failure reads as a regression: the first
-    /// merge request judged was held by two tests it had not touched.
+    /// The retry is what keeps the failing attempt: nextest records it inside
+    /// `flakyFailure`, and the lane's verdict fails on a retried pass anyway.
+    /// Without the retry the same throw leaves one red attempt and no record
+    /// that the test reached a pass on the next one.
     #[test]
-    fn the_judged_profile_does_not_take_one_failure_as_evidence() {
+    fn the_judged_profile_keeps_the_attempt_it_retried() {
         let nextest: toml::Value = toml::from_str(
             &fs::read_to_string(workspace_root().join(".config/nextest.toml")).unwrap(),
         )
@@ -107,7 +109,7 @@ mod tests {
         let retries = nextest["profile"]["ci"].get("retries");
         assert!(
             retries.is_some_and(|value| value.as_integer().is_some_and(|count| count > 0)),
-            "the CI profile must retry, or every flake reads as a regression"
+            "the CI profile must retry, or a flake leaves no record of being one"
         );
     }
 


### PR DESCRIPTION
## What this fixes

A nextest retry keeps the failing attempt — its streams, its panic and its hang
dump land inside `flakyFailure` — and then the run exits zero with
`Summary … 1 passed (1 flaky)`. Judged by its exit code alone, a lane that
reproduced a defect reads as a clean lane, and nothing in the repo read the
report to say otherwise.

That is not hypothetical. `linux-test-simulated-clock` runs `--profile ci`,
which declares `retries = 1`, so every timing defect it caught was reported
green; [this run](https://github.com/gerasim13/kithara/actions/runs/34514525301/job/102996831749)
is one of them. `linux-test-real-clock` runs the default profile and grants no
retry, so it was never affected.

## What changed

`run_lane` now ends in a verdict (`crates/kithara-devtools/src/retried.rs`):

- It reads the retry count and the report location from `.config/nextest.toml`,
  the single owner of runner profiles, so neither is copied into a second
  place. A key the profile does not set is inherited from `default`, the way
  nextest resolves it, and `retries` is accepted both as a count and as a table
  around one.
- A lane whose profile grants no retry cannot hide anything and is returned
  unchanged — `stress`, `rtsan`, `perf`, `fast`, `harness`, `support` and
  `default` are untouched. So is a lane that runs no nextest at all.
- A profile that retries while declaring no report, or declares one the lane
  did not leave, is an error: a retried pass would be unjudgeable.
- Retried passes come from the existing `parse_junit` and `CaseTiming::flaky`;
  no second parser. nextest already prints the failing attempt inline, so the
  verdict names the tests and points at the report rather than reprinting the
  evidence.

The profile selection follows nextest's own rule: `--profile` names a Cargo
profile to `cargo test` and a runner profile to `cargo nextest`, so it is read
only past the `nextest` token, and the last one wins — a lane carrying
`--profile support` in `prefix_args` still resolves to `ci` when the CI step
appends it.

## The registry

`test.known_flakes` in `.config/xtask.toml` owns the exceptions. **It is
empty.** Each entry must name the issue that owns the defect, and
`validate_config` rejects one that does not. An entry is a visible admission in
the diff that a known defect is being waited on instead of fixed — not a list a
lane grows to stay green.

Both places that documented the retry as a shield now document it as what it
is: an evidence collector. Whether the second attempt passes is what separates
a non-deterministic test from a change that broke it; it is not permission for
the lane to pass.

## Measured, not assumed

- nextest resolves `junit.path` against its own store, and that store stays at
  `<workspace root>/target/nextest/<profile>/` even when `CARGO_TARGET_DIR`
  points elsewhere. Proven with a throwaway crate, so the resolution is a
  single unconditional join and not a fallback chain.
- The wiring test was proven to fail before the change: stubbing the verdict
  out turns `a_green_status_is_not_the_whole_verdict_of_a_retrying_lane` red.

## Validation

- `just fmt check` clean.
- `just lint fast` clean, warn total back to its pre-change baseline (996), no
  suppressions and no baseline entries.
- `just test`: 4610 tests run, 4610 passed, 227 skipped.
