### PR TITLE
fix: two stress defects at their root, and a pin for the third

### DIFF
--- a/crates/kithara-events/src/bus.rs
+++ b/crates/kithara-events/src/bus.rs
@@ -150,6 +150,20 @@ mod tests {
         Error { error: String },
     }
 
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, crate::Event)]
+    struct Early(u8);
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, crate::Event)]
+    struct Late(u8);
+
+    /// `Late` is declared first so that declaration order and publication
+    /// order can disagree.
+    #[derive(Clone, Debug, crate::EventSet)]
+    enum Pair {
+        Late(Late),
+        Early(Early),
+    }
+
     #[kithara::test]
     fn publish_without_subscribers_does_not_panic() {
         let bus = EventBus::new(16);
@@ -276,6 +290,26 @@ mod tests {
         let ea = rx_a.recv().await.unwrap();
         assert_eq!(ea.event, TestEvent::EndOfStream);
         assert!(rx_a.try_recv().is_err());
+    }
+
+    /// The bus carries one channel per event type, so a receiver spanning
+    /// several of them has no cross-topic order to report: it hands back
+    /// whichever member it polls first. A caller that wants to know what was
+    /// published first has to subscribe to that one topic.
+    #[kithara::test(tokio)]
+    async fn a_receiver_over_several_topics_does_not_preserve_publication_order() {
+        let bus = EventBus::new(16);
+        let mut pair = bus.subscribe::<Pair>();
+        let mut early = bus.subscribe::<Early>();
+
+        bus.publish(Early(1));
+        bus.publish(Late(2));
+
+        assert!(matches!(
+            pair.try_recv().map(|envelope| envelope.event),
+            Ok(Pair::Late(Late(2)))
+        ));
+        assert_eq!(early.try_recv().unwrap().event, Early(1));
     }
 
     #[kithara::test]

--- a/crates/kithara-platform/src/flash/sync/mpsc.rs
+++ b/crates/kithara-platform/src/flash/sync/mpsc.rs
@@ -76,10 +76,17 @@ impl<T> Drop for Sender<T> {
 impl<T> Receiver<T> {
     /// Block until a value arrives.
     ///
+    /// The `no_block` detector hears this at the call and not at the park: a
+    /// message already queued returns without ever waiting, and a detector
+    /// that only saw the wait would judge the same code differently from one
+    /// run to the next.
+    ///
     /// # Errors
     ///
     /// Returns [`RecvError`] if all senders have been dropped.
+    #[track_caller]
     pub fn recv(&self) -> Result<T, RecvError> {
+        crate::no_block::forbid("mpsc::recv");
         let mut q = self.0.queue.lock();
         loop {
             if let Some(v) = q.pop_front() {
@@ -99,7 +106,11 @@ impl<T> Receiver<T> {
     /// Returns [`RecvTimeoutError::Timeout`] when no value arrives before
     /// `deadline`, or [`RecvTimeoutError::Disconnected`] if all senders are
     /// dropped.
+    ///
+    /// Reaches the `no_block` detector at the call, like [`Self::recv`].
+    #[track_caller]
     pub fn recv_timeout(&self, deadline: Instant) -> Result<T, RecvTimeoutError> {
+        crate::no_block::forbid("mpsc::recv_timeout");
         let mut q = self.0.queue.lock();
         loop {
             if let Some(v) = q.pop_front() {

--- a/crates/kithara-test-fixtures/src/signal/provenance.rs
+++ b/crates/kithara-test-fixtures/src/signal/provenance.rs
@@ -11,8 +11,15 @@ pub enum FrameClass {
 }
 
 /// Per-window classification of a mono f32 stream.
+///
 /// `window` = frames per window; `tol` = allowed deviation of the mean
 /// per-frame modular delta from +/-1.0 i16 units.
+///
+/// A window's mean covers the step into its first frame as well as the steps
+/// between its own frames, so the windows together read every step the stream
+/// contains. Reading only the interior steps would drop one step per window --
+/// precisely the steps that land on a window boundary -- and a splice that
+/// landed there would be invisible to every caller.
 #[must_use]
 pub fn classify_windows(left: &[f32], window: usize, tol: f32) -> Vec<FrameClass> {
     if window < 2 {
@@ -20,7 +27,11 @@ pub fn classify_windows(left: &[f32], window: usize, tol: f32) -> Vec<FrameClass
     }
 
     left.chunks_exact(window)
-        .map(|samples| classify_window(samples, tol))
+        .enumerate()
+        .map(|(index, samples)| {
+            let preceding = (index > 0).then(|| left[index * window - 1]);
+            classify_window(samples, preceding, tol)
+        })
         .collect()
 }
 
@@ -80,16 +91,18 @@ pub fn ascending_phase_replays(
     replays
 }
 
-fn classify_window(samples: &[f32], tol: f32) -> FrameClass {
+fn classify_window(samples: &[f32], preceding: Option<f32>, tol: f32) -> FrameClass {
     if samples.iter().all(|sample| is_silence(*sample)) {
         return FrameClass::Silence;
     }
 
-    let delta_sum = samples
-        .windows(2)
-        .map(|pair| f32::from(phase::delta(phase::units(pair[0]), phase::units(pair[1]))))
+    let entry = preceding.map(|prior| step(prior, samples[0]));
+    let delta_sum = entry
+        .into_iter()
+        .chain(samples.windows(2).map(|pair| step(pair[0], pair[1])))
         .sum::<f32>();
-    let steps: f32 = cast(samples.len() - 1).expect("invariant: a window length fits f32");
+    let count = samples.len() - 1 + usize::from(entry.is_some());
+    let steps: f32 = cast(count).expect("invariant: a window length fits f32");
     let mean_delta = delta_sum / steps;
 
     if (mean_delta - 1.0).abs() <= tol {
@@ -99,6 +112,10 @@ fn classify_window(samples: &[f32], tol: f32) -> FrameClass {
     } else {
         FrameClass::Unknown
     }
+}
+
+fn step(from: f32, to: f32) -> f32 {
+    f32::from(phase::delta(phase::units(from), phase::units(to)))
 }
 
 fn expected_phase_error(sample: f32, base_phase: usize, frame_offset: usize) -> i32 {
@@ -115,7 +132,7 @@ fn is_silence(sample: f32) -> bool {
 mod tests {
     use kithara_test_utils::kithara;
 
-    use super::{FrameClass, Replay, ascending_phase_replays, classify_windows};
+    use super::{FrameClass, Replay, SAW_PERIOD, ascending_phase_replays, classify_windows};
     use crate::fixtures::{
         ascending_pcm, ascending_wrap_pcm, descending_pcm, descending_wrap_pcm, provenance_silence,
     };
@@ -144,6 +161,23 @@ mod tests {
         assert_eq!(
             classify_windows(&silence, WINDOW, 0.5),
             vec![FrameClass::Silence]
+        );
+    }
+
+    /// A splice is a splice wherever it falls. The frame it lands on is set by
+    /// whatever the renderer had committed when the flush arrived, so a reader
+    /// that saw only the steps inside a window would report the same stream as
+    /// continuous in one run and broken in the next.
+    #[kithara::test(native, flash(false))]
+    fn a_splice_on_a_window_boundary_still_breaks_the_class(ascending_pcm: Vec<f32>) {
+        const JUMP: usize = SAW_PERIOD / 2;
+
+        let mut left = ascending_pcm[..WINDOW * 2].to_vec();
+        left[WINDOW..].copy_from_slice(&ascending_pcm[JUMP..JUMP + WINDOW]);
+
+        assert_eq!(
+            classify_windows(&left, WINDOW, 0.5),
+            vec![FrameClass::Ascending, FrameClass::Unknown]
         );
     }
 

--- a/tests/crates/audio/tests/audio_tests.rs
+++ b/tests/crates/audio/tests/audio_tests.rs
@@ -103,13 +103,18 @@ async fn test_audio_new(#[case] wav_input: NamedTempFile) {
     let _audio = worker.open(config).await.unwrap();
 }
 
+/// The bus gives one channel per event type, so "the first event" is a
+/// property only within a single topic: a receiver spanning several of them
+/// reports whichever member it polls first, not whichever was published first.
+/// Subscribing to the decoder topic alone is what makes the assertion below a
+/// property of publication order rather than of declaration order.
 #[kithara::test(tokio)]
 async fn test_audio_new_publishes_initial_decoder_changed(wav_1000: NamedTempFile) {
     let region = pools();
     let worker = PlayWorker::new(PlayWorkerConfig::builder(region).build());
     let (_cache, config) = test_wav_config(&wav_1000, &worker);
     let bus = EventBus::new(16);
-    let mut events = bus.subscribe();
+    let mut events = bus.subscribe::<DecoderEvent>();
     let config = AudioConfig::<kithara::file::File<TestPools>>::for_stream(config.stream().clone())
         .maybe_hint(config.hint().map(str::to_owned))
         .events(bus)
@@ -119,13 +124,13 @@ async fn test_audio_new_publishes_initial_decoder_changed(wav_1000: NamedTempFil
     let expected_backend = DecoderBackend::Symphonia;
 
     match events.try_recv().map(|env| env.event) {
-        Ok(TestEvent::Decoder(DecoderEvent::DecoderChanged {
+        Ok(DecoderEvent::DecoderChanged {
             backend,
             sample_rate,
             channels,
             cause,
             ..
-        })) => {
+        }) => {
             assert_eq!(backend, expected_backend);
             assert_eq!(sample_rate, audio.spec().sample_rate.get());
             assert_eq!(channels, audio.spec().channels);

--- a/tests/crates/harness/tests/no_block.rs
+++ b/tests/crates/harness/tests/no_block.rs
@@ -1,8 +1,8 @@
 use kithara::platform::{
     no_block::force_panic_mode,
-    sync::{Arc, Condvar, Mutex},
+    sync::{Arc, Condvar, Mutex, mpsc},
     thread,
-    time::Duration,
+    time::{Duration, Instant},
 };
 use kithara_integration_tests::kithara;
 
@@ -47,6 +47,30 @@ async fn allow_block_bridge_passes() {
         cvar.notify_all();
     });
     sanctioned_bridge(&pair);
+}
+
+/// A message already in the queue is not a licence. `recv` is a blocking API
+/// at every call site, and which side wins the race with its producer changes
+/// between runs; a detector that reads only the park reports the same code in
+/// one run and stays silent in the next.
+#[kithara::test(flash(false))]
+#[should_panic(expected = "[no_block]")]
+async fn a_queued_message_does_not_hide_mpsc_recv() {
+    let _mode = force_panic_mode();
+    let (tx, rx) = mpsc::channel();
+    tx.send(()).expect("the receiver is alive");
+    let _ = rx.recv();
+}
+
+/// The deadline form blocks for the same reason and is reported the same way,
+/// whatever the queue holds when it is called.
+#[kithara::test(flash(false))]
+#[should_panic(expected = "[no_block]")]
+async fn a_queued_message_does_not_hide_mpsc_recv_timeout() {
+    let _mode = force_panic_mode();
+    let (tx, rx) = mpsc::channel();
+    tx.send(()).expect("the receiver is alive");
+    let _ = rx.recv_timeout(Instant::now());
 }
 
 #[kithara::allow_block]


### PR DESCRIPTION
Two defects the nightly stress run reported, each fixed where it is
owned, plus an executable pin for the contract behind a third that
#366 has already landed. Every fix is measured against a test that
fails on the old code.

## 1. A splice on a window boundary was invisible to the classifier

`classify_windows` partitioned the stream with `chunks_exact` and took
deltas with `windows(2)`, so a window reported the mean of its 63
interior steps and never the step that entered it. One step per window
was read by nobody — precisely the steps that land on a boundary.

A seek seam landing on a multiple of the window length left both
neighbouring windows `Ascending`, their runs merged, and
`require_run_containing(runs, Ascending, last_ascending_window)`
answered with the run that starts a thousand windows earlier. The
artifact shows exactly that shape: `landing_frame=64`,
`phase_delta=18882`, `class_runs=[(Unknown,0,1),(Ascending,1,1038),…]`.
One landing frame in 64 matches the observed rate of about one in
fifty for `seek_near_end_then_eof_advance_emits_only_b_flac`.

Each window now folds in the step from its predecessor's last frame, so
the windows together read every step the stream contains. The other
consumer, `full_playthrough_census`, skips `Unknown` windows and is
unaffected.

## 2. A queued message hid a blocking `mpsc::recv` from the detector

The flash `mpsc::Receiver` reached `no_block::forbid` only on its way
into the `Condvar`. A message the producer had already queued was
popped before that, so the same call site was reported in one run and
passed over in the next, decided by a race the caller does not control.
`system` and `loom` already forbid at entry: three implementations of
one platform contract disagreed about when a blocking call is blocking.

`recv` and `recv_timeout` now forbid first and read the queue after.

The two new tests queue a message before calling — the exact state the
old code let through. They live in the external harness crate because a
lib unit test compiles the platform a second time and the two copies do
not share the detector's thread-local context.

## 3. The multi-topic receiver contract, as a test

#366 fixed `test_audio_new_publishes_initial_decoder_changed` and wrote
the reason on `EventSet` and `EventReceiver`: a multi-member receiver
polls members in declaration order, so it reports no order between
them. That contract had no test. The new bus test publishes to the
later-declared topic second and shows the receiver handing back the
earlier-declared one, so the next caller to assert publication order
through a multi-topic receiver fails here rather than under stress.

## Validation

Each fix measured against its own test, before and after:

| defect | before | after |
| --- | --- | --- |
| classifier | `FAIL a_splice_on_a_window_boundary_still_breaks_the_class` | 14 passed, including the 13 `advance_boundary_provenance` siblings |
| mpsc | `FAIL` ×2 | 3 passed, with `session_command_bridge_does_not_suppress_runtime_blocking` |

Lanes on the merged head: `just fmt check` clean; `just lint fast` at
`0 deny, 996 warn, 0 regression(s)` — the baseline unchanged;
`just test run --no-block=on` 4641/4642; `just test` 4612/4613.

The single failure in each lane is that lane's own flake, not this
change. Across four full runs the failure landed on six different tests
and never twice on the same one in the same lane: `duplicate_src_in_queue::…same_url_entry`,
which reaches `https://example.com/repeat.mp3` on the real network and
takes its live 404 as a track failure; `local_track_plays::…_symphonia`;
`early_seek_size_withheld_advance::…` at a flat 60 s timeout;
`stress_offline_crossfade_no_gaps`; and two `packaged_hls_single_variant_continuity`
cases that did not reproduce on a rerun of the same tree.
